### PR TITLE
Make the blockchain interface async again on wasm32-unknown-unknown

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 language: rust
 rust:
   - stable
-#  - 1.31.0
-#  - 1.22.0
 before_script:
+  # Install a recent version of clang that supports wasm32
+  - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+  - sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main"
+  - sudo apt-get update
+  - sudo apt-get install -y clang-10 libc6-dev-i386
+  # Install the required components and targets
   - rustup component add rustfmt
+  - rustup target add wasm32-unknown-unknown
 script:
   - cargo fmt -- --check --verbose
   - cargo test --verbose --all
@@ -13,6 +18,7 @@ script:
   - cargo build --verbose --no-default-features --features=minimal,esplora
   - cargo build --verbose --no-default-features --features=key-value-db
   - cargo build --verbose --no-default-features --features=electrum
+  - CC="clang-10" CFLAGS="-I/usr/include" cargo build --verbose --no-default-features --features=cli-utils,esplora --target=wasm32-unknown-unknown
 
 notifications:
   email: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2018"
 authors = ["Riccardo Casatta <riccardo@casatta.it>", "Alekos Filini <alekos.filini@gmail.com>"]
 
 [dependencies]
+magical-macros = { path = "./macros" }
 log = "^0.4"
 bitcoin = { version = "0.23", features = ["use-serde"] }
 miniscript = { version = "1.0" }
@@ -15,17 +16,23 @@ serde_json = { version = "^1.0" }
 sled = { version = "0.31.0", optional = true }
 electrum-client = { version = "0.2.0-beta.1", optional = true }
 reqwest = { version = "0.10", optional = true, features = ["json"] }
-tokio = { version = "0.2", optional = true, features = ["rt-core"] }
 futures = { version = "0.3", optional = true }
 clap = { version = "2.33", optional = true }
 base64 = { version = "^0.11", optional = true }
+
+# Platform-specific dependencies
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "0.2", features = ["rt-core"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+async-trait = "0.1"
 
 [features]
 minimal = []
 compiler = ["miniscript/compiler"]
 default = ["key-value-db", "electrum"]
 electrum = ["electrum-client"]
-esplora = ["reqwest", "futures", "tokio"]
+esplora = ["reqwest", "futures"]
 key-value-db = ["sled"]
 cli-utils = ["clap", "base64"]
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "magical-macros"
+version = "0.1.0"
+authors = ["Alekos Filini <alekos.filini@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+syn = { version = "1.0", features = ["parsing"] }
+proc-macro2 = "1.0"
+quote = "1.0"
+
+[lib]
+proc-macro = true

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,0 +1,134 @@
+#[macro_use]
+extern crate quote;
+
+use proc_macro::TokenStream;
+
+use syn::spanned::Spanned;
+use syn::{parse, ImplItemMethod, ItemImpl, ItemTrait, Token};
+
+fn add_async_trait(mut parsed: ItemTrait) -> TokenStream {
+    let output = quote! {
+        #[cfg(not(target_arch = "wasm32"))]
+        #parsed
+    };
+
+    for mut item in &mut parsed.items {
+        if let syn::TraitItem::Method(m) = &mut item {
+            m.sig.asyncness = Some(Token![async](m.span()));
+        }
+    }
+
+    let output = quote! {
+        #output
+
+        #[cfg(target_arch = "wasm32")]
+        #[async_trait(?Send)]
+        #parsed
+    };
+
+    output.into()
+}
+
+fn add_async_method(mut parsed: ImplItemMethod) -> TokenStream {
+    let output = quote! {
+        #[cfg(not(target_arch = "wasm32"))]
+        #parsed
+    };
+
+    parsed.sig.asyncness = Some(Token![async](parsed.span()));
+
+    let output = quote! {
+        #output
+
+        #[cfg(target_arch = "wasm32")]
+        #parsed
+    };
+
+    output.into()
+}
+
+fn add_async_impl_trait(mut parsed: ItemImpl) -> TokenStream {
+    let output = quote! {
+        #[cfg(not(target_arch = "wasm32"))]
+        #parsed
+    };
+
+    for mut item in &mut parsed.items {
+        if let syn::ImplItem::Method(m) = &mut item {
+            m.sig.asyncness = Some(Token![async](m.span()));
+        }
+    }
+
+    let output = quote! {
+        #output
+
+        #[cfg(target_arch = "wasm32")]
+        #[async_trait(?Send)]
+        #parsed
+    };
+
+    output.into()
+}
+
+/// Makes a method or every method of a trait "async" only if the target_arch is "wasm32"
+///
+/// Requires the `async-trait` crate as a dependency whenever this attribute is used on a trait
+/// definition or trait implementation.
+#[proc_macro_attribute]
+pub fn maybe_async(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    if let Ok(parsed) = parse(item.clone()) {
+        add_async_trait(parsed)
+    } else if let Ok(parsed) = parse(item.clone()) {
+        add_async_method(parsed)
+    } else if let Ok(parsed) = parse(item) {
+        add_async_impl_trait(parsed)
+    } else {
+        (quote! {
+            compile_error!("#[maybe_async] can only be used on methods, trait or trait impl blocks")
+        }).into()
+    }
+}
+
+/// Awaits if target_arch is "wasm32", does nothing otherwise
+#[proc_macro]
+pub fn maybe_await(expr: TokenStream) -> TokenStream {
+    let expr: proc_macro2::TokenStream = expr.into();
+    let quoted = quote! {
+        {
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                #expr
+            }
+
+            #[cfg(target_arch = "wasm32")]
+            {
+                #expr.await
+            }
+        }
+    };
+
+    quoted.into()
+}
+
+/// Awaits if target_arch is "wasm32", uses `futures::executor::block_on()` otherwise
+///
+/// Requires the `tokio` crate as a dependecy with `rt-core` or `rt-threaded` to build on non-wasm32 platforms.
+#[proc_macro]
+pub fn await_or_block(expr: TokenStream) -> TokenStream {
+    let expr: proc_macro2::TokenStream = expr.into();
+    let quoted = quote! {
+        {
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                tokio::runtime::Runtime::new().unwrap().block_on(#expr)
+            }
+
+            #[cfg(target_arch = "wasm32")]
+            {
+                #expr.await
+            }
+        }
+    };
+
+    quoted.into()
+}

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -41,6 +41,7 @@ impl Blockchain for OfflineBlockchain {
     }
 }
 
+#[maybe_async]
 pub trait OnlineBlockchain: Blockchain {
     fn get_capabilities(&self) -> HashSet<Capability>;
 
@@ -56,7 +57,7 @@ pub trait OnlineBlockchain: Blockchain {
         database: &mut D,
         progress_update: P,
     ) -> Result<(), Error> {
-        self.setup(stop_gap, database, progress_update)
+        maybe_await!(self.setup(stop_gap, database, progress_update))
     }
 
     fn get_tx(&mut self, txid: &Txid) -> Result<Option<Transaction>, Error>;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -276,6 +276,7 @@ pub fn add_global_flags<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
     .subcommand(SubCommand::with_name("repl").about("Opens an interactive shell"))
 }
 
+#[maybe_async]
 pub fn handle_matches<C, D>(
     wallet: &Wallet<C, D>,
     matches: ArgMatches<'_>,
@@ -287,7 +288,7 @@ where
     if let Some(_sub_matches) = matches.subcommand_matches("get_new_address") {
         Ok(Some(format!("{}", wallet.get_new_address()?)))
     } else if let Some(_sub_matches) = matches.subcommand_matches("sync") {
-        wallet.sync(None, None)?;
+        maybe_await!(wallet.sync(None, None))?;
         Ok(None)
     } else if let Some(_sub_matches) = matches.subcommand_matches("list_unspent") {
         let mut res = String::new();
@@ -382,7 +383,7 @@ where
             panic!("Missing `psbt` and `tx` option");
         };
 
-        let txid = wallet.broadcast(tx)?;
+        let txid = maybe_await!(wallet.broadcast(tx))?;
 
         Ok(Some(format!("TXID: {}", txid)))
     } else if let Some(sub_matches) = matches.subcommand_matches("extract_psbt") {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,12 @@ extern crate serde;
 #[macro_use]
 extern crate serde_json;
 
+#[cfg(target_arch = "wasm32")]
+#[macro_use]
+extern crate async_trait;
+#[macro_use]
+extern crate magical_macros;
+
 #[cfg(test)]
 #[macro_use]
 extern crate lazy_static;

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -709,6 +709,7 @@ where
     B: OnlineBlockchain,
     D: BatchDatabase,
 {
+    #[maybe_async]
     pub fn new(
         descriptor: &str,
         change_descriptor: Option<&str>,
@@ -738,7 +739,7 @@ where
             None => None,
         };
 
-        let current_height = Some(client.get_height()? as u32);
+        let current_height = Some(maybe_await!(client.get_height())? as u32);
 
         Ok(Wallet {
             descriptor,
@@ -752,6 +753,7 @@ where
         })
     }
 
+    #[maybe_async]
     pub fn sync(
         &self,
         max_address: Option<u32>,
@@ -811,15 +813,16 @@ where
             self.database.borrow_mut().commit_batch(address_batch)?;
         }
 
-        self.client.borrow_mut().sync(
+        maybe_await!(self.client.borrow_mut().sync(
             None,
             self.database.borrow_mut().deref_mut(),
             noop_progress(),
-        )
+        ))
     }
 
+    #[maybe_async]
     pub fn broadcast(&self, tx: Transaction) -> Result<Txid, Error> {
-        self.client.borrow_mut().broadcast(&tx)?;
+        maybe_await!(self.client.borrow_mut().broadcast(&tx))?;
 
         Ok(tx.txid())
     }


### PR DESCRIPTION
The procedural macro `#[maybe_async]` makes a method or every method of a trait
"async" whenever the target_arch is `wasm32`, and leaves them untouched on
every other platform.

The macro `maybe_await!($e:expr)` can be used to call `maybe_async` methods on
multi-platform code: it expands to `$e` on non-wasm32 platforms and to
`$e.await` on wasm32.

The macro `await_or_block!($e:expr)` can be used to contain async code as much
as possible: it expands to `tokio::runtime::Runtime::new().unwrap().block_on($e)`
on non-wasm32 platforms, and to `$e.await` on wasm32.