### PR TITLE
[examples] Fix renamed thresh_m descriptor

### DIFF
--- a/examples/parse_descriptor.rs
+++ b/examples/parse_descriptor.rs
@@ -8,7 +8,7 @@ use magical_bitcoin_wallet::descriptor::*;
 
 fn main() {
     let desc = "wsh(or_d(\
-                    thresh_m(\
+                    multi(\
                       2,[d34db33f/44'/0'/0']xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/1/*,tprv8ZgxMBicQKsPduL5QnGihpprdHyypMGi4DhimjtzYemu7se5YQNcZfAPLqXRuGHb5ZX2eTQj62oNqMnyxJ7B7wz54Uzswqw8fFqMVdcmVF7/1/*\
                     ),\
                     and_v(vc:pk_h(cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy),older(1000))\


### PR DESCRIPTION
In miniscript 1.0, `thresh_m` has been renamed to `multi`

See https://github.com/rust-bitcoin/rust-miniscript/blob/master/CHANGELOG.md#100---july-6-2020