### PR TITLE
Fix offline wallet signing

### DIFF
--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -357,17 +357,7 @@ impl DescriptorMeta for Descriptor<DescriptorPublicKey> {
                 let root_fingerprint = xpub.root_fingerprint();
                 derive_path = index
                     .get_key_value(&root_fingerprint)
-                    .and_then(|(fingerprint, path)| xpub.matches(*fingerprint, path))
-                    .map(|prefix_path| prefix_path.into_iter().cloned().collect::<Vec<_>>())
-                    .map(|prefix| {
-                        index
-                            .get(&xpub.root_fingerprint())
-                            .unwrap()
-                            .into_iter()
-                            .skip(prefix.len())
-                            .cloned()
-                            .collect()
-                    });
+                    .and_then(|(fingerprint, path)| xpub.matches(*fingerprint, path));
             }
 
             Ok(DummyKey::default())


### PR DESCRIPTION
The offline wallet descriptor recovery is broken (is needed because the DB isn't populated with UTXOs) because it recovers the generic descriptor (drops last child number) while the finalizer in rust-miniscript expects a concrete descriptor with the full derivation paths. This can be replicated using [this example code](https://gist.github.com/sgeisler/bdb55710792edbe982645cd70529e3c9) (needs compiler feature and a regtest electrum node).

As I don't know the code base very well this is very likely to introduce other unwanted behavior, so I'm very open to suggestions how to properly fix the bug.

This fixes a part of #108 but might break other things.