### PR TITLE
Fix the recovery of a descriptor given a PSBT

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ tiny-bip39 = { version = "^0.7", optional = true }
 
 [patch.crates-io]
 bitcoin = { git = "https://github.com/rust-bitcoin/rust-bitcoin/", rev = "478e091" }
-miniscript = { git = "https://github.com/MagicalBitcoin/rust-miniscript", branch = "descriptor-public-key" }
+miniscript = { git = "https://github.com/MagicalBitcoin/rust-miniscript", rev = "d0322ac" }
 
 # Platform-specific dependencies
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -358,13 +358,12 @@ impl DescriptorMeta for Descriptor<DescriptorPublicKey> {
                 derive_path = index
                     .get_key_value(&root_fingerprint)
                     .and_then(|(fingerprint, path)| xpub.matches(*fingerprint, path))
-                    .map(|prefix_path| prefix_path.into_iter().cloned().collect::<Vec<_>>())
                     .map(|prefix| {
                         index
                             .get(&xpub.root_fingerprint())
                             .unwrap()
                             .into_iter()
-                            .skip(prefix.len())
+                            .skip(prefix.into_iter().count())
                             .cloned()
                             .collect()
                     });

--- a/src/keys/bip39.rs
+++ b/src/keys/bip39.rs
@@ -77,14 +77,14 @@ impl<Ctx: ScriptContext> DerivableKey<Ctx> for Mnemonic {
 }
 
 impl<Ctx: ScriptContext> GeneratableKey<Ctx> for Mnemonic {
-    const ENTROPY_LENGTH: usize = 32;
+    type Entropy = [u8; 32];
 
     type Options = (MnemonicType, Language);
     type Error = Option<bip39::ErrorKind>;
 
-    fn generate_with_entropy<E: AsRef<[u8]>>(
+    fn generate_with_entropy(
         (mnemonic_type, language): Self::Options,
-        entropy: E,
+        entropy: Self::Entropy,
     ) -> Result<GeneratedKey<Self, Ctx>, Self::Error> {
         let entropy = &entropy.as_ref()[..(mnemonic_type.entropy_bits() / 8)];
         let mnemonic = Mnemonic::from_entropy(entropy, language).map_err(|e| e.downcast().ok())?;

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -2405,6 +2405,21 @@ mod test {
     }
 
     #[test]
+    fn test_sign_single_xprv_bip44_path() {
+        let (wallet, _, _) = get_funded_wallet("wpkh(tprv8ZgxMBicQKsPd3EupYiPRhaMooHKUHJxNsTfYuScep13go8QFfHdtkG9nRkFGb7busX4isf6X9dURGCoKgitaApQ6MupRhZMcELAxTBRJgS/44'/0'/0'/0/*)");
+        let addr = wallet.get_new_address().unwrap();
+        let (psbt, _) = wallet
+            .create_tx(TxBuilder::with_recipients(vec![(addr.script_pubkey(), 0)]).send_all())
+            .unwrap();
+
+        let (signed_psbt, finalized) = wallet.sign(psbt, None).unwrap();
+        assert_eq!(finalized, true);
+
+        let extracted = signed_psbt.extract_tx();
+        assert_eq!(extracted.input[0].witness.len(), 2);
+    }
+
+    #[test]
     fn test_sign_single_xprv_sh_wpkh() {
         let (wallet, _, _) = get_funded_wallet("sh(wpkh(tprv8ZgxMBicQKsPd3EupYiPRhaMooHKUHJxNsTfYuScep13go8QFfHdtkG9nRkFGb7busX4isf6X9dURGCoKgitaApQ6MupRhZMcELAxTBRJgS/*))");
         let addr = wallet.get_new_address().unwrap();


### PR DESCRIPTION
This commit upgrades `rust-miniscript` with a fix to only return the prefix that
matches a `hd_keypath` instead of the full derivation path, and then adapts the
signer code accordingly.

This commit closes #108 and #109.