### PR TITLE
[ci] create github actions "Continuous integration" workflow

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -1,0 +1,200 @@
+on: [push, pull_request]
+
+name: Continuous integration
+
+jobs:
+
+  test:
+    name: Test Default
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - 1.45.0 # MSRV
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+  check-features:
+    name: Check Features
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        features:
+          - minimal
+          - all-keys
+          - minimal,esplora
+          - key-value-db
+          - electrum
+          - compact_filters
+          - cli-utils,esplora
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.45.0 # MSRV
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --features ${{ matrix.features }} --no-default-features
+
+  test-compiler:
+    name: Test Compiler
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.45.0 # MSRV
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features compiler --no-default-features
+
+  test-electrum:
+    name: Test Electrum
+    runs-on: ubuntu-16.04
+    env:
+      MAGICAL_RPC_COOKIEFILE: /home/runner/.bitcoin/regtest/.cookie
+      MAGICAL_ELECTRUM_URL: tcp://127.0.0.1:60401
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.45.0 # MSRV
+          override: true
+      - run: ./ci/start-core.sh || exit 1
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features test-electrum --no-default-features
+
+  test-md-docs:
+    name: Test MD Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features test-md-docs --no-default-features
+        
+  check-wasm:
+    name: Check WASM
+    runs-on: ubuntu-16.04
+    env:
+      CC: clang-10
+      CFLAGS: -I/usr/include
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+        # Install a recent version of clang that supports wasm32
+      - run: wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - || exit 1
+      - run: sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main" || exit 1
+      - run: sudo apt-get update || exit 1
+      - run: sudo apt-get install -y clang-10 libc6-dev-i386 || exit 1
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.45.0 # MSRV
+          target: wasm32-unknown-unknown
+          override: true
+      - uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --target wasm32-unknown-unknown --features cli-utils,esplora --no-default-features
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.45.0 # MSRV
+          override: true
+          components: rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+# TODO enable this after existing clippy warnings are fixed
+#  clippy:
+#    name: Clippy
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#      - uses: actions-rs/toolchain@v1
+#        with:
+#          profile: minimal
+#          toolchain: 1.45.0 # MSRV
+#          override: true
+#          components: clippy
+#      - uses: actions-rs/cargo@v1
+#        with:
+#          command: clippy
+#          args: -- -D warnings

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
   <p>
     <!-- <a href="https://crates.io/crates/magical"><img alt="Crate Info" src="https://img.shields.io/crates/v/magical.svg"/></a> -->
-    <a href="https://travis-ci.org/bitcoindevkit/bdk"><img alt="Traivs Status" src="https://travis-ci.org/bitcoindevkit/bdk.svg?branch=master"></a>
+    <a href="https://github.com/bitcoindevkit/bdk/actions?query=workflow%3A%22Continuous+integration%22"><img alt="Continuous integration Status" src="https://github.com/bitcoindevkit/bdk/workflows/Continuous%20integration/badge.svg"></a>
     <a href="https://bitcoindevkit.org/docs-rs/bdk"><img alt="API Docs" src="https://img.shields.io/badge/docs.rs-bdk-green"/></a>
     <a href="https://blog.rust-lang.org/2020/07/16/Rust-1.45.0.html"><img alt="Rustc Version 1.45+" src="https://img.shields.io/badge/rustc-1.45%2B-lightgrey.svg"/></a>
   </p>

--- a/ci/start-core.sh
+++ b/ci/start-core.sh
@@ -4,7 +4,11 @@ set -e
 
 BITCOIN_VERSION=0.20.1
 
-# This should be cached by Travis
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - || exit 1
+sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main" || exit 1
+sudo apt-get update || exit 1
+sudo apt-get install -y libllvm10 clang-10 libclang-common-10-dev || exit 1
+
 cargo install --git https://github.com/romanz/electrs --bin electrs
 
 curl -O -L https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/bitcoin-$BITCOIN_VERSION-x86_64-linux-gnu.tar.gz
@@ -20,5 +24,5 @@ done
 ADDR=$(bitcoin-cli -regtest getnewaddress)
 bitcoin-cli -regtest generatetoaddress 150 $ADDR
 
-nohup electrs --network regtest --jsonrpc-import --cookie-file /home/travis/.bitcoin/regtest/.cookie &
+nohup electrs --network regtest --jsonrpc-import --cookie-file $HOME/.bitcoin/regtest/.cookie &
 sleep 5


### PR DESCRIPTION
This PR:

* Resolves https://github.com/bitcoindevkit/bdk/issues/59
* Created github actions jobs that do the same builds (using cargo check) and tests as the original Travis version 
* Updated README.md with new "Continuous integration" badge pointing to Github Actions

Improvements:

* Original Travis CI took about 20 mins, Github Actions takes about 15 mins, but most jobs are done in 5-10 mins
* Github [actions-rs/cargo](https://github.com/actions-rs/cargo) tool provides a nice summary of `cargo check` warnings

TODO in future PRs:

* Disable original Travis CI and remove `.travis.yml` file
* Enable nightly dependency security audit check job https://github.com/bitcoindevkit/bdk/issues/116
* Fix clippy warnings and enable that job https://github.com/bitcoindevkit/bdk/issues/118
* Add test coverage job
* Add job to update and publish Rust Docs on website
* Add job to publish to [crates.io](https://doc.rust-lang.org/cargo/reference/publishing.html) when new release is created

Example run is here: https://github.com/notmandatory/bdk/actions/runs/289760360