### PR TITLE
Fix clippy warnings and enable clippy check in CI workflow

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -4,40 +4,14 @@ name: Continuous integration
 
 jobs:
 
-  test:
-    name: Test Default
+  build-test:
+    name: Build and Test
     runs-on: ubuntu-latest
     strategy:
       matrix:
         rust:
           - stable
           - 1.45.0 # MSRV
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.rust }}
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-
-  check-features:
-    name: Check Features
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
         features:
           - minimal
           - all-keys
@@ -46,46 +20,58 @@ jobs:
           - electrum
           - compact_filters
           - cli-utils,esplora
+          - compiler
+        include:
+          - rust: stable
+            features: default
+            clippy: false
+            test: true
+          - rust: 1.45.0
+            features: default
+            test: true
+          - rust: nightly
+            features: test-md-docs
+            test: true
+          - rust: stable
+            features: compiler
+            test: true
+          - rust: 1.45.0
+            features: compiler
+            test: true
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: cache
+        uses: actions/cache@v2
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
-      - uses: actions-rs/toolchain@v1
+      - name: toolchain
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.45.0 # MSRV
+          toolchain: ${{ matrix.rust }}
           override: true
-      - uses: actions-rs/cargo@v1
+      - name: build
+        uses: actions-rs/cargo@v1
         with:
-          command: check
+          command: build
           args: --features ${{ matrix.features }} --no-default-features
-
-  test-compiler:
-    name: Test Compiler
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - name: clippy
+        if: ${{ matrix.clippy == true }}
+        uses: actions-rs/cargo@v1
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: 1.45.0 # MSRV
-          override: true
-      - uses: actions-rs/cargo@v1
+          command: clippy
+          args: -- -D warnings
+      - name: test
+        if: ${{ matrix.test == true }}
+        uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --features compiler --no-default-features
+          args: --features ${{ matrix.features }} --no-default-features
 
   test-electrum:
     name: Test Electrum
@@ -94,47 +80,30 @@ jobs:
       MAGICAL_RPC_COOKIEFILE: /home/runner/.bitcoin/regtest/.cookie
       MAGICAL_ELECTRUM_URL: tcp://127.0.0.1:60401
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: cache
+        uses: actions/cache@v2
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
-      - uses: actions-rs/toolchain@v1
+      - name: toolchain
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.45.0 # MSRV
+          toolchain: stable
           override: true
-      - run: ./ci/start-core.sh || exit 1
-      - uses: actions-rs/cargo@v1
+      - name: start core
+        run: ./ci/start-core.sh || exit 1
+      - name: test
+        uses: actions-rs/cargo@v1
         with:
           command: test
           args: --features test-electrum --no-default-features
 
-  test-md-docs:
-    name: Test MD Docs
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features test-md-docs --no-default-features
-        
   check-wasm:
     name: Check WASM
     runs-on: ubuntu-16.04
@@ -142,8 +111,10 @@ jobs:
       CC: clang-10
       CFLAGS: -I/usr/include
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: cache
+        uses: actions/cache@v2
         with:
           path: |
             ~/.cargo/registry
@@ -155,46 +126,34 @@ jobs:
       - run: sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main" || exit 1
       - run: sudo apt-get update || exit 1
       - run: sudo apt-get install -y clang-10 libc6-dev-i386 || exit 1
-      - uses: actions-rs/toolchain@v1
+      - name: toolchain
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.45.0 # MSRV
+          toolchain: stable
           target: wasm32-unknown-unknown
           override: true
-      - uses: actions-rs/cargo@v1
+      - name: check
+        uses: actions-rs/cargo@v1
         with:
           command: check
           args: --target wasm32-unknown-unknown --features cli-utils,esplora --no-default-features
 
   fmt:
-    name: Rustfmt
+    name: Rust fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: toolchain
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.45.0 # MSRV
+          toolchain: stable
           override: true
           components: rustfmt
-      - uses: actions-rs/cargo@v1
+      - name: fmt check
+        uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
-
-# TODO enable this after existing clippy warnings are fixed
-#  clippy:
-#    name: Clippy
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - uses: actions-rs/toolchain@v1
-#        with:
-#          profile: minimal
-#          toolchain: 1.45.0 # MSRV
-#          override: true
-#          components: clippy
-#      - uses: actions-rs/cargo@v1
-#        with:
-#          command: clippy
-#          args: -- -D warnings

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -78,8 +78,12 @@ jobs:
   test-electrum:
     name: Test Electrum
     runs-on: ubuntu-16.04
+    container: bitcoindevkit/electrs
     env:
-      MAGICAL_RPC_COOKIEFILE: /home/runner/.bitcoin/regtest/.cookie
+      MAGICAL_RPC_AUTH: USER_PASS
+      MAGICAL_RPC_USER: admin
+      MAGICAL_RPC_PASS: passw
+      MAGICAL_RPC_URL: 127.0.0.1:18443
       MAGICAL_ELECTRUM_URL: tcp://127.0.0.1:60401
     steps:
       - name: checkout
@@ -99,7 +103,7 @@ jobs:
           toolchain: stable
           override: true
       - name: start core
-        run: ./ci/start-core.sh || exit 1
+        run: ./ci/start-core.sh
       - name: test
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -24,10 +24,11 @@ jobs:
         include:
           - rust: stable
             features: default
-            clippy: false
+            clippy: true
             test: true
           - rust: 1.45.0
             features: default
+            clippy: true
             test: true
           - rust: nightly
             features: test-md-docs
@@ -55,6 +56,7 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
+          components: clippy
       - name: build
         uses: actions-rs/cargo@v1
         with:

--- a/ci/start-core.sh
+++ b/ci/start-core.sh
@@ -1,28 +1,17 @@
 #!/usr/bin/env sh
 
-set -e
+echo "Starting bitcoin node."
+/root/bitcoind -regtest -server -daemon -fallbackfee=0.0002 -rpcuser=admin -rpcpassword=passw -rpcallowip=0.0.0.0/0 -rpcbind=0.0.0.0
 
-BITCOIN_VERSION=0.20.1
-
-wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - || exit 1
-sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main" || exit 1
-sudo apt-get update || exit 1
-sudo apt-get install -y libllvm10 clang-10 libclang-common-10-dev || exit 1
-
-cargo install --git https://github.com/romanz/electrs --bin electrs
-
-curl -O -L https://bitcoincore.org/bin/bitcoin-core-$BITCOIN_VERSION/bitcoin-$BITCOIN_VERSION-x86_64-linux-gnu.tar.gz
-tar xf bitcoin-$BITCOIN_VERSION-x86_64-linux-gnu.tar.gz
-
-export PATH=$PATH:./bitcoin-$BITCOIN_VERSION/bin
-
-bitcoind -regtest=1 -daemon=1 -fallbackfee=0.0002
-until bitcoin-cli -regtest getblockchaininfo; do
+echo "Waiting for bitcoin node."
+until /root/bitcoin-cli -regtest -rpcuser=admin -rpcpassword=passw getblockchaininfo; do
     sleep 1
 done
 
-ADDR=$(bitcoin-cli -regtest getnewaddress)
-bitcoin-cli -regtest generatetoaddress 150 $ADDR
+echo "Generating 150 bitcoin blocks."
+ADDR=$(/root/bitcoin-cli -regtest -rpcuser=admin -rpcpassword=passw getnewaddress)
+/root/bitcoin-cli -regtest -rpcuser=admin -rpcpassword=passw generatetoaddress 150 $ADDR
 
-nohup electrs --network regtest --jsonrpc-import --cookie-file $HOME/.bitcoin/regtest/.cookie &
+echo "Starting electrs node."
+nohup /root/electrs --network regtest --jsonrpc-import &
 sleep 5

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -221,7 +221,11 @@ pub fn log_progress() -> LogProgress {
 
 impl Progress for LogProgress {
     fn update(&self, progress: f32, message: Option<String>) -> Result<(), Error> {
-        log::info!("Sync {:.3}%: `{}`", progress, message.unwrap_or("".into()));
+        log::info!(
+            "Sync {:.3}%: `{}`",
+            progress,
+            message.unwrap_or_else(|| "".into())
+        );
 
         Ok(())
     }

--- a/src/database/keyvalue.rs
+++ b/src/database/keyvalue.rs
@@ -314,7 +314,7 @@ impl Database for Tree {
                 let is_internal = serde_json::from_value(val["i"].take())?;
 
                 Ok(UTXO {
-                    outpoint: outpoint.clone(),
+                    outpoint: *outpoint,
                     txout,
                     is_internal,
                 })

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -191,7 +191,7 @@ pub(crate) trait DatabaseUtils: Database {
         self.get_raw_tx(&outpoint.txid)?
             .map(|previous_tx| {
                 if outpoint.vout as usize >= previous_tx.output.len() {
-                    Err(Error::InvalidOutpoint(outpoint.clone()))
+                    Err(Error::InvalidOutpoint(*outpoint))
                 } else {
                     Ok(previous_tx.output[outpoint.vout as usize].clone())
                 }

--- a/src/descriptor/error.rs
+++ b/src/descriptor/error.rs
@@ -57,7 +57,7 @@ impl From<crate::keys::KeyError> for Error {
         match key_error {
             crate::keys::KeyError::Miniscript(inner) => Error::Miniscript(inner),
             crate::keys::KeyError::BIP32(inner) => Error::BIP32(inner),
-            e @ _ => Error::Key(e),
+            e => Error::Key(e),
         }
     }
 }

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -78,8 +78,8 @@ impl ToWalletDescriptor for &str {
         self,
         network: Network,
     ) -> Result<(ExtendedDescriptor, KeyMap), KeyError> {
-        let descriptor = if self.contains("#") {
-            let parts: Vec<&str> = self.splitn(2, "#").collect();
+        let descriptor = if self.contains('#') {
+            let parts: Vec<&str> = self.splitn(2, '#').collect();
             if !get_checksum(parts[0])
                 .ok()
                 .map(|computed| computed == parts[1])
@@ -171,7 +171,7 @@ impl ToWalletDescriptor for (ExtendedDescriptor, KeyMap, ValidNetworks) {
 
                             DescriptorPublicKey::XPub(xpub)
                         }
-                        other @ _ => other.clone(),
+                        other => other.clone(),
                     };
 
                     Ok(pk)
@@ -201,19 +201,19 @@ pub(crate) trait XKeyUtils {
 
 impl<K: InnerXKey> XKeyUtils for DescriptorXKey<K> {
     fn full_path(&self, append: &[ChildNumber]) -> DerivationPath {
-        let full_path = match &self.source {
-            &Some((_, ref path)) => path
+        let full_path = match self.source {
+            Some((_, ref path)) => path
                 .into_iter()
                 .chain(self.derivation_path.into_iter())
                 .cloned()
                 .collect(),
-            &None => self.derivation_path.clone(),
+            None => self.derivation_path.clone(),
         };
 
         if self.is_wildcard {
             full_path
                 .into_iter()
-                .chain(append.into_iter())
+                .chain(append.iter())
                 .cloned()
                 .collect()
         } else {
@@ -222,9 +222,9 @@ impl<K: InnerXKey> XKeyUtils for DescriptorXKey<K> {
     }
 
     fn root_fingerprint(&self) -> Fingerprint {
-        match &self.source {
-            &Some((fingerprint, _)) => fingerprint.clone(),
-            &None => self.xkey.xkey_fingerprint(),
+        match self.source {
+            Some((fingerprint, _)) => fingerprint,
+            None => self.xkey.xkey_fingerprint(),
         }
     }
 }

--- a/src/descriptor/policy.rs
+++ b/src/descriptor/policy.rs
@@ -140,13 +140,11 @@ pub enum SatisfiableItem {
 
 impl SatisfiableItem {
     pub fn is_leaf(&self) -> bool {
-        match self {
-            SatisfiableItem::Thresh {
-                items: _,
-                threshold: _,
-            } => false,
-            _ => true,
-        }
+        !matches!(self,
+        SatisfiableItem::Thresh {
+            items: _,
+            threshold: _,
+        })
     }
 
     pub fn id(&self) -> String {

--- a/src/error.rs
+++ b/src/error.rs
@@ -122,7 +122,7 @@ impl From<crate::keys::KeyError> for Error {
             crate::keys::KeyError::Miniscript(inner) => Error::Miniscript(inner),
             crate::keys::KeyError::BIP32(inner) => Error::BIP32(inner),
             crate::keys::KeyError::InvalidChecksum => Error::ChecksumMismatch,
-            e @ _ => Error::Key(e),
+            e => Error::Key(e),
         }
     }
 }

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -562,12 +562,12 @@ pub mod test {
 
     use super::*;
 
-    const test_entropy: [u8; 32] = [0xAA; 32];
+    const TEST_ENTROPY: [u8; 32] = [0xAA; 32];
 
     #[test]
     fn test_keys_generate_xprv() {
         let generated_xprv: GeneratedKey<_, miniscript::Segwitv0> =
-            bip32::ExtendedPrivKey::generate_with_entropy((), test_entropy).unwrap();
+            bip32::ExtendedPrivKey::generate_with_entropy((), TEST_ENTROPY).unwrap();
 
         assert_eq!(generated_xprv.valid_networks, any_network());
         assert_eq!(generated_xprv.to_string(), "xprv9s21ZrQH143K4Xr1cJyqTvuL2FWR8eicgY9boWqMBv8MDVUZ65AXHnzBrK1nyomu6wdcabRgmGTaAKawvhAno1V5FowGpTLVx3jxzE5uk3Q");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ extern crate async_trait;
 #[macro_use]
 extern crate bdk_macros;
 
-#[cfg(any(test, feature = "compact_filters"))]
+#[cfg(feature = "compact_filters")]
 #[macro_use]
 extern crate lazy_static;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -39,8 +39,8 @@ pub enum ScriptType {
 impl ScriptType {
     pub fn as_byte(&self) -> u8 {
         match self {
-            ScriptType::External => 'e' as u8,
-            ScriptType::Internal => 'i' as u8,
+            ScriptType::External => b'e',
+            ScriptType::Internal => b'i',
         }
     }
 

--- a/src/wallet/export.rs
+++ b/src/wallet/export.rs
@@ -133,7 +133,7 @@ impl WalletExport {
                     .into_iter()
                     .map(|tx| tx.height.unwrap_or(0))
                     .collect::<Vec<_>>();
-                heights.sort();
+                heights.sort_unstable();
 
                 *heights.last().unwrap_or(&0)
             }

--- a/testutils/src/lib.rs
+++ b/testutils/src/lib.rs
@@ -24,8 +24,6 @@
 
 #[macro_use]
 extern crate serde_json;
-#[macro_use]
-extern crate serial_test;
 
 pub use serial_test::serial;
 


### PR DESCRIPTION
In this PR I fixed all the clippy warnings and enable the clippy check in the github actions CI workflow. I also simplified the workflow by using a new docker image built from the https://github.com/bitcoindevkit/bitcoin-regtest-box repo. 

Because of the clippy suggested code changes this PR is more than just a CI change and needs some review.

Improvements

- clippy checks performed and passing for rust versions 1.45.0 and stable (1.47.0) 
- `test-electrum` integration tests now executed from new docker image `bitcoinddevkit/electrs`
- continuous integration test time reduced from ~15 mins to ~9 mins

closes https://github.com/bitcoindevkit/bdk/issues/118