### PR TITLE
[wallet] Make coin_select take may/must use utxo lists

### DIFF
--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -359,13 +359,18 @@ where
             &builder.unspendable,
             builder.send_all,
         )?;
+
+        let (must_use_utxos, may_use_utxos) = match use_all_utxos {
+            true => (available_utxos, vec![]),
+            false => (vec![], available_utxos),
+        };
         let coin_selection::CoinSelectionResult {
             txin,
             selected_amount,
             mut fee_amount,
         } = builder.coin_selection.coin_select(
-            available_utxos,
-            use_all_utxos,
+            must_use_utxos,
+            may_use_utxos,
             fee_rate,
             outgoing,
             input_witness_weight,
@@ -597,13 +602,19 @@ where
                         self.database.borrow().deref(),
                         available_utxos.into_iter(),
                     )?;
+
+                    let (must_use_utxos, may_use_utxos) = match use_all_utxos {
+                        true => (available_utxos, vec![]),
+                        false => (vec![], available_utxos),
+                    };
+
                     let coin_selection::CoinSelectionResult {
                         txin,
                         selected_amount,
                         fee_amount,
                     } = builder.coin_selection.coin_select(
-                        available_utxos,
-                        use_all_utxos,
+                        must_use_utxos,
+                        may_use_utxos,
                         new_feerate,
                         fee_difference.saturating_sub(removed_change_output.value),
                         input_witness_weight,


### PR DESCRIPTION
so that in the future you can add a UTXO that you *must* spend and let the coin selection fill in the rest.

This is needed as a step towards #114
This partially addresses #121

I habitually refined `coin_select` into a functional style using [`scan`]. This makes the change a bit bigger than it could otherwise have been but I liked the way it turned out.

Feel free to ignore this if you want to do a PR which implements the entire vision of #121 in one go :)

[`scan`]: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.scan