### PR TITLE
Update coin selection terminology

### DIFF
--- a/src/wallet/coin_selection.rs
+++ b/src/wallet/coin_selection.rs
@@ -53,7 +53,7 @@
 //!     fn coin_select(
 //!         &self,
 //!         database: &D,
-//!         must_use_utxos: Vec<(UTXO, usize)>,
+//!         required_utxos: Vec<(UTXO, usize)>,
 //!         may_use_utxos: Vec<(UTXO, usize)>,
 //!         fee_rate: FeeRate,
 //!         amount_needed: u64,
@@ -61,7 +61,7 @@
 //!     ) -> Result<CoinSelectionResult, bdk::Error> {
 //!         let mut selected_amount = 0;
 //!         let mut additional_weight = 0;
-//!         let all_utxos_selected = must_use_utxos
+//!         let all_utxos_selected = required_utxos
 //!             .into_iter().chain(may_use_utxos)
 //!             .scan((&mut selected_amount, &mut additional_weight), |(selected_amount, additional_weight), (utxo, weight)| {
 //!                 let txin = TxIn {
@@ -139,7 +139,7 @@ pub trait CoinSelectionAlgorithm<D: Database>: std::fmt::Debug {
     ///
     /// - `database`: a reference to the wallet's database that can be used to lookup additional
     ///               details for a specific UTXO
-    /// - `must_use_utxos`: the utxos that must be spent regardless of `amount_needed` with their
+    /// - `required_utxos`: the utxos that must be spent regardless of `amount_needed` with their
     ///                     weight cost
     /// - `may_be_spent`: the utxos that may be spent to satisfy `amount_needed` with their weight
     ///                   cost
@@ -150,7 +150,7 @@ pub trait CoinSelectionAlgorithm<D: Database>: std::fmt::Debug {
     fn coin_select(
         &self,
         database: &D,
-        must_use_utxos: Vec<(UTXO, usize)>,
+        required_utxos: Vec<(UTXO, usize)>,
         may_use_utxos: Vec<(UTXO, usize)>,
         fee_rate: FeeRate,
         amount_needed: u64,
@@ -169,7 +169,7 @@ impl<D: Database> CoinSelectionAlgorithm<D> for DumbCoinSelection {
     fn coin_select(
         &self,
         _database: &D,
-        must_use_utxos: Vec<(UTXO, usize)>,
+        required_utxos: Vec<(UTXO, usize)>,
         mut may_use_utxos: Vec<(UTXO, usize)>,
         fee_rate: FeeRate,
         amount_needed: u64,
@@ -188,7 +188,7 @@ impl<D: Database> CoinSelectionAlgorithm<D> for DumbCoinSelection {
         // smallest to largest, before being reversed with `.rev()`.
         let utxos = {
             may_use_utxos.sort_unstable_by_key(|(utxo, _)| utxo.txout.value);
-            must_use_utxos
+            required_utxos
                 .into_iter()
                 .map(|utxo| (true, utxo))
                 .chain(may_use_utxos.into_iter().rev().map(|utxo| (false, utxo)))

--- a/src/wallet/coin_selection.rs
+++ b/src/wallet/coin_selection.rs
@@ -54,7 +54,7 @@
 //!         &self,
 //!         database: &D,
 //!         required_utxos: Vec<(UTXO, usize)>,
-//!         may_use_utxos: Vec<(UTXO, usize)>,
+//!         optional_utxos: Vec<(UTXO, usize)>,
 //!         fee_rate: FeeRate,
 //!         amount_needed: u64,
 //!         fee_amount: f32,
@@ -62,7 +62,7 @@
 //!         let mut selected_amount = 0;
 //!         let mut additional_weight = 0;
 //!         let all_utxos_selected = required_utxos
-//!             .into_iter().chain(may_use_utxos)
+//!             .into_iter().chain(optional_utxos)
 //!             .scan((&mut selected_amount, &mut additional_weight), |(selected_amount, additional_weight), (utxo, weight)| {
 //!                 let txin = TxIn {
 //!                     previous_output: utxo.outpoint,
@@ -141,8 +141,8 @@ pub trait CoinSelectionAlgorithm<D: Database>: std::fmt::Debug {
     ///               details for a specific UTXO
     /// - `required_utxos`: the utxos that must be spent regardless of `amount_needed` with their
     ///                     weight cost
-    /// - `may_be_spent`: the utxos that may be spent to satisfy `amount_needed` with their weight
-    ///                   cost
+    /// - `optional_utxos`: the remaining available utxos to satisfy `amount_needed` with their
+    ///                     weight cost
     /// - `fee_rate`: fee rate to use
     /// - `amount_needed`: the amount in satoshi to select
     /// - `fee_amount`: the amount of fees in satoshi already accumulated from adding outputs and
@@ -151,7 +151,7 @@ pub trait CoinSelectionAlgorithm<D: Database>: std::fmt::Debug {
         &self,
         database: &D,
         required_utxos: Vec<(UTXO, usize)>,
-        may_use_utxos: Vec<(UTXO, usize)>,
+        optional_utxos: Vec<(UTXO, usize)>,
         fee_rate: FeeRate,
         amount_needed: u64,
         fee_amount: f32,
@@ -170,7 +170,7 @@ impl<D: Database> CoinSelectionAlgorithm<D> for DumbCoinSelection {
         &self,
         _database: &D,
         required_utxos: Vec<(UTXO, usize)>,
-        mut may_use_utxos: Vec<(UTXO, usize)>,
+        mut optional_utxos: Vec<(UTXO, usize)>,
         fee_rate: FeeRate,
         amount_needed: u64,
         mut fee_amount: f32,
@@ -184,14 +184,14 @@ impl<D: Database> CoinSelectionAlgorithm<D> for DumbCoinSelection {
             fee_rate
         );
 
-        // We put the "must_use" UTXOs first and make sure the "may_use" are sorted, initially
-        // smallest to largest, before being reversed with `.rev()`.
+        // We put the "required UTXOs" first and make sure the optional UTXOs are sorted,
+        // initially smallest to largest, before being reversed with `.rev()`.
         let utxos = {
-            may_use_utxos.sort_unstable_by_key(|(utxo, _)| utxo.txout.value);
+            optional_utxos.sort_unstable_by_key(|(utxo, _)| utxo.txout.value);
             required_utxos
                 .into_iter()
                 .map(|utxo| (true, utxo))
-                .chain(may_use_utxos.into_iter().rev().map(|utxo| (false, utxo)))
+                .chain(optional_utxos.into_iter().rev().map(|utxo| (false, utxo)))
         };
 
         // Keep including inputs until we've got enough.

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -348,7 +348,7 @@ where
             ));
         }
 
-        let (required_utxos, may_use_utxos) = self.get_must_may_use_utxos(
+        let (required_utxos, optional_utxos) = self.get_must_may_use_utxos(
             builder.change_policy,
             &builder.unspendable,
             &builder.utxos,
@@ -364,7 +364,7 @@ where
         } = builder.coin_selection.coin_select(
             self.database.borrow().deref(),
             required_utxos,
-            may_use_utxos,
+            optional_utxos,
             fee_rate,
             outgoing,
             fee_amount,
@@ -604,7 +604,7 @@ where
             .cloned()
             .collect::<Vec<_>>();
 
-        let (mut required_utxos, may_use_utxos) = self.get_must_may_use_utxos(
+        let (mut required_utxos, optional_utxos) = self.get_must_may_use_utxos(
             builder.change_policy,
             &builder.unspendable,
             &builder_extra_utxos[..],
@@ -646,7 +646,7 @@ where
         } = builder.coin_selection.coin_select(
             self.database.borrow().deref(),
             required_utxos,
-            may_use_utxos,
+            optional_utxos,
             new_feerate,
             amount_needed,
             initial_fee,

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -348,7 +348,7 @@ where
             ));
         }
 
-        let (must_use_utxos, may_use_utxos) = self.get_must_may_use_utxos(
+        let (required_utxos, may_use_utxos) = self.get_must_may_use_utxos(
             builder.change_policy,
             &builder.unspendable,
             &builder.utxos,
@@ -363,7 +363,7 @@ where
             mut fee_amount,
         } = builder.coin_selection.coin_select(
             self.database.borrow().deref(),
-            must_use_utxos,
+            required_utxos,
             may_use_utxos,
             fee_rate,
             outgoing,
@@ -604,7 +604,7 @@ where
             .cloned()
             .collect::<Vec<_>>();
 
-        let (mut must_use_utxos, may_use_utxos) = self.get_must_may_use_utxos(
+        let (mut required_utxos, may_use_utxos) = self.get_must_may_use_utxos(
             builder.change_policy,
             &builder.unspendable,
             &builder_extra_utxos[..],
@@ -613,7 +613,7 @@ where
             true, // we only want confirmed transactions for RBF
         )?;
 
-        must_use_utxos.append(&mut original_utxos);
+        required_utxos.append(&mut original_utxos);
 
         let amount_needed = tx.output.iter().fold(0, |acc, out| acc + out.value);
         let (new_feerate, initial_fee) = match builder
@@ -645,7 +645,7 @@ where
             fee_amount,
         } = builder.coin_selection.coin_select(
             self.database.borrow().deref(),
-            must_use_utxos,
+            required_utxos,
             may_use_utxos,
             new_feerate,
             amount_needed,

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -348,7 +348,7 @@ where
             ));
         }
 
-        let (required_utxos, optional_utxos) = self.get_must_may_use_utxos(
+        let (required_utxos, optional_utxos) = self.preselect_utxos(
             builder.change_policy,
             &builder.unspendable,
             &builder.utxos,
@@ -604,7 +604,7 @@ where
             .cloned()
             .collect::<Vec<_>>();
 
-        let (mut required_utxos, optional_utxos) = self.get_must_may_use_utxos(
+        let (mut required_utxos, optional_utxos) = self.preselect_utxos(
             builder.change_policy,
             &builder.unspendable,
             &builder_extra_utxos[..],
@@ -985,7 +985,7 @@ where
     /// Given the options returns the list of utxos that must be used to form the
     /// transaction and any further that may be used if needed.
     #[allow(clippy::type_complexity)]
-    fn get_must_may_use_utxos(
+    fn preselect_utxos(
         &self,
         change_policy: tx_builder::ChangeSpendPolicy,
         unspendable: &HashSet<OutPoint>,


### PR DESCRIPTION
This renames the following:

* must_use_utxos ⇒ required_utxos
* may_use_utxos ⇒ optional_utxos
* get_must_may_use_utxos ⇒ preselect_utxos

"must_use" and "may_use" are visually similar and this change improves the readability as well as better describing the two separate sets.