### PR TITLE
[CI] Enable clippy and tests for optional features by default

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -20,15 +20,15 @@ jobs:
           - key-value-db
           - electrum
           - compact_filters
-          - cli-utils,esplora
+          - cli-utils,esplora,key-value-db,electrum
           - compiler
         include:
           - rust: stable
             features: compact_filters
-            clippy: false
+            clippy: skip
           - rust: 1.45.0
             features: compact_filters
-            clippy: false
+            clippy: skip
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -53,12 +53,13 @@ jobs:
           command: build
           args: --features ${{ matrix.features }} --no-default-features
       - name: clippy
-        if: ${{ matrix.clippy == true }}
+        if: ${{ matrix.rust == 'stable' && matrix.clippy != 'skip' }}
         uses: actions-rs/cargo@v1
         with:
           command: clippy
           args: -- -D warnings
       - name: test
+        if: ${{ matrix.test != 'skip' }}
         uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -13,6 +13,7 @@ jobs:
           - stable
           - 1.45.0 # MSRV
         features:
+          - default
           - minimal
           - all-keys
           - minimal,esplora
@@ -23,22 +24,11 @@ jobs:
           - compiler
         include:
           - rust: stable
-            features: default
-            clippy: true
-            test: true
+            features: compact_filters
+            clippy: false
           - rust: 1.45.0
-            features: default
-            clippy: true
-            test: true
-          - rust: nightly
-            features: test-md-docs
-            test: true
-          - rust: stable
-            features: compiler
-            test: true
-          - rust: 1.45.0
-            features: compiler
-            test: true
+            features: compact_filters
+            clippy: false
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -69,7 +59,6 @@ jobs:
           command: clippy
           args: -- -D warnings
       - name: test
-        if: ${{ matrix.test == true }}
         uses: actions-rs/cargo@v1
         with:
           command: test

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -37,8 +37,9 @@ use log::{debug, error, info, trace, LevelFilter};
 use bitcoin::Network;
 
 use bdk::bitcoin;
-use bdk::blockchain::electrum::{ElectrumBlockchain, ElectrumBlockchainConfig};
 use bdk::blockchain::ConfigurableBlockchain;
+use bdk::blockchain::ElectrumBlockchain;
+use bdk::blockchain::ElectrumBlockchainConfig;
 use bdk::cli;
 use bdk::sled;
 use bdk::Wallet;

--- a/src/blockchain/compact_filters/mod.rs
+++ b/src/blockchain/compact_filters/mod.rs
@@ -55,7 +55,7 @@
 //!     ))
 //!     .collect::<Result<_, _>>()?;
 //! let blockchain = CompactFiltersBlockchain::new(peers, "./wallet-filters", Some(500_000))?;
-//! # Ok::<(), bdk::error::Error>(())
+//! # Ok::<(), CompactFiltersError>(())
 //! ```
 
 use std::collections::HashSet;

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -52,6 +52,8 @@ pub use any::{AnyBlockchain, AnyBlockchainConfig};
 pub mod electrum;
 #[cfg(feature = "electrum")]
 pub use self::electrum::ElectrumBlockchain;
+#[cfg(feature = "electrum")]
+pub use self::electrum::ElectrumBlockchainConfig;
 
 #[cfg(feature = "esplora")]
 #[cfg_attr(docsrs, doc(cfg(feature = "esplora")))]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,7 +41,7 @@ use crate::types::ScriptType;
 use crate::{FeeRate, TxBuilder, Wallet};
 
 fn parse_recipient(s: &str) -> Result<(Script, u64), String> {
-    let parts: Vec<_> = s.split(":").collect();
+    let parts: Vec<_> = s.split(':').collect();
     if parts.len() != 2 {
         return Err("Invalid format".to_string());
     }
@@ -387,7 +387,7 @@ where
             .unwrap()
             .map(|s| parse_recipient(s))
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|s| Error::Generic(s))?;
+            .map_err(Error::Generic)?;
         let mut tx_builder = TxBuilder::with_recipients(recipients);
 
         if sub_matches.is_present("send_all") {
@@ -405,7 +405,7 @@ where
             let utxos = utxos
                 .map(|i| parse_outpoint(i))
                 .collect::<Result<Vec<_>, _>>()
-                .map_err(|s| Error::Generic(s.to_string()))?;
+                .map_err(Error::Generic)?;
             tx_builder = tx_builder.utxos(utxos).manually_selected_only();
         }
 
@@ -413,7 +413,7 @@ where
             let unspendable = unspendable
                 .map(|i| parse_outpoint(i))
                 .collect::<Result<Vec<_>, _>>()
-                .map_err(|s| Error::Generic(s.to_string()))?;
+                .map_err(Error::Generic)?;
             tx_builder = tx_builder.unspendable(unspendable);
         }
         if let Some(policy) = sub_matches.value_of("policy") {
@@ -443,7 +443,7 @@ where
             let utxos = utxos
                 .map(|i| parse_outpoint(i))
                 .collect::<Result<Vec<_>, _>>()
-                .map_err(|s| Error::Generic(s.to_string()))?;
+                .map_err(Error::Generic)?;
             tx_builder = tx_builder.utxos(utxos);
         }
 
@@ -451,7 +451,7 @@ where
             let unspendable = unspendable
                 .map(|i| parse_outpoint(i))
                 .collect::<Result<Vec<_>, _>>()
-                .map_err(|s| Error::Generic(s.to_string()))?;
+                .map_err(Error::Generic)?;
             tx_builder = tx_builder.unspendable(unspendable);
         }
 
@@ -475,7 +475,7 @@ where
         let psbt: PartiallySignedTransaction = deserialize(&psbt).unwrap();
         let assume_height = sub_matches
             .value_of("assume_height")
-            .and_then(|s| Some(s.parse().unwrap()));
+            .map(|s| s.parse().unwrap());
         let (psbt, finalized) = wallet.sign(psbt, assume_height)?;
         Ok(json!({
             "psbt": base64::encode(&serialize(&psbt)),
@@ -507,7 +507,7 @@ where
 
         let assume_height = sub_matches
             .value_of("assume_height")
-            .and_then(|s| Some(s.parse().unwrap()));
+            .map(|s| s.parse().unwrap());
 
         let (psbt, finalized) = wallet.finalize_psbt(psbt, assume_height)?;
         Ok(json!({

--- a/src/database/any.rs
+++ b/src/database/any.rs
@@ -322,7 +322,7 @@ impl BatchDatabase for AnyDatabase {
     }
     fn commit_batch(&mut self, batch: Self::Batch) -> Result<(), Error> {
         // TODO: refactor once `move_ref_pattern` is stable
-
+        #[allow(irrefutable_let_patterns)]
         match self {
             AnyDatabase::Memory(db) => {
                 if let AnyBatch::Memory(batch) = batch {

--- a/src/keys/bip39.rs
+++ b/src/keys/bip39.rs
@@ -136,7 +136,7 @@ mod test {
         let generated_mnemonic: GeneratedKey<_, miniscript::Segwitv0> =
             Mnemonic::generate_with_entropy(
                 (MnemonicType::Words12, Language::English),
-                crate::keys::test::get_test_entropy(),
+                crate::keys::test::TEST_ENTROPY,
             )
             .unwrap();
         assert_eq!(generated_mnemonic.valid_networks, any_network());
@@ -148,7 +148,7 @@ mod test {
         let generated_mnemonic: GeneratedKey<_, miniscript::Segwitv0> =
             Mnemonic::generate_with_entropy(
                 (MnemonicType::Words24, Language::English),
-                crate::keys::test::get_test_entropy(),
+                crate::keys::test::TEST_ENTROPY,
             )
             .unwrap();
         assert_eq!(generated_mnemonic.valid_networks, any_network());

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -578,7 +578,7 @@ pub mod test {
 
     use super::*;
 
-    const TEST_ENTROPY: [u8; 32] = [0xAA; 32];
+    pub const TEST_ENTROPY: [u8; 32] = [0xAA; 32];
 
     #[test]
     fn test_keys_generate_xprv() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,12 +61,15 @@ pub extern crate sled;
 #[cfg(feature = "cli-utils")]
 pub mod cli;
 
+#[allow(unused_imports)]
 #[cfg(test)]
 #[macro_use]
 extern crate testutils;
+#[allow(unused_imports)]
 #[cfg(test)]
 #[macro_use]
 extern crate testutils_macros;
+#[allow(unused_imports)]
 #[cfg(test)]
 #[macro_use]
 extern crate serial_test;

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1753,7 +1753,7 @@ mod test {
     fn test_create_tx_absolute_high_fee() {
         let (wallet, _, _) = get_funded_wallet(get_test_wpkh());
         let addr = wallet.get_new_address().unwrap();
-        let (psbt, details) = wallet
+        let (_psbt, _details) = wallet
             .create_tx(
                 TxBuilder::with_recipients(vec![(addr.script_pubkey(), 0)])
                     .fee_absolute(60_000)

--- a/src/wallet/utils.rs
+++ b/src/wallet/utils.rs
@@ -103,6 +103,7 @@ pub struct ChunksIterator<I: Iterator> {
 }
 
 impl<I: Iterator> ChunksIterator<I> {
+    #[allow(dead_code)]
     pub fn new(iter: I, size: usize) -> Self {
         ChunksIterator { iter, size }
     }


### PR DESCRIPTION
This PR enables clippy for stable, and fixes #151 by running tests for stable and 1.45.0, for default and optional features.

Also part of this PR:
- Fix or ignore (when no obvious fix) clippy warnings 
- Fix all-keys and cli-utils tests

TODO in future PR;
- Fix compact_filters clippy warnings (they're tricky)