### PR TITLE
Stop Arc<Box<dyn Thing>> signers and address validators and make them Send + Sync

### DIFF
--- a/examples/address_validator.rs
+++ b/examples/address_validator.rs
@@ -62,7 +62,7 @@ fn main() -> Result<(), bdk::Error> {
     let mut wallet: OfflineWallet<_> =
         Wallet::new_offline(descriptor, None, Network::Regtest, MemoryDatabase::new())?;
 
-    wallet.add_address_validator(Arc::new(Box::new(DummyValidator)));
+    wallet.add_address_validator(Arc::new(DummyValidator));
 
     wallet.get_new_address()?;
     wallet.get_new_address()?;

--- a/src/wallet/address_validator.rs
+++ b/src/wallet/address_validator.rs
@@ -67,7 +67,7 @@
 //!
 //! let descriptor = "wpkh(tpubD6NzVbkrYhZ4Xferm7Pz4VnjdcDPFyjVu5K4iZXQ4pVN8Cks4pHVowTBXBKRhX64pkRyJZJN5xAKj4UDNnLPb5p2sSKXhewoYx5GbTdUFWq/*)";
 //! let mut wallet: OfflineWallet<_> = Wallet::new_offline(descriptor, None, Network::Testnet, MemoryDatabase::default())?;
-//! wallet.add_address_validator(Arc::new(Box::new(PrintAddressAndContinue)));
+//! wallet.add_address_validator(Arc::new(PrintAddressAndContinue));
 //!
 //! let address = wallet.get_new_address()?;
 //! println!("Address: {}", address);
@@ -140,7 +140,7 @@ mod test {
     #[should_panic(expected = "InvalidScript")]
     fn test_address_validator_external() {
         let (mut wallet, _, _) = get_funded_wallet(get_test_wpkh());
-        wallet.add_address_validator(Arc::new(Box::new(TestValidator)));
+        wallet.add_address_validator(Arc::new(TestValidator));
 
         wallet.get_new_address().unwrap();
     }
@@ -149,7 +149,7 @@ mod test {
     #[should_panic(expected = "InvalidScript")]
     fn test_address_validator_internal() {
         let (mut wallet, descriptors, _) = get_funded_wallet(get_test_wpkh());
-        wallet.add_address_validator(Arc::new(Box::new(TestValidator)));
+        wallet.add_address_validator(Arc::new(TestValidator));
 
         let addr = testutils!(@external descriptors, 10);
         wallet

--- a/src/wallet/address_validator.rs
+++ b/src/wallet/address_validator.rs
@@ -106,7 +106,7 @@ impl std::error::Error for AddressValidatorError {}
 /// validator will be propagated up to the original caller that triggered the address generation.
 ///
 /// For a usage example see [this module](crate::address_validator)'s documentation.
-pub trait AddressValidator {
+pub trait AddressValidator: Send + Sync {
     /// Validate or inspect an address
     fn validate(
         &self,

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -205,7 +205,7 @@ where
         script_type: ScriptType,
         id: SignerId,
         ordering: SignerOrdering,
-        signer: Arc<Box<dyn Signer>>,
+        signer: Arc<dyn Signer>,
     ) {
         let signers = match script_type {
             ScriptType::External => Arc::make_mut(&mut self.signers),

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -89,7 +89,7 @@ pub struct Wallet<B: BlockchainMarker, D: BatchDatabase> {
     signers: Arc<SignersContainer>,
     change_signers: Arc<SignersContainer>,
 
-    address_validators: Vec<Arc<Box<dyn AddressValidator>>>,
+    address_validators: Vec<Arc<dyn AddressValidator>>,
 
     network: Network,
 
@@ -218,7 +218,7 @@ where
     /// Add an address validator
     ///
     /// See [the `address_validator` module](address_validator) for an example.
-    pub fn add_address_validator(&mut self, validator: Arc<Box<dyn AddressValidator>>) {
+    pub fn add_address_validator(&mut self, validator: Arc<dyn AddressValidator>) {
         self.address_validators.push(validator);
     }
 

--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -162,7 +162,7 @@ impl std::error::Error for SignerError {}
 ///
 /// This trait can be implemented to provide customized signers to the wallet. For an example see
 /// [`this module`](crate::wallet::signer)'s documentation.
-pub trait Signer: fmt::Debug {
+pub trait Signer: fmt::Debug + Send + Sync {
     /// Sign a PSBT
     ///
     /// The `input_index` argument is only provided if the wallet doesn't declare to sign the whole

--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -82,7 +82,7 @@
 //!     ScriptType::External,
 //!     Fingerprint::from_str("e30f11b8").unwrap().into(),
 //!     SignerOrdering(200),
-//!     Arc::new(Box::new(custom_signer))
+//!     Arc::new(custom_signer)
 //! );
 //!
 //! # Ok::<_, bdk::Error>(())
@@ -320,7 +320,7 @@ impl From<(SignerId, SignerOrdering)> for SignersContainerKey {
 
 /// Container for multiple signers
 #[derive(Debug, Default, Clone)]
-pub struct SignersContainer(BTreeMap<SignersContainerKey, Arc<Box<dyn Signer>>>);
+pub struct SignersContainer(BTreeMap<SignersContainerKey, Arc<dyn Signer>>);
 
 impl SignersContainer {
     pub fn as_key_map(&self) -> KeyMap {
@@ -346,12 +346,12 @@ impl From<KeyMap> for SignersContainer {
                             .to_pubkeyhash(),
                     ),
                     SignerOrdering::default(),
-                    Arc::new(Box::new(private_key.key)),
+                    Arc::new(private_key.key),
                 ),
                 DescriptorSecretKey::XPrv(xprv) => container.add_external(
                     SignerId::from(xprv.root_fingerprint()),
                     SignerOrdering::default(),
-                    Arc::new(Box::new(xprv)),
+                    Arc::new(xprv),
                 ),
             };
         }
@@ -372,17 +372,13 @@ impl SignersContainer {
         &mut self,
         id: SignerId,
         ordering: SignerOrdering,
-        signer: Arc<Box<dyn Signer>>,
-    ) -> Option<Arc<Box<dyn Signer>>> {
+        signer: Arc<dyn Signer>,
+    ) -> Option<Arc<dyn Signer>> {
         self.0.insert((id, ordering).into(), signer)
     }
 
     /// Removes a signer from the container and returns it
-    pub fn remove(
-        &mut self,
-        id: SignerId,
-        ordering: SignerOrdering,
-    ) -> Option<Arc<Box<dyn Signer>>> {
+    pub fn remove(&mut self, id: SignerId, ordering: SignerOrdering) -> Option<Arc<dyn Signer>> {
         self.0.remove(&(id, ordering).into())
     }
 
@@ -395,12 +391,12 @@ impl SignersContainer {
     }
 
     /// Returns the list of signers in the container, sorted by lowest to highest `ordering`
-    pub fn signers(&self) -> Vec<&Arc<Box<dyn Signer>>> {
+    pub fn signers(&self) -> Vec<&Arc<dyn Signer>> {
         self.0.values().collect()
     }
 
     /// Finds the signer with lowest ordering for a given id in the container.
-    pub fn find(&self, id: SignerId) -> Option<&Arc<Box<dyn Signer>>> {
+    pub fn find(&self, id: SignerId) -> Option<&Arc<dyn Signer>> {
         self.0
             .range((
                 Included(&(id.clone(), SignerOrdering(0)).into()),


### PR DESCRIPTION
I encountered problems sharing a `Wallet` across threads. This PR fixes them.

- `Arc<Box<dyn Thing>>` can just be `Arc<dyn Thing>`
- `Singer` and `AddressValidator` are now `Send + Sync`