### PR TITLE
[wallet] Take both spending policies into account in create_tx

### DIFF
--- a/src/descriptor/policy.rs
+++ b/src/descriptor/policy.rs
@@ -433,7 +433,7 @@ impl Condition {
         }
     }
 
-    fn merge(mut self, other: &Condition) -> Result<Self, PolicyError> {
+    pub(crate) fn merge(mut self, other: &Condition) -> Result<Self, PolicyError> {
         match (self.csv, other.csv) {
             (Some(a), Some(b)) => self.csv = Some(Self::merge_timelock(a, b)?),
             (None, any) => self.csv = any,

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,7 +60,7 @@ pub enum Error {
     ChecksumMismatch,
     DifferentDescriptorStructure,
 
-    SpendingPolicyRequired,
+    SpendingPolicyRequired(crate::types::ScriptType),
     InvalidPolicyPathError(crate::descriptor::policy::PolicyError),
 
     Signer(crate::wallet::signer::SignerError),


### PR DESCRIPTION
This allows specifying different "policy paths" for the internal and external
descriptors, and adds additional checks to make sure they are compatibile (i.e.
the timelocks are expressed in the same unit).

It's still suboptimal, since the `n_sequence`s are per-input and not per-transaction,
so it should be possibile to spend different inputs with different, otherwise
incompatible, `CSV` timelocks, but that requires a larger refactor that
can be done in a future patch.

This commit also tries to clarify how the "policy path" should be used by adding
a fairly detailed example to the docs.