### PR TITLE
Return UTXO struct from coin selection

### DIFF
--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -484,11 +484,7 @@ where
         builder.ordering.sort_tx(&mut tx);
 
         let txid = tx.txid();
-        let lookup_output = selected
-            .into_iter()
-            .map(|utxo| (utxo.outpoint, utxo))
-            .collect();
-        let psbt = self.complete_transaction(tx, lookup_output, builder)?;
+        let psbt = self.complete_transaction(tx, selected, builder)?;
 
         let transaction_details = TransactionDetails {
             transaction: None,
@@ -771,14 +767,10 @@ where
         // TODO: check that we are not replacing more than 100 txs from mempool
 
         details.txid = tx.txid();
-        let lookup_output = selected
-            .into_iter()
-            .map(|utxo| (utxo.outpoint, utxo))
-            .collect();
         details.fees = fee_amount;
         details.timestamp = time::get_timestamp();
 
-        let psbt = self.complete_transaction(tx, lookup_output, builder)?;
+        let psbt = self.complete_transaction(tx, selected, builder)?;
 
         Ok((psbt, details))
     }
@@ -1131,10 +1123,14 @@ where
     >(
         &self,
         tx: Transaction,
-        lookup_output: HashMap<OutPoint, UTXO>,
+        selected: Vec<UTXO>,
         builder: TxBuilder<D, Cs, Ctx>,
     ) -> Result<PSBT, Error> {
         let mut psbt = PSBT::from_unsigned_tx(tx)?;
+        let lookup_output = selected
+            .into_iter()
+            .map(|utxo| (utxo.outpoint, utxo))
+            .collect::<HashMap<_, _>>();
 
         // add metadata for the inputs
         for (psbt_input, input) in psbt

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -2122,6 +2122,23 @@ mod test {
     }
 
     #[test]
+    fn test_create_tx_shwpkh_has_witness_utxo() {
+        let (wallet, _, _) =
+            get_funded_wallet("sh(wpkh(cVpPVruEDdmutPzisEsYvtST1usBR3ntr8pXSyt6D2YYqXRyPcFW))");
+        let addr = wallet.get_new_address().unwrap();
+        let (psbt, _) = wallet
+            .create_tx(
+                TxBuilder::new()
+                    .set_single_recipient(addr.script_pubkey())
+                    .drain_wallet(),
+            )
+            .unwrap();
+
+        assert!(psbt.inputs[0].non_witness_utxo.is_none());
+        assert!(psbt.inputs[0].witness_utxo.is_some());
+    }
+
+    #[test]
     fn test_create_tx_both_non_witness_utxo_and_witness_utxo() {
         let (wallet, _, _) =
             get_funded_wallet("wsh(pk(cVpPVruEDdmutPzisEsYvtST1usBR3ntr8pXSyt6D2YYqXRyPcFW))");


### PR DESCRIPTION
The benefits of this PR are the following:

-  Removes this responsibility from the coin selection algorithms it was a bit awkward since the coin selection can't fill in any of the details in the TxIn anyway.
- Preserves the metadata about the UTXOs that were selected so that they can passed down to `complete_transaction`. In most cases `complete_transaction` does not need to do another database lookup now because it has all the metadata already.
- This makes it easier to introduce foreign UTXOs in the future.
