### PR TITLE
[wallet] Use the branch-and-bound cs by default

### DIFF
--- a/src/wallet/coin_selection.rs
+++ b/src/wallet/coin_selection.rs
@@ -119,7 +119,10 @@ use rand::{rngs::StdRng, SeedableRng};
 
 /// Default coin selection algorithm used by [`TxBuilder`](super::tx_builder::TxBuilder) if not
 /// overridden
-pub type DefaultCoinSelectionAlgorithm = LargestFirstCoinSelection;
+#[cfg(not(test))]
+pub type DefaultCoinSelectionAlgorithm = BranchAndBoundCoinSelection;
+#[cfg(test)]
+pub type DefaultCoinSelectionAlgorithm = LargestFirstCoinSelection; // make the tests more predictable
 
 /// Result of a successful coin selection
 #[derive(Debug)]


### PR DESCRIPTION
Keep the `LargestFirst` coin selection for the tests, to make them more
predictable.