### PR TITLE
[wallet] Add witness and redeem scripts to PSBT outputs

### DIFF
--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -90,6 +90,7 @@ pub struct TxBuilder<D: Database, Cs: CoinSelectionAlgorithm<D>, Ctx: TxBuilderC
     pub(crate) change_policy: ChangeSpendPolicy,
     pub(crate) force_non_witness_utxo: bool,
     pub(crate) coin_selection: Cs,
+    pub(crate) include_output_redeem_witness_script: bool,
 
     phantom: PhantomData<(D, Ctx)>,
 }
@@ -131,6 +132,7 @@ where
             change_policy: Default::default(),
             force_non_witness_utxo: Default::default(),
             coin_selection: Default::default(),
+            include_output_redeem_witness_script: Default::default(),
 
             phantom: PhantomData,
         }
@@ -374,9 +376,19 @@ impl<D: Database, Cs: CoinSelectionAlgorithm<D>, Ctx: TxBuilderContext> TxBuilde
             change_policy: self.change_policy,
             force_non_witness_utxo: self.force_non_witness_utxo,
             coin_selection,
+            include_output_redeem_witness_script: self.include_output_redeem_witness_script,
 
             phantom: PhantomData,
         }
+    }
+
+    /// Fill-in the [`psbt::Output::redeem_script`](bitcoin::util::psbt::Output::redeem_script) and
+    /// [`psbt::Output::witness_script`](bitcoin::util::psbt::Output::witness_script) fields.
+    ///
+    /// This is useful for signers which always require it, like ColdCard hardware wallets.
+    pub fn include_output_redeem_witness_script(mut self) -> Self {
+        self.include_output_redeem_witness_script = true;
+        self
     }
 }
 


### PR DESCRIPTION
If you try to sign a BDK-created PSBT using a ColdCard, it will currently hit [this error](https://github.com/Coldcard/firmware/blob/6e112a0b5a6f82ad8d8cb6ce72ac7a044bbbe1d8/shared/psbt.py#L653).

To fix this we must add witness and redeem scripts to PSBT outputs, which this PR does.

Question: should this be a `TxBuilder` option and not happen by default? 