### PR TITLE
Make request to esplora in parallel

### DIFF
--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -95,6 +95,9 @@ fn main() {
     let config = match matches.value_of("esplora") {
         Some(base_url) => AnyBlockchainConfig::Esplora(EsploraBlockchainConfig {
             base_url: base_url.to_string(),
+            concurrency: matches
+                .value_of("esplora_concurrency")
+                .and_then(|v| v.parse::<u8>().ok()),
         }),
         None => AnyBlockchainConfig::Electrum(ElectrumBlockchainConfig {
             url: matches.value_of("server").unwrap().to_string(),

--- a/src/blockchain/any.rs
+++ b/src/blockchain/any.rs
@@ -52,7 +52,7 @@
 //!
 //! # #[cfg(feature = "esplora")]
 //! # {
-//! let esplora_blockchain = EsploraBlockchain::new("...");
+//! let esplora_blockchain = EsploraBlockchain::new("...", None);
 //! let wallet_esplora: Wallet<AnyBlockchain, _> = Wallet::new(
 //!     "...",
 //!     None,

--- a/src/blockchain/esplora.rs
+++ b/src/blockchain/esplora.rs
@@ -38,7 +38,7 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 
-use futures::stream::{self, StreamExt, TryStreamExt};
+use futures::stream::{self, FuturesOrdered, StreamExt, TryStreamExt};
 
 #[allow(unused_imports)]
 use log::{debug, error, info, trace};
@@ -56,7 +56,10 @@ use self::utils::{ELSGetHistoryRes, ElectrumLikeSync};
 use super::*;
 use crate::database::BatchDatabase;
 use crate::error::Error;
+use crate::wallet::utils::ChunksIterator;
 use crate::FeeRate;
+
+const CONCURRENT: usize = 4;
 
 #[derive(Debug)]
 struct UrlClient {
@@ -301,10 +304,16 @@ impl ElectrumLikeSync for UrlClient {
         scripts: I,
     ) -> Result<Vec<Vec<ELSGetHistoryRes>>, Error> {
         let future = async {
-            Ok(stream::iter(scripts)
-                .then(|script| self._script_get_history(&script))
-                .try_collect()
-                .await?)
+            let mut results = vec![];
+            for chunk in ChunksIterator::new(scripts.into_iter(), CONCURRENT) {
+                let mut futs = FuturesOrdered::new();
+                for script in chunk {
+                    futs.push(self._script_get_history(&script));
+                }
+                let partial_results: Vec<Vec<ELSGetHistoryRes>> = futs.try_collect().await?;
+                results.extend(partial_results);
+            }
+            Ok(stream::iter(results).collect().await)
         };
 
         await_or_block!(future)
@@ -315,10 +324,16 @@ impl ElectrumLikeSync for UrlClient {
         txids: I,
     ) -> Result<Vec<Transaction>, Error> {
         let future = async {
-            Ok(stream::iter(txids)
-                .then(|txid| self._get_tx_no_opt(&txid))
-                .try_collect()
-                .await?)
+            let mut results = vec![];
+            for chunk in ChunksIterator::new(txids.into_iter(), CONCURRENT) {
+                let mut futs = FuturesOrdered::new();
+                for txid in chunk {
+                    futs.push(self._get_tx_no_opt(&txid));
+                }
+                let partial_results: Vec<Transaction> = futs.try_collect().await?;
+                results.extend(partial_results);
+            }
+            Ok(stream::iter(results).collect().await)
         };
 
         await_or_block!(future)
@@ -329,10 +344,16 @@ impl ElectrumLikeSync for UrlClient {
         heights: I,
     ) -> Result<Vec<BlockHeader>, Error> {
         let future = async {
-            Ok(stream::iter(heights)
-                .then(|h| self._get_header(h))
-                .try_collect()
-                .await?)
+            let mut results = vec![];
+            for chunk in ChunksIterator::new(heights.into_iter(), CONCURRENT) {
+                let mut futs = FuturesOrdered::new();
+                for height in chunk {
+                    futs.push(self._get_header(height));
+                }
+                let partial_results: Vec<BlockHeader> = futs.try_collect().await?;
+                results.extend(partial_results);
+            }
+            Ok(stream::iter(results).collect().await)
         };
 
         await_or_block!(future)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -362,14 +362,23 @@ pub fn add_global_flags<'a, 'b>(app: App<'a, 'b>) -> App<'a, 'b> {
         );
 
     if cfg!(feature = "esplora") {
-        app = app.arg(
-            Arg::with_name("esplora")
-                .short("e")
-                .long("esplora")
-                .value_name("ESPLORA")
-                .help("Use the esplora server if given as parameter")
-                .takes_value(true),
-        );
+        app = app
+            .arg(
+                Arg::with_name("esplora")
+                    .short("e")
+                    .long("esplora")
+                    .value_name("ESPLORA")
+                    .help("Use the esplora server if given as parameter")
+                    .takes_value(true),
+            )
+            .arg(
+                Arg::with_name("esplora_concurrency")
+                    .long("esplora_concurrency")
+                    .value_name("ESPLORA_CONCURRENCY")
+                    .help("Concurrency of requests made to the esplora server")
+                    .default_value("4")
+                    .takes_value(true),
+            )
     }
 
     if cfg!(feature = "electrum") {


### PR DESCRIPTION
At the moment the Esplora blockchain source, used in our [playground](https://bitcoindevkit.org/repl/playground/), is making non-blocking requests but they are not parallelized.
This allows specifying the desired concurrency level when using this blockchain source.
I went for a default of 4, which is pretty conservative but library users and our repl could obviously use a custom value. 

Test with `--esplora_concurrency X`

```
RUST_LOG=info cargo run --release --example repl --features cli-utils,electrum,esplora -- --esplora https://blockstream.info/testnet/api --esplora_concurrency 10 --wallet change_deep --descriptor "wpkh(tpubD6NzVbkrYhZ4WrmVQXmpVcPoh1LUtuBaVLJ3PDPNEaFpw5iiBW9GwkMmtkpT3ucpN5G64Tfj9EAGVGkXrYFrpdBdvp8RMDaKhtoEp5cBDWY/0/*)" --change_descriptor "wpkh(tpubD6NzVbkrYhZ4WrmVQXmpVcPoh1LUtuBaVLJ3PDPNEaFpw5iiBW9GwkMmtkpT3ucpN5G64Tfj9EAGVGkXrYFrpdBdvp8RMDaKhtoEp5cBDWY/1/*)" sync  --max_addresses 200
```

concurrency | time for first sync
-|-
1|59s
4(default)|16s
10|8s 
