### PR TITLE
cargo audit in CI

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,19 @@
+name: Audit
+
+on:
+  push:
+    paths:
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+  schedule:
+    - cron: '0 0 * * 0' # Once per week
+
+jobs:
+
+  security_audit:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ bdk-testutils-macros = { version = "0.1.0-beta.1", path = "./testutils-macros" }
 serial_test = "0.4"
 lazy_static = "1.4"
 rustyline = "6.0"
-dirs = "2.0"
+dirs-next = "2.0"
 env_logger = "0.7"
 
 [[example]]

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -48,7 +48,7 @@ use bdk::blockchain::esplora::EsploraBlockchainConfig;
 
 fn prepare_home_dir() -> PathBuf {
     let mut dir = PathBuf::new();
-    dir.push(&dirs::home_dir().unwrap());
+    dir.push(&dirs_next::home_dir().unwrap());
     dir.push(".bdk-bitcoin");
 
     if !dir.exists() {


### PR DESCRIPTION
`cargo audit` is based on https://github.com/RustSec/advisory-db

It warns if some library used is insecure or unmantained. We haven't any critical vulnerability but 3 warnings about the following dependency: `dirs`, `net2` and `failure` which results unmaintained. I fixed `dirs` because is used by us directly. The other 2 are from dependant crates