### PR TITLE
Add experimental add_foreign_utxo to TxBuilder

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -22,6 +22,7 @@ jobs:
           - compact_filters
           - cli-utils,esplora,key-value-db,electrum
           - compiler
+          - experimental
         include:
           - rust: stable
             features: compact_filters

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ cli-utils = ["clap", "base64"]
 async-interface = ["async-trait"]
 all-keys = ["keys-bip39"]
 keys-bip39 = ["tiny-bip39"]
+experimental = []
 
 # Debug/Test features
 debug-proc-macros = ["bdk-macros/debug", "bdk-testutils-macros/debug"]
@@ -83,6 +84,6 @@ members = ["macros", "testutils", "testutils-macros"]
 # Generate docs with nightly to add the "features required" badge
 # https://stackoverflow.com/questions/61417452/how-to-get-a-feature-requirement-tag-in-the-documentation-generated-by-cargo-do
 [package.metadata.docs.rs]
-features = ["compiler", "electrum", "esplora", "compact_filters", "key-value-db", "all-keys"]
+features = ["compiler", "electrum", "esplora", "compact_filters", "key-value-db", "all-keys", "experimental"]
 # defines the configuration attribute `docsrs`
 rustdoc-args = ["--cfg", "docsrs"]

--- a/src/wallet/foreign_utxo.rs
+++ b/src/wallet/foreign_utxo.rs
@@ -1,0 +1,35 @@
+use crate::UTXO;
+use bitcoin::OutPoint;
+use bitcoin::TxOut;
+
+/// A foregin utxo is a utxo that is not owned by the wallet.
+///
+/// For use in [`TxBuilder::add_foreign_utxo`]. You should take this information from a possibly
+/// malicious party without verifying it against the actual blockchain. This is especially true for
+/// the `txout.value` but may also be wise for the `satisfaction_weight` if security depends on
+/// guaranteeing a minimum feerate for the transaction.
+///
+/// Foreign UTXOs are currently experimental and only work if the `txout.script_pubkey` is a witness
+/// program.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ForeignUtxo {
+    /// The `TxOut` for the utxo, required since we need to know the value and scriptPubKey.
+    pub txout: TxOut,
+    /// The location of the output.
+    pub outpoint: OutPoint,
+    /// The weight that the other party will add to the transaction when signing it.
+    pub satisfaction_weight: usize,
+}
+
+impl ForeignUtxo {
+    pub(crate) fn into_utxo_and_weight(self) -> (UTXO, usize) {
+        (
+            UTXO {
+                outpoint: self.outpoint,
+                txout: self.txout,
+                is_internal: false,
+            },
+            self.satisfaction_weight,
+        )
+    }
+}


### PR DESCRIPTION
Partially addresses #141

This is experimental since it won't work for non-segwit outputs because we can't set witness_utxo or non_witness_utxo strictly correctly without knowing whether it's wrapped p2wsh or not and it is difficult to let the user provide this information without more radical changes.

Also adds the experimental feature flag. Just looking at it now perhaps I should add a new feature `add_foreign_utxo` as well as the experimental flag? https://github.com/bitcoindevkit/bdk/issues/195.

I'll mark it as draft until further discussion in meeting.