### PR TITLE
Rename UTXO to LocalUtxo

### DIFF
--- a/src/blockchain/compact_filters/mod.rs
+++ b/src/blockchain/compact_filters/mod.rs
@@ -79,7 +79,7 @@ mod sync;
 use super::{Blockchain, Capability, ConfigurableBlockchain, Progress};
 use crate::database::{BatchDatabase, BatchOperations, DatabaseUtils};
 use crate::error::Error;
-use crate::types::{ScriptType, TransactionDetails, UTXO};
+use crate::types::{LocalUtxo, ScriptType, TransactionDetails};
 use crate::FeeRate;
 
 use peer::*;
@@ -190,10 +190,10 @@ impl CompactFiltersBlockchain {
                 database.get_path_from_script_pubkey(&output.script_pubkey)?
             {
                 debug!("{} output #{} is mine, adding utxo", tx.txid(), i);
-                updates.set_utxo(&UTXO {
+                updates.set_utxo(&LocalUtxo {
                     outpoint: OutPoint::new(tx.txid(), i as u32),
                     txout: output.clone(),
-                    is_internal: script_type.is_internal(),
+                    script_type,
                 })?;
                 incoming += output.value;
 

--- a/src/blockchain/utils.rs
+++ b/src/blockchain/utils.rs
@@ -34,7 +34,7 @@ use bitcoin::{BlockHeader, OutPoint, Script, Transaction, Txid};
 use super::*;
 use crate::database::{BatchDatabase, BatchOperations, DatabaseUtils};
 use crate::error::Error;
-use crate::types::{ScriptType, TransactionDetails, UTXO};
+use crate::types::{LocalUtxo, ScriptType, TransactionDetails};
 use crate::wallet::time::Instant;
 use crate::wallet::utils::ChunksIterator;
 
@@ -355,10 +355,10 @@ fn save_transaction_details_and_utxos<D: BatchDatabase>(
             db.get_path_from_script_pubkey(&output.script_pubkey)?
         {
             debug!("{} output #{} is mine, adding utxo", txid, i);
-            updates.set_utxo(&UTXO {
+            updates.set_utxo(&LocalUtxo {
                 outpoint: OutPoint::new(tx.txid(), i as u32),
                 txout: output.clone(),
-                is_internal: script_type.is_internal(),
+                script_type,
             })?;
 
             incoming += output.value;

--- a/src/database/any.rs
+++ b/src/database/any.rs
@@ -129,7 +129,7 @@ impl BatchOperations for AnyDatabase {
             child
         )
     }
-    fn set_utxo(&mut self, utxo: &UTXO) -> Result<(), Error> {
+    fn set_utxo(&mut self, utxo: &LocalUtxo) -> Result<(), Error> {
         impl_inner_method!(AnyDatabase, self, set_utxo, utxo)
     }
     fn set_raw_tx(&mut self, transaction: &Transaction) -> Result<(), Error> {
@@ -161,7 +161,7 @@ impl BatchOperations for AnyDatabase {
     ) -> Result<Option<(ScriptType, u32)>, Error> {
         impl_inner_method!(AnyDatabase, self, del_path_from_script_pubkey, script)
     }
-    fn del_utxo(&mut self, outpoint: &OutPoint) -> Result<Option<UTXO>, Error> {
+    fn del_utxo(&mut self, outpoint: &OutPoint) -> Result<Option<LocalUtxo>, Error> {
         impl_inner_method!(AnyDatabase, self, del_utxo, outpoint)
     }
     fn del_raw_tx(&mut self, txid: &Txid) -> Result<Option<Transaction>, Error> {
@@ -197,7 +197,7 @@ impl Database for AnyDatabase {
     fn iter_script_pubkeys(&self, script_type: Option<ScriptType>) -> Result<Vec<Script>, Error> {
         impl_inner_method!(AnyDatabase, self, iter_script_pubkeys, script_type)
     }
-    fn iter_utxos(&self) -> Result<Vec<UTXO>, Error> {
+    fn iter_utxos(&self) -> Result<Vec<LocalUtxo>, Error> {
         impl_inner_method!(AnyDatabase, self, iter_utxos)
     }
     fn iter_raw_txs(&self) -> Result<Vec<Transaction>, Error> {
@@ -226,7 +226,7 @@ impl Database for AnyDatabase {
     ) -> Result<Option<(ScriptType, u32)>, Error> {
         impl_inner_method!(AnyDatabase, self, get_path_from_script_pubkey, script)
     }
-    fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<UTXO>, Error> {
+    fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<LocalUtxo>, Error> {
         impl_inner_method!(AnyDatabase, self, get_utxo, outpoint)
     }
     fn get_raw_tx(&self, txid: &Txid) -> Result<Option<Transaction>, Error> {
@@ -260,7 +260,7 @@ impl BatchOperations for AnyBatch {
             child
         )
     }
-    fn set_utxo(&mut self, utxo: &UTXO) -> Result<(), Error> {
+    fn set_utxo(&mut self, utxo: &LocalUtxo) -> Result<(), Error> {
         impl_inner_method!(AnyBatch, self, set_utxo, utxo)
     }
     fn set_raw_tx(&mut self, transaction: &Transaction) -> Result<(), Error> {
@@ -292,7 +292,7 @@ impl BatchOperations for AnyBatch {
     ) -> Result<Option<(ScriptType, u32)>, Error> {
         impl_inner_method!(AnyBatch, self, del_path_from_script_pubkey, script)
     }
-    fn del_utxo(&mut self, outpoint: &OutPoint) -> Result<Option<UTXO>, Error> {
+    fn del_utxo(&mut self, outpoint: &OutPoint) -> Result<Option<LocalUtxo>, Error> {
         impl_inner_method!(AnyBatch, self, del_utxo, outpoint)
     }
     fn del_raw_tx(&mut self, txid: &Txid) -> Result<Option<Transaction>, Error> {

--- a/src/database/memory.rs
+++ b/src/database/memory.rs
@@ -157,10 +157,10 @@ impl BatchOperations for MemoryDatabase {
         Ok(())
     }
 
-    fn set_utxo(&mut self, utxo: &UTXO) -> Result<(), Error> {
+    fn set_utxo(&mut self, utxo: &LocalUtxo) -> Result<(), Error> {
         let key = MapKey::UTXO(Some(&utxo.outpoint)).as_map_key();
         self.map
-            .insert(key, Box::new((utxo.txout.clone(), utxo.is_internal)));
+            .insert(key, Box::new((utxo.txout.clone(), utxo.script_type)));
 
         Ok(())
     }
@@ -223,7 +223,7 @@ impl BatchOperations for MemoryDatabase {
             }
         }
     }
-    fn del_utxo(&mut self, outpoint: &OutPoint) -> Result<Option<UTXO>, Error> {
+    fn del_utxo(&mut self, outpoint: &OutPoint) -> Result<Option<LocalUtxo>, Error> {
         let key = MapKey::UTXO(Some(outpoint)).as_map_key();
         let res = self.map.remove(&key);
         self.deleted_keys.push(key);
@@ -231,11 +231,11 @@ impl BatchOperations for MemoryDatabase {
         match res {
             None => Ok(None),
             Some(b) => {
-                let (txout, is_internal) = b.downcast_ref().cloned().unwrap();
-                Ok(Some(UTXO {
+                let (txout, script_type) = b.downcast_ref().cloned().unwrap();
+                Ok(Some(LocalUtxo {
                     outpoint: *outpoint,
                     txout,
-                    is_internal,
+                    script_type,
                 }))
             }
         }
@@ -316,17 +316,17 @@ impl Database for MemoryDatabase {
             .collect()
     }
 
-    fn iter_utxos(&self) -> Result<Vec<UTXO>, Error> {
+    fn iter_utxos(&self) -> Result<Vec<LocalUtxo>, Error> {
         let key = MapKey::UTXO(None).as_map_key();
         self.map
             .range::<Vec<u8>, _>((Included(&key), Excluded(&after(&key))))
             .map(|(k, v)| {
                 let outpoint = deserialize(&k[1..]).unwrap();
-                let (txout, is_internal) = v.downcast_ref().cloned().unwrap();
-                Ok(UTXO {
+                let (txout, script_type) = v.downcast_ref().cloned().unwrap();
+                Ok(LocalUtxo {
                     outpoint,
                     txout,
-                    is_internal,
+                    script_type,
                 })
             })
             .collect()
@@ -382,14 +382,14 @@ impl Database for MemoryDatabase {
         }))
     }
 
-    fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<UTXO>, Error> {
+    fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<LocalUtxo>, Error> {
         let key = MapKey::UTXO(Some(outpoint)).as_map_key();
         Ok(self.map.get(&key).map(|b| {
-            let (txout, is_internal) = b.downcast_ref().cloned().unwrap();
-            UTXO {
+            let (txout, script_type) = b.downcast_ref().cloned().unwrap();
+            LocalUtxo {
                 outpoint: *outpoint,
                 txout,
-                is_internal,
+                script_type,
             }
         }))
     }
@@ -501,13 +501,13 @@ impl MemoryDatabase {
 
         self.set_tx(&tx_details).unwrap();
         for (vout, out) in tx.output.iter().enumerate() {
-            self.set_utxo(&UTXO {
+            self.set_utxo(&LocalUtxo {
                 txout: out.clone(),
                 outpoint: OutPoint {
                     txid,
                     vout: vout as u32,
                 },
-                is_internal: false,
+                script_type: ScriptType::External,
             })
             .unwrap();
         }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -64,8 +64,8 @@ pub trait BatchOperations {
         script_type: ScriptType,
         child: u32,
     ) -> Result<(), Error>;
-    /// Store a [`UTXO`]
-    fn set_utxo(&mut self, utxo: &UTXO) -> Result<(), Error>;
+    /// Store a [`LocalUtxo`]
+    fn set_utxo(&mut self, utxo: &LocalUtxo) -> Result<(), Error>;
     /// Store a raw transaction
     fn set_raw_tx(&mut self, transaction: &Transaction) -> Result<(), Error>;
     /// Store the metadata of a transaction
@@ -85,8 +85,8 @@ pub trait BatchOperations {
         &mut self,
         script: &Script,
     ) -> Result<Option<(ScriptType, u32)>, Error>;
-    /// Delete a [`UTXO`] given its [`OutPoint`]
-    fn del_utxo(&mut self, outpoint: &OutPoint) -> Result<Option<UTXO>, Error>;
+    /// Delete a [`LoaclUtxo`] given its [`OutPoint`]
+    fn del_utxo(&mut self, outpoint: &OutPoint) -> Result<Option<LocalUtxo>, Error>;
     /// Delete a raw transaction given its [`Txid`]
     fn del_raw_tx(&mut self, txid: &Txid) -> Result<Option<Transaction>, Error>;
     /// Delete the metadata of a transaction and optionally the raw transaction itself
@@ -116,8 +116,8 @@ pub trait Database: BatchOperations {
 
     /// Return the list of script_pubkeys
     fn iter_script_pubkeys(&self, script_type: Option<ScriptType>) -> Result<Vec<Script>, Error>;
-    /// Return the list of [`UTXO`]s
-    fn iter_utxos(&self) -> Result<Vec<UTXO>, Error>;
+    /// Return the list of [`LocalUtxo`]s
+    fn iter_utxos(&self) -> Result<Vec<LocalUtxo>, Error>;
     /// Return the list of raw transactions
     fn iter_raw_txs(&self) -> Result<Vec<Transaction>, Error>;
     /// Return the list of transactions metadata
@@ -134,8 +134,8 @@ pub trait Database: BatchOperations {
         &self,
         script: &Script,
     ) -> Result<Option<(ScriptType, u32)>, Error>;
-    /// Fetch a [`UTXO`] given its [`OutPoint`]
-    fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<UTXO>, Error>;
+    /// Fetch a [`LocalUtxo`] given its [`OutPoint`]
+    fn get_utxo(&self, outpoint: &OutPoint) -> Result<Option<LocalUtxo>, Error>;
     /// Fetch a raw transaction given its [`Txid`]
     fn get_raw_tx(&self, txid: &Txid) -> Result<Option<Transaction>, Error>;
     /// Fetch the transaction metadata and optionally also the raw transaction
@@ -298,10 +298,10 @@ pub mod test {
             value: 133742,
             script_pubkey: script,
         };
-        let utxo = UTXO {
+        let utxo = LocalUtxo {
             txout,
             outpoint,
-            is_internal: false,
+            script_type: ScriptType::External,
         };
 
         tree.set_utxo(&utxo).unwrap();

--- a/src/types.rs
+++ b/src/types.rs
@@ -31,9 +31,25 @@ use serde::{Deserialize, Serialize};
 
 /// Types of script
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[serde(try_from = "bool", into = "bool")]
 pub enum ScriptType {
     External = 0,
     Internal = 1,
+}
+
+impl From<bool> for ScriptType {
+    fn from(from: bool) -> Self {
+        match from {
+            false => ScriptType::External,
+            true => ScriptType::Internal,
+        }
+    }
+}
+
+impl From<ScriptType> for bool {
+    fn from(from: ScriptType) -> Self {
+        (from as u8) == 1
+    }
 }
 
 impl ScriptType {
@@ -42,10 +58,6 @@ impl ScriptType {
             ScriptType::External => b'e',
             ScriptType::Internal => b'i',
         }
-    }
-
-    pub fn is_internal(&self) -> bool {
-        self == &ScriptType::Internal
     }
 }
 
@@ -93,10 +105,10 @@ impl std::default::Default for FeeRate {
 
 /// A wallet unspent output
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-pub struct UTXO {
+pub struct LocalUtxo {
     pub outpoint: OutPoint,
     pub txout: TxOut,
-    pub is_internal: bool,
+    pub script_type: ScriptType,
 }
 
 /// A wallet transaction

--- a/testutils-macros/src/lib.rs
+++ b/testutils-macros/src/lib.rs
@@ -120,7 +120,7 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     wallet.sync(noop_progress(), None).unwrap();
 
                     assert_eq!(wallet.get_balance().unwrap(), 50_000);
-                    assert_eq!(wallet.list_unspent().unwrap()[0].is_internal, false);
+                    assert_eq!(wallet.list_unspent().unwrap()[0].script_type, ScriptType::External);
 
                     let list_tx_item = &wallet.list_transactions(false).unwrap()[0];
                     assert_eq!(list_tx_item.txid, txid);


### PR DESCRIPTION
I've closed https://github.com/bitcoindevkit/bdk/pull/202 in favor of doing it a better way.
The plan for coin selection is that UTXOs will be an enum of "LocalUtxo" and "ForeignUtxo". Everywhere else they will stay as `LocalUtxo`.

This PR does the first step which is to rename the existing UTXO struct to LocalUtxo (without introducing ForeignUtxo).

Also change `is_internal` field to `script_type` to avoid unnecessary mapping between bool and `ScriptType`.
`script_type` is still stored as a bool through serde magic so db representation doesn't change.