### PR TITLE
[wallet] Set the correct nSequence when RBF and OP_CSV are used

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -60,7 +60,7 @@ pub enum Error {
     TransactionNotFound,
     /// Happens when trying to bump a transaction that is already confirmed
     TransactionConfirmed,
-    /// Trying to replace a tx that has a sequence = `0xFFFFFFFF`
+    /// Trying to replace a tx that has a sequence >= `0xFFFFFFFE`
     IrreplaceableTransaction,
     /// When bumping a tx the fee rate requested is lower than required
     FeeRateTooLow {


### PR DESCRIPTION
This commit also fixes the timelock comparing logic in the policy module, since the rules are different for absolute (OP_CLTV) and relative (OP_CSV) timelocks.

Fixes #215

Still in draft since tests are missing.

Also, the big `match` to determine the `nSequence` value is horrible, if anybody has any ideas to improve it I'm open to suggestions.