### PR TITLE
Make Esplora feature optional for CLI/REPL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ env_logger = "0.7"
 
 [[example]]
 name = "repl"
-required-features = ["cli-utils", "esplora"]
+required-features = ["cli-utils"]
 [[example]]
 name = "parse_descriptor"
 [[example]]

--- a/examples/repl.rs
+++ b/examples/repl.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 
 use bitcoin::Network;
 use clap::AppSettings;
-use log::{debug, error, info, trace, warn, LevelFilter};
+use log::{debug, info, warn, LevelFilter};
 use rustyline::error::ReadlineError;
 use rustyline::Editor;
 use structopt::StructOpt;


### PR DESCRIPTION
I found this low-hanging fruit [in Discord](https://discord.com/channels/753336465005608961/753336465005608964/785575944688500806) about making `esplora` optional for CLI. 