### PR TITLE
Experimental feature

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install tarpaulin
         run: cargo install cargo-tarpaulin
       - name: Tarpaulin
-        run: cargo tarpaulin --features all-keys,cli-utils,compiler,esplora,experimental-compact-filters --run-types Tests,Doctests --exclude-files "testutils/*"
+        run: cargo tarpaulin --features all-keys,experimental-cli-utils,compiler,esplora,experimental-compact-filters --run-types Tests,Doctests --exclude-files "testutils/*"
 
       - name: Publish to codecov.io
         uses: codecov/codecov-action@v1.0.14

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install tarpaulin
         run: cargo install cargo-tarpaulin
       - name: Tarpaulin
-        run: cargo tarpaulin --features all-keys,cli-utils,compiler,esplora,compact_filters --run-types Tests,Doctests --exclude-files "testutils/*"
+        run: cargo tarpaulin --features all-keys,cli-utils,compiler,esplora,experimental-compact-filters --run-types Tests,Doctests --exclude-files "testutils/*"
 
       - name: Publish to codecov.io
         uses: codecov/codecov-action@v1.0.14

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -20,7 +20,7 @@ jobs:
           - key-value-db
           - electrum
           - experimental-compact-filters
-          - cli-utils,esplora,key-value-db,electrum
+          - experimental-cli-utils,esplora,key-value-db,electrum
           - compiler
         include:
           - rust: stable
@@ -118,7 +118,7 @@ jobs:
       - name: Add target wasm32
         run: rustup target add wasm32-unknown-unknown
       - name: Check
-        run: cargo check --target wasm32-unknown-unknown --features cli-utils,esplora --no-default-features
+        run: cargo check --target wasm32-unknown-unknown --features experimental-cli-utils,esplora --no-default-features
 
   fmt:
     name: Rust fmt

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -19,15 +19,15 @@ jobs:
           - minimal,esplora
           - key-value-db
           - electrum
-          - compact_filters
+          - experimental-compact-filters
           - cli-utils,esplora,key-value-db,electrum
           - compiler
         include:
           - rust: stable
-            features: compact_filters
+            features: experimental-compact-filters
             clippy: skip
           - rust: 1.45.0
-            features: compact_filters
+            features: experimental-compact-filters
             clippy: skip
     steps:
       - name: checkout

--- a/.github/workflows/nightly_docs.yml
+++ b/.github/workflows/nightly_docs.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: rustdoc
-          args: --verbose --features=compiler,electrum,esplora,compact_filters,key-value-db,all-keys -- --cfg docsrs
+          args: --verbose --features=compiler,electrum,esplora,experimental-compact-filters,key-value-db,all-keys -- --cfg docsrs
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,12 +44,14 @@ compiler = ["clap", "miniscript/compiler"]
 default = ["key-value-db", "electrum"]
 electrum = ["electrum-client"]
 esplora = ["reqwest", "futures"]
-experimental-compact-filters = ["rocksdb", "socks", "lazy_static", "cc"]
 key-value-db = ["sled"]
-cli-utils = ["clap", "base64", "structopt"]
 async-interface = ["async-trait"]
 all-keys = ["keys-bip39"]
 keys-bip39 = ["tiny-bip39"]
+
+# experimental features, less ready to be used
+experimental-compact-filters = ["rocksdb", "socks", "lazy_static", "cc"]
+experimental-cli-utils = ["clap", "base64", "structopt"]
 
 # Debug/Test features
 debug-proc-macros = ["bdk-macros/debug", "bdk-testutils-macros/debug"]
@@ -67,7 +69,7 @@ env_logger = "0.7"
 
 [[example]]
 name = "repl"
-required-features = ["cli-utils", "esplora"]
+required-features = ["experimental-cli-utils", "esplora"]
 [[example]]
 name = "parse_descriptor"
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ compiler = ["clap", "miniscript/compiler"]
 default = ["key-value-db", "electrum"]
 electrum = ["electrum-client"]
 esplora = ["reqwest", "futures"]
-compact_filters = ["rocksdb", "socks", "lazy_static", "cc"]
+experimental-compact-filters = ["rocksdb", "socks", "lazy_static", "cc"]
 key-value-db = ["sled"]
 cli-utils = ["clap", "base64", "structopt"]
 async-interface = ["async-trait"]
@@ -84,6 +84,6 @@ members = ["macros", "testutils", "testutils-macros"]
 # Generate docs with nightly to add the "features required" badge
 # https://stackoverflow.com/questions/61417452/how-to-get-a-feature-requirement-tag-in-the-documentation-generated-by-cargo-do
 [package.metadata.docs.rs]
-features = ["compiler", "electrum", "esplora", "compact_filters", "key-value-db", "all-keys"]
+features = ["compiler", "electrum", "esplora", "experimental-compact-filters", "key-value-db", "all-keys"]
 # defines the configuration attribute `docsrs`
 rustdoc-args = ["--cfg", "docsrs"]

--- a/src/blockchain/any.rs
+++ b/src/blockchain/any.rs
@@ -99,7 +99,7 @@ macro_rules! impl_inner_method {
             AnyBlockchain::Electrum(inner) => inner.$name( $($args, )* ),
             #[cfg(feature = "esplora")]
             AnyBlockchain::Esplora(inner) => inner.$name( $($args, )* ),
-            #[cfg(feature = "compact_filters")]
+            #[cfg(feature = "experimental-compact-filters")]
             AnyBlockchain::CompactFilters(inner) => inner.$name( $($args, )* ),
         }
     }
@@ -119,8 +119,8 @@ pub enum AnyBlockchain {
     #[cfg_attr(docsrs, doc(cfg(feature = "esplora")))]
     #[allow(missing_docs)]
     Esplora(esplora::EsploraBlockchain),
-    #[cfg(feature = "compact_filters")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "compact_filters")))]
+    #[cfg(feature = "experimental-compact-filters")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental-compact-filters")))]
     #[allow(missing_docs)]
     CompactFilters(compact_filters::CompactFiltersBlockchain),
 }
@@ -177,7 +177,7 @@ impl Blockchain for AnyBlockchain {
 
 impl_from!(electrum::ElectrumBlockchain, AnyBlockchain, Electrum, #[cfg(feature = "electrum")]);
 impl_from!(esplora::EsploraBlockchain, AnyBlockchain, Esplora, #[cfg(feature = "esplora")]);
-impl_from!(compact_filters::CompactFiltersBlockchain, AnyBlockchain, CompactFilters, #[cfg(feature = "compact_filters")]);
+impl_from!(compact_filters::CompactFiltersBlockchain, AnyBlockchain, CompactFilters, #[cfg(feature = "experimental-compact-filters")]);
 
 /// Type that can contain any of the blockchain configurations defined by the library
 ///
@@ -194,8 +194,8 @@ pub enum AnyBlockchainConfig {
     #[cfg_attr(docsrs, doc(cfg(feature = "esplora")))]
     #[allow(missing_docs)]
     Esplora(esplora::EsploraBlockchainConfig),
-    #[cfg(feature = "compact_filters")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "compact_filters")))]
+    #[cfg(feature = "experimental-compact-filters")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "experimental-compact-filters")))]
     #[allow(missing_docs)]
     CompactFilters(compact_filters::CompactFiltersBlockchainConfig),
 }
@@ -213,7 +213,7 @@ impl ConfigurableBlockchain for AnyBlockchain {
             AnyBlockchainConfig::Esplora(inner) => {
                 AnyBlockchain::Esplora(esplora::EsploraBlockchain::from_config(inner)?)
             }
-            #[cfg(feature = "compact_filters")]
+            #[cfg(feature = "experimental-compact-filters")]
             AnyBlockchainConfig::CompactFilters(inner) => AnyBlockchain::CompactFilters(
                 compact_filters::CompactFiltersBlockchain::from_config(inner)?,
             ),
@@ -223,4 +223,4 @@ impl ConfigurableBlockchain for AnyBlockchain {
 
 impl_from!(electrum::ElectrumBlockchainConfig, AnyBlockchainConfig, Electrum, #[cfg(feature = "electrum")]);
 impl_from!(esplora::EsploraBlockchainConfig, AnyBlockchainConfig, Esplora, #[cfg(feature = "esplora")]);
-impl_from!(compact_filters::CompactFiltersBlockchainConfig, AnyBlockchainConfig, CompactFilters, #[cfg(feature = "compact_filters")]);
+impl_from!(compact_filters::CompactFiltersBlockchainConfig, AnyBlockchainConfig, CompactFilters, #[cfg(feature = "experimental-compact-filters")]);

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -43,9 +43,17 @@ use crate::FeeRate;
 #[cfg(any(feature = "electrum", feature = "esplora"))]
 pub(crate) mod utils;
 
-#[cfg(any(feature = "electrum", feature = "esplora", feature = "compact_filters"))]
+#[cfg(any(
+    feature = "electrum",
+    feature = "esplora",
+    feature = "experimental-compact-filters"
+))]
 pub mod any;
-#[cfg(any(feature = "electrum", feature = "esplora", feature = "compact_filters"))]
+#[cfg(any(
+    feature = "electrum",
+    feature = "esplora",
+    feature = "experimental-compact-filters"
+))]
 pub use any::{AnyBlockchain, AnyBlockchainConfig};
 
 #[cfg(feature = "electrum")]
@@ -62,10 +70,10 @@ pub mod esplora;
 #[cfg(feature = "esplora")]
 pub use self::esplora::EsploraBlockchain;
 
-#[cfg(feature = "compact_filters")]
-#[cfg_attr(docsrs, doc(cfg(feature = "compact_filters")))]
+#[cfg(feature = "experimental-compact-filters")]
+#[cfg_attr(docsrs, doc(cfg(feature = "experimental-compact-filters")))]
 pub mod compact_filters;
-#[cfg(feature = "compact_filters")]
+#[cfg(feature = "experimental-compact-filters")]
 pub use self::compact_filters::CompactFiltersBlockchain;
 
 /// Capabilities that can be supported by a [`Blockchain`] backend

--- a/src/error.rs
+++ b/src/error.rs
@@ -134,7 +134,7 @@ pub enum Error {
     #[allow(missing_docs)]
     Esplora(crate::blockchain::esplora::EsploraError),
     #[allow(missing_docs)]
-    #[cfg(feature = "compact_filters")]
+    #[cfg(feature = "experimental-compact-filters")]
     CompactFilters(crate::blockchain::compact_filters::CompactFiltersError),
     #[cfg(feature = "key-value-db")]
     #[allow(missing_docs)]
@@ -193,7 +193,7 @@ impl_error!(crate::blockchain::esplora::EsploraError, Esplora);
 #[cfg(feature = "key-value-db")]
 impl_error!(sled::Error, Sled);
 
-#[cfg(feature = "compact_filters")]
+#[cfg(feature = "experimental-compact-filters")]
 impl From<crate::blockchain::compact_filters::CompactFiltersError> for Error {
     fn from(other: crate::blockchain::compact_filters::CompactFiltersError) -> Self {
         match other {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ pub extern crate reqwest;
 #[cfg(feature = "key-value-db")]
 pub extern crate sled;
 
-#[cfg(feature = "cli-utils")]
+#[cfg(feature = "experimental-cli-utils")]
 pub mod cli;
 
 #[allow(unused_imports)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ extern crate async_trait;
 #[macro_use]
 extern crate bdk_macros;
 
-#[cfg(feature = "compact_filters")]
+#[cfg(feature = "experimental-compact-filters")]
 #[macro_use]
 extern crate lazy_static;
 


### PR DESCRIPTION
The intention was to add the experimental feature and use a proc_macro_attribute over all the project that automatically add the experimental to selected features. However, it would require nightly and has been excluded.

For the previous reason, since we have to change all the place where the target feature exists, maybe it's better to add `experimental_` suffix to experimental features (instead of adding a new `experimental` feature to use in conjunction)

Since `compact_filters` feature is going to change, I used the dash instead of the underscore to be coherent with other features

closes https://github.com/bitcoindevkit/bdk/issues/195

Should I add the prefix to other features?