### PR TITLE
bugfix: keep BTreeMap for SignersContainer

### DIFF
--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -531,7 +531,7 @@ impl Ord for SignersContainerKey {
 
 impl PartialEq for SignersContainerKey {
     fn eq(&self, other: &Self) -> bool {
-        self.ordering == other.ordering
+        self.id == other.id && self.ordering == other.ordering
     }
 }
 

--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -523,7 +523,9 @@ impl PartialOrd for SignersContainerKey {
 
 impl Ord for SignersContainerKey {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.ordering.cmp(&other.ordering).then(self.id.cmp(&other.id))
+        self.ordering
+            .cmp(&other.ordering)
+            .then(self.id.cmp(&other.id))
     }
 }
 
@@ -539,14 +541,14 @@ impl Eq for SignersContainerKey {}
 mod signers_container_tests {
     use super::*;
     use crate::descriptor;
-    use miniscript::ScriptContext;
-    use crate::keys::{DescriptorKey, ToDescriptorKey};
-    use bitcoin::util::bip32;
-    use bitcoin::secp256k1::All;
-    use std::str::FromStr;
     use crate::descriptor::ToWalletDescriptor;
-    use bitcoin::Network;
+    use crate::keys::{DescriptorKey, ToDescriptorKey};
+    use bitcoin::secp256k1::All;
+    use bitcoin::util::bip32;
     use bitcoin::util::psbt::PartiallySignedTransaction;
+    use bitcoin::Network;
+    use miniscript::ScriptContext;
+    use std::str::FromStr;
 
     // Signers added with the same ordering (like `Ordering::default`) created from `KeyMap`
     // should be preserved and not overwritten.
@@ -572,9 +574,21 @@ mod signers_container_tests {
         let signer2 = Arc::new(DummySigner);
         let signer3 = Arc::new(DummySigner);
 
-        signers.add_external(SignerId::Fingerprint(b"cafe"[..].into()), SignerOrdering(1), signer1.clone());
-        signers.add_external(SignerId::Fingerprint(b"babe"[..].into()), SignerOrdering(2), signer2.clone());
-        signers.add_external(SignerId::Fingerprint(b"feed"[..].into()), SignerOrdering(3), signer3.clone());
+        signers.add_external(
+            SignerId::Fingerprint(b"cafe"[..].into()),
+            SignerOrdering(1),
+            signer1.clone(),
+        );
+        signers.add_external(
+            SignerId::Fingerprint(b"babe"[..].into()),
+            SignerOrdering(2),
+            signer2.clone(),
+        );
+        signers.add_external(
+            SignerId::Fingerprint(b"feed"[..].into()),
+            SignerOrdering(3),
+            signer3.clone(),
+        );
 
         // Check that signers are sorted from lowest to highest ordering
         let signers = signers.signers();
@@ -600,14 +614,22 @@ mod signers_container_tests {
         signers.add_external(id2.clone(), SignerOrdering(2), signer2.clone());
         signers.add_external(id3.clone(), SignerOrdering(3), signer3.clone());
 
-        assert!(matches!(signers.find(id1), Some(signer) if Arc::as_ptr(&signer1) == Arc::as_ptr(signer)));
-        assert!(matches!(signers.find(id2), Some(signer) if Arc::as_ptr(&signer2) == Arc::as_ptr(signer)));
-        assert!(matches!(signers.find(id3.clone()), Some(signer) if Arc::as_ptr(&signer3) == Arc::as_ptr(signer)));
+        assert!(
+            matches!(signers.find(id1), Some(signer) if Arc::as_ptr(&signer1) == Arc::as_ptr(signer))
+        );
+        assert!(
+            matches!(signers.find(id2), Some(signer) if Arc::as_ptr(&signer2) == Arc::as_ptr(signer))
+        );
+        assert!(
+            matches!(signers.find(id3.clone()), Some(signer) if Arc::as_ptr(&signer3) == Arc::as_ptr(signer))
+        );
 
         // The `signer4` has the same ID as `signer3` but lower ordering.
         // It should be found by `id3` instead of `signer3`.
         signers.add_external(id3.clone(), SignerOrdering(2), signer4.clone());
-        assert!(matches!(signers.find(id3), Some(signer) if Arc::as_ptr(&signer4) == Arc::as_ptr(signer)));
+        assert!(
+            matches!(signers.find(id3), Some(signer) if Arc::as_ptr(&signer4) == Arc::as_ptr(signer))
+        );
 
         // Can't find anything with ID that doesn't exist
         assert!(matches!(signers.find(id_nonexistent), None));
@@ -616,7 +638,12 @@ mod signers_container_tests {
     #[derive(Debug)]
     struct DummySigner;
     impl Signer for DummySigner {
-        fn sign(&self, _psbt: &mut PartiallySignedTransaction, _input_index: Option<usize>, _secp: &SecpCtx) -> Result<(), SignerError> {
+        fn sign(
+            &self,
+            _psbt: &mut PartiallySignedTransaction,
+            _input_index: Option<usize>,
+            _secp: &SecpCtx,
+        ) -> Result<(), SignerError> {
             Ok(())
         }
 

--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -403,8 +403,9 @@ impl SignersContainer {
         self.0
             .range((
                 Included(&(id.clone(), SignerOrdering(0)).into()),
-                Included(&(id, SignerOrdering(usize::MAX)).into()),
+                Included(&(id.clone(), SignerOrdering(usize::MAX)).into()),
             ))
+            .filter(|(k, _)| k.id == id)
             .map(|(_, v)| v)
             .next()
     }

--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -112,7 +112,7 @@ use crate::descriptor::XKeyUtils;
 
 /// Identifier of a signer in the `SignersContainers`. Used as a key to find the right signer among
 /// multiple of them
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Ord, PartialOrd, PartialEq, Eq, Hash)]
 pub enum SignerId {
     PkHash(hash160::Hash),
     Fingerprint(Fingerprint),
@@ -522,7 +522,7 @@ impl PartialOrd for SignersContainerKey {
 
 impl Ord for SignersContainerKey {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.ordering.cmp(&other.ordering)
+        self.ordering.cmp(&other.ordering).then(self.id.cmp(&other.id))
     }
 }
 


### PR DESCRIPTION
### Description

This is a follow-up to #224 when we decided that while the main cause of bug is fixed, it's better to try to keep the `BTreeMap` as a primary data structure for the container.

This PR reverts some commits from the previous one, but keeps the unit tests and adds fix to the `find` function.

### Notes to the reviewers

The fix to the `find` function introduced in commit c58236f may not be the best one. Is there a better way?

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [x] This pull request breaks the existing API (only when relied upon `SignersContainer::find` function)
* [x] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
