### PR TITLE
[ci] Fix publishing coverage to codecov.io

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Install tarpaulin
         run: cargo install cargo-tarpaulin
       - name: Tarpaulin
-        run: cargo tarpaulin --features all-keys,cli-utils,compiler,esplora,compact_filters --run-types Tests,Doctests --exclude-files "testutils/*"
+        run: cargo tarpaulin --features all-keys,cli-utils,compiler,esplora,compact_filters --run-types Tests,Doctests --exclude-files "testutils/*" --out Xml
 
       - name: Publish to codecov.io
-        uses: codecov/codecov-action@v1.0.14
+        uses: codecov/codecov-action@v1.0.15
         with:
-          token: ${{secrets.CODECOV_TOKEN}}
           fail_ci_if_error: true
+          file: ./cobertura.xml


### PR DESCRIPTION
### Description

This PR fixes #230, the "Code Coverage" github actions CI job. This job was broken when I removed the `actions-rs/tarpaulin` step and replaced it with the `run:  cargo tarpaulin ...` command. 

To make `cargo tarpaulin` work with codecov I had to add the option `-out Xml` and I also updated the step that publishes the results to only push the `./cobertura.xml` file (created by `cargo tarpaulin`). I also removed the unneeded `token` (it's only needed for private repos). 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* NA I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* NA This pull request breaks the existing API
* NA I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
