### PR TITLE
always build docs and create artifacts, publish only on master

### DIFF
--- a/.github/workflows/nightly_docs.yml
+++ b/.github/workflows/nightly_docs.yml
@@ -1,9 +1,6 @@
 name: Publish Nightly Docs
 
-on:
-  push:
-    branches:
-      - master
+on: [push, pull_request]
 
 jobs:
   build_docs:
@@ -39,6 +36,7 @@ jobs:
 
   publish_docs:
     name: 'Publish docs'
+    if: github.ref == 'refs/heads/master'
     needs: [build_docs]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

At the moment we build and create docs only on master, while with this we will build docs at every push (making it available as an artifact in github) but publish only on master.

### Notes to the reviewers

Pipeline building the docs but skipping the publishing https://github.com/RCasatta/bdk/actions/runs/425233916

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

