### PR TITLE
Add missing docs and format code in docs

### DIFF
--- a/src/blockchain/any.rs
+++ b/src/blockchain/any.rs
@@ -75,7 +75,13 @@
 //! # use bdk::Wallet;
 //! let config = serde_json::from_str("...")?;
 //! let blockchain = AnyBlockchain::from_config(&config)?;
-//! let wallet = Wallet::new("...", None, Network::Testnet, MemoryDatabase::default(), blockchain)?;
+//! let wallet = Wallet::new(
+//!     "...",
+//!     None,
+//!     Network::Testnet,
+//!     MemoryDatabase::default(),
+//!     blockchain,
+//! )?;
 //! # Ok::<(), bdk::Error>(())
 //! ```
 

--- a/src/blockchain/any.rs
+++ b/src/blockchain/any.rs
@@ -113,15 +113,15 @@ macro_rules! impl_inner_method {
 pub enum AnyBlockchain {
     #[cfg(feature = "electrum")]
     #[cfg_attr(docsrs, doc(cfg(feature = "electrum")))]
-    #[allow(missing_docs)]
+    /// Electrum client
     Electrum(electrum::ElectrumBlockchain),
     #[cfg(feature = "esplora")]
     #[cfg_attr(docsrs, doc(cfg(feature = "esplora")))]
-    #[allow(missing_docs)]
+    /// Esplora client
     Esplora(esplora::EsploraBlockchain),
     #[cfg(feature = "compact_filters")]
     #[cfg_attr(docsrs, doc(cfg(feature = "compact_filters")))]
-    #[allow(missing_docs)]
+    /// Compact filters client
     CompactFilters(compact_filters::CompactFiltersBlockchain),
 }
 
@@ -188,15 +188,15 @@ impl_from!(compact_filters::CompactFiltersBlockchain, AnyBlockchain, CompactFilt
 pub enum AnyBlockchainConfig {
     #[cfg(feature = "electrum")]
     #[cfg_attr(docsrs, doc(cfg(feature = "electrum")))]
-    #[allow(missing_docs)]
+    /// Electrum client
     Electrum(electrum::ElectrumBlockchainConfig),
     #[cfg(feature = "esplora")]
     #[cfg_attr(docsrs, doc(cfg(feature = "esplora")))]
-    #[allow(missing_docs)]
+    /// Esplora client
     Esplora(esplora::EsploraBlockchainConfig),
     #[cfg(feature = "compact_filters")]
     #[cfg_attr(docsrs, doc(cfg(feature = "compact_filters")))]
-    #[allow(missing_docs)]
+    /// Compact filters client
     CompactFilters(compact_filters::CompactFiltersBlockchainConfig),
 }
 

--- a/src/blockchain/compact_filters/mod.rs
+++ b/src/blockchain/compact_filters/mod.rs
@@ -50,11 +50,13 @@
 //!
 //! let mempool = Arc::new(Mempool::default());
 //! let peers = (0..num_threads)
-//!     .map(|_| Peer::connect(
-//!         "btcd-mainnet.lightning.computer:8333",
-//!         Arc::clone(&mempool),
-//!         Network::Bitcoin,
-//!     ))
+//!     .map(|_| {
+//!         Peer::connect(
+//!             "btcd-mainnet.lightning.computer:8333",
+//!             Arc::clone(&mempool),
+//!             Network::Bitcoin,
+//!         )
+//!     })
 //!     .collect::<Result<_, _>>()?;
 //! let blockchain = CompactFiltersBlockchain::new(peers, "./wallet-filters", Some(500_000))?;
 //! # Ok::<(), CompactFiltersError>(())

--- a/src/blockchain/utils.rs
+++ b/src/blockchain/utils.rs
@@ -370,7 +370,7 @@ fn save_transaction_details_and_utxos<D: BatchDatabase>(
         sent: outgoing,
         height,
         timestamp,
-        fees: inputs_sum.saturating_sub(outputs_sum), // if the tx is a coinbase, fees would be negative
+        fees: inputs_sum.saturating_sub(outputs_sum), /* if the tx is a coinbase, fees would be negative */
     };
     updates.set_tx(&tx_details)?;
 

--- a/src/database/any.rs
+++ b/src/database/any.rs
@@ -36,12 +36,14 @@
 //! # use bdk::database::{AnyDatabase, MemoryDatabase};
 //! # use bdk::{Wallet, OfflineWallet};
 //! let memory = MemoryDatabase::default().into();
-//! let wallet_memory: OfflineWallet<AnyDatabase> = Wallet::new_offline("...", None, Network::Testnet, memory)?;
+//! let wallet_memory: OfflineWallet<AnyDatabase> =
+//!     Wallet::new_offline("...", None, Network::Testnet, memory)?;
 //!
 //! # #[cfg(feature = "key-value-db")]
 //! # {
 //! let sled = sled::open("my-database")?.open_tree("default_tree")?.into();
-//! let wallet_sled: OfflineWallet<AnyDatabase> = Wallet::new_offline("...", None, Network::Testnet, sled)?;
+//! let wallet_sled: OfflineWallet<AnyDatabase> =
+//!     Wallet::new_offline("...", None, Network::Testnet, sled)?;
 //! # }
 //! # Ok::<(), bdk::Error>(())
 //! ```

--- a/src/database/any.rs
+++ b/src/database/any.rs
@@ -89,11 +89,11 @@ macro_rules! impl_inner_method {
 /// See [this module](crate::database::any)'s documentation for a usage example.
 #[derive(Debug)]
 pub enum AnyDatabase {
-    #[allow(missing_docs)]
+    /// In-memory ephemeral database
     Memory(memory::MemoryDatabase),
     #[cfg(feature = "key-value-db")]
     #[cfg_attr(docsrs, doc(cfg(feature = "key-value-db")))]
-    #[allow(missing_docs)]
+    /// Simple key-value embedded database based on [`sled`]
     Sled(sled::Tree),
 }
 
@@ -102,11 +102,11 @@ impl_from!(sled::Tree, AnyDatabase, Sled, #[cfg(feature = "key-value-db")]);
 
 /// Type that contains any of the [`BatchDatabase::Batch`] types defined by the library
 pub enum AnyBatch {
-    #[allow(missing_docs)]
+    /// In-memory ephemeral database
     Memory(<memory::MemoryDatabase as BatchDatabase>::Batch),
     #[cfg(feature = "key-value-db")]
     #[cfg_attr(docsrs, doc(cfg(feature = "key-value-db")))]
-    #[allow(missing_docs)]
+    /// Simple key-value embedded database based on [`sled`]
     Sled(<sled::Tree as BatchDatabase>::Batch),
 }
 
@@ -364,7 +364,7 @@ pub enum AnyDatabaseConfig {
     Memory(()),
     #[cfg(feature = "key-value-db")]
     #[cfg_attr(docsrs, doc(cfg(feature = "key-value-db")))]
-    #[allow(missing_docs)]
+    /// Simple key-value embedded database based on [`sled`]
     Sled(SledDbConfiguration),
 }
 

--- a/src/descriptor/dsl.rs
+++ b/src/descriptor/dsl.rs
@@ -254,8 +254,11 @@ macro_rules! impl_sortedmulti {
 ///
 /// ```
 /// # use std::str::FromStr;
-/// let my_key_1 = bitcoin::PublicKey::from_str("02e96fe52ef0e22d2f131dd425ce1893073a3c6ad20e8cac36726393dfb4856a4c")?;
-/// let my_key_2 = bitcoin::PrivateKey::from_wif("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy")?;
+/// let my_key_1 = bitcoin::PublicKey::from_str(
+///     "02e96fe52ef0e22d2f131dd425ce1893073a3c6ad20e8cac36726393dfb4856a4c",
+/// )?;
+/// let my_key_2 =
+///     bitcoin::PrivateKey::from_wif("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy")?;
 ///
 /// let (descriptor, key_map, networks) = bdk::descriptor! {
 ///     wsh (
@@ -270,9 +273,10 @@ macro_rules! impl_sortedmulti {
 /// Native-Segwit single-sig, equivalent to: `wpkh(...)`
 ///
 /// ```
-/// let my_key = bitcoin::PrivateKey::from_wif("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy")?;
+/// let my_key =
+///     bitcoin::PrivateKey::from_wif("cVt4o7BGAig1UXywgGSmARhxMdzP5qvQsxKkSsc1XEkw3tDTQFpy")?;
 ///
-/// let (descriptor, key_map, networks) = bdk::descriptor!(wpkh ( my_key ) )?;
+/// let (descriptor, key_map, networks) = bdk::descriptor!(wpkh(my_key))?;
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 #[macro_export]

--- a/src/descriptor/template.rs
+++ b/src/descriptor/template.rs
@@ -47,15 +47,15 @@ pub type DescriptorTemplateOut = (ExtendedDescriptor, KeyMap, ValidNetworks);
 /// ## Example
 ///
 /// ```
-/// use bdk::keys::{ToDescriptorKey, KeyError};
-/// use bdk::template::{DescriptorTemplate, DescriptorTemplateOut};
+/// use bdk::keys::{KeyError, ToDescriptorKey};
 /// use bdk::miniscript::Legacy;
+/// use bdk::template::{DescriptorTemplate, DescriptorTemplateOut};
 ///
 /// struct MyP2PKH<K: ToDescriptorKey<Legacy>>(K);
 ///
 /// impl<K: ToDescriptorKey<Legacy>> DescriptorTemplate for MyP2PKH<K> {
 ///     fn build(self) -> Result<DescriptorTemplateOut, KeyError> {
-///         Ok(bdk::descriptor!(pkh ( self.0 ) )?)
+///         Ok(bdk::descriptor!(pkh(self.0))?)
 ///     }
 /// }
 /// ```
@@ -85,10 +85,19 @@ impl<T: DescriptorTemplate> ToWalletDescriptor for T {
 /// # use bdk::database::MemoryDatabase;
 /// use bdk::template::P2PKH;
 ///
-/// let key = bitcoin::PrivateKey::from_wif("cTc4vURSzdx6QE6KVynWGomDbLaA75dNALMNyfjh3p8DRRar84Um")?;
-/// let wallet: OfflineWallet<_> = Wallet::new_offline(P2PKH(key), None, Network::Testnet, MemoryDatabase::default())?;
+/// let key =
+///     bitcoin::PrivateKey::from_wif("cTc4vURSzdx6QE6KVynWGomDbLaA75dNALMNyfjh3p8DRRar84Um")?;
+/// let wallet: OfflineWallet<_> = Wallet::new_offline(
+///     P2PKH(key),
+///     None,
+///     Network::Testnet,
+///     MemoryDatabase::default(),
+/// )?;
 ///
-/// assert_eq!(wallet.get_new_address()?.to_string(), "mwJ8hxFYW19JLuc65RCTaP4v1rzVU8cVMT");
+/// assert_eq!(
+///     wallet.get_new_address()?.to_string(),
+///     "mwJ8hxFYW19JLuc65RCTaP4v1rzVU8cVMT"
+/// );
 /// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
 pub struct P2PKH<K: ToDescriptorKey<Legacy>>(pub K);
@@ -109,10 +118,19 @@ impl<K: ToDescriptorKey<Legacy>> DescriptorTemplate for P2PKH<K> {
 /// # use bdk::database::MemoryDatabase;
 /// use bdk::template::P2WPKH_P2SH;
 ///
-/// let key = bitcoin::PrivateKey::from_wif("cTc4vURSzdx6QE6KVynWGomDbLaA75dNALMNyfjh3p8DRRar84Um")?;
-/// let wallet: OfflineWallet<_> = Wallet::new_offline(P2WPKH_P2SH(key), None, Network::Testnet, MemoryDatabase::default())?;
+/// let key =
+///     bitcoin::PrivateKey::from_wif("cTc4vURSzdx6QE6KVynWGomDbLaA75dNALMNyfjh3p8DRRar84Um")?;
+/// let wallet: OfflineWallet<_> = Wallet::new_offline(
+///     P2WPKH_P2SH(key),
+///     None,
+///     Network::Testnet,
+///     MemoryDatabase::default(),
+/// )?;
 ///
-/// assert_eq!(wallet.get_new_address()?.to_string(), "2NB4ox5VDRw1ecUv6SnT3VQHPXveYztRqk5");
+/// assert_eq!(
+///     wallet.get_new_address()?.to_string(),
+///     "2NB4ox5VDRw1ecUv6SnT3VQHPXveYztRqk5"
+/// );
 /// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
 #[allow(non_camel_case_types)]
@@ -134,10 +152,19 @@ impl<K: ToDescriptorKey<Segwitv0>> DescriptorTemplate for P2WPKH_P2SH<K> {
 /// # use bdk::database::MemoryDatabase;
 /// use bdk::template::P2WPKH;
 ///
-/// let key = bitcoin::PrivateKey::from_wif("cTc4vURSzdx6QE6KVynWGomDbLaA75dNALMNyfjh3p8DRRar84Um")?;
-/// let wallet: OfflineWallet<_> = Wallet::new_offline(P2WPKH(key), None, Network::Testnet, MemoryDatabase::default())?;
+/// let key =
+///     bitcoin::PrivateKey::from_wif("cTc4vURSzdx6QE6KVynWGomDbLaA75dNALMNyfjh3p8DRRar84Um")?;
+/// let wallet: OfflineWallet<_> = Wallet::new_offline(
+///     P2WPKH(key),
+///     None,
+///     Network::Testnet,
+///     MemoryDatabase::default(),
+/// )?;
 ///
-/// assert_eq!(wallet.get_new_address()?.to_string(), "tb1q4525hmgw265tl3drrl8jjta7ayffu6jf68ltjd");
+/// assert_eq!(
+///     wallet.get_new_address()?.to_string(),
+///     "tb1q4525hmgw265tl3drrl8jjta7ayffu6jf68ltjd"
+/// );
 /// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
 pub struct P2WPKH<K: ToDescriptorKey<Segwitv0>>(pub K);

--- a/src/error.rs
+++ b/src/error.rs
@@ -78,15 +78,15 @@ pub enum Error {
     ///
     /// [`TxBuilder::add_global_xpubs`]: crate::wallet::tx_builder::TxBuilder::add_global_xpubs
     MissingKeyOrigin(String),
-    #[allow(missing_docs)]
+    /// Error while working with [`keys`](crate::keys)
     Key(crate::keys::KeyError),
     /// Descriptor checksum mismatch
     ChecksumMismatch,
     /// Spending policy is not compatible with this [`KeychainKind`](crate::types::KeychainKind)
     SpendingPolicyRequired(crate::types::KeychainKind),
-    #[allow(missing_docs)]
+    /// Error while extracting and manipulating policies
     InvalidPolicyPathError(crate::descriptor::policy::PolicyError),
-    #[allow(missing_docs)]
+    /// Signing error
     Signer(crate::wallet::signer::SignerError),
 
     // Blockchain interface errors
@@ -101,23 +101,23 @@ pub enum Error {
     /// Requested outpoint doesn't exist in the tx (vout greater than available outputs)
     InvalidOutpoint(OutPoint),
 
-    #[allow(missing_docs)]
+    /// Error related to the parsing and usage of descriptors
     Descriptor(crate::descriptor::error::Error),
-    #[allow(missing_docs)]
+    /// Error that can be returned to fail the validation of an address
     AddressValidator(crate::wallet::address_validator::AddressValidatorError),
-    #[allow(missing_docs)]
+    /// Encoding error
     Encode(bitcoin::consensus::encode::Error),
-    #[allow(missing_docs)]
+    /// Miniscript error
     Miniscript(miniscript::Error),
-    #[allow(missing_docs)]
+    /// BIP32 error
     BIP32(bitcoin::util::bip32::Error),
-    #[allow(missing_docs)]
+    /// An ECDSA error
     Secp256k1(bitcoin::secp256k1::Error),
-    #[allow(missing_docs)]
+    /// Error serializing or deserializing JSON data
     JSON(serde_json::Error),
-    #[allow(missing_docs)]
+    /// Hex decoding error
     Hex(bitcoin::hashes::hex::Error),
-    #[allow(missing_docs)]
+    /// Partially signed bitcoin transaction error
     PSBT(bitcoin::util::psbt::Error),
 
     //KeyMismatch(bitcoin::secp256k1::PublicKey, bitcoin::secp256k1::PublicKey),
@@ -128,16 +128,16 @@ pub enum Error {
     //Uncapable(crate::blockchain::Capability),
     //MissingCachedAddresses,
     #[cfg(feature = "electrum")]
-    #[allow(missing_docs)]
+    /// Electrum client error
     Electrum(electrum_client::Error),
     #[cfg(feature = "esplora")]
-    #[allow(missing_docs)]
+    /// Esplora client error
     Esplora(crate::blockchain::esplora::EsploraError),
-    #[allow(missing_docs)]
     #[cfg(feature = "compact_filters")]
+    /// Compact filters client error)
     CompactFilters(crate::blockchain::compact_filters::CompactFiltersError),
     #[cfg(feature = "key-value-db")]
-    #[allow(missing_docs)]
+    /// Sled database error
     Sled(sled::Error),
 }
 

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -198,7 +198,7 @@ impl<Ctx: ScriptContext + 'static> ExtScriptContext for Ctx {
 /// ```
 /// use bdk::bitcoin::PublicKey;
 ///
-/// use bdk::keys::{ScriptContext, ToDescriptorKey, DescriptorKey, KeyError};
+/// use bdk::keys::{DescriptorKey, KeyError, ScriptContext, ToDescriptorKey};
 ///
 /// pub struct MyKeyType {
 ///     pubkey: PublicKey,
@@ -216,7 +216,10 @@ impl<Ctx: ScriptContext + 'static> ExtScriptContext for Ctx {
 /// ```
 /// use bdk::bitcoin::PublicKey;
 ///
-/// use bdk::keys::{mainnet_network, ScriptContext, ToDescriptorKey, DescriptorKey, DescriptorPublicKey, DescriptorSinglePub, KeyError};
+/// use bdk::keys::{
+///     mainnet_network, DescriptorKey, DescriptorPublicKey, DescriptorSinglePub, KeyError,
+///     ScriptContext, ToDescriptorKey,
+/// };
 ///
 /// pub struct MyKeyType {
 ///     pubkey: PublicKey,
@@ -224,10 +227,13 @@ impl<Ctx: ScriptContext + 'static> ExtScriptContext for Ctx {
 ///
 /// impl<Ctx: ScriptContext> ToDescriptorKey<Ctx> for MyKeyType {
 ///     fn to_descriptor_key(self) -> Result<DescriptorKey<Ctx>, KeyError> {
-///         Ok(DescriptorKey::from_public(DescriptorPublicKey::SinglePub(DescriptorSinglePub {
-///             origin: None,
-///             key: self.pubkey
-///         }), mainnet_network()))
+///         Ok(DescriptorKey::from_public(
+///             DescriptorPublicKey::SinglePub(DescriptorSinglePub {
+///                 origin: None,
+///                 key: self.pubkey,
+///             }),
+///             mainnet_network(),
+///         ))
 ///     }
 /// }
 /// ```
@@ -237,7 +243,7 @@ impl<Ctx: ScriptContext + 'static> ExtScriptContext for Ctx {
 /// ```
 /// use bdk::bitcoin::PublicKey;
 ///
-/// use bdk::keys::{ExtScriptContext, ScriptContext, ToDescriptorKey, DescriptorKey, KeyError};
+/// use bdk::keys::{DescriptorKey, ExtScriptContext, KeyError, ScriptContext, ToDescriptorKey};
 ///
 /// pub struct MyKeyType {
 ///     is_legacy: bool,
@@ -263,10 +269,10 @@ impl<Ctx: ScriptContext + 'static> ExtScriptContext for Ctx {
 /// makes the compiler (correctly) fail.
 ///
 /// ```compile_fail
-/// use std::str::FromStr;
 /// use bdk::bitcoin::PublicKey;
+/// use std::str::FromStr;
 ///
-/// use bdk::keys::{ToDescriptorKey, DescriptorKey, KeyError};
+/// use bdk::keys::{DescriptorKey, KeyError, ToDescriptorKey};
 ///
 /// pub struct MySegwitOnlyKeyType {
 ///     pubkey: PublicKey,
@@ -281,7 +287,7 @@ impl<Ctx: ScriptContext + 'static> ExtScriptContext for Ctx {
 /// let key = MySegwitOnlyKeyType {
 ///     pubkey: PublicKey::from_str("...")?,
 /// };
-/// let (descriptor, _, _) = bdk::descriptor!(pkh ( key ) )?;
+/// let (descriptor, _, _) = bdk::descriptor!(pkh(key))?;
 /// //                                       ^^^^^ changing this to `wpkh` would make it compile
 ///
 /// # Ok::<_, Box<dyn std::error::Error>>(())

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -684,9 +684,9 @@ pub enum KeyError {
     /// Custom error message
     Message(String),
 
-    #[allow(missing_docs)]
+    /// BIP32 error
     BIP32(bitcoin::util::bip32::Error),
-    #[allow(missing_docs)]
+    /// Miniscript error
     Miniscript(miniscript::Error),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,7 +258,6 @@ pub mod descriptor;
 mod doctest;
 pub mod keys;
 pub(crate) mod psbt;
-#[allow(missing_docs)] // TODO add missing docs and remove this allow
 pub(crate) mod types;
 pub mod wallet;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -29,7 +29,7 @@ use bitcoin::hash_types::Txid;
 
 use serde::{Deserialize, Serialize};
 
-/// Types of script
+/// Types of keychains
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum KeychainKind {
     /// External
@@ -39,6 +39,7 @@ pub enum KeychainKind {
 }
 
 impl KeychainKind {
+    /// Return [`KeychainKind`] as a byte
     pub fn as_byte(&self) -> u8 {
         match self {
             KeychainKind::External => b'e',
@@ -92,19 +93,29 @@ impl std::default::Default for FeeRate {
 /// A wallet unspent output
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub struct UTXO {
+    /// Reference to a transaction output
     pub outpoint: OutPoint,
+    /// Transaction output
     pub txout: TxOut,
+    /// Type of keychain
     pub keychain: KeychainKind,
 }
 
 /// A wallet transaction
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
 pub struct TransactionDetails {
+    /// Optional transaction
     pub transaction: Option<Transaction>,
+    /// Transaction id
     pub txid: Txid,
+    /// Timestamp
     pub timestamp: u64,
+    /// Received value (sats)
     pub received: u64,
+    /// Sent value (sats)
     pub sent: u64,
+    /// Fee value (sats)
     pub fees: u64,
+    /// Confirmed in block height, `None` means unconfirmed
     pub height: Option<u32>,
 }

--- a/src/wallet/export.rs
+++ b/src/wallet/export.rs
@@ -43,7 +43,12 @@
 //! }"#;
 //!
 //! let import = WalletExport::from_str(import)?;
-//! let wallet: OfflineWallet<_> = Wallet::new_offline(&import.descriptor(), import.change_descriptor().as_ref(), Network::Testnet, MemoryDatabase::default())?;
+//! let wallet: OfflineWallet<_> = Wallet::new_offline(
+//!     &import.descriptor(),
+//!     import.change_descriptor().as_ref(),
+//!     Network::Testnet,
+//!     MemoryDatabase::default(),
+//! )?;
 //! # Ok::<_, bdk::Error>(())
 //! ```
 //!


### PR DESCRIPTION
### Description

This PR fixes #192 by doing some final cleanup to remove all `allow(missing_docs)` and replacing them with basic docs instead. This was done on some other docs PRs with the reasoning that even basic docs are better than no docs.

I also formatting all code in docs with the command:
```
cargo +nightly fmt -- --config format_code_in_doc_comments=true
```

This will make all code in docs formatted consistently with the rest of the code formatted with `cargo fmt` and make it easier to format future code in docs using this same command.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [x] I'm linking the issue being fixed by this PR
