### PR TITLE
Remove unneeded skip step conditionals in CI, fix empty checkboxes in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,18 +13,18 @@ of the PR were done in a specific way -->
 
 #### All Submissions:
 
-* [] I've signed all my commits
-* [] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
-* [] I ran `cargo fmt` and `cargo clippy` before committing
+* [ ] I've signed all my commits
+* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
+* [ ] I ran `cargo fmt` and `cargo clippy` before committing
 
 #### New Features:
 
-* [] I've added tests for the new feature
-* [] I've added docs for the new feature
-* [] I've updated `CHANGELOG.md`
+* [ ] I've added tests for the new feature
+* [ ] I've added docs for the new feature
+* [ ] I've updated `CHANGELOG.md`
 
 #### Bugfixes:
 
-* [] This pull request breaks the existing API
-* [] I've added tests to reproduce the issue which are now passing
-* [] I'm linking the issue being fixed by this PR
+* [ ] This pull request breaks the existing API
+* [ ] I've added tests to reproduce the issue which are now passing
+* [ ] I'm linking the issue being fixed by this PR

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -22,13 +22,6 @@ jobs:
           - compact_filters
           - cli-utils,esplora,key-value-db,electrum
           - compiler
-        include:
-          - rust: stable
-            features: compact_filters
-            clippy: skip
-          - rust: 1.45.0
-            features: compact_filters
-            clippy: skip
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -51,10 +44,8 @@ jobs:
       - name: Build
         run: cargo build --features ${{ matrix.features }} --no-default-features
       - name: Clippy
-        if: ${{ matrix.rust == 'stable' && matrix.clippy != 'skip' }}
         run: cargo clippy -- -D warnings
       - name: Test
-        if: ${{ matrix.test != 'skip' }}
         run: cargo test --features ${{ matrix.features }} --no-default-features
 
   test-readme-examples:


### PR DESCRIPTION
### Description

This is just a couple small cleanups to the CI workflow and PR template. For the CI build-test workflow we don't need to skip test or the clippy check anywhere so I removed those conditionals. For the PR template I added spaces in the check boxes so they render correctly when not checked. 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
