### PR TITLE
Re-export structopt

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -92,6 +92,7 @@
 use std::collections::BTreeMap;
 use std::str::FromStr;
 
+pub use structopt;
 use structopt::StructOpt;
 
 #[allow(unused_imports)]
@@ -116,8 +117,7 @@ use crate::{FeeRate, TxBuilder, Wallet};
 /// # Example
 ///
 /// ```
-/// # use bdk::cli::{WalletOpt, WalletSubCommand};
-/// # use structopt::StructOpt;
+/// # use bdk::cli::{WalletOpt, WalletSubCommand, structopt::StructOpt};
 ///
 /// let cli_args = vec!["repl", "--network", "testnet",
 ///                     "--descriptor", "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/44'/1'/0'/0/*)",

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,6 +33,10 @@
 //!
 //! See [`WalletOpt`] for global wallet options and [`WalletSubCommand`] for supported sub-commands.
 //!
+// we need esplora feature for this example to work
+#[cfg_attr(
+    feature = "esplora",
+    doc = r##"
 //! # Example
 //!
 //! ```
@@ -88,7 +92,8 @@
 //! let result = cli::handle_wallet_subcommand(&wallet, cli_opt.subcommand).unwrap();
 //! println!("{}", serde_json::to_string_pretty(&result).unwrap());
 //! ```
-
+"##
+)]
 use std::collections::BTreeMap;
 use std::str::FromStr;
 
@@ -607,6 +612,7 @@ mod test {
     use structopt::StructOpt;
 
     #[test]
+    #[cfg(feature = "esplora")]
     fn test_get_new_address() {
         let cli_args = vec!["repl", "--network", "bitcoin",
                             "--descriptor", "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)",
@@ -624,9 +630,7 @@ mod test {
             descriptor: "wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)".to_string(),
             change_descriptor: Some("wpkh(xpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/1/*)".to_string()),
             log_level: "info".to_string(),
-            #[cfg(feature = "esplora")]
             esplora: Some("https://blockstream.info/api/".to_string()),
-            #[cfg(feature = "esplora")]
             esplora_concurrency: 5,
             electrum: "ssl://electrum.blockstream.info:60002".to_string(),
             subcommand: WalletSubCommand::GetNewAddress,


### PR DESCRIPTION
So consumers of the cli module don't have to keep track of their own version.

+ bonus: fix tests so that they work when `cli-utils` is enabled but `esplora` isn't. I haven't added CI to test for this because I think the plan was to spin off cli into its own repo.