### PR TITLE
Use () to indicate a missing blockchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Remove `BlockchainMarker`, `OfflineClient` and `OfflineWallet` in favor of just using the unit
+  type to mark for a missing client.
+
 ## [v0.2.0] - [0.1.0-beta.1]
 
 ### Project

--- a/README.md
+++ b/README.md
@@ -66,11 +66,10 @@ fn main() -> Result<(), bdk::Error> {
 ### Generate a few addresses
 
 ```rust
-use bdk::{Wallet, OfflineWallet};
-use bdk::database::MemoryDatabase;
+use bdk::{Wallet, database::MemoryDatabase};
 
 fn main() -> Result<(), bdk::Error> {
-    let wallet: OfflineWallet<_> = Wallet::new_offline(
+    let wallet = Wallet::new_offline(
         "wpkh([c258d2e4/84h/1h/0h]tpubDDYkZojQFQjht8Tm4jsS3iuEmKjTiEGjG6KnuFNKKJb5A6ZUCUZKdvLdSDWofKi4ToRCwb9poe1XdqfUnP4jaJjCB2Zwv11ZLgSbnZSNecE/0/*)",
         Some("wpkh([c258d2e4/84h/1h/0h]tpubDDYkZojQFQjht8Tm4jsS3iuEmKjTiEGjG6KnuFNKKJb5A6ZUCUZKdvLdSDWofKi4ToRCwb9poe1XdqfUnP4jaJjCB2Zwv11ZLgSbnZSNecE/1/*)"),
         bitcoin::Network::Testnet,
@@ -126,13 +125,12 @@ fn main() -> Result<(), bdk::Error> {
 ### Sign a transaction
 
 ```rust,no_run
-use bdk::{Wallet, OfflineWallet};
-use bdk::database::MemoryDatabase;
+use bdk::{Wallet, database::MemoryDatabase};
 
 use bitcoin::consensus::deserialize;
 
 fn main() -> Result<(), bdk::Error> {
-    let wallet: OfflineWallet<_> = Wallet::new_offline(
+    let wallet = Wallet::new_offline(
         "wpkh([c258d2e4/84h/1h/0h]tprv8griRPhA7342zfRyB6CqeKF8CJDXYu5pgnj1cjL1u2ngKcJha5jjTRimG82ABzJQ4MQe71CV54xfn25BbhCNfEGGJZnxvCDQCd6JkbvxW6h/0/*)",
         Some("wpkh([c258d2e4/84h/1h/0h]tprv8griRPhA7342zfRyB6CqeKF8CJDXYu5pgnj1cjL1u2ngKcJha5jjTRimG82ABzJQ4MQe71CV54xfn25BbhCNfEGGJZnxvCDQCd6JkbvxW6h/1/*)"),
         bitcoin::Network::Testnet,

--- a/examples/address_validator.rs
+++ b/examples/address_validator.rs
@@ -29,7 +29,7 @@ use bdk::database::MemoryDatabase;
 use bdk::descriptor::HDKeyPaths;
 use bdk::wallet::address_validator::{AddressValidator, AddressValidatorError};
 use bdk::KeychainKind;
-use bdk::{OfflineWallet, Wallet};
+use bdk::Wallet;
 
 use bitcoin::hashes::hex::FromHex;
 use bitcoin::util::bip32::Fingerprint;
@@ -59,7 +59,7 @@ impl AddressValidator for DummyValidator {
 
 fn main() -> Result<(), bdk::Error> {
     let descriptor = "sh(and_v(v:pk(tpubDDpWvmUrPZrhSPmUzCMBHffvC3HyMAPnWDSAQNBTnj1iZeJa7BZQEttFiP4DS4GCcXQHezdXhn86Hj6LHX5EDstXPWrMaSneRWM8yUf6NFd/*),after(630000)))";
-    let mut wallet: OfflineWallet<_> =
+    let mut wallet =
         Wallet::new_offline(descriptor, None, Network::Regtest, MemoryDatabase::new())?;
 
     wallet.add_address_validator(Arc::new(DummyValidator));

--- a/examples/compiler.rs
+++ b/examples/compiler.rs
@@ -40,7 +40,7 @@ use miniscript::policy::Concrete;
 use miniscript::Descriptor;
 
 use bdk::database::memory::MemoryDatabase;
-use bdk::{KeychainKind, OfflineWallet, Wallet};
+use bdk::{KeychainKind, Wallet};
 
 fn main() {
     env_logger::init_from_env(
@@ -98,8 +98,7 @@ fn main() {
         Some("regtest") => Network::Regtest,
         Some("testnet") | _ => Network::Testnet,
     };
-    let wallet: OfflineWallet<_> =
-        Wallet::new_offline(&format!("{}", descriptor), None, network, database).unwrap();
+    let wallet = Wallet::new_offline(&format!("{}", descriptor), None, network, database).unwrap();
 
     info!("... First address: {}", wallet.get_new_address().unwrap());
 

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -79,29 +79,9 @@ pub enum Capability {
     AccurateFees,
 }
 
-/// Marker trait for a blockchain backend
-///
-/// This is a marker trait for blockchain types. It is automatically implemented for types that
-/// implement [`Blockchain`], so as a user of the library you won't have to implement this
-/// manually.
-///
-/// Users of the library will probably never have to implement this trait manually, but they
-/// could still need to import it to define types and structs with generics;
-/// Implementing only the marker trait is pointless, since [`OfflineBlockchain`]
-/// already does that, and whenever [`Blockchain`] is implemented, the marker trait is also
-/// automatically implemented by the library.
-pub trait BlockchainMarker {}
-
-/// The [`BlockchainMarker`] marker trait is automatically implemented for [`Blockchain`] types
-impl<T: Blockchain> BlockchainMarker for T {}
-
-/// Type that only implements [`BlockchainMarker`] and is always "offline"
-pub struct OfflineBlockchain;
-impl BlockchainMarker for OfflineBlockchain {}
-
 /// Trait that defines the actions that must be supported by a blockchain backend
 #[maybe_async]
-pub trait Blockchain: BlockchainMarker {
+pub trait Blockchain {
     /// Return the set of [`Capability`] supported by this backend
     fn get_capabilities(&self) -> HashSet<Capability>;
 

--- a/src/database/any.rs
+++ b/src/database/any.rs
@@ -29,20 +29,20 @@
 //!
 //! ## Example
 //!
-//! In this example, `wallet_memory` and `wallet_sled` have the same type of `Wallet<OfflineBlockchain, AnyDatabase>`.
+//! In this example, `wallet_memory` and `wallet_sled` have the same type of `Wallet<(), AnyDatabase>`.
 //!
 //! ```no_run
 //! # use bitcoin::Network;
 //! # use bdk::database::{AnyDatabase, MemoryDatabase};
-//! # use bdk::{Wallet, OfflineWallet};
-//! let memory = MemoryDatabase::default().into();
-//! let wallet_memory: OfflineWallet<AnyDatabase> =
+//! # use bdk::{Wallet};
+//! let memory = MemoryDatabase::default();
+//! let wallet_memory =
 //!     Wallet::new_offline("...", None, Network::Testnet, memory)?;
 //!
 //! # #[cfg(feature = "key-value-db")]
 //! # {
-//! let sled = sled::open("my-database")?.open_tree("default_tree")?.into();
-//! let wallet_sled: OfflineWallet<AnyDatabase> =
+//! let sled = sled::open("my-database")?.open_tree("default_tree")?;
+//! let wallet_sled =
 //!     Wallet::new_offline("...", None, Network::Testnet, sled)?;
 //! # }
 //! # Ok::<(), bdk::Error>(())
@@ -54,10 +54,10 @@
 //! ```no_run
 //! # use bitcoin::Network;
 //! # use bdk::database::*;
-//! # use bdk::{Wallet, OfflineWallet};
+//! # use bdk::{Wallet};
 //! let config = serde_json::from_str("...")?;
 //! let database = AnyDatabase::from_config(&config)?;
-//! let wallet: OfflineWallet<_> = Wallet::new_offline("...", None, Network::Testnet, database)?;
+//! let wallet = Wallet::new_offline("...", None, Network::Testnet, database)?;
 //! # Ok::<(), bdk::Error>(())
 //! ```
 

--- a/src/descriptor/template.rs
+++ b/src/descriptor/template.rs
@@ -81,13 +81,13 @@ impl<T: DescriptorTemplate> ToWalletDescriptor for T {
 ///
 /// ```
 /// # use bdk::bitcoin::{PrivateKey, Network};
-/// # use bdk::{Wallet, OfflineWallet};
+/// # use bdk::{Wallet};
 /// # use bdk::database::MemoryDatabase;
 /// use bdk::template::P2PKH;
 ///
 /// let key =
 ///     bitcoin::PrivateKey::from_wif("cTc4vURSzdx6QE6KVynWGomDbLaA75dNALMNyfjh3p8DRRar84Um")?;
-/// let wallet: OfflineWallet<_> = Wallet::new_offline(
+/// let wallet = Wallet::new_offline(
 ///     P2PKH(key),
 ///     None,
 ///     Network::Testnet,
@@ -114,13 +114,13 @@ impl<K: ToDescriptorKey<Legacy>> DescriptorTemplate for P2PKH<K> {
 ///
 /// ```
 /// # use bdk::bitcoin::{PrivateKey, Network};
-/// # use bdk::{Wallet, OfflineWallet};
+/// # use bdk::{Wallet};
 /// # use bdk::database::MemoryDatabase;
 /// use bdk::template::P2WPKH_P2SH;
 ///
 /// let key =
 ///     bitcoin::PrivateKey::from_wif("cTc4vURSzdx6QE6KVynWGomDbLaA75dNALMNyfjh3p8DRRar84Um")?;
-/// let wallet: OfflineWallet<_> = Wallet::new_offline(
+/// let wallet = Wallet::new_offline(
 ///     P2WPKH_P2SH(key),
 ///     None,
 ///     Network::Testnet,
@@ -148,13 +148,13 @@ impl<K: ToDescriptorKey<Segwitv0>> DescriptorTemplate for P2WPKH_P2SH<K> {
 ///
 /// ```
 /// # use bdk::bitcoin::{PrivateKey, Network};
-/// # use bdk::{Wallet, OfflineWallet};
+/// # use bdk::{Wallet};
 /// # use bdk::database::MemoryDatabase;
 /// use bdk::template::P2WPKH;
 ///
 /// let key =
 ///     bitcoin::PrivateKey::from_wif("cTc4vURSzdx6QE6KVynWGomDbLaA75dNALMNyfjh3p8DRRar84Um")?;
-/// let wallet: OfflineWallet<_> = Wallet::new_offline(
+/// let wallet = Wallet::new_offline(
 ///     P2WPKH(key),
 ///     None,
 ///     Network::Testnet,
@@ -186,12 +186,12 @@ impl<K: ToDescriptorKey<Segwitv0>> DescriptorTemplate for P2WPKH<K> {
 /// ```
 /// # use std::str::FromStr;
 /// # use bdk::bitcoin::{PrivateKey, Network};
-/// # use bdk::{Wallet, OfflineWallet, KeychainKind};
+/// # use bdk::{Wallet,  KeychainKind};
 /// # use bdk::database::MemoryDatabase;
 /// use bdk::template::BIP44;
 ///
 /// let key = bitcoin::util::bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPeZRHk4rTG6orPS2CRNFX3njhUXx5vj9qGog5ZMH4uGReDWN5kCkY3jmWEtWause41CDvBRXD1shKknAMKxT99o9qUTRVC6m")?;
-/// let wallet: OfflineWallet<_> = Wallet::new_offline(
+/// let wallet = Wallet::new_offline(
 ///     BIP44(key.clone(), KeychainKind::External),
 ///     Some(BIP44(key, KeychainKind::Internal)),
 ///     Network::Testnet,
@@ -224,13 +224,13 @@ impl<K: DerivableKey<Legacy>> DescriptorTemplate for BIP44<K> {
 /// ```
 /// # use std::str::FromStr;
 /// # use bdk::bitcoin::{PrivateKey, Network};
-/// # use bdk::{Wallet, OfflineWallet, KeychainKind};
+/// # use bdk::{Wallet,  KeychainKind};
 /// # use bdk::database::MemoryDatabase;
 /// use bdk::template::BIP44Public;
 ///
 /// let key = bitcoin::util::bip32::ExtendedPubKey::from_str("tpubDDDzQ31JkZB7VxUr9bjvBivDdqoFLrDPyLWtLapArAi51ftfmCb2DPxwLQzX65iNcXz1DGaVvyvo6JQ6rTU73r2gqdEo8uov9QKRb7nKCSU")?;
 /// let fingerprint = bitcoin::util::bip32::Fingerprint::from_str("c55b303f")?;
-/// let wallet: OfflineWallet<_> = Wallet::new_offline(
+/// let wallet = Wallet::new_offline(
 ///     BIP44Public(key.clone(), fingerprint, KeychainKind::External),
 ///     Some(BIP44Public(key, fingerprint, KeychainKind::Internal)),
 ///     Network::Testnet,
@@ -260,12 +260,12 @@ impl<K: DerivableKey<Legacy>> DescriptorTemplate for BIP44Public<K> {
 /// ```
 /// # use std::str::FromStr;
 /// # use bdk::bitcoin::{PrivateKey, Network};
-/// # use bdk::{Wallet, OfflineWallet, KeychainKind};
+/// # use bdk::{Wallet,  KeychainKind};
 /// # use bdk::database::MemoryDatabase;
 /// use bdk::template::BIP49;
 ///
 /// let key = bitcoin::util::bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPeZRHk4rTG6orPS2CRNFX3njhUXx5vj9qGog5ZMH4uGReDWN5kCkY3jmWEtWause41CDvBRXD1shKknAMKxT99o9qUTRVC6m")?;
-/// let wallet: OfflineWallet<_> = Wallet::new_offline(
+/// let wallet = Wallet::new_offline(
 ///     BIP49(key.clone(), KeychainKind::External),
 ///     Some(BIP49(key, KeychainKind::Internal)),
 ///     Network::Testnet,
@@ -298,13 +298,13 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for BIP49<K> {
 /// ```
 /// # use std::str::FromStr;
 /// # use bdk::bitcoin::{PrivateKey, Network};
-/// # use bdk::{Wallet, OfflineWallet, KeychainKind};
+/// # use bdk::{Wallet,  KeychainKind};
 /// # use bdk::database::MemoryDatabase;
 /// use bdk::template::BIP49Public;
 ///
 /// let key = bitcoin::util::bip32::ExtendedPubKey::from_str("tpubDC49r947KGK52X5rBWS4BLs5m9SRY3pYHnvRrm7HcybZ3BfdEsGFyzCMzayi1u58eT82ZeyFZwH7DD6Q83E3fM9CpfMtmnTygnLfP59jL9L")?;
 /// let fingerprint = bitcoin::util::bip32::Fingerprint::from_str("c55b303f")?;
-/// let wallet: OfflineWallet<_> = Wallet::new_offline(
+/// let wallet = Wallet::new_offline(
 ///     BIP49Public(key.clone(), fingerprint, KeychainKind::External),
 ///     Some(BIP49Public(key, fingerprint, KeychainKind::Internal)),
 ///     Network::Testnet,
@@ -334,12 +334,12 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for BIP49Public<K> {
 /// ```
 /// # use std::str::FromStr;
 /// # use bdk::bitcoin::{PrivateKey, Network};
-/// # use bdk::{Wallet, OfflineWallet, KeychainKind};
+/// # use bdk::{Wallet,  KeychainKind};
 /// # use bdk::database::MemoryDatabase;
 /// use bdk::template::BIP84;
 ///
 /// let key = bitcoin::util::bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPeZRHk4rTG6orPS2CRNFX3njhUXx5vj9qGog5ZMH4uGReDWN5kCkY3jmWEtWause41CDvBRXD1shKknAMKxT99o9qUTRVC6m")?;
-/// let wallet: OfflineWallet<_> = Wallet::new_offline(
+/// let wallet = Wallet::new_offline(
 ///     BIP84(key.clone(), KeychainKind::External),
 ///     Some(BIP84(key, KeychainKind::Internal)),
 ///     Network::Testnet,
@@ -372,13 +372,13 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for BIP84<K> {
 /// ```
 /// # use std::str::FromStr;
 /// # use bdk::bitcoin::{PrivateKey, Network};
-/// # use bdk::{Wallet, OfflineWallet, KeychainKind};
+/// # use bdk::{Wallet,  KeychainKind};
 /// # use bdk::database::MemoryDatabase;
 /// use bdk::template::BIP84Public;
 ///
 /// let key = bitcoin::util::bip32::ExtendedPubKey::from_str("tpubDC2Qwo2TFsaNC4ju8nrUJ9mqVT3eSgdmy1yPqhgkjwmke3PRXutNGRYAUo6RCHTcVQaDR3ohNU9we59brGHuEKPvH1ags2nevW5opEE9Z5Q")?;
 /// let fingerprint = bitcoin::util::bip32::Fingerprint::from_str("c55b303f")?;
-/// let wallet: OfflineWallet<_> = Wallet::new_offline(
+/// let wallet = Wallet::new_offline(
 ///     BIP84Public(key.clone(), fingerprint, KeychainKind::External),
 ///     Some(BIP84Public(key, fingerprint, KeychainKind::Internal)),
 ///     Network::Testnet,

--- a/src/error.rs
+++ b/src/error.rs
@@ -89,11 +89,6 @@ pub enum Error {
     /// Signing error
     Signer(crate::wallet::signer::SignerError),
 
-    // Blockchain interface errors
-    /// Thrown when trying to call a method that requires a network connection, [`Wallet::sync`](crate::Wallet::sync) and [`Wallet::broadcast`](crate::Wallet::broadcast)
-    /// This error is thrown when creating the Client for the first time, while recovery attempts are tried
-    /// during the sync
-    OfflineClient,
     /// Progress value must be between `0.0` (included) and `100.0` (included)
     InvalidProgressValue(f32),
     /// Progress update error (maybe the channel has been closed)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,11 +91,11 @@
 //!
 //! ### Example
 //! ```
-//! use bdk::{Wallet, OfflineWallet};
+//! use bdk::{Wallet};
 //! use bdk::database::MemoryDatabase;
 //!
 //! fn main() -> Result<(), bdk::Error> {
-//!     let wallet: OfflineWallet<_> = Wallet::new_offline(
+//!     let wallet = Wallet::new_offline(
 //!         "wpkh([c258d2e4/84h/1h/0h]tpubDDYkZojQFQjht8Tm4jsS3iuEmKjTiEGjG6KnuFNKKJb5A6ZUCUZKdvLdSDWofKi4ToRCwb9poe1XdqfUnP4jaJjCB2Zwv11ZLgSbnZSNecE/0/*)",
 //!         Some("wpkh([c258d2e4/84h/1h/0h]tpubDDYkZojQFQjht8Tm4jsS3iuEmKjTiEGjG6KnuFNKKJb5A6ZUCUZKdvLdSDWofKi4ToRCwb9poe1XdqfUnP4jaJjCB2Zwv11ZLgSbnZSNecE/1/*)"),
 //!         bitcoin::Network::Testnet,
@@ -155,13 +155,13 @@
 //! ### Example
 //! ```ignore
 //! use base64::decode;
-//! use bdk::{Wallet, OfflineWallet};
+//! use bdk::{Wallet};
 //! use bdk::database::MemoryDatabase;
 //!
 //! use bitcoin::consensus::deserialize;
 //!
 //! fn main() -> Result<(), bdk::Error> {
-//!     let wallet: OfflineWallet<_> = Wallet::new_offline(
+//!     let wallet = Wallet::new_offline(
 //!         "wpkh([c258d2e4/84h/1h/0h]tprv8griRPhA7342zfRyB6CqeKF8CJDXYu5pgnj1cjL1u2ngKcJha5jjTRimG82ABzJQ4MQe71CV54xfn25BbhCNfEGGJZnxvCDQCd6JkbvxW6h/0/*)",
 //!         Some("wpkh([c258d2e4/84h/1h/0h]tprv8griRPhA7342zfRyB6CqeKF8CJDXYu5pgnj1cjL1u2ngKcJha5jjTRimG82ABzJQ4MQe71CV54xfn25BbhCNfEGGJZnxvCDQCd6JkbvxW6h/1/*)"),
 //!         bitcoin::Network::Testnet,
@@ -268,4 +268,4 @@ pub use types::*;
 pub use wallet::address_validator;
 pub use wallet::signer;
 pub use wallet::tx_builder::TxBuilder;
-pub use wallet::{OfflineWallet, Wallet};
+pub use wallet::Wallet;

--- a/src/wallet/address_validator.rs
+++ b/src/wallet/address_validator.rs
@@ -66,7 +66,7 @@
 //! }
 //!
 //! let descriptor = "wpkh(tpubD6NzVbkrYhZ4Xferm7Pz4VnjdcDPFyjVu5K4iZXQ4pVN8Cks4pHVowTBXBKRhX64pkRyJZJN5xAKj4UDNnLPb5p2sSKXhewoYx5GbTdUFWq/*)";
-//! let mut wallet: OfflineWallet<_> = Wallet::new_offline(descriptor, None, Network::Testnet, MemoryDatabase::default())?;
+//! let mut wallet = Wallet::new_offline(descriptor, None, Network::Testnet, MemoryDatabase::default())?;
 //! wallet.add_address_validator(Arc::new(PrintAddressAndContinue));
 //!
 //! let address = wallet.get_new_address()?;

--- a/src/wallet/coin_selection.rs
+++ b/src/wallet/coin_selection.rs
@@ -84,7 +84,7 @@
 //!     }
 //! }
 //!
-//! # let wallet: OfflineWallet<_> = Wallet::new_offline("", None, Network::Testnet, bdk::database::MemoryDatabase::default())?;
+//! # let wallet = Wallet::new_offline("", None, Network::Testnet, bdk::database::MemoryDatabase::default())?;
 //! // create wallet, sync, ...
 //!
 //! let to_address = Address::from_str("2N4eQYCbKUHCCTUjBJeHcJp9ok6J2GZsTDt").unwrap();

--- a/src/wallet/export.rs
+++ b/src/wallet/export.rs
@@ -43,7 +43,7 @@
 //! }"#;
 //!
 //! let import = WalletExport::from_str(import)?;
-//! let wallet: OfflineWallet<_> = Wallet::new_offline(
+//! let wallet = Wallet::new_offline(
 //!     &import.descriptor(),
 //!     import.change_descriptor().as_ref(),
 //!     Network::Testnet,
@@ -58,7 +58,7 @@
 //! # use bdk::database::*;
 //! # use bdk::wallet::export::*;
 //! # use bdk::*;
-//! let wallet: OfflineWallet<_> = Wallet::new_offline(
+//! let wallet = Wallet::new_offline(
 //!     "wpkh([c258d2e4/84h/1h/0h]tpubDD3ynpHgJQW8VvWRzQ5WFDCrs4jqVFGHB3vLC3r49XHJSqP8bHKdK4AriuUKLccK68zfzowx7YhmDN8SiSkgCDENUFx9qVw65YyqM78vyVe/0/*)",
 //!     Some("wpkh([c258d2e4/84h/1h/0h]tpubDD3ynpHgJQW8VvWRzQ5WFDCrs4jqVFGHB3vLC3r49XHJSqP8bHKdK4AriuUKLccK68zfzowx7YhmDN8SiSkgCDENUFx9qVw65YyqM78vyVe/1/*)"),
 //!     Network::Testnet,
@@ -78,7 +78,6 @@ use serde::{Deserialize, Serialize};
 
 use miniscript::{Descriptor, DescriptorPublicKey, ScriptContext, Terminal};
 
-use crate::blockchain::BlockchainMarker;
 use crate::database::BatchDatabase;
 use crate::wallet::Wallet;
 
@@ -120,7 +119,7 @@ impl WalletExport {
     ///
     /// If the database is empty or `include_blockheight` is false, the `blockheight` field
     /// returned will be `0`.
-    pub fn export_wallet<B: BlockchainMarker, D: BatchDatabase>(
+    pub fn export_wallet<B, D: BatchDatabase>(
         wallet: &Wallet<B, D>,
         label: &str,
         include_blockheight: bool,
@@ -208,7 +207,7 @@ mod test {
     use super::*;
     use crate::database::{memory::MemoryDatabase, BatchOperations};
     use crate::types::TransactionDetails;
-    use crate::wallet::{OfflineWallet, Wallet};
+    use crate::wallet::Wallet;
 
     fn get_test_db() -> MemoryDatabase {
         let mut db = MemoryDatabase::new();
@@ -234,7 +233,7 @@ mod test {
         let descriptor = "wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/44'/0'/0'/0/*)";
         let change_descriptor = "wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/44'/0'/0'/1/*)";
 
-        let wallet: OfflineWallet<_> = Wallet::new_offline(
+        let wallet = Wallet::new_offline(
             descriptor,
             Some(change_descriptor),
             Network::Bitcoin,
@@ -258,7 +257,7 @@ mod test {
 
         let descriptor = "wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/44'/0'/0'/0/*)";
 
-        let wallet: OfflineWallet<_> =
+        let wallet =
             Wallet::new_offline(descriptor, None, Network::Bitcoin, get_test_db()).unwrap();
         WalletExport::export_wallet(&wallet, "Test Label", true).unwrap();
     }
@@ -272,7 +271,7 @@ mod test {
         let descriptor = "wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/44'/0'/0'/0/*)";
         let change_descriptor = "wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/50'/0'/1/*)";
 
-        let wallet: OfflineWallet<_> = Wallet::new_offline(
+        let wallet = Wallet::new_offline(
             descriptor,
             Some(change_descriptor),
             Network::Bitcoin,
@@ -295,7 +294,7 @@ mod test {
                                        [c98b1535/48'/0'/0'/2']tpubDCDi5W4sP6zSnzJeowy8rQDVhBdRARaPhK1axABi8V1661wEPeanpEXj4ZLAUEoikVtoWcyK26TKKJSecSfeKxwHCcRrge9k1ybuiL71z4a/1/*\
                                  ))";
 
-        let wallet: OfflineWallet<_> = Wallet::new_offline(
+        let wallet = Wallet::new_offline(
             descriptor,
             Some(change_descriptor),
             Network::Testnet,
@@ -315,7 +314,7 @@ mod test {
         let descriptor = "wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/44'/0'/0'/0/*)";
         let change_descriptor = "wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/44'/0'/0'/1/*)";
 
-        let wallet: OfflineWallet<_> = Wallet::new_offline(
+        let wallet = Wallet::new_offline(
             descriptor,
             Some(change_descriptor),
             Network::Bitcoin,

--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -79,7 +79,7 @@
 //! let custom_signer = CustomSigner::connect();
 //!
 //! let descriptor = "wpkh(tpubD6NzVbkrYhZ4Xferm7Pz4VnjdcDPFyjVu5K4iZXQ4pVN8Cks4pHVowTBXBKRhX64pkRyJZJN5xAKj4UDNnLPb5p2sSKXhewoYx5GbTdUFWq/*)";
-//! let mut wallet: OfflineWallet<_> = Wallet::new_offline(descriptor, None, Network::Testnet, MemoryDatabase::default())?;
+//! let mut wallet = Wallet::new_offline(descriptor, None, Network::Testnet, MemoryDatabase::default())?;
 //! wallet.add_signer(
 //!     KeychainKind::External,
 //!     Fingerprint::from_str("e30f11b8").unwrap().into(),


### PR DESCRIPTION
### Description

Greatly simplifies the "offline" blockchain by using the unit type `()` to as the type for the blockchain when it's missing.
This means:

1. There are no runtime errors associated with calling a method on something that doesn't have a blockchain
2. There less type annotations needed
3. Less traits and stuff to document

I made this PR because this was creating some friction while I was doing other things.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [x] I've updated `CHANGELOG.md`
* [x] This pull request breaks the existing API

