### PR TITLE
Fix CI workflow clippy step to enable matrix features

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Build
         run: cargo build --features ${{ matrix.features }} --no-default-features
       - name: Clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --features ${{ matrix.features }} --no-default-features -- -D warnings
       - name: Test
         run: cargo test --features ${{ matrix.features }} --no-default-features
 

--- a/src/blockchain/compact_filters/mod.rs
+++ b/src/blockchain/compact_filters/mod.rs
@@ -131,7 +131,7 @@ impl CompactFiltersBlockchain {
 
         let network = peers[0].get_network();
 
-        let cfs = DB::list_cf(&opts, &storage_dir).unwrap_or(vec!["default".to_string()]);
+        let cfs = DB::list_cf(&opts, &storage_dir).unwrap_or_else(|_| vec!["default".to_string()]);
         let db = DB::open_cf(&opts, &storage_dir, &cfs)?;
         let headers = Arc::new(ChainStore::new(db, network)?);
 
@@ -221,7 +221,7 @@ impl CompactFiltersBlockchain {
                 sent: outgoing,
                 height,
                 timestamp,
-                fees: inputs_sum.checked_sub(outputs_sum).unwrap_or(0),
+                fees: inputs_sum.saturating_sub(outputs_sum),
             };
 
             info!("Saving tx {}", tx.txid);
@@ -257,13 +257,10 @@ impl Blockchain for CompactFiltersBlockchain {
             .map(|x| x / 1000)
             .unwrap_or(0)
             + 1;
-        let expected_bundles_to_sync = total_bundles
-            .checked_sub(cf_sync.pruned_bundles()?)
-            .unwrap_or(0);
+        let expected_bundles_to_sync = total_bundles.saturating_sub(cf_sync.pruned_bundles()?);
 
         let headers_cost = (first_peer.get_version().start_height as usize)
-            .checked_sub(initial_height)
-            .unwrap_or(0) as f32
+            .saturating_sub(initial_height) as f32
             * SYNC_HEADERS_COST;
         let filters_cost = expected_bundles_to_sync as f32 * SYNC_FILTERS_COST;
 
@@ -274,7 +271,7 @@ impl Blockchain for CompactFiltersBlockchain {
             Arc::clone(&self.headers),
             |new_height| {
                 let local_headers_cost =
-                    new_height.checked_sub(initial_height).unwrap_or(0) as f32 * SYNC_HEADERS_COST;
+                    new_height.saturating_sub(initial_height) as f32 * SYNC_HEADERS_COST;
                 progress_update.update(
                     local_headers_cost / total_cost * 100.0,
                     Some(format!("Synced headers to {}", new_height)),
@@ -288,9 +285,7 @@ impl Blockchain for CompactFiltersBlockchain {
         }
 
         let synced_height = self.headers.get_height()?;
-        let buried_height = synced_height
-            .checked_sub(sync::BURIED_CONFIRMATIONS)
-            .unwrap_or(0);
+        let buried_height = synced_height.saturating_sub(sync::BURIED_CONFIRMATIONS);
         info!("Synced headers to height: {}", synced_height);
 
         cf_sync.prepare_sync(Arc::clone(&first_peer))?;
@@ -303,7 +298,9 @@ impl Blockchain for CompactFiltersBlockchain {
                 .collect::<Vec<_>>(),
         );
 
+        #[allow(clippy::mutex_atomic)]
         let last_synced_block = Arc::new(Mutex::new(synced_height));
+
         let synced_bundles = Arc::new(AtomicUsize::new(0));
         let progress_update = Arc::new(Mutex::new(progress_update));
 
@@ -328,10 +325,7 @@ impl Blockchain for CompactFiltersBlockchain {
                         }
 
                         let block_height = headers.get_height_for(block_hash)?.unwrap_or(0);
-                        let saved_correct_block = match headers.get_full_block(block_height)? {
-                            Some(block) if &block.block_hash() == block_hash => true,
-                            _ => false,
-                        };
+                        let saved_correct_block = matches!(headers.get_full_block(block_height)?, Some(block) if &block.block_hash() == block_hash);
 
                         if saved_correct_block {
                             Ok(false)

--- a/src/blockchain/compact_filters/peer.rs
+++ b/src/blockchain/compact_filters/peer.rs
@@ -333,7 +333,7 @@ impl Peer {
                 NetworkMessage::Alert(_) => continue,
                 NetworkMessage::GetData(ref inv) => {
                     let (found, not_found): (Vec<_>, Vec<_>) = inv
-                        .into_iter()
+                        .iter()
                         .map(|item| (*item, reader_thread_mempool.get_tx(item)))
                         .partition(|(_, d)| d.is_some());
                     for (_, found_tx) in found {
@@ -518,10 +518,9 @@ impl InvPeer for Peer {
         let getdata = inv
             .iter()
             .cloned()
-            .filter(|item| match item {
-                Inventory::Transaction(txid) if !self.mempool.has_tx(txid) => true,
-                _ => false,
-            })
+            .filter(
+                |item| matches!(item, Inventory::Transaction(txid) if !self.mempool.has_tx(txid)),
+            )
             .collect::<Vec<_>>();
         let num_txs = getdata.len();
         self.send(NetworkMessage::GetData(getdata))?;

--- a/src/blockchain/compact_filters/store.rs
+++ b/src/blockchain/compact_filters/store.rs
@@ -375,7 +375,7 @@ impl ChainStore<Full> {
         let min_height = match iterator
             .next()
             .and_then(|(k, _)| k[1..].try_into().ok())
-            .map(|bytes| usize::from_be_bytes(bytes))
+            .map(usize::from_be_bytes)
         {
             None => {
                 std::mem::drop(iterator);
@@ -444,9 +444,6 @@ impl ChainStore<Full> {
         }
 
         read_store.write(batch)?;
-
-        std::mem::drop(snapshot_cf_handle);
-        std::mem::drop(cf_handle);
         std::mem::drop(read_store);
 
         self.store.write().unwrap().drop_cf(&snaphost.cf_name)?;
@@ -461,7 +458,7 @@ impl ChainStore<Full> {
         let read_store = self.store.read().unwrap();
         let cf_handle = read_store.cf_handle(&self.cf_name).unwrap();
 
-        let key = StoreEntry::BlockHeaderIndex(Some(block_hash.clone())).get_key();
+        let key = StoreEntry::BlockHeaderIndex(Some(*block_hash)).get_key();
         let data = read_store.get_pinned_cf(cf_handle, key)?;
         Ok(data
             .map(|data| {
@@ -642,7 +639,6 @@ impl<T: StoreType> ChainStore<T> {
             );
         }
 
-        std::mem::drop(cf_handle);
         std::mem::drop(read_store);
 
         self.store.write().unwrap().write(batch)?;

--- a/src/blockchain/compact_filters/sync.rs
+++ b/src/blockchain/compact_filters/sync.rs
@@ -204,9 +204,8 @@ impl CFSync {
             if let BundleStatus::CFilters { cf_filters } = status {
                 log::trace!("status: CFilters");
 
-                let last_sync_buried_height = (start_height + already_processed)
-                    .checked_sub(BURIED_CONFIRMATIONS)
-                    .unwrap_or(0);
+                let last_sync_buried_height =
+                    (start_height + already_processed).saturating_sub(BURIED_CONFIRMATIONS);
 
                 for (filter_index, filter) in cf_filters.iter().enumerate() {
                     let height = filter_index + start_height;
@@ -280,10 +279,7 @@ where
 
         match locators_map.get(&headers[0].prev_blockhash) {
             None => return Err(CompactFiltersError::InvalidHeaders),
-            Some(from) => (
-                store.start_snapshot(*from)?,
-                headers[0].prev_blockhash.clone(),
-            ),
+            Some(from) => (store.start_snapshot(*from)?, headers[0].prev_blockhash),
         }
     } else {
         return Err(CompactFiltersError::InvalidResponse);

--- a/src/error.rs
+++ b/src/error.rs
@@ -193,7 +193,7 @@ impl From<crate::blockchain::compact_filters::CompactFiltersError> for Error {
     fn from(other: crate::blockchain::compact_filters::CompactFiltersError) -> Self {
         match other {
             crate::blockchain::compact_filters::CompactFiltersError::Global(e) => *e,
-            err @ _ => Error::CompactFilters(err),
+            err => Error::CompactFilters(err),
         }
     }
 }


### PR DESCRIPTION
### Description

The CI workflow clippy check step wasn't enabling the features being tested in the workflow matrix. This PR fixes that issue and also fixes clippy issues found in the `compact_filters` feature. 

This change is related to #126 

### Notes to the reviewers

I had to allow the clippy:mutex_atomic warning in `blockchain/compact_filters/mod.rs` because if we change the Mutex<usize> to an AtomicUsize we won't get the locking of that value needed for lines 372-441.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
