### PR TITLE
[wallet] Transaction creation overhaul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove `BlockchainMarker`, `OfflineClient` and `OfflineWallet` in favor of just using the unit
   type to mark for a missing client.
 - Upgrade `tokio` to `1.0`.
-  
+
 #### Transaction Creation Overhaul
 
 The `TxBuilder` is now created from the `build_tx` or `build_fee_bump` functions on wallet and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The `TxBuilder` is now created from the `build_tx` or `build_fee_bump` functions on wallet and the
 final transaction is created by calling `finish` on the builder.
 
-- Removed `TxBuilder::utxos` in favor of repeatedly calling `add_utxo`
+- Removed `TxBuilder::utxos` in favor of `TxBuilder::add_utxos`
 - Added `Wallet::build_tx` to replace `Wallet::create_tx`
 - Added `Wallet::build_fee_bump` to replace `Wallet::bump_fee`
 - Added `Wallet::get_utxo`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 - Remove `BlockchainMarker`, `OfflineClient` and `OfflineWallet` in favor of just using the unit
   type to mark for a missing client.
+  
+#### Transaction Creation Overhaul
+
+The `TxBuilder` is now created from the `build_tx` or `build_fee_bump` functions on wallet and the
+final transaction is created by calling `finish` on the builder.
+
+- Removed `TxBuilder::utxos` in favor of repeatedly calling `add_utxo`
+- Added `Wallet::build_tx` to replace `Wallet::create_tx`
+- Added `Wallet::build_fee_bump` to replace `Wallet::bump_fee`
+- Added `Wallet::get_utxo`
+- Added `Wallet::get_descriptor_for_keychain`
 
 ### CLI
 #### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,8 +60,8 @@ test-electrum = ["electrum"]
 test-md-docs = ["electrum"]
 
 [dev-dependencies]
-bdk-testutils = "0.2"
-bdk-testutils-macros = "0.2"
+bdk-testutils = { path = "./testutils" }
+bdk-testutils-macros = { path = "./testutils-macros" }
 serial_test = "0.4"
 lazy_static = "1.4"
 env_logger = "0.7"

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ fn main() -> Result<(), bdk::Error> {
     wallet.sync(noop_progress(), None)?;
 
     let send_to = wallet.get_new_address()?;
-    let (psbt, details) = { 
+    let (psbt, details) = {
         let mut builder = wallet.build_tx();
         builder
             .add_recipient(send_to.script_pubkey(), 50_000)

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ fn main() -> Result<(), bdk::Error> {
 ### Create a transaction
 
 ```rust,no_run
-use bdk::{FeeRate, TxBuilder, Wallet};
+use bdk::{FeeRate, Wallet};
 use bdk::database::MemoryDatabase;
 use bdk::blockchain::{noop_progress, ElectrumBlockchain};
 
@@ -108,12 +108,12 @@ fn main() -> Result<(), bdk::Error> {
     wallet.sync(noop_progress(), None)?;
 
     let send_to = wallet.get_new_address()?;
-    let (psbt, details) = wallet.create_tx(
-        TxBuilder::with_recipients(vec![(send_to.script_pubkey(), 50_000)])
-            .enable_rbf()
-            .do_not_spend_change()
-            .fee_rate(FeeRate::from_sat_per_vb(5.0))
-    )?;
+    let (psbt, details) = wallet.build_tx()
+        .add_recipient(send_to.script_pubkey(), 50_000)
+        .enable_rbf()
+        .do_not_spend_change()
+        .fee_rate(FeeRate::from_sat_per_vb(5.0))
+        .finish()?;
 
     println!("Transaction details: {:#?}", details);
     println!("Unsigned PSBT: {}", base64::encode(&serialize(&psbt)));

--- a/README.md
+++ b/README.md
@@ -108,12 +108,15 @@ fn main() -> Result<(), bdk::Error> {
     wallet.sync(noop_progress(), None)?;
 
     let send_to = wallet.get_new_address()?;
-    let (psbt, details) = wallet.build_tx()
-        .add_recipient(send_to.script_pubkey(), 50_000)
-        .enable_rbf()
-        .do_not_spend_change()
-        .fee_rate(FeeRate::from_sat_per_vb(5.0))
-        .finish()?;
+    let (psbt, details) = { 
+        let mut builder = wallet.build_tx();
+        builder
+            .add_recipient(send_to.script_pubkey(), 50_000)
+            .enable_rbf()
+            .do_not_spend_change()
+            .fee_rate(FeeRate::from_sat_per_vb(5.0));
+        builder.finish()?
+    };
 
     println!("Transaction details: {:#?}", details);
     println!("Unsigned PSBT: {}", base64::encode(&serialize(&psbt)));

--- a/examples/address_validator.rs
+++ b/examples/address_validator.rs
@@ -35,6 +35,7 @@ use bitcoin::hashes::hex::FromHex;
 use bitcoin::util::bip32::Fingerprint;
 use bitcoin::{Network, Script};
 
+#[derive(Debug)]
 struct DummyValidator;
 impl AddressValidator for DummyValidator {
     fn validate(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@
 //! ### Example
 //! ```ignore
 //! use base64::decode;
-//! use bdk::{FeeRate, TxBuilder, Wallet};
+//! use bdk::{FeeRate, Wallet};
 //! use bdk::database::MemoryDatabase;
 //! use bdk::blockchain::{noop_progress, ElectrumBlockchain};
 //!
@@ -136,12 +136,12 @@
 //!     wallet.sync(noop_progress(), None)?;
 //!
 //!     let send_to = wallet.get_new_address()?;
-//!     let (psbt, details) = wallet.create_tx(
-//!         TxBuilder::with_recipients(vec![(send_to.script_pubkey(), 50_000)])
-//!             .enable_rbf()
-//!             .do_not_spend_change()
-//!             .fee_rate(FeeRate::from_sat_per_vb(5.0))
-//!     )?;
+//!     let (psbt, details) = wallet.build_tx()
+//!         .add_recipient(send_to.script_pubkey(), 50_000)
+//!         .enable_rbf()
+//!         .do_not_spend_change()
+//!         .fee_rate(FeeRate::from_sat_per_vb(5.0))
+//!         .finish()?;
 //!
 //!     println!("Transaction details: {:#?}", details);
 //!     println!("Unsigned PSBT: {}", base64::encode(&serialize(&psbt)));

--- a/src/wallet/address_validator.rs
+++ b/src/wallet/address_validator.rs
@@ -156,10 +156,8 @@ mod test {
         wallet.add_address_validator(Arc::new(TestValidator));
 
         let addr = testutils!(@external descriptors, 10);
-        wallet
-            .build_tx()
-            .add_recipient(addr.script_pubkey(), 25_000)
-            .finish()
-            .unwrap();
+        let mut builder = wallet.build_tx();
+        builder.add_recipient(addr.script_pubkey(), 25_000);
+        builder.finish().unwrap();
     }
 }

--- a/src/wallet/address_validator.rs
+++ b/src/wallet/address_validator.rs
@@ -127,7 +127,6 @@ mod test {
 
     use super::*;
     use crate::wallet::test::{get_funded_wallet, get_test_wpkh};
-    use crate::wallet::TxBuilder;
 
     struct TestValidator;
     impl AddressValidator for TestValidator {
@@ -158,10 +157,9 @@ mod test {
 
         let addr = testutils!(@external descriptors, 10);
         wallet
-            .create_tx(TxBuilder::with_recipients(vec![(
-                addr.script_pubkey(),
-                25_000,
-            )]))
+            .build_tx()
+            .add_recipient(addr.script_pubkey(), 25_000)
+            .finish()
             .unwrap();
     }
 }

--- a/src/wallet/address_validator.rs
+++ b/src/wallet/address_validator.rs
@@ -45,6 +45,7 @@
 //! # use bdk::address_validator::*;
 //! # use bdk::database::*;
 //! # use bdk::*;
+//! #[derive(Debug)]
 //! struct PrintAddressAndContinue;
 //!
 //! impl AddressValidator for PrintAddressAndContinue {
@@ -111,7 +112,7 @@ impl std::error::Error for AddressValidatorError {}
 /// validator will be propagated up to the original caller that triggered the address generation.
 ///
 /// For a usage example see [this module](crate::address_validator)'s documentation.
-pub trait AddressValidator: Send + Sync {
+pub trait AddressValidator: Send + Sync + fmt::Debug {
     /// Validate or inspect an address
     fn validate(
         &self,
@@ -128,6 +129,7 @@ mod test {
     use super::*;
     use crate::wallet::test::{get_funded_wallet, get_test_wpkh};
 
+    #[derive(Debug)]
     struct TestValidator;
     impl AddressValidator for TestValidator {
         fn validate(

--- a/src/wallet/coin_selection.rs
+++ b/src/wallet/coin_selection.rs
@@ -32,7 +32,7 @@
 //! be used if it is not explicitly set.
 //!
 //! [`TxBuilder`]: super::tx_builder::TxBuilder
-//! [`coin_selection`]: super::tx_builder::coin_selection
+//! [`coin_selection`]: super::tx_builder::TxBuilder::coin_selection
 //!
 //! ## Example
 //!

--- a/src/wallet/coin_selection.rs
+++ b/src/wallet/coin_selection.rs
@@ -36,7 +36,7 @@
 //!
 //! ## Example
 //!
-//! ```no_run
+//! ```
 //! # use std::str::FromStr;
 //! # use bitcoin::*;
 //! # use bdk::wallet::coin_selection::*;
@@ -81,7 +81,7 @@
 //!     }
 //! }
 //!
-//! # let wallet = Wallet::new_offline("", None, Network::Testnet, bdk::database::MemoryDatabase::default())?;
+//! # let wallet = doctest_wallet!();
 //! // create wallet, sync, ...
 //!
 //! let to_address = Address::from_str("2N4eQYCbKUHCCTUjBJeHcJp9ok6J2GZsTDt").unwrap();

--- a/src/wallet/coin_selection.rs
+++ b/src/wallet/coin_selection.rs
@@ -85,9 +85,12 @@
 //! // create wallet, sync, ...
 //!
 //! let to_address = Address::from_str("2N4eQYCbKUHCCTUjBJeHcJp9ok6J2GZsTDt").unwrap();
-//! let (psbt, details) = wallet.build_tx().coin_selection(AlwaysSpendEverything)
-//!     .add_recipient(to_address.script_pubkey(), 50_000)
-//!     .finish()?;
+//! let (psbt, details) = {
+//!     let mut builder = wallet.build_tx().coin_selection(AlwaysSpendEverything);
+//!     builder
+//!         .add_recipient(to_address.script_pubkey(), 50_000);
+//!     builder.finish()?
+//! };
 //!
 //! // inspect, sign, broadcast, ...
 //!

--- a/src/wallet/coin_selection.rs
+++ b/src/wallet/coin_selection.rs
@@ -27,15 +27,12 @@
 //! This module provides the trait [`CoinSelectionAlgorithm`] that can be implemented to
 //! define custom coin selection algorithms.
 //!
-//! The coin selection algorithm is not globally part of a [`Wallet`](super::Wallet), instead it
-//! is selected whenever a [`Wallet::create_tx`](super::Wallet::create_tx) call is made, through
-//! the use of the [`TxBuilder`] structure, specifically with
-//! [`TxBuilder::coin_selection`](super::tx_builder::TxBuilder::coin_selection) method.
-//!
-//! The [`DefaultCoinSelectionAlgorithm`] selects the default coin selection algorithm that
-//! [`TxBuilder`] uses, if it's not explicitly overridden.
+//! You can specify a custom coin selection algorithm through the [`coin_selection`] method on
+//! [`TxBuilder`]. [`DefaultCoinSelectionAlgorithm`] aliases the coin selection algorithm that will
+//! be used if it is not explicitly set.
 //!
 //! [`TxBuilder`]: super::tx_builder::TxBuilder
+//! [`coin_selection`]: super::tx_builder::coin_selection
 //!
 //! ## Example
 //!
@@ -88,10 +85,9 @@
 //! // create wallet, sync, ...
 //!
 //! let to_address = Address::from_str("2N4eQYCbKUHCCTUjBJeHcJp9ok6J2GZsTDt").unwrap();
-//! let (psbt, details) = wallet.create_tx(
-//!     TxBuilder::with_recipients(vec![(to_address.script_pubkey(), 50_000)])
-//!         .coin_selection(AlwaysSpendEverything),
-//! )?;
+//! let (psbt, details) = wallet.build_tx().coin_selection(AlwaysSpendEverything)
+//!     .add_recipient(to_address.script_pubkey(), 50_000)
+//!     .finish()?;
 //!
 //! // inspect, sign, broadcast, ...
 //!

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -2543,7 +2543,8 @@ mod test {
         let mut builder = wallet.build_fee_bump(txid).unwrap();
         builder
             .fee_rate(FeeRate::from_sat_per_vb(2.5))
-            .maintain_single_recipient();
+            .maintain_single_recipient()
+            .unwrap();
         let (psbt, details) = builder.finish().unwrap();
 
         assert_eq!(details.sent, original_details.sent);
@@ -2584,7 +2585,10 @@ mod test {
             .unwrap();
 
         let mut builder = wallet.build_fee_bump(txid).unwrap();
-        builder.maintain_single_recipient().fee_absolute(300);
+        builder
+            .maintain_single_recipient()
+            .unwrap()
+            .fee_absolute(300);
         let (psbt, details) = builder.finish().unwrap();
 
         assert_eq!(details.sent, original_details.sent);
@@ -2643,6 +2647,7 @@ mod test {
         builder
             .drain_wallet()
             .maintain_single_recipient()
+            .unwrap()
             .fee_rate(FeeRate::from_sat_per_vb(5.0));
         let (_, details) = builder.finish().unwrap();
         assert_eq!(details.sent, 75_000);

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -448,7 +448,6 @@ where
             output: vec![],
         };
 
-        // try not to move from `params` because we still need to use it later.
         let recipients = match &params.single_recipient {
             Some(recipient) => vec![(recipient, 0)],
             None => params.recipients.iter().map(|(r, v)| (r, *v)).collect(),

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1569,11 +1569,12 @@ mod test {
         )
         .unwrap();
 
-        let txid = wallet.database.borrow_mut().received_tx(
+        let txid = crate::populate_test_db!(
+            wallet.database.borrow_mut(),
             testutils! {
                 @tx ( (@external descriptors, 0) => 50_000 ) (@confirmations 1)
             },
-            Some(100),
+            Some(100)
         );
 
         (wallet, descriptors, txid)
@@ -2262,7 +2263,8 @@ mod test {
     #[test]
     fn test_create_tx_add_utxo() {
         let (wallet, descriptors, _) = get_funded_wallet(get_test_wpkh());
-        let small_output_txid = wallet.database.borrow_mut().received_tx(
+        let small_output_txid = crate::populate_test_db!(
+            wallet.database.borrow_mut(),
             testutils! (@tx ( (@external descriptors, 0) => 25_000 ) (@confirmations 1)),
             Some(100),
         );
@@ -2291,7 +2293,8 @@ mod test {
     #[should_panic(expected = "InsufficientFunds")]
     fn test_create_tx_manually_selected_insufficient() {
         let (wallet, descriptors, _) = get_funded_wallet(get_test_wpkh());
-        let small_output_txid = wallet.database.borrow_mut().received_tx(
+        let small_output_txid = crate::populate_test_db!(
+            wallet.database.borrow_mut(),
             testutils! (@tx ( (@external descriptors, 0) => 25_000 ) (@confirmations 1)),
             Some(100),
         );
@@ -2765,7 +2768,8 @@ mod test {
     fn test_bump_fee_drain_wallet() {
         let (wallet, descriptors, _) = get_funded_wallet(get_test_wpkh());
         // receive an extra tx so that our wallet has two utxos.
-        let incoming_txid = wallet.database.borrow_mut().received_tx(
+        let incoming_txid = crate::populate_test_db!(
+            wallet.database.borrow_mut(),
             testutils! (@tx ( (@external descriptors, 0) => 25_000 ) (@confirmations 1)),
             Some(100),
         );
@@ -2823,7 +2827,8 @@ mod test {
         // them, and make sure that `bump_fee` doesn't try to add more. eventually, it should fail
         // because the fee rate is too high and the single utxo isn't enough to create a non-dust
         // output
-        let incoming_txid = wallet.database.borrow_mut().received_tx(
+        let incoming_txid = crate::populate_test_db!(
+            wallet.database.borrow_mut(),
             testutils! (@tx ( (@external descriptors, 0) => 25_000 ) (@confirmations 1)),
             Some(100),
         );
@@ -2873,7 +2878,8 @@ mod test {
     #[test]
     fn test_bump_fee_add_input() {
         let (wallet, descriptors, _) = get_funded_wallet(get_test_wpkh());
-        wallet.database.borrow_mut().received_tx(
+        crate::populate_test_db!(
+            wallet.database.borrow_mut(),
             testutils! (@tx ( (@external descriptors, 0) => 25_000 ) (@confirmations 1)),
             Some(100),
         );
@@ -2938,7 +2944,8 @@ mod test {
     #[test]
     fn test_bump_fee_absolute_add_input() {
         let (wallet, descriptors, _) = get_funded_wallet(get_test_wpkh());
-        wallet.database.borrow_mut().received_tx(
+        crate::populate_test_db!(
+            wallet.database.borrow_mut(),
             testutils! (@tx ( (@external descriptors, 0) => 25_000 ) (@confirmations 1)),
             Some(100),
         );
@@ -3000,7 +3007,8 @@ mod test {
     #[test]
     fn test_bump_fee_no_change_add_input_and_change() {
         let (wallet, descriptors, _) = get_funded_wallet(get_test_wpkh());
-        let incoming_txid = wallet.database.borrow_mut().received_tx(
+        let incoming_txid = crate::populate_test_db!(
+            wallet.database.borrow_mut(),
             testutils! (@tx ( (@external descriptors, 0) => 25_000 ) (@confirmations 1)),
             Some(100),
         );
@@ -3079,7 +3087,8 @@ mod test {
     #[test]
     fn test_bump_fee_add_input_change_dust() {
         let (wallet, descriptors, _) = get_funded_wallet(get_test_wpkh());
-        wallet.database.borrow_mut().received_tx(
+        crate::populate_test_db!(
+            wallet.database.borrow_mut(),
             testutils! (@tx ( (@external descriptors, 0) => 25_000 ) (@confirmations 1)),
             Some(100),
         );
@@ -3141,7 +3150,8 @@ mod test {
     #[test]
     fn test_bump_fee_force_add_input() {
         let (wallet, descriptors, _) = get_funded_wallet(get_test_wpkh());
-        let incoming_txid = wallet.database.borrow_mut().received_tx(
+        let incoming_txid = crate::populate_test_db!(
+            wallet.database.borrow_mut(),
             testutils! (@tx ( (@external descriptors, 0) => 25_000 ) (@confirmations 1)),
             Some(100),
         );
@@ -3213,7 +3223,8 @@ mod test {
     #[test]
     fn test_bump_fee_absolute_force_add_input() {
         let (wallet, descriptors, _) = get_funded_wallet(get_test_wpkh());
-        let incoming_txid = wallet.database.borrow_mut().received_tx(
+        let incoming_txid = crate::populate_test_db!(
+            wallet.database.borrow_mut(),
             testutils! (@tx ( (@external descriptors, 0) => 25_000 ) (@confirmations 1)),
             Some(100),
         );

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -87,6 +87,7 @@ const CACHE_ADDR_BATCH_SIZE: u32 = 100;
 /// A wallet can be either "online" if the [`blockchain`](crate::blockchain) type provided
 /// implements [`Blockchain`], or "offline" if it is the unit type `()`. Offline wallets only expose
 /// methods that don't need any interaction with the blockchain to work.
+#[derive(Debug)]
 pub struct Wallet<B, D> {
     descriptor: ExtendedDescriptor,
     change_descriptor: Option<ExtendedDescriptor>,

--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -414,6 +414,10 @@ impl<'a, B, D: BatchDatabase, Cs: CoinSelectionAlgorithm<D>, Ctx: TxBuilderConte
         self,
         coin_selection: P,
     ) -> TxBuilder<'a, B, D, P, Ctx> {
+        assert!(
+            self.coin_selection.is_some(),
+            "can't set coin_selection after finish() has been called"
+        );
         TxBuilder {
             wallet: self.wallet,
             params: self.params,

--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -514,12 +514,13 @@ impl<'a, B, D: BatchDatabase> TxBuilder<'a, B, D, DefaultCoinSelectionAlgorithm,
     /// Fails if the transaction has more than one outputs.
     ///
     /// [`add_utxo`]: Self::add_utxo
-    pub fn maintain_single_recipient(&mut self) -> &mut Self {
+    pub fn maintain_single_recipient(&mut self) -> Result<&mut Self, Error> {
         let mut recipients = self.params.recipients.drain(..).collect::<Vec<_>>();
-        assert_eq!(recipients.len(), 1, "maintain_single_recipient must not be called while bumping a transactions with more than one output");
+        if recipients.len() != 1 {
+            return Err(Error::SingleRecipientMultipleOutputs);
+        }
         self.params.single_recipient = Some(recipients.pop().unwrap().0);
-        // Since we are fee bumping and maintaining a single recipient we never want to add any more non-manual inputs.
-        self
+        Ok(self)
     }
 }
 

--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -127,6 +127,7 @@ impl TxBuilderContext for BumpFee {}
 /// [`build_fee_bump`]: Wallet::build_fee_bump
 /// [`finish`]: Self::finish
 /// [`coin_selection`]: Self::coin_selection
+#[derive(Clone, Debug)]
 pub struct TxBuilder<'a, B, D, Cs, Ctx> {
     pub(crate) wallet: &'a Wallet<B, D>,
     // params and coin_selection are Options not becasue they are optionally set (they are always
@@ -139,7 +140,7 @@ pub struct TxBuilder<'a, B, D, Cs, Ctx> {
 
 /// The parameters for transaction creation sans coin selection algorithm.
 //TODO: TxParams should eventually be exposed publicly.
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone)]
 pub(crate) struct TxParams {
     pub(crate) recipients: Vec<(Script, u64)>,
     pub(crate) drain_wallet: bool,
@@ -168,7 +169,7 @@ pub(crate) struct PreviousFee {
     pub rate: f32,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) enum FeePolicy {
     FeeRate(FeeRate),
     FeeAmount(u64),

--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -124,8 +124,11 @@ impl TxBuilderContext for BumpFee {}
 /// [`finish`]: Self::finish
 /// [`coin_selection`]: Self::coin_selection
 pub struct TxBuilder<'a, B, D, Cs, Ctx> {
-    pub(crate) params: Option<TxParams>,
     pub(crate) wallet: &'a Wallet<B, D>,
+    // params and coin_selection are Options not becasue they are optionally set (they are always
+    // there) but because `.finish()` uses `Option::take` to get an owned value from a &mut self.
+    // They are only `None` after `.finish()` is called.
+    pub(crate) params: Option<TxParams>,
     pub(crate) coin_selection: Option<Cs>,
     pub(crate) phantom: PhantomData<Ctx>,
 }

--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -119,8 +119,8 @@ impl TxBuilderContext for BumpFee {}
 ///
 /// For further examples see [this module](super::tx_builder)'s documentation;
 ///
-/// [`build_tx`]: Self::build_tx
-/// [`build_fee_bump`]: Self::build_fee_bump
+/// [`build_tx`]: Wallet::build_tx
+/// [`build_fee_bump`]: Wallet::build_fee_bump
 /// [`finish`]: Self::finish
 /// [`coin_selection`]: Self::coin_selection
 pub struct TxBuilder<'a, B, D, Cs, Ctx> {

--- a/testutils-macros/src/lib.rs
+++ b/testutils-macros/src/lib.rs
@@ -307,7 +307,9 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     wallet.sync(noop_progress(), None).unwrap();
                     assert_eq!(wallet.get_balance().unwrap(), 50_000);
 
-                    let (psbt, details) = wallet.build_tx().add_recipient(node_addr.script_pubkey(), 25_000).finish().unwrap();
+                    let mut builder = wallet.build_tx();
+                    builder.add_recipient(node_addr.script_pubkey(), 25_000);
+                    let (psbt, details) = builder.finish().unwrap();
                     let (psbt, finalized) = wallet.sign(psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     let tx = psbt.extract_tx();
@@ -334,7 +336,9 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     wallet.sync(noop_progress(), None).unwrap();
                     assert_eq!(wallet.get_balance().unwrap(), 50_000);
 
-                    let (psbt, details) = wallet.build_tx().add_recipient(node_addr.script_pubkey(), 25_000).finish().unwrap();
+                    let mut builder = wallet.build_tx();
+                    builder.add_recipient(node_addr.script_pubkey(), 25_000);
+                    let (psbt, details) = builder.finish().unwrap();
                     let (psbt, finalized) = wallet.sign(psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     let sent_txid = wallet.broadcast(psbt.extract_tx()).unwrap();
@@ -373,7 +377,9 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
 
                     let mut total_sent = 0;
                     for _ in 0..5 {
-                        let (psbt, details) = wallet.build_tx().add_recipient(node_addr.script_pubkey(), 5_000).finish().unwrap();
+                        let mut builder = wallet.build_tx();
+                        builder.add_recipient(node_addr.script_pubkey(), 5_000);
+                        let (psbt, details) = builder.finish().unwrap();
                         let (psbt, finalized) = wallet.sign(psbt, None).unwrap();
                         assert!(finalized, "Cannot finalize transaction");
                         wallet.broadcast(psbt.extract_tx()).unwrap();
@@ -405,7 +411,9 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     wallet.sync(noop_progress(), None).unwrap();
                     assert_eq!(wallet.get_balance().unwrap(), 50_000);
 
-                    let (psbt, details) = wallet.build_tx().add_recipient(node_addr.script_pubkey().clone(), 5_000).enable_rbf().finish().unwrap();
+                    let mut builder = wallet.build_tx();
+                    builder.add_recipient(node_addr.script_pubkey().clone(), 5_000).enable_rbf();
+                    let (psbt, details) = builder.finish().unwrap();
                     let (psbt, finalized) = wallet.sign(psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(psbt.extract_tx()).unwrap();
@@ -413,7 +421,9 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     assert_eq!(wallet.get_balance().unwrap(), 50_000 - details.fees - 5_000);
                     assert_eq!(wallet.get_balance().unwrap(), details.received);
 
-                    let (new_psbt, new_details) = wallet.build_fee_bump(details.txid).unwrap().fee_rate(FeeRate::from_sat_per_vb(2.1)).finish().unwrap();
+                    let mut builder = wallet.build_fee_bump(details.txid).unwrap();
+                    builder.fee_rate(FeeRate::from_sat_per_vb(2.1));
+                    let (new_psbt, new_details) = builder.finish().unwrap();
                     let (new_psbt, finalized) = wallet.sign(new_psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(new_psbt.extract_tx()).unwrap();
@@ -437,7 +447,9 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     wallet.sync(noop_progress(), None).unwrap();
                     assert_eq!(wallet.get_balance().unwrap(), 50_000);
 
-                    let (psbt, details) = wallet.build_tx().add_recipient(node_addr.script_pubkey().clone(), 49_000).enable_rbf().finish().unwrap();
+                    let mut builder = wallet.build_tx();
+                    builder.add_recipient(node_addr.script_pubkey().clone(), 49_000).enable_rbf();
+                    let (psbt, details) = builder.finish().unwrap();
                     let (psbt, finalized) = wallet.sign(psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(psbt.extract_tx()).unwrap();
@@ -445,7 +457,9 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     assert_eq!(wallet.get_balance().unwrap(), 1_000 - details.fees);
                     assert_eq!(wallet.get_balance().unwrap(), details.received);
 
-                    let (new_psbt, new_details) = wallet.build_fee_bump(details.txid).unwrap().fee_rate(FeeRate::from_sat_per_vb(5.0)).finish().unwrap();
+                    let mut builder = wallet.build_fee_bump(details.txid).unwrap();
+                    builder.fee_rate(FeeRate::from_sat_per_vb(5.0));
+                    let (new_psbt, new_details) = builder.finish().unwrap();
                     let (new_psbt, finalized) = wallet.sign(new_psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(new_psbt.extract_tx()).unwrap();
@@ -469,7 +483,9 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     wallet.sync(noop_progress(), None).unwrap();
                     assert_eq!(wallet.get_balance().unwrap(), 75_000);
 
-                    let (psbt, details) = wallet.build_tx().add_recipient(node_addr.script_pubkey().clone(), 49_000).enable_rbf().finish().unwrap();
+                    let mut builder = wallet.build_tx();
+                    builder.add_recipient(node_addr.script_pubkey().clone(), 49_000).enable_rbf();
+                    let (psbt, details) = builder.finish().unwrap();
                     let (psbt, finalized) = wallet.sign(psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(psbt.extract_tx()).unwrap();
@@ -477,7 +493,9 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     assert_eq!(wallet.get_balance().unwrap(), 26_000 - details.fees);
                     assert_eq!(details.received, 1_000 - details.fees);
 
-                    let (new_psbt, new_details) = wallet.build_fee_bump(details.txid).unwrap().fee_rate(FeeRate::from_sat_per_vb(10.0)).finish().unwrap();
+                    let mut builder = wallet.build_fee_bump(details.txid).unwrap();
+                    builder.fee_rate(FeeRate::from_sat_per_vb(10.0));
+                    let (new_psbt, new_details) = builder.finish().unwrap();
                     let (new_psbt, finalized) = wallet.sign(new_psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(new_psbt.extract_tx()).unwrap();
@@ -499,7 +517,9 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     wallet.sync(noop_progress(), None).unwrap();
                     assert_eq!(wallet.get_balance().unwrap(), 75_000);
 
-                    let (psbt, details) = wallet.build_tx().add_recipient(node_addr.script_pubkey().clone(), 49_000).enable_rbf().finish().unwrap();
+                    let mut builder = wallet.build_tx();
+                    builder.add_recipient(node_addr.script_pubkey().clone(), 49_000).enable_rbf();
+                    let (psbt, details) = builder.finish().unwrap();
                     let (psbt, finalized) = wallet.sign(psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(psbt.extract_tx()).unwrap();
@@ -507,7 +527,9 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     assert_eq!(wallet.get_balance().unwrap(), 26_000 - details.fees);
                     assert_eq!(details.received, 1_000 - details.fees);
 
-                    let (new_psbt, new_details) = wallet.build_fee_bump(details.txid).unwrap().fee_rate(FeeRate::from_sat_per_vb(123.0)).finish().unwrap();
+                    let mut builder = wallet.build_fee_bump(details.txid).unwrap();
+                    builder.fee_rate(FeeRate::from_sat_per_vb(123.0));
+                    let (new_psbt, new_details) = builder.finish().unwrap();
                     println!("{:#?}", new_details);
 
                     let (new_psbt, finalized) = wallet.sign(new_psbt, None).unwrap();

--- a/testutils-macros/src/lib.rs
+++ b/testutils-macros/src/lib.rs
@@ -307,7 +307,7 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     wallet.sync(noop_progress(), None).unwrap();
                     assert_eq!(wallet.get_balance().unwrap(), 50_000);
 
-                    let (psbt, details) = wallet.create_tx(TxBuilder::with_recipients(vec![(node_addr.script_pubkey(), 25_000)])).unwrap();
+                    let (psbt, details) = wallet.build_tx().add_recipient(node_addr.script_pubkey(), 25_000).finish().unwrap();
                     let (psbt, finalized) = wallet.sign(psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     let tx = psbt.extract_tx();
@@ -334,7 +334,7 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     wallet.sync(noop_progress(), None).unwrap();
                     assert_eq!(wallet.get_balance().unwrap(), 50_000);
 
-                    let (psbt, details) = wallet.create_tx(TxBuilder::with_recipients(vec![(node_addr.script_pubkey(), 25_000)])).unwrap();
+                    let (psbt, details) = wallet.build_tx().add_recipient(node_addr.script_pubkey(), 25_000).finish().unwrap();
                     let (psbt, finalized) = wallet.sign(psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     let sent_txid = wallet.broadcast(psbt.extract_tx()).unwrap();
@@ -373,7 +373,7 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
 
                     let mut total_sent = 0;
                     for _ in 0..5 {
-                        let (psbt, details) = wallet.create_tx(TxBuilder::with_recipients(vec![(node_addr.script_pubkey().clone(), 5_000)])).unwrap();
+                        let (psbt, details) = wallet.build_tx().add_recipient(node_addr.script_pubkey(), 5_000).finish().unwrap();
                         let (psbt, finalized) = wallet.sign(psbt, None).unwrap();
                         assert!(finalized, "Cannot finalize transaction");
                         wallet.broadcast(psbt.extract_tx()).unwrap();
@@ -405,7 +405,7 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     wallet.sync(noop_progress(), None).unwrap();
                     assert_eq!(wallet.get_balance().unwrap(), 50_000);
 
-                    let (psbt, details) = wallet.create_tx(TxBuilder::with_recipients(vec![(node_addr.script_pubkey().clone(), 5_000)]).enable_rbf()).unwrap();
+                    let (psbt, details) = wallet.build_tx().add_recipient(node_addr.script_pubkey().clone(), 5_000).enable_rbf().finish().unwrap();
                     let (psbt, finalized) = wallet.sign(psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(psbt.extract_tx()).unwrap();
@@ -413,7 +413,7 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     assert_eq!(wallet.get_balance().unwrap(), 50_000 - details.fees - 5_000);
                     assert_eq!(wallet.get_balance().unwrap(), details.received);
 
-                    let (new_psbt, new_details) = wallet.bump_fee(&details.txid, TxBuilder::new().fee_rate(FeeRate::from_sat_per_vb(2.1))).unwrap();
+                    let (new_psbt, new_details) = wallet.build_fee_bump(details.txid).unwrap().fee_rate(FeeRate::from_sat_per_vb(2.1)).finish().unwrap();
                     let (new_psbt, finalized) = wallet.sign(new_psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(new_psbt.extract_tx()).unwrap();
@@ -437,7 +437,7 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     wallet.sync(noop_progress(), None).unwrap();
                     assert_eq!(wallet.get_balance().unwrap(), 50_000);
 
-                    let (psbt, details) = wallet.create_tx(TxBuilder::with_recipients(vec![(node_addr.script_pubkey().clone(), 49_000)]).enable_rbf()).unwrap();
+                    let (psbt, details) = wallet.build_tx().add_recipient(node_addr.script_pubkey().clone(), 49_000).enable_rbf().finish().unwrap();
                     let (psbt, finalized) = wallet.sign(psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(psbt.extract_tx()).unwrap();
@@ -445,8 +445,7 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     assert_eq!(wallet.get_balance().unwrap(), 1_000 - details.fees);
                     assert_eq!(wallet.get_balance().unwrap(), details.received);
 
-                    let (new_psbt, new_details) = wallet.bump_fee(&details.txid, TxBuilder::new().fee_rate(FeeRate::from_sat_per_vb(5.0))).unwrap();
-
+                    let (new_psbt, new_details) = wallet.build_fee_bump(details.txid).unwrap().fee_rate(FeeRate::from_sat_per_vb(5.0)).finish().unwrap();
                     let (new_psbt, finalized) = wallet.sign(new_psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(new_psbt.extract_tx()).unwrap();
@@ -470,7 +469,7 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     wallet.sync(noop_progress(), None).unwrap();
                     assert_eq!(wallet.get_balance().unwrap(), 75_000);
 
-                    let (psbt, details) = wallet.create_tx(TxBuilder::with_recipients(vec![(node_addr.script_pubkey().clone(), 49_000)]).enable_rbf()).unwrap();
+                    let (psbt, details) = wallet.build_tx().add_recipient(node_addr.script_pubkey().clone(), 49_000).enable_rbf().finish().unwrap();
                     let (psbt, finalized) = wallet.sign(psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(psbt.extract_tx()).unwrap();
@@ -478,8 +477,7 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     assert_eq!(wallet.get_balance().unwrap(), 26_000 - details.fees);
                     assert_eq!(details.received, 1_000 - details.fees);
 
-                    let (new_psbt, new_details) = wallet.bump_fee(&details.txid, TxBuilder::new().fee_rate(FeeRate::from_sat_per_vb(10.0))).unwrap();
-
+                    let (new_psbt, new_details) = wallet.build_fee_bump(details.txid).unwrap().fee_rate(FeeRate::from_sat_per_vb(10.0)).finish().unwrap();
                     let (new_psbt, finalized) = wallet.sign(new_psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(new_psbt.extract_tx()).unwrap();
@@ -501,7 +499,7 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     wallet.sync(noop_progress(), None).unwrap();
                     assert_eq!(wallet.get_balance().unwrap(), 75_000);
 
-                    let (psbt, details) = wallet.create_tx(TxBuilder::with_recipients(vec![(node_addr.script_pubkey().clone(), 49_000)]).enable_rbf()).unwrap();
+                    let (psbt, details) = wallet.build_tx().add_recipient(node_addr.script_pubkey().clone(), 49_000).enable_rbf().finish().unwrap();
                     let (psbt, finalized) = wallet.sign(psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(psbt.extract_tx()).unwrap();
@@ -509,7 +507,7 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     assert_eq!(wallet.get_balance().unwrap(), 26_000 - details.fees);
                     assert_eq!(details.received, 1_000 - details.fees);
 
-                    let (new_psbt, new_details) = wallet.bump_fee(&details.txid, TxBuilder::new().fee_rate(FeeRate::from_sat_per_vb(123.0))).unwrap();
+                    let (new_psbt, new_details) = wallet.build_fee_bump(details.txid).unwrap().fee_rate(FeeRate::from_sat_per_vb(123.0)).finish().unwrap();
                     println!("{:#?}", new_details);
 
                     let (new_psbt, finalized) = wallet.sign(new_psbt, None).unwrap();


### PR DESCRIPTION
HAPPY NEW YEAR!

## Background

While trying to do bitcoindevkit/bdk#114 I was making a mess.
This PR is an attempt to tackle the problems with the internals of transactions creation that made the PR difficult.

In addition it fixes bitcoindevkit/bdk#251.

## Major Changes/Improvements

- `TxBuilder`s are not created directly but through `build_tx` and `build_fee_bump` methods on `Wallet`. To finally create the tx you call `.finish()` on the builder.
  - The same code is now used to create the fee bumping tx as a normal tx 🎉. A lot of the code from `bump_fee` is gone!
- `TxBuilder` methods take `&mut self` rather than `self` -- makes building transactions more ergonomic since you can use chaining or assign the tx builder and just make calls on it.
- `TxBuilder.add_utxo` now retrieves UTXO data and stores it. If the UTXO doesn't exist then you get an error early.
  - This fixes bitcoindevkit/bdk#251 and is the main change intended to make bitcoindevkit/bdk#114 easier since it allows normalizing the local and foreign UTXOs into the same list early.
  - ~`TxBuilder.utxos` has been removed in favor of repeatedly calling `add_utxo` (which is now more ergonomic because of the `&mut self` change).~ `TxBuilder.utxos` has been replaced with `TxBuilder.add_utxos` which doesn't overwrite the existing utxos but allows you to add a list on top the existing list.
  - `TxBuilder`'s internal list of UTXOs is now stored as a BTreeMap to prevent duplicates. 
- `wallet.get_utxo` and `wallet.get_descriptor_for_keychain` are now exposed publicly.
  - I could have made them `pub(crate)` only but I think they are fine to be public.
- The `[cfg(test)]` only method `received_tx` that was used internally for testing is now a macro so it can be used from doctests. It's called `populate_test_db`. Several `no_run` tests can now be run. See fb167ad and 5fad5e2 .
- `TxBuilder` is now `Clone`.
- `Wallet` is now `Debug`.

This opens up the door to fixing the following issues:

- [#144](https://github.com/bitcoindevkit/bdk/issues/144) - whether the tx has been confirmed or not can now be checked in `add_utxo`.
- [#153](https://github.com/bitcoindevkit/bdk_wallet/issues/194) - merging an existing transaction into the builder is now easy -- this is how `build_fee_bump` works internally.
- [#114](https://github.com/bitcoindevkit/bdk/issues/114) - adding a foreign utxo without losing the order is now easier since we normalize and populate UTXO data up front both local and foreign utxos can be placed in the same `utxos` `Vec`.

### Notes to the reviewers

This is based of https://github.com/bitcoindevkit/bdk/pull/255 so merge after that.
Sorry for the very large PR I wasn't able to nicely separate the external and internal changes easily.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`
