### PR TITLE
[ci] Fail 'Build docs' job if warnings

### DIFF
--- a/.github/workflows/nightly_docs.yml
+++ b/.github/workflows/nightly_docs.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: rustdoc
-          args: --verbose --features=compiler,electrum,esplora,compact_filters,key-value-db,all-keys -- --cfg docsrs
+          args: --verbose --features=compiler,electrum,esplora,compact_filters,key-value-db,all-keys -- --cfg docsrs -Dwarnings
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -420,7 +420,7 @@ where
 /// [`ToDescriptorKey`]: the generated keys can be directly used in descriptors if `Self` is also
 /// [`ToDescriptorKey`].
 pub trait GeneratableKey<Ctx: ScriptContext>: Sized {
-    /// Type specifying the amount of entropy required e.g. [u8;32]
+    /// Type specifying the amount of entropy required e.g. `[u8;32]`
     type Entropy: AsMut<[u8]> + Default;
 
     /// Extra options required by the `generate_with_entropy`


### PR DESCRIPTION
### Description

This PR fixes #259 by making `rustdoc` warnings fail the 'Build docs' CI job.

### Notes to the reviewers

I also fixed a small, existing `rustdoc` warning.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

