### PR TITLE
Fix crates.io license info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ documentation = "https://docs.rs/bdk"
 description = "A modern, lightweight, descriptor-based wallet library"
 keywords = ["bitcoin", "wallet", "descriptor", "psbt"]
 readme = "README.md"
-license-file = "LICENSE"
+license = "MIT"
 
 [dependencies]
 bdk-macros = "0.2"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/bitcoindevkit/bdk"
 documentation = "https://docs.rs/bdk-macros"
 description = "Supporting macros for `bdk`"
 keywords = ["bdk"]
-license-file = "../LICENSE"
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/testutils-macros/Cargo.toml
+++ b/testutils-macros/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/bitcoindevkit/bdk"
 documentation = "https://docs.rs/bdk-testutils-macros"
 description = "Supporting testing macros for `bdk`"
 keywords = ["bdk"]
-license-file = "../LICENSE"
+license = "MIT"
 
 [lib]
 proc-macro = true

--- a/testutils/Cargo.toml
+++ b/testutils/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/bitcoindevkit/bdk"
 documentation = "https://docs.rs/bdk-testutils"
 description = "Supporting testing utilities for `bdk`"
 keywords = ["bdk"]
-license-file = "../LICENSE"
+license = "MIT"
 
 [lib]
 name = "testutils"


### PR DESCRIPTION
### Description

Small cleanup to set the license in `cargo.toml` to MIT so it won't show up as non-standard on crates.io.

https://crates.io/crates/bdk

### Notes to the reviewers

@RCasatta noticed this when reviewing https://github.com/bitcoindevkit/bdk-cli/pull/8

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
