### PR TITLE
Permit to not set timeout in ElectrumBlockchainConfig

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rand = "^0.7"
 
 # Optional dependencies
 sled = { version = "0.34", optional = true }
-electrum-client = { version = "0.4.0-beta.1", optional = true }
+electrum-client = { version = "0.5.0-beta.1", optional = true }
 reqwest = { version = "0.10", optional = true, features = ["json"] }
 futures = { version = "0.3", optional = true }
 async-trait = { version = "0.1", optional = true }

--- a/src/blockchain/electrum.rs
+++ b/src/blockchain/electrum.rs
@@ -168,7 +168,7 @@ pub struct ElectrumBlockchainConfig {
     /// Request retry count
     pub retry: u8,
     /// Request timeout (seconds)
-    pub timeout: u8,
+    pub timeout: Option<u8>,
 }
 
 impl ConfigurableBlockchain for ElectrumBlockchain {
@@ -178,8 +178,8 @@ impl ConfigurableBlockchain for ElectrumBlockchain {
         let socks5 = config.socks5.as_ref().map(Socks5Config::new);
         let electrum_config = ConfigBuilder::new()
             .retry(config.retry)
-            .socks5(socks5)?
             .timeout(config.timeout)?
+            .socks5(socks5)?
             .build();
 
         Ok(ElectrumBlockchain(Client::from_config(


### PR DESCRIPTION
### Description

Allows to use socks5 which requires None timeout by accepting Option<u8> in `ElectrumBlockchainConfig`

closes https://github.com/bitcoindevkit/bdk/issues/246

### Notes to the reviewers

~~requires https://github.com/bitcoindevkit/rust-electrum-client/pull/29 merged and released (after that needs an update on Cargo.toml to refer to `rust-electrum-client` released  )~~

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [x] This pull request breaks the existing API
* [x] I'm linking the issue being fixed by this PR

tested with 
```
cargo run -- -p 127.0.0.1:9050 --descriptor "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/*)" sync  
```
on https://github.com/bitcoindevkit/bdk-cli/pull/9 (fails on master as specified in the relative issue)

