### PR TITLE
descriptor: Use `DescriptorError` instead of `Error` when reasonable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Descriptor
+#### Changed
+- Added an alias `DescriptorError` for `descriptor::error::Error`
+- Changed the error returned by `descriptor!()` and `fragment!()` to `DescriptorError`
+- Changed the error type in `ToWalletDescriptor` to `DescriptorError`
+- Improved checks on descriptors built using the macros
+
 ### Blockchain
 #### Changed
 - Remove `BlockchainMarker`, `OfflineClient` and `OfflineWallet` in favor of just using the unit

--- a/src/database/any.rs
+++ b/src/database/any.rs
@@ -36,14 +36,12 @@
 //! # use bdk::database::{AnyDatabase, MemoryDatabase};
 //! # use bdk::{Wallet};
 //! let memory = MemoryDatabase::default();
-//! let wallet_memory =
-//!     Wallet::new_offline("...", None, Network::Testnet, memory)?;
+//! let wallet_memory = Wallet::new_offline("...", None, Network::Testnet, memory)?;
 //!
 //! # #[cfg(feature = "key-value-db")]
 //! # {
 //! let sled = sled::open("my-database")?.open_tree("default_tree")?;
-//! let wallet_sled =
-//!     Wallet::new_offline("...", None, Network::Testnet, sled)?;
+//! let wallet_sled = Wallet::new_offline("...", None, Network::Testnet, sled)?;
 //! # }
 //! # Ok::<(), bdk::Error>(())
 //! ```

--- a/src/descriptor/checksum.rs
+++ b/src/descriptor/checksum.rs
@@ -29,7 +29,7 @@
 
 use std::iter::FromIterator;
 
-use crate::descriptor::Error;
+use crate::descriptor::DescriptorError;
 
 const INPUT_CHARSET: &str =  "0123456789()[],'/*abcdefgh@:$%{}IJKLMNOPQRSTUVWXYZ&+-.;<=>?!^_|~ijklmnopqrstuvwxyzABCDEFGH`#\"\\ ";
 const CHECKSUM_CHARSET: &str = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
@@ -57,14 +57,14 @@ fn poly_mod(mut c: u64, val: u64) -> u64 {
 }
 
 /// Compute the checksum of a descriptor
-pub fn get_checksum(desc: &str) -> Result<String, Error> {
+pub fn get_checksum(desc: &str) -> Result<String, DescriptorError> {
     let mut c = 1;
     let mut cls = 0;
     let mut clscount = 0;
     for ch in desc.chars() {
         let pos = INPUT_CHARSET
             .find(ch)
-            .ok_or(Error::InvalidDescriptorCharacter(ch))? as u64;
+            .ok_or(DescriptorError::InvalidDescriptorCharacter(ch))? as u64;
         c = poly_mod(c, pos & 31);
         cls = cls * 3 + (pos >> 5);
         clscount += 1;
@@ -120,7 +120,7 @@ mod test {
 
         assert!(matches!(
             get_checksum(&invalid_desc).err(),
-            Some(Error::InvalidDescriptorCharacter(invalid_char)) if invalid_char == sparkle_heart
+            Some(DescriptorError::InvalidDescriptorCharacter(invalid_char)) if invalid_char == sparkle_heart
         ));
     }
 }

--- a/src/descriptor/error.rs
+++ b/src/descriptor/error.rs
@@ -27,26 +27,19 @@
 /// Errors related to the parsing and usage of descriptors
 #[derive(Debug)]
 pub enum Error {
-    //InternalError,
-    //InvalidPrefix(Vec<u8>),
-    //HardenedDerivationOnXpub,
-    //MalformedInput,
     /// Invalid HD Key path, such as having a wildcard but a length != 1
     InvalidHDKeyPath,
+    /// The provided descriptor doesn't match its checksum
+    InvalidDescriptorChecksum,
 
-    //KeyParsingError(String),
     /// Error thrown while working with [`keys`](crate::keys)
     Key(crate::keys::KeyError),
     /// Error while extracting and manipulating policies
     Policy(crate::descriptor::policy::PolicyError),
 
-    //InputIndexDoesntExist,
-    //MissingPublicKey,
-    //MissingDetails,
     /// Invalid character found in the descriptor checksum
     InvalidDescriptorCharacter(char),
 
-    //CantDeriveWithMiniscript,
     /// BIP32 error
     BIP32(bitcoin::util::bip32::Error),
     /// Error during base58 decoding

--- a/src/descriptor/policy.rs
+++ b/src/descriptor/policy.rs
@@ -1145,11 +1145,12 @@ mod test {
         let (prvkey0, _pubkey0, _fingerprint0) = setup_keys(TPRV0_STR);
         let (_prvkey1, pubkey1, _fingerprint1) = setup_keys(TPRV1_STR);
         let sequence = 50;
+        #[rustfmt::skip]
         let desc = descriptor!(wsh(thresh(
             2,
             pk(prvkey0),
-            s: pk(pubkey1),
-            s: d: v: older(sequence)
+            s:pk(pubkey1),
+            s:d:v:older(sequence)
         )))
         .unwrap();
 


### PR DESCRIPTION
Change the return type of the `descriptor!()` macro and `ToWalletDescriptor` to avoid having to map errors.

Also introduce more checks to validate descriptors built using the macro.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`

#### Bugfixes:

* [x] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
