### PR TITLE
[ci] Update start-core.sh to create default wallet for bitcoind 0.21.0

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -76,13 +76,14 @@ jobs:
   test-electrum:
     name: Test electrum
     runs-on: ubuntu-16.04
-    container: bitcoindevkit/electrs
+    container: bitcoindevkit/electrs:0.2.0
     env:
-      MAGICAL_RPC_AUTH: USER_PASS
-      MAGICAL_RPC_USER: admin
-      MAGICAL_RPC_PASS: passw
-      MAGICAL_RPC_URL: 127.0.0.1:18443
-      MAGICAL_ELECTRUM_URL: tcp://127.0.0.1:60401
+      BDK_RPC_AUTH: USER_PASS
+      BDK_RPC_USER: admin
+      BDK_RPC_PASS: passw
+      BDK_RPC_URL: 127.0.0.1:18443
+      BDK_RPC_WALLET: bdk-test
+      BDK_ELECTRUM_URL: tcp://127.0.0.1:60401
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,8 +59,8 @@ test-electrum = ["electrum"]
 test-md-docs = ["electrum"]
 
 [dev-dependencies]
-bdk-testutils = "^0.3"
-bdk-testutils-macros = "^0.3"
+bdk-testutils = { path = "./testutils"}
+bdk-testutils-macros = { path = "./testutils-macros"}
 serial_test = "0.4"
 lazy_static = "1.4"
 env_logger = "0.7"

--- a/ci/start-core.sh
+++ b/ci/start-core.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env sh
 
 echo "Starting bitcoin node."
-/root/bitcoind -regtest -server -daemon -fallbackfee=0.0002 -rpcuser=admin -rpcpassword=passw -rpcallowip=0.0.0.0/0 -rpcbind=0.0.0.0 -blockfilterindex=1 -peerblockfilters=1
+/root/bitcoind -regtest -server -daemon -fallbackfee=0.0002 -rpcuser=$BDK_RPC_USER -rpcpassword=$BDK_RPC_PASS -rpcallowip=0.0.0.0/0 -rpcbind=0.0.0.0 -blockfilterindex=1 -peerblockfilters=1
 
 echo "Waiting for bitcoin node."
-until /root/bitcoin-cli -regtest -rpcuser=admin -rpcpassword=passw getblockchaininfo; do
+until /root/bitcoin-cli -regtest -rpcuser=$BDK_RPC_USER -rpcpassword=$BDK_RPC_PASS getblockchaininfo; do
     sleep 1
 done
-/root/bitcoind -regtest -rpcuser=admin -rpcpassword=passw createwallet bdk-test
+/root/bitcoin-cli -regtest -rpcuser=$BDK_RPC_USER -rpcpassword=$BDK_RPC_PASS createwallet $BDK_RPC_WALLET
 echo "Generating 150 bitcoin blocks."
-ADDR=$(/root/bitcoin-cli -regtest -rpcuser=admin -rpcpassword=passw getnewaddress)
-/root/bitcoin-cli -regtest -rpcuser=admin -rpcpassword=passw generatetoaddress 150 $ADDR
+ADDR=$(/root/bitcoin-cli -regtest -rpcuser=$BDK_RPC_USER -rpcpassword=$BDK_RPC_PASS -rpcwallet=$BDK_RPC_WALLET getnewaddress)
+/root/bitcoin-cli -regtest -rpcuser=$BDK_RPC_USER -rpcpassword=$BDK_RPC_PASS generatetoaddress 150 $ADDR
 
 echo "Starting electrs node."
 nohup /root/electrs --network regtest --jsonrpc-import &

--- a/ci/start-core.sh
+++ b/ci/start-core.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env sh
 
 echo "Starting bitcoin node."
-/root/bitcoind -regtest -server -daemon -fallbackfee=0.0002 -rpcuser=admin -rpcpassword=passw -rpcallowip=0.0.0.0/0 -rpcbind=0.0.0.0
+/root/bitcoind -regtest -server -daemon -fallbackfee=0.0002 -rpcuser=admin -rpcpassword=passw -rpcallowip=0.0.0.0/0 -rpcbind=0.0.0.0 -blockfilterindex=1 -peerblockfilters=1
 
 echo "Waiting for bitcoin node."
 until /root/bitcoin-cli -regtest -rpcuser=admin -rpcpassword=passw getblockchaininfo; do
     sleep 1
 done
-
+/root/bitcoind -regtest -rpcuser=admin -rpcpassword=passw createwallet bdk-test
 echo "Generating 150 bitcoin blocks."
 ADDR=$(/root/bitcoin-cli -regtest -rpcuser=admin -rpcpassword=passw getnewaddress)
 /root/bitcoin-cli -regtest -rpcuser=admin -rpcpassword=passw generatetoaddress 150 $ADDR

--- a/testutils/src/lib.rs
+++ b/testutils/src/lib.rs
@@ -360,7 +360,7 @@ impl TestClient {
         }
 
         if self.get_balance(None, None).unwrap() < Amount::from_sat(required_balance) {
-            panic!("Insufficient funds in bitcoind. Plase generate a few blocks with: `bitcoin-cli generatetoaddress 10 {}`", self.get_new_address(None, None).unwrap());
+            panic!("Insufficient funds in bitcoind. Please generate a few blocks with: `bitcoin-cli generatetoaddress 10 {}`", self.get_new_address(None, None).unwrap());
         }
 
         // FIXME: core can't create a tx with two outputs to the same address

--- a/testutils/src/lib.rs
+++ b/testutils/src/lib.rs
@@ -53,20 +53,20 @@ pub use electrum_client::{Client as ElectrumClient, ElectrumApi};
 
 // TODO: we currently only support env vars, we could also parse a toml file
 fn get_auth() -> Auth {
-    match env::var("MAGICAL_RPC_AUTH").as_ref().map(String::as_ref) {
+    match env::var("BDK_RPC_AUTH").as_ref().map(String::as_ref) {
         Ok("USER_PASS") => Auth::UserPass(
-            env::var("MAGICAL_RPC_USER").unwrap(),
-            env::var("MAGICAL_RPC_PASS").unwrap(),
+            env::var("BDK_RPC_USER").unwrap(),
+            env::var("BDK_RPC_PASS").unwrap(),
         ),
         _ => Auth::CookieFile(PathBuf::from(
-            env::var("MAGICAL_RPC_COOKIEFILE")
+            env::var("BDK_RPC_COOKIEFILE")
                 .unwrap_or("/home/user/.bitcoin/regtest/.cookie".to_string()),
         )),
     }
 }
 
 pub fn get_electrum_url() -> String {
-    env::var("MAGICAL_ELECTRUM_URL").unwrap_or("tcp://127.0.0.1:50001".to_string())
+    env::var("BDK_ELECTRUM_URL").unwrap_or("tcp://127.0.0.1:50001".to_string())
 }
 
 pub struct TestClient {
@@ -311,8 +311,10 @@ where
 
 impl TestClient {
     pub fn new() -> Self {
-        let url = env::var("MAGICAL_RPC_URL").unwrap_or("127.0.0.1:18443".to_string());
-        let client = RpcClient::new(format!("http://{}", url), get_auth()).unwrap();
+        let url = env::var("BDK_RPC_URL").unwrap_or("127.0.0.1:18443".to_string());
+        let wallet = env::var("BDK_RPC_WALLET").unwrap_or("bdk-test".to_string());
+        let client =
+            RpcClient::new(format!("http://{}/wallet/{}", url, wallet), get_auth()).unwrap();
         let electrum = ElectrumClient::new(&get_electrum_url()).unwrap();
 
         TestClient { client, electrum }


### PR DESCRIPTION
### Description

The new bitcoin core release `0.21.0` does not create a default wallet. We need to create a default wallet ourselves in the `start-core.sh` script so that electrum (and future) integration tests will work.

To support this change I also created a new docker image `bitcoindevkit/esplora:0.2.0` which includes `bitcoind` `0.21.0` and enables compact block filters, see https://github.com/bitcoindevkit/bitcoin-regtest-box/pull/3.

Fixes #267 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
