### PR TITLE
[signer] Add `Signer::id()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 - Added a function to get the version of BDK at runtime
 
+### Wallet
+#### Changed
+- Removed the explicit `id` argument from `Wallet::add_signer()` since that's now part of `Signer` itself
+
 ## [v0.3.0] - [v0.2.0]
 
 ### Descriptor

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -57,7 +57,7 @@ pub(crate) mod utils;
 pub use utils::IsDust;
 
 use address_validator::AddressValidator;
-use signer::{Signer, SignerId, SignerOrdering, SignersContainer};
+use signer::{Signer, SignerOrdering, SignersContainer};
 use tx_builder::{BumpFee, CreateTx, FeePolicy, TxBuilder, TxBuilderContext};
 use utils::{
     check_nlocktime, check_nsequence_rbf, descriptor_to_pk_ctx, After, Older, SecpCtx,
@@ -228,7 +228,6 @@ where
     pub fn add_signer(
         &mut self,
         keychain: KeychainKind,
-        id: SignerId,
         ordering: SignerOrdering,
         signer: Arc<dyn Signer>,
     ) {
@@ -237,7 +236,7 @@ where
             KeychainKind::Internal => Arc::make_mut(&mut self.change_signers),
         };
 
-        signers.add_external(id, ordering, signer);
+        signers.add_external(signer.id(&self.secp), ordering, signer);
     }
 
     /// Add an address validator


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Implement `Eq` for `dyn Signer` to make it easier to compare them.

Also adds a `Dummy` variant to `SignerId` that can be used when the signer doesn't actually have a "key" identifier itself.

Closes #261 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`

#### Bugfixes:

* [X] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
