### PR TITLE
Add a function to return the version of BDK at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Misc
+#### Added
+- Added a function to get the version of BDK at runtime
+
 ## [v0.3.0] - [v0.2.0]
 
 ### Descriptor

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,3 +265,8 @@ pub use wallet::address_validator;
 pub use wallet::signer;
 pub use wallet::tx_builder::TxBuilder;
 pub use wallet::Wallet;
+
+/// Get the version of BDK at runtime
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION", "unknown")
+}


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

This can be used in a few different ways:

- For dynamically-linked libraries this can be used to determine at runtime if the version of BDK is compatible, i.e. if it's the same an executable was linked against originally
- We can print this in bdk-cli or other tools

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`