### PR TITLE
[keys] Add mnemonic_to_master helper function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 - Remove `cli.rs` module, `cli-utils` feature and `repl.rs` example; moved to new [`bdk-cli`](https://github.com/bitcoindevkit/bdk-cli) repository
 
+### Keys
+#### Changed
+- Added function to create master extended private key from a network, mnemonic words, and optional password
+- Re-export BIP-39 enums and structures: Language, Mnemonic, MnemonicType, Seed
+
 ## [v0.2.0] - [0.1.0-beta.1]
 
 ### Project

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -301,7 +301,7 @@ pub trait ToDescriptorKey<Ctx: ScriptContext>: Sized {
 
 /// Trait for keys that can be derived.
 ///
-/// When extra metadata are provided, a [`DerivableKey`] can be transofrmed into a
+/// When extra metadata are provided, a [`DerivableKey`] can be transformed into a
 /// [`DescriptorKey`]: the trait [`ToDescriptorKey`] is automatically implemented
 /// for `(DerivableKey, DerivationPath)` and
 /// `(DerivableKey, KeySource, DerivationPath)` tuples.


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

This PR makes the changes needed for the `bdk-cli` to provide key commands: 

* reexport bip-39 structures
* add function to create master extended private key from a network, mnemonic words, and optional password

### Notes to the reviewers

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`
