### PR TITLE
[keys] Improve the API of `DerivableKey`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Keys
+#### Changed
+- Renamed `DerivableKey::add_metadata()` to `DerivableKey::into_descriptor_key()`
+#### Added
+- Added an `ExtendedKey` type that is an enum of `bip32::ExtendedPubKey` and `bip32::ExtendedPrivKey`
+- Added `DerivableKey::into_extended_key()` as the only method that needs to be implemented
+
 ### Misc
 #### Added
 - Added a function to get the version of BDK at runtime


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

A new `ExtendedKey` type has been added, which is basically an enum of `bip32::ExtendedPubKey` and `bip32::ExtendedPrivKey`, with some extra metadata regarding the `ScriptContext`.

This type has some methods that make it very easy to extract its content as either an `xprv` or `xpub`.

The `DerivableKey` trait has been updated so that the user now only has to implement a method (`DerivableKey::into_extended_key()`) to perform the conversion into an `ExtendedKey`.

The method that was previously called `add_metadata()` has now been renamed to `into_descriptor_key()`, and it has a blanket implementation.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`

#### Bugfixes:

* [x] This pull request breaks the existing API
