### PR TITLE
Emit specific compile error if incompatible features are enabled

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,6 +210,11 @@ extern crate serde;
 #[macro_use]
 extern crate serde_json;
 
+#[cfg(all(feature = "async-interface", feature = "electrum"))]
+compile_error!(
+    "Features async-interface and electrum are mutually exclusive and cannot be enabled together"
+);
+
 #[cfg(feature = "keys-bip39")]
 extern crate bip39;
 


### PR DESCRIPTION
This is motivated by the feature `electrum` being part of the`default` features of this crate. It is easy to naively enable
`esplora` and `async-interface` and forget that `electrum` is enabled by default, running into not so obvious compile errors.
