### PR TITLE
Fix clippy warnings for new stable rust `1.50.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Wallet
 #### Changed
 - Removed the explicit `id` argument from `Wallet::add_signer()` since that's now part of `Signer` itself
+- Renamed `ToWalletDescriptor::to_wallet_descriptor` to `ToWalletDescriptor::into_wallet_descriptor`
+
+### Policy 
+#### Changed
+- Removed unneeded `Result<(), PolicyError>` return type for `Satisfaction::finalize()`
 
 ## [v0.3.0] - [v0.2.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Wallet
 #### Changed
 - Removed the explicit `id` argument from `Wallet::add_signer()` since that's now part of `Signer` itself
-- Renamed `ToWalletDescriptor::to_wallet_descriptor` to `ToWalletDescriptor::into_wallet_descriptor`
+- Renamed `ToWalletDescriptor::to_wallet_descriptor` to `IntoWalletDescriptor::into_wallet_descriptor`
 
 ### Policy 
 #### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Keys
 #### Changed
 - Renamed `DerivableKey::add_metadata()` to `DerivableKey::into_descriptor_key()`
+- Renamed `ToDescriptorKey::to_descriptor_key()` to `IntoDescriptorKey::into_descriptor_key()`
 #### Added
 - Added an `ExtendedKey` type that is an enum of `bip32::ExtendedPubKey` and `bip32::ExtendedPrivKey`
 - Added `DerivableKey::into_extended_key()` as the only method that needs to be implemented
@@ -27,9 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Wallet
 #### Changed
 - Removed the explicit `id` argument from `Wallet::add_signer()` since that's now part of `Signer` itself
-- Renamed `ToWalletDescriptor::to_wallet_descriptor` to `IntoWalletDescriptor::into_wallet_descriptor`
+- Renamed `ToWalletDescriptor::to_wallet_descriptor()` to `IntoWalletDescriptor::into_wallet_descriptor()`
 
-### Policy 
+### Policy
 #### Changed
 - Removed unneeded `Result<(), PolicyError>` return type for `Satisfaction::finalize()`
 

--- a/src/blockchain/compact_filters/peer.rs
+++ b/src/blockchain/compact_filters/peer.rs
@@ -223,14 +223,14 @@ impl Peer {
             )),
         )?;
         let version = if let NetworkMessage::Version(version) =
-            Self::_recv(&responses, "version", None)?.unwrap()
+            Self::_recv(&responses, "version", None).unwrap()
         {
             version
         } else {
             return Err(CompactFiltersError::InvalidResponse);
         };
 
-        if let NetworkMessage::Verack = Self::_recv(&responses, "verack", None)?.unwrap() {
+        if let NetworkMessage::Verack = Self::_recv(&responses, "verack", None).unwrap() {
             Self::_send(&mut locked_writer, network.magic(), NetworkMessage::Verack)?;
         } else {
             return Err(CompactFiltersError::InvalidResponse);
@@ -271,7 +271,7 @@ impl Peer {
         responses: &Arc<RwLock<ResponsesMap>>,
         wait_for: &'static str,
         timeout: Option<Duration>,
-    ) -> Result<Option<NetworkMessage>, CompactFiltersError> {
+    ) -> Option<NetworkMessage> {
         let message_resp = {
             let mut lock = responses.write().unwrap();
             let message_resp = lock.entry(wait_for).or_default();
@@ -287,15 +287,14 @@ impl Peer {
                 Some(t) => {
                     let result = cvar.wait_timeout(messages, t).unwrap();
                     if result.1.timed_out() {
-                        return Ok(None);
+                        return None;
                     }
-
                     messages = result.0;
                 }
             }
         }
 
-        Ok(messages.pop())
+        messages.pop()
     }
 
     /// Return the [`VersionMessage`] sent by the peer
@@ -415,7 +414,7 @@ impl Peer {
         wait_for: &'static str,
         timeout: Option<Duration>,
     ) -> Result<Option<NetworkMessage>, CompactFiltersError> {
-        Self::_recv(&self.responses, wait_for, timeout)
+        Ok(Self::_recv(&self.responses, wait_for, timeout))
     }
 }
 

--- a/src/descriptor/dsl.rs
+++ b/src/descriptor/dsl.rs
@@ -79,7 +79,7 @@ macro_rules! impl_top_level_pk {
         use $crate::keys::{DescriptorKey, ToDescriptorKey};
         let secp = $crate::bitcoin::secp256k1::Secp256k1::new();
 
-        $key.to_descriptor_key()
+        $key.into_descriptor_key()
             .and_then(|key: DescriptorKey<$ctx>| key.extract(&secp))
             .map_err($crate::descriptor::DescriptorError::Key)
             .map(|(pk, key_map, valid_networks)| ($inner_type::new(pk), key_map, valid_networks))
@@ -230,7 +230,7 @@ macro_rules! impl_sortedmulti {
 
         let mut keys = vec![];
         $(
-            keys.push($key.to_descriptor_key());
+            keys.push($key.into_descriptor_key());
         )*
 
         keys.into_iter().collect::<Result<Vec<_>, _>>()
@@ -658,7 +658,7 @@ macro_rules! fragment {
 
         let mut keys = vec![];
         $(
-            keys.push($key.to_descriptor_key());
+            keys.push($key.into_descriptor_key());
         )*
 
         keys.into_iter().collect::<Result<Vec<_>, _>>()
@@ -808,7 +808,7 @@ mod test {
         let xprv = bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPcx5nBGsR63Pe8KnRUqmbJNENAfGftF3yuXoMMoVJJcYeUw5eVkm9WBPjWYt6HMWYJNesB5HaNVBaFc1M6dRjWSYnmewUMYy").unwrap();
 
         let path = bip32::DerivationPath::from_str("m/0").unwrap();
-        let desc_key = (xprv, path.clone()).to_descriptor_key().unwrap();
+        let desc_key = (xprv, path.clone()).into_descriptor_key().unwrap();
         check(
             descriptor!(pk(desc_key)),
             false,
@@ -820,7 +820,7 @@ mod test {
             ],
         );
 
-        let desc_key = (xprv, path.clone()).to_descriptor_key().unwrap();
+        let desc_key = (xprv, path.clone()).into_descriptor_key().unwrap();
         check(
             descriptor!(pkh(desc_key)),
             false,
@@ -833,8 +833,8 @@ mod test {
         );
 
         let path2 = bip32::DerivationPath::from_str("m/2147483647'/0").unwrap();
-        let desc_key1 = (xprv, path).to_descriptor_key().unwrap();
-        let desc_key2 = (xprv, path2).to_descriptor_key().unwrap();
+        let desc_key1 = (xprv, path).into_descriptor_key().unwrap();
+        let desc_key2 = (xprv, path2).into_descriptor_key().unwrap();
 
         check(
             descriptor!(sh(multi(1, desc_key1, desc_key2))),
@@ -853,7 +853,7 @@ mod test {
         let xprv = bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPcx5nBGsR63Pe8KnRUqmbJNENAfGftF3yuXoMMoVJJcYeUw5eVkm9WBPjWYt6HMWYJNesB5HaNVBaFc1M6dRjWSYnmewUMYy").unwrap();
 
         let path = bip32::DerivationPath::from_str("m/0").unwrap();
-        let desc_key = (xprv, path.clone()).to_descriptor_key().unwrap();
+        let desc_key = (xprv, path.clone()).into_descriptor_key().unwrap();
         check(
             descriptor!(wpkh(desc_key)),
             true,
@@ -865,7 +865,7 @@ mod test {
             ],
         );
 
-        let desc_key = (xprv, path.clone()).to_descriptor_key().unwrap();
+        let desc_key = (xprv, path.clone()).into_descriptor_key().unwrap();
         check(
             descriptor!(sh(wpkh(desc_key))),
             true,
@@ -878,8 +878,8 @@ mod test {
         );
 
         let path2 = bip32::DerivationPath::from_str("m/2147483647'/0").unwrap();
-        let desc_key1 = (xprv, path.clone()).to_descriptor_key().unwrap();
-        let desc_key2 = (xprv, path2.clone()).to_descriptor_key().unwrap();
+        let desc_key1 = (xprv, path.clone()).into_descriptor_key().unwrap();
+        let desc_key2 = (xprv, path2.clone()).into_descriptor_key().unwrap();
         check(
             descriptor!(wsh(multi(1, desc_key1, desc_key2))),
             true,
@@ -891,8 +891,8 @@ mod test {
             ],
         );
 
-        let desc_key1 = (xprv, path).to_descriptor_key().unwrap();
-        let desc_key2 = (xprv, path2).to_descriptor_key().unwrap();
+        let desc_key1 = (xprv, path).into_descriptor_key().unwrap();
+        let desc_key2 = (xprv, path2).into_descriptor_key().unwrap();
         check(
             descriptor!(sh(wsh(multi(1, desc_key1, desc_key2)))),
             true,
@@ -968,7 +968,7 @@ mod test {
     fn test_valid_networks() {
         let xprv = bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPcx5nBGsR63Pe8KnRUqmbJNENAfGftF3yuXoMMoVJJcYeUw5eVkm9WBPjWYt6HMWYJNesB5HaNVBaFc1M6dRjWSYnmewUMYy").unwrap();
         let path = bip32::DerivationPath::from_str("m/0").unwrap();
-        let desc_key = (xprv, path.clone()).to_descriptor_key().unwrap();
+        let desc_key = (xprv, path.clone()).into_descriptor_key().unwrap();
 
         let (_desc, _key_map, valid_networks) = descriptor!(pkh(desc_key)).unwrap();
         assert_eq!(
@@ -978,7 +978,7 @@ mod test {
 
         let xprv = bip32::ExtendedPrivKey::from_str("xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi").unwrap();
         let path = bip32::DerivationPath::from_str("m/10/20/30/40").unwrap();
-        let desc_key = (xprv, path.clone()).to_descriptor_key().unwrap();
+        let desc_key = (xprv, path.clone()).into_descriptor_key().unwrap();
 
         let (_desc, _key_map, valid_networks) = descriptor!(wpkh(desc_key)).unwrap();
         assert_eq!(valid_networks, [Bitcoin].iter().cloned().collect());
@@ -991,26 +991,26 @@ mod test {
 
         let xprv1 = bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPcx5nBGsR63Pe8KnRUqmbJNENAfGftF3yuXoMMoVJJcYeUw5eVkm9WBPjWYt6HMWYJNesB5HaNVBaFc1M6dRjWSYnmewUMYy").unwrap();
         let path1 = bip32::DerivationPath::from_str("m/0").unwrap();
-        let desc_key1 = (xprv1, path1.clone()).to_descriptor_key().unwrap();
+        let desc_key1 = (xprv1, path1.clone()).into_descriptor_key().unwrap();
 
         let xprv2 = bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPegBHHnq7YEgM815dG24M2Jk5RVqipgDxF1HJ1tsnT815X5Fd5FRfMVUs8NZs9XCb6y9an8hRPThnhfwfXJ36intaekySHGF").unwrap();
         let path2 = bip32::DerivationPath::from_str("m/2147483647'/0").unwrap();
-        let desc_key2 = (xprv2, path2.clone()).to_descriptor_key().unwrap();
+        let desc_key2 = (xprv2, path2.clone()).into_descriptor_key().unwrap();
 
         let xprv3 = bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPdZXrcHNLf5JAJWFAoJ2TrstMRdSKtEggz6PddbuSkvHKM9oKJyFgZV1B7rw8oChspxyYbtmEXYyg1AjfWbL3ho3XHDpHRZf").unwrap();
         let path3 = bip32::DerivationPath::from_str("m/10/20/30/40").unwrap();
-        let desc_key3 = (xprv3, path3.clone()).to_descriptor_key().unwrap();
+        let desc_key3 = (xprv3, path3.clone()).into_descriptor_key().unwrap();
 
         let (_desc, key_map, _valid_networks) =
             descriptor!(sh(wsh(multi(2, desc_key1, desc_key2, desc_key3)))).unwrap();
         assert_eq!(key_map.len(), 3);
 
         let desc_key1: DescriptorKey<Segwitv0> =
-            (xprv1, path1.clone()).to_descriptor_key().unwrap();
+            (xprv1, path1.clone()).into_descriptor_key().unwrap();
         let desc_key2: DescriptorKey<Segwitv0> =
-            (xprv2, path2.clone()).to_descriptor_key().unwrap();
+            (xprv2, path2.clone()).into_descriptor_key().unwrap();
         let desc_key3: DescriptorKey<Segwitv0> =
-            (xprv3, path3.clone()).to_descriptor_key().unwrap();
+            (xprv3, path3.clone()).into_descriptor_key().unwrap();
 
         let (key1, _key_map, _valid_networks) = desc_key1.extract(&secp).unwrap();
         let (key2, _key_map, _valid_networks) = desc_key2.extract(&secp).unwrap();
@@ -1026,13 +1026,13 @@ mod test {
         // this compiles
         let xprv = bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPcx5nBGsR63Pe8KnRUqmbJNENAfGftF3yuXoMMoVJJcYeUw5eVkm9WBPjWYt6HMWYJNesB5HaNVBaFc1M6dRjWSYnmewUMYy").unwrap();
         let path = bip32::DerivationPath::from_str("m/0").unwrap();
-        let desc_key: DescriptorKey<Legacy> = (xprv, path.clone()).to_descriptor_key().unwrap();
+        let desc_key: DescriptorKey<Legacy> = (xprv, path.clone()).into_descriptor_key().unwrap();
 
         let (desc, _key_map, _valid_networks) = descriptor!(pkh(desc_key)).unwrap();
         assert_eq!(desc.to_string(), "pkh(tpubD6NzVbkrYhZ4WR7a4vY1VT3khMJMeAxVsfq9TBJyJWrNk247zCJtV7AWf6UJP7rAVsn8NNKdJi3gFyKPTmWZS9iukb91xbn2HbFSMQm2igY/0/*)#yrnz9pp2");
 
         // as expected this does not compile due to invalid context
-        //let desc_key:DescriptorKey<Segwitv0> = (xprv, path.clone()).to_descriptor_key().unwrap();
+        //let desc_key:DescriptorKey<Segwitv0> = (xprv, path.clone()).into_descriptor_key().unwrap();
         //let (desc, _key_map, _valid_networks) = descriptor!(pkh(desc_key)).unwrap();
     }
 

--- a/src/descriptor/dsl.rs
+++ b/src/descriptor/dsl.rs
@@ -76,7 +76,7 @@ macro_rules! impl_top_level_pk {
         use $crate::miniscript::descriptor::$inner_type;
 
         #[allow(unused_imports)]
-        use $crate::keys::{DescriptorKey, ToDescriptorKey};
+        use $crate::keys::{DescriptorKey, IntoDescriptorKey};
         let secp = $crate::bitcoin::secp256k1::Secp256k1::new();
 
         $key.into_descriptor_key()
@@ -225,7 +225,7 @@ macro_rules! impl_sortedmulti {
         $crate::keys::make_sortedmulti($thresh, $keys, $build_desc, &secp)
     });
     ( $build_desc:expr, sortedmulti ( $thresh:expr $(, $key:expr )+ ) ) => ({
-        use $crate::keys::ToDescriptorKey;
+        use $crate::keys::IntoDescriptorKey;
         let secp = $crate::bitcoin::secp256k1::Secp256k1::new();
 
         let mut keys = vec![];
@@ -326,11 +326,11 @@ macro_rules! apply_modifier {
 /// broken up to `s:d:v:older(144)`.
 ///
 /// The `pk()`, `pk_k()` and `pk_h()` operands can take as argument any type that implements
-/// [`ToDescriptorKey`]. This means that keys can also be written inline as strings, but in that
+/// [`IntoDescriptorKey`]. This means that keys can also be written inline as strings, but in that
 /// case they must be wrapped in quotes, which is another difference compared to the standard
 /// descriptor syntax.
 ///
-/// [`ToDescriptorKey`]: crate::keys::ToDescriptorKey
+/// [`IntoDescriptorKey`]: crate::keys::IntoDescriptorKey
 ///
 /// ## Example
 ///
@@ -653,7 +653,7 @@ macro_rules! fragment {
         $crate::keys::make_multi($thresh, $keys)
     });
     ( multi ( $thresh:expr $(, $key:expr )+ ) ) => ({
-        use $crate::keys::ToDescriptorKey;
+        use $crate::keys::IntoDescriptorKey;
         let secp = $crate::bitcoin::secp256k1::Secp256k1::new();
 
         let mut keys = vec![];
@@ -685,7 +685,7 @@ mod test {
     use std::str::FromStr;
 
     use crate::descriptor::{DescriptorError, DescriptorMeta};
-    use crate::keys::{DescriptorKey, ToDescriptorKey, ValidNetworks};
+    use crate::keys::{DescriptorKey, IntoDescriptorKey, ValidNetworks};
     use bitcoin::network::constants::Network::{Bitcoin, Regtest, Signet, Testnet};
     use bitcoin::util::bip32;
     use bitcoin::PrivateKey;
@@ -724,7 +724,7 @@ mod test {
     }
 
     // - at least one of each "type" of operator; ie. one modifier, one leaf_opcode, one leaf_opcode_value, etc.
-    // - mixing up key types that implement ToDescriptorKey in multi() or thresh()
+    // - mixing up key types that implement IntoDescriptorKey in multi() or thresh()
 
     // expected script for pk and bare manually created
     // expected addresses created with `bitcoin-cli getdescriptorinfo` (for hash) and `bitcoin-cli deriveaddresses`
@@ -1020,7 +1020,7 @@ mod test {
         assert_eq!(key_map.get(&key3).unwrap().to_string(), "tprv8ZgxMBicQKsPdZXrcHNLf5JAJWFAoJ2TrstMRdSKtEggz6PddbuSkvHKM9oKJyFgZV1B7rw8oChspxyYbtmEXYyg1AjfWbL3ho3XHDpHRZf/10/20/30/40/*");
     }
 
-    // - verify the ScriptContext is correctly validated (i.e. passing a type that only impl ToDescriptorKey<Segwitv0> to a pkh() descriptor should throw a compilation error
+    // - verify the ScriptContext is correctly validated (i.e. passing a type that only impl IntoDescriptorKey<Segwitv0> to a pkh() descriptor should throw a compilation error
     #[test]
     fn test_script_context_validation() {
         // this compiles

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -72,7 +72,7 @@ pub type DerivedDescriptor<'s> = Descriptor<DerivedDescriptorKey<'s>>;
 pub type HDKeyPaths = BTreeMap<PublicKey, KeySource>;
 
 /// Trait for types which can be converted into an [`ExtendedDescriptor`] and a [`KeyMap`] usable by a wallet in a specific [`Network`]
-pub trait ToWalletDescriptor {
+pub trait IntoWalletDescriptor {
     /// Convert to wallet descriptor
     fn into_wallet_descriptor(
         self,
@@ -81,7 +81,7 @@ pub trait ToWalletDescriptor {
     ) -> Result<(ExtendedDescriptor, KeyMap), DescriptorError>;
 }
 
-impl ToWalletDescriptor for &str {
+impl IntoWalletDescriptor for &str {
     fn into_wallet_descriptor(
         self,
         secp: &SecpCtx,
@@ -107,7 +107,7 @@ impl ToWalletDescriptor for &str {
     }
 }
 
-impl ToWalletDescriptor for &String {
+impl IntoWalletDescriptor for &String {
     fn into_wallet_descriptor(
         self,
         secp: &SecpCtx,
@@ -117,7 +117,7 @@ impl ToWalletDescriptor for &String {
     }
 }
 
-impl ToWalletDescriptor for ExtendedDescriptor {
+impl IntoWalletDescriptor for ExtendedDescriptor {
     fn into_wallet_descriptor(
         self,
         secp: &SecpCtx,
@@ -127,7 +127,7 @@ impl ToWalletDescriptor for ExtendedDescriptor {
     }
 }
 
-impl ToWalletDescriptor for (ExtendedDescriptor, KeyMap) {
+impl IntoWalletDescriptor for (ExtendedDescriptor, KeyMap) {
     fn into_wallet_descriptor(
         self,
         secp: &SecpCtx,
@@ -160,7 +160,7 @@ impl ToWalletDescriptor for (ExtendedDescriptor, KeyMap) {
     }
 }
 
-impl ToWalletDescriptor for DescriptorTemplateOut {
+impl IntoWalletDescriptor for DescriptorTemplateOut {
     fn into_wallet_descriptor(
         self,
         _secp: &SecpCtx,
@@ -637,7 +637,7 @@ mod test {
         assert_eq!(wallet_desc.to_string(), "wpkh(tpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)#y8p7e8kk");
     }
 
-    // test ToWalletDescriptor trait from &str with and without checksum appended
+    // test IntoWalletDescriptor trait from &str with and without checksum appended
     #[test]
     fn test_descriptor_from_str_with_checksum() {
         let secp = Secp256k1::new();
@@ -673,7 +673,7 @@ mod test {
         ));
     }
 
-    // test ToWalletDescriptor trait from &str with keys from right and wrong network
+    // test IntoWalletDescriptor trait from &str with keys from right and wrong network
     #[test]
     fn test_descriptor_from_str_with_keys_network() {
         let secp = Secp256k1::new();
@@ -717,7 +717,7 @@ mod test {
         ));
     }
 
-    // test ToWalletDescriptor trait from the output of the descriptor!() macro
+    // test IntoWalletDescriptor trait from the output of the descriptor!() macro
     #[test]
     fn test_descriptor_from_str_from_output_of_macro() {
         let secp = Secp256k1::new();

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -54,7 +54,7 @@ pub use self::derived::DerivedDescriptorKey;
 pub use self::error::Error as DescriptorError;
 pub use self::policy::Policy;
 use self::template::DescriptorTemplateOut;
-use crate::keys::{KeyError, ToDescriptorKey};
+use crate::keys::{IntoDescriptorKey, KeyError};
 use crate::wallet::signer::SignersContainer;
 use crate::wallet::utils::SecpCtx;
 
@@ -614,7 +614,7 @@ mod test {
 
     #[test]
     fn test_to_wallet_descriptor_fixup_networks() {
-        use crate::keys::{any_network, ToDescriptorKey};
+        use crate::keys::{any_network, IntoDescriptorKey};
 
         let secp = Secp256k1::new();
 

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -74,7 +74,7 @@ pub type HDKeyPaths = BTreeMap<PublicKey, KeySource>;
 /// Trait for types which can be converted into an [`ExtendedDescriptor`] and a [`KeyMap`] usable by a wallet in a specific [`Network`]
 pub trait ToWalletDescriptor {
     /// Convert to wallet descriptor
-    fn to_wallet_descriptor(
+    fn into_wallet_descriptor(
         self,
         secp: &SecpCtx,
         network: Network,
@@ -82,7 +82,7 @@ pub trait ToWalletDescriptor {
 }
 
 impl ToWalletDescriptor for &str {
-    fn to_wallet_descriptor(
+    fn into_wallet_descriptor(
         self,
         secp: &SecpCtx,
         network: Network,
@@ -102,32 +102,33 @@ impl ToWalletDescriptor for &str {
             self
         };
 
-        ExtendedDescriptor::parse_descriptor(secp, descriptor)?.to_wallet_descriptor(secp, network)
+        ExtendedDescriptor::parse_descriptor(secp, descriptor)?
+            .into_wallet_descriptor(secp, network)
     }
 }
 
 impl ToWalletDescriptor for &String {
-    fn to_wallet_descriptor(
+    fn into_wallet_descriptor(
         self,
         secp: &SecpCtx,
         network: Network,
     ) -> Result<(ExtendedDescriptor, KeyMap), DescriptorError> {
-        self.as_str().to_wallet_descriptor(secp, network)
+        self.as_str().into_wallet_descriptor(secp, network)
     }
 }
 
 impl ToWalletDescriptor for ExtendedDescriptor {
-    fn to_wallet_descriptor(
+    fn into_wallet_descriptor(
         self,
         secp: &SecpCtx,
         network: Network,
     ) -> Result<(ExtendedDescriptor, KeyMap), DescriptorError> {
-        (self, KeyMap::default()).to_wallet_descriptor(secp, network)
+        (self, KeyMap::default()).into_wallet_descriptor(secp, network)
     }
 }
 
 impl ToWalletDescriptor for (ExtendedDescriptor, KeyMap) {
-    fn to_wallet_descriptor(
+    fn into_wallet_descriptor(
         self,
         secp: &SecpCtx,
         network: Network,
@@ -137,11 +138,11 @@ impl ToWalletDescriptor for (ExtendedDescriptor, KeyMap) {
         let check_key = |pk: &DescriptorPublicKey| {
             let (pk, _, networks) = if self.0.is_witness() {
                 let desciptor_key: DescriptorKey<miniscript::Segwitv0> =
-                    pk.clone().to_descriptor_key()?;
+                    pk.clone().into_descriptor_key()?;
                 desciptor_key.extract(&secp)?
             } else {
                 let desciptor_key: DescriptorKey<miniscript::Legacy> =
-                    pk.clone().to_descriptor_key()?;
+                    pk.clone().into_descriptor_key()?;
                 desciptor_key.extract(&secp)?
             };
 
@@ -160,7 +161,7 @@ impl ToWalletDescriptor for (ExtendedDescriptor, KeyMap) {
 }
 
 impl ToWalletDescriptor for DescriptorTemplateOut {
-    fn to_wallet_descriptor(
+    fn into_wallet_descriptor(
         self,
         _secp: &SecpCtx,
         network: Network,
@@ -622,14 +623,16 @@ mod test {
 
         // here `to_descriptor_key` will set the valid networks for the key to only mainnet, since
         // we are using an "xpub"
-        let key = (xpub, path).to_descriptor_key().unwrap();
+        let key = (xpub, path).into_descriptor_key().unwrap();
         // override it with any. this happens in some key conversions, like bip39
         let key = key.override_valid_networks(any_network());
 
         // make a descriptor out of it
         let desc = crate::descriptor!(wpkh(key)).unwrap();
         // this should conver the key that supports "any_network" to the right network (testnet)
-        let (wallet_desc, _) = desc.to_wallet_descriptor(&secp, Network::Testnet).unwrap();
+        let (wallet_desc, _) = desc
+            .into_wallet_descriptor(&secp, Network::Testnet)
+            .unwrap();
 
         assert_eq!(wallet_desc.to_string(), "wpkh(tpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)#y8p7e8kk");
     }
@@ -640,30 +643,30 @@ mod test {
         let secp = Secp256k1::new();
 
         let desc = "wpkh(tprv8ZgxMBicQKsPdpkqS7Eair4YxjcuuvDPNYmKX3sCniCf16tHEVrjjiSXEkFRnUH77yXc6ZcwHHcLNfjdi5qUvw3VDfgYiH5mNsj5izuiu2N/1/2/*)#tqz0nc62"
-            .to_wallet_descriptor(&secp, Network::Testnet);
+            .into_wallet_descriptor(&secp, Network::Testnet);
         assert!(desc.is_ok());
 
         let desc = "wpkh(tprv8ZgxMBicQKsPdpkqS7Eair4YxjcuuvDPNYmKX3sCniCf16tHEVrjjiSXEkFRnUH77yXc6ZcwHHcLNfjdi5qUvw3VDfgYiH5mNsj5izuiu2N/1/2/*)"
-            .to_wallet_descriptor(&secp, Network::Testnet);
+            .into_wallet_descriptor(&secp, Network::Testnet);
         assert!(desc.is_ok());
 
         let desc = "wpkh(tpubD6NzVbkrYhZ4XHndKkuB8FifXm8r5FQHwrN6oZuWCz13qb93rtgKvD4PQsqC4HP4yhV3tA2fqr2RbY5mNXfM7RxXUoeABoDtsFUq2zJq6YK/1/2/*)#67ju93jw"
-            .to_wallet_descriptor(&secp, Network::Testnet);
+            .into_wallet_descriptor(&secp, Network::Testnet);
         assert!(desc.is_ok());
 
         let desc = "wpkh(tpubD6NzVbkrYhZ4XHndKkuB8FifXm8r5FQHwrN6oZuWCz13qb93rtgKvD4PQsqC4HP4yhV3tA2fqr2RbY5mNXfM7RxXUoeABoDtsFUq2zJq6YK/1/2/*)"
-            .to_wallet_descriptor(&secp, Network::Testnet);
+            .into_wallet_descriptor(&secp, Network::Testnet);
         assert!(desc.is_ok());
 
         let desc = "wpkh(tprv8ZgxMBicQKsPdpkqS7Eair4YxjcuuvDPNYmKX3sCniCf16tHEVrjjiSXEkFRnUH77yXc6ZcwHHcLNfjdi5qUvw3VDfgYiH5mNsj5izuiu2N/1/2/*)#67ju93jw"
-            .to_wallet_descriptor(&secp, Network::Testnet);
+            .into_wallet_descriptor(&secp, Network::Testnet);
         assert!(matches!(
             desc.err(),
             Some(DescriptorError::InvalidDescriptorChecksum)
         ));
 
         let desc = "wpkh(tprv8ZgxMBicQKsPdpkqS7Eair4YxjcuuvDPNYmKX3sCniCf16tHEVrjjiSXEkFRnUH77yXc6ZcwHHcLNfjdi5qUvw3VDfgYiH5mNsj5izuiu2N/1/2/*)#67ju93jw"
-            .to_wallet_descriptor(&secp, Network::Testnet);
+            .into_wallet_descriptor(&secp, Network::Testnet);
         assert!(matches!(
             desc.err(),
             Some(DescriptorError::InvalidDescriptorChecksum)
@@ -676,38 +679,38 @@ mod test {
         let secp = Secp256k1::new();
 
         let desc = "wpkh(tprv8ZgxMBicQKsPdpkqS7Eair4YxjcuuvDPNYmKX3sCniCf16tHEVrjjiSXEkFRnUH77yXc6ZcwHHcLNfjdi5qUvw3VDfgYiH5mNsj5izuiu2N/1/2/*)"
-            .to_wallet_descriptor(&secp, Network::Testnet);
+            .into_wallet_descriptor(&secp, Network::Testnet);
         assert!(desc.is_ok());
 
         let desc = "wpkh(tprv8ZgxMBicQKsPdpkqS7Eair4YxjcuuvDPNYmKX3sCniCf16tHEVrjjiSXEkFRnUH77yXc6ZcwHHcLNfjdi5qUvw3VDfgYiH5mNsj5izuiu2N/1/2/*)"
-            .to_wallet_descriptor(&secp, Network::Regtest);
+            .into_wallet_descriptor(&secp, Network::Regtest);
         assert!(desc.is_ok());
 
         let desc = "wpkh(tpubD6NzVbkrYhZ4XHndKkuB8FifXm8r5FQHwrN6oZuWCz13qb93rtgKvD4PQsqC4HP4yhV3tA2fqr2RbY5mNXfM7RxXUoeABoDtsFUq2zJq6YK/1/2/*)"
-            .to_wallet_descriptor(&secp, Network::Testnet);
+            .into_wallet_descriptor(&secp, Network::Testnet);
         assert!(desc.is_ok());
 
         let desc = "wpkh(tpubD6NzVbkrYhZ4XHndKkuB8FifXm8r5FQHwrN6oZuWCz13qb93rtgKvD4PQsqC4HP4yhV3tA2fqr2RbY5mNXfM7RxXUoeABoDtsFUq2zJq6YK/1/2/*)"
-            .to_wallet_descriptor(&secp, Network::Regtest);
+            .into_wallet_descriptor(&secp, Network::Regtest);
         assert!(desc.is_ok());
 
         let desc = "sh(wpkh(02864bb4ad00cefa806098a69e192bbda937494e69eb452b87bb3f20f6283baedb))"
-            .to_wallet_descriptor(&secp, Network::Testnet);
+            .into_wallet_descriptor(&secp, Network::Testnet);
         assert!(desc.is_ok());
 
         let desc = "sh(wpkh(02864bb4ad00cefa806098a69e192bbda937494e69eb452b87bb3f20f6283baedb))"
-            .to_wallet_descriptor(&secp, Network::Bitcoin);
+            .into_wallet_descriptor(&secp, Network::Bitcoin);
         assert!(desc.is_ok());
 
         let desc = "wpkh(tprv8ZgxMBicQKsPdpkqS7Eair4YxjcuuvDPNYmKX3sCniCf16tHEVrjjiSXEkFRnUH77yXc6ZcwHHcLNfjdi5qUvw3VDfgYiH5mNsj5izuiu2N/1/2/*)"
-            .to_wallet_descriptor(&secp, Network::Bitcoin);
+            .into_wallet_descriptor(&secp, Network::Bitcoin);
         assert!(matches!(
             desc.err(),
             Some(DescriptorError::Key(KeyError::InvalidNetwork))
         ));
 
         let desc = "wpkh(tpubD6NzVbkrYhZ4XHndKkuB8FifXm8r5FQHwrN6oZuWCz13qb93rtgKvD4PQsqC4HP4yhV3tA2fqr2RbY5mNXfM7RxXUoeABoDtsFUq2zJq6YK/1/2/*)"
-            .to_wallet_descriptor(&secp, Network::Bitcoin);
+            .into_wallet_descriptor(&secp, Network::Bitcoin);
         assert!(matches!(
             desc.err(),
             Some(DescriptorError::Key(KeyError::InvalidNetwork))
@@ -721,17 +724,19 @@ mod test {
 
         let tpub = bip32::ExtendedPubKey::from_str("tpubD6NzVbkrYhZ4XHndKkuB8FifXm8r5FQHwrN6oZuWCz13qb93rtgKvD4PQsqC4HP4yhV3tA2fqr2RbY5mNXfM7RxXUoeABoDtsFUq2zJq6YK").unwrap();
         let path = bip32::DerivationPath::from_str("m/1/2").unwrap();
-        let key = (tpub, path).to_descriptor_key().unwrap();
+        let key = (tpub, path).into_descriptor_key().unwrap();
 
         // make a descriptor out of it
         let desc = crate::descriptor!(wpkh(key)).unwrap();
 
-        let (wallet_desc, _) = desc.to_wallet_descriptor(&secp, Network::Testnet).unwrap();
+        let (wallet_desc, _) = desc
+            .into_wallet_descriptor(&secp, Network::Testnet)
+            .unwrap();
         let wallet_desc_str = wallet_desc.to_string();
         assert_eq!(wallet_desc_str, "wpkh(tpubD6NzVbkrYhZ4XHndKkuB8FifXm8r5FQHwrN6oZuWCz13qb93rtgKvD4PQsqC4HP4yhV3tA2fqr2RbY5mNXfM7RxXUoeABoDtsFUq2zJq6YK/1/2/*)#67ju93jw");
 
         let (wallet_desc2, _) = wallet_desc_str
-            .to_wallet_descriptor(&secp, Network::Testnet)
+            .into_wallet_descriptor(&secp, Network::Testnet)
             .unwrap();
         assert_eq!(wallet_desc, wallet_desc2)
     }

--- a/src/descriptor/policy.rs
+++ b/src/descriptor/policy.rs
@@ -913,8 +913,8 @@ mod test {
         let tprv = bip32::ExtendedPrivKey::from_str(tprv).unwrap();
         let tpub = bip32::ExtendedPubKey::from_private(&secp, &tprv);
         let fingerprint = tprv.fingerprint(&secp);
-        let prvkey = (tprv, path.clone()).to_descriptor_key().unwrap();
-        let pubkey = (tpub, path).to_descriptor_key().unwrap();
+        let prvkey = (tprv, path.clone()).into_descriptor_key().unwrap();
+        let pubkey = (tpub, path).into_descriptor_key().unwrap();
 
         (prvkey, pubkey, fingerprint)
     }
@@ -927,7 +927,9 @@ mod test {
 
         let (prvkey, pubkey, fingerprint) = setup_keys(TPRV0_STR);
         let desc = descriptor!(wpkh(pubkey)).unwrap();
-        let (wallet_desc, keymap) = desc.to_wallet_descriptor(&secp, Network::Testnet).unwrap();
+        let (wallet_desc, keymap) = desc
+            .into_wallet_descriptor(&secp, Network::Testnet)
+            .unwrap();
         let signers_container = Arc::new(SignersContainer::from(keymap));
         let policy = wallet_desc
             .extract_policy(&signers_container, &Secp256k1::new())
@@ -940,7 +942,9 @@ mod test {
         assert!(matches!(&policy.contribution, Satisfaction::None));
 
         let desc = descriptor!(wpkh(prvkey)).unwrap();
-        let (wallet_desc, keymap) = desc.to_wallet_descriptor(&secp, Network::Testnet).unwrap();
+        let (wallet_desc, keymap) = desc
+            .into_wallet_descriptor(&secp, Network::Testnet)
+            .unwrap();
         let signers_container = Arc::new(SignersContainer::from(keymap));
         let policy = wallet_desc
             .extract_policy(&signers_container, &Secp256k1::new())
@@ -1023,7 +1027,9 @@ mod test {
         let (_prvkey0, pubkey0, fingerprint0) = setup_keys(TPRV0_STR);
         let (prvkey1, _pubkey1, fingerprint1) = setup_keys(TPRV1_STR);
         let desc = descriptor!(sh(multi(1, pubkey0, prvkey1))).unwrap();
-        let (wallet_desc, keymap) = desc.to_wallet_descriptor(&secp, Network::Testnet).unwrap();
+        let (wallet_desc, keymap) = desc
+            .into_wallet_descriptor(&secp, Network::Testnet)
+            .unwrap();
         let signers_container = Arc::new(SignersContainer::from(keymap));
         let policy = wallet_desc
             .extract_policy(&signers_container, &Secp256k1::new())
@@ -1053,7 +1059,9 @@ mod test {
         let (prvkey0, _pubkey0, fingerprint0) = setup_keys(TPRV0_STR);
         let (prvkey1, _pubkey1, fingerprint1) = setup_keys(TPRV1_STR);
         let desc = descriptor!(sh(multi(2, prvkey0, prvkey1))).unwrap();
-        let (wallet_desc, keymap) = desc.to_wallet_descriptor(&secp, Network::Testnet).unwrap();
+        let (wallet_desc, keymap) = desc
+            .into_wallet_descriptor(&secp, Network::Testnet)
+            .unwrap();
         let signers_container = Arc::new(SignersContainer::from(keymap));
         let policy = wallet_desc
             .extract_policy(&signers_container, &Secp256k1::new())
@@ -1083,7 +1091,9 @@ mod test {
 
         let (prvkey, pubkey, fingerprint) = setup_keys(TPRV0_STR);
         let desc = descriptor!(wpkh(pubkey)).unwrap();
-        let (wallet_desc, keymap) = desc.to_wallet_descriptor(&secp, Network::Testnet).unwrap();
+        let (wallet_desc, keymap) = desc
+            .into_wallet_descriptor(&secp, Network::Testnet)
+            .unwrap();
         let single_key = wallet_desc.derive(0);
         let signers_container = Arc::new(SignersContainer::from(keymap));
         let policy = single_key
@@ -1097,7 +1107,9 @@ mod test {
         assert!(matches!(&policy.contribution, Satisfaction::None));
 
         let desc = descriptor!(wpkh(prvkey)).unwrap();
-        let (wallet_desc, keymap) = desc.to_wallet_descriptor(&secp, Network::Testnet).unwrap();
+        let (wallet_desc, keymap) = desc
+            .into_wallet_descriptor(&secp, Network::Testnet)
+            .unwrap();
         let single_key = wallet_desc.derive(0);
         let signers_container = Arc::new(SignersContainer::from(keymap));
         let policy = single_key
@@ -1122,7 +1134,9 @@ mod test {
         let (_prvkey0, pubkey0, fingerprint0) = setup_keys(TPRV0_STR);
         let (prvkey1, _pubkey1, fingerprint1) = setup_keys(TPRV1_STR);
         let desc = descriptor!(sh(multi(1, pubkey0, prvkey1))).unwrap();
-        let (wallet_desc, keymap) = desc.to_wallet_descriptor(&secp, Network::Testnet).unwrap();
+        let (wallet_desc, keymap) = desc
+            .into_wallet_descriptor(&secp, Network::Testnet)
+            .unwrap();
         let single_key = wallet_desc.derive(0);
         let signers_container = Arc::new(SignersContainer::from(keymap));
         let policy = single_key
@@ -1164,7 +1178,9 @@ mod test {
         )))
         .unwrap();
 
-        let (wallet_desc, keymap) = desc.to_wallet_descriptor(&secp, Network::Testnet).unwrap();
+        let (wallet_desc, keymap) = desc
+            .into_wallet_descriptor(&secp, Network::Testnet)
+            .unwrap();
         let signers_container = Arc::new(SignersContainer::from(keymap));
         let policy = wallet_desc
             .extract_policy(&signers_container, &Secp256k1::new())

--- a/src/descriptor/policy.rs
+++ b/src/descriptor/policy.rs
@@ -892,7 +892,7 @@ mod test {
 
     use super::*;
     use crate::descriptor::policy::SatisfiableItem::{Multisig, Signature, Thresh};
-    use crate::keys::{DescriptorKey, ToDescriptorKey};
+    use crate::keys::{DescriptorKey, IntoDescriptorKey};
     use crate::wallet::signer::SignersContainer;
     use bitcoin::secp256k1::{All, Secp256k1};
     use bitcoin::util::bip32;

--- a/src/descriptor/policy.rs
+++ b/src/descriptor/policy.rs
@@ -888,7 +888,7 @@ impl ExtractPolicy for Descriptor<DescriptorPublicKey> {
 #[cfg(test)]
 mod test {
     use crate::descriptor;
-    use crate::descriptor::{ExtractPolicy, ToWalletDescriptor};
+    use crate::descriptor::{ExtractPolicy, IntoWalletDescriptor};
 
     use super::*;
     use crate::descriptor::policy::SatisfiableItem::{Multisig, Signature, Thresh};

--- a/src/descriptor/policy.rs
+++ b/src/descriptor/policy.rs
@@ -354,7 +354,7 @@ impl Satisfaction {
         }
     }
 
-    fn finalize(&mut self) -> Result<(), PolicyError> {
+    fn finalize(&mut self) {
         // if partial try to bump it to a partialcomplete
         if let Satisfaction::Partial {
             n,
@@ -420,8 +420,6 @@ impl Satisfaction {
                 };
             }
         }
-
-        Ok(())
     }
 }
 
@@ -575,7 +573,7 @@ impl Policy {
         for (index, item) in items.iter().enumerate() {
             contribution.add(&item.contribution, index)?;
         }
-        contribution.finalize()?;
+        contribution.finalize();
 
         let mut policy: Policy = SatisfiableItem::Thresh { items, threshold }.into();
         policy.contribution = contribution;
@@ -613,7 +611,7 @@ impl Policy {
                 )?;
             }
         }
-        contribution.finalize()?;
+        contribution.finalize();
 
         let mut policy: Policy = SatisfiableItem::Multisig {
             keys: parsed_keys,

--- a/src/descriptor/template.rs
+++ b/src/descriptor/template.rs
@@ -34,7 +34,7 @@ use miniscript::{Legacy, Segwitv0};
 
 use super::{ExtendedDescriptor, IntoWalletDescriptor, KeyMap};
 use crate::descriptor::DescriptorError;
-use crate::keys::{DerivableKey, ToDescriptorKey, ValidNetworks};
+use crate::keys::{DerivableKey, IntoDescriptorKey, ValidNetworks};
 use crate::wallet::utils::SecpCtx;
 use crate::{descriptor, KeychainKind};
 
@@ -50,13 +50,13 @@ pub type DescriptorTemplateOut = (ExtendedDescriptor, KeyMap, ValidNetworks);
 ///
 /// ```
 /// use bdk::descriptor::error::Error as DescriptorError;
-/// use bdk::keys::{KeyError, ToDescriptorKey};
+/// use bdk::keys::{KeyError, IntoDescriptorKey};
 /// use bdk::miniscript::Legacy;
 /// use bdk::template::{DescriptorTemplate, DescriptorTemplateOut};
 ///
-/// struct MyP2PKH<K: ToDescriptorKey<Legacy>>(K);
+/// struct MyP2PKH<K: IntoDescriptorKey<Legacy>>(K);
 ///
-/// impl<K: ToDescriptorKey<Legacy>> DescriptorTemplate for MyP2PKH<K> {
+/// impl<K: IntoDescriptorKey<Legacy>> DescriptorTemplate for MyP2PKH<K> {
 ///     fn build(self) -> Result<DescriptorTemplateOut, DescriptorError> {
 ///         Ok(bdk::descriptor!(pkh(self.0))?)
 ///     }
@@ -104,9 +104,9 @@ impl<T: DescriptorTemplate> IntoWalletDescriptor for T {
 /// );
 /// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
-pub struct P2PKH<K: ToDescriptorKey<Legacy>>(pub K);
+pub struct P2PKH<K: IntoDescriptorKey<Legacy>>(pub K);
 
-impl<K: ToDescriptorKey<Legacy>> DescriptorTemplate for P2PKH<K> {
+impl<K: IntoDescriptorKey<Legacy>> DescriptorTemplate for P2PKH<K> {
     fn build(self) -> Result<DescriptorTemplateOut, DescriptorError> {
         Ok(descriptor!(pkh(self.0))?)
     }
@@ -138,9 +138,9 @@ impl<K: ToDescriptorKey<Legacy>> DescriptorTemplate for P2PKH<K> {
 /// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
 #[allow(non_camel_case_types)]
-pub struct P2WPKH_P2SH<K: ToDescriptorKey<Segwitv0>>(pub K);
+pub struct P2WPKH_P2SH<K: IntoDescriptorKey<Segwitv0>>(pub K);
 
-impl<K: ToDescriptorKey<Segwitv0>> DescriptorTemplate for P2WPKH_P2SH<K> {
+impl<K: IntoDescriptorKey<Segwitv0>> DescriptorTemplate for P2WPKH_P2SH<K> {
     fn build(self) -> Result<DescriptorTemplateOut, DescriptorError> {
         Ok(descriptor!(sh(wpkh(self.0)))?)
     }
@@ -171,9 +171,9 @@ impl<K: ToDescriptorKey<Segwitv0>> DescriptorTemplate for P2WPKH_P2SH<K> {
 /// );
 /// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
-pub struct P2WPKH<K: ToDescriptorKey<Segwitv0>>(pub K);
+pub struct P2WPKH<K: IntoDescriptorKey<Segwitv0>>(pub K);
 
-impl<K: ToDescriptorKey<Segwitv0>> DescriptorTemplate for P2WPKH<K> {
+impl<K: IntoDescriptorKey<Segwitv0>> DescriptorTemplate for P2WPKH<K> {
     fn build(self) -> Result<DescriptorTemplateOut, DescriptorError> {
         Ok(descriptor!(wpkh(self.0))?)
     }
@@ -410,7 +410,7 @@ macro_rules! expand_make_bipxx {
                 bip: u32,
                 key: K,
                 keychain: KeychainKind,
-            ) -> Result<impl ToDescriptorKey<$ctx>, DescriptorError> {
+            ) -> Result<impl IntoDescriptorKey<$ctx>, DescriptorError> {
                 let mut derivation_path = Vec::with_capacity(4);
                 derivation_path.push(bip32::ChildNumber::from_hardened_idx(bip)?);
                 derivation_path.push(bip32::ChildNumber::from_hardened_idx(0)?);
@@ -434,7 +434,7 @@ macro_rules! expand_make_bipxx {
                 key: K,
                 parent_fingerprint: bip32::Fingerprint,
                 keychain: KeychainKind,
-            ) -> Result<impl ToDescriptorKey<$ctx>, DescriptorError> {
+            ) -> Result<impl IntoDescriptorKey<$ctx>, DescriptorError> {
                 let derivation_path: bip32::DerivationPath = match keychain {
                     KeychainKind::External => vec![bip32::ChildNumber::from_normal_idx(0)?].into(),
                     KeychainKind::Internal => vec![bip32::ChildNumber::from_normal_idx(1)?].into(),

--- a/src/descriptor/template.rs
+++ b/src/descriptor/template.rs
@@ -32,7 +32,7 @@ use bitcoin::Network;
 
 use miniscript::{Legacy, Segwitv0};
 
-use super::{ExtendedDescriptor, KeyMap, ToWalletDescriptor};
+use super::{ExtendedDescriptor, IntoWalletDescriptor, KeyMap};
 use crate::descriptor::DescriptorError;
 use crate::keys::{DerivableKey, ToDescriptorKey, ValidNetworks};
 use crate::wallet::utils::SecpCtx;
@@ -43,7 +43,7 @@ pub type DescriptorTemplateOut = (ExtendedDescriptor, KeyMap, ValidNetworks);
 
 /// Trait for descriptor templates that can be built into a full descriptor
 ///
-/// Since [`ToWalletDescriptor`] is implemented for any [`DescriptorTemplate`], they can also be
+/// Since [`IntoWalletDescriptor`] is implemented for any [`DescriptorTemplate`], they can also be
 /// passed directly to the [`Wallet`](crate::Wallet) constructor.
 ///
 /// ## Example
@@ -69,7 +69,7 @@ pub trait DescriptorTemplate {
 
 /// Turns a [`DescriptorTemplate`] into a valid wallet descriptor by calling its
 /// [`build`](DescriptorTemplate::build) method
-impl<T: DescriptorTemplate> ToWalletDescriptor for T {
+impl<T: DescriptorTemplate> IntoWalletDescriptor for T {
     fn into_wallet_descriptor(
         self,
         secp: &SecpCtx,

--- a/src/descriptor/template.rs
+++ b/src/descriptor/template.rs
@@ -70,12 +70,12 @@ pub trait DescriptorTemplate {
 /// Turns a [`DescriptorTemplate`] into a valid wallet descriptor by calling its
 /// [`build`](DescriptorTemplate::build) method
 impl<T: DescriptorTemplate> ToWalletDescriptor for T {
-    fn to_wallet_descriptor(
+    fn into_wallet_descriptor(
         self,
         secp: &SecpCtx,
         network: Network,
     ) -> Result<(ExtendedDescriptor, KeyMap), DescriptorError> {
-        Ok(self.build()?.to_wallet_descriptor(secp, network)?)
+        Ok(self.build()?.into_wallet_descriptor(secp, network)?)
     }
 }
 

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -67,7 +67,7 @@ use crate::database::{BatchDatabase, BatchOperations, DatabaseUtils};
 use crate::descriptor::derived::AsDerived;
 use crate::descriptor::{
     get_checksum, DerivedDescriptor, DerivedDescriptorMeta, DescriptorMeta, DescriptorScripts,
-    ExtendedDescriptor, ExtractPolicy, Policy, ToWalletDescriptor, XKeyUtils,
+    ExtendedDescriptor, ExtractPolicy, IntoWalletDescriptor, Policy, XKeyUtils,
 };
 use crate::error::Error;
 use crate::psbt::PSBTUtils;
@@ -110,7 +110,7 @@ where
     D: BatchDatabase,
 {
     /// Create a new "offline" wallet
-    pub fn new_offline<E: ToWalletDescriptor>(
+    pub fn new_offline<E: IntoWalletDescriptor>(
         descriptor: E,
         change_descriptor: Option<E>,
         network: Network,
@@ -124,7 +124,7 @@ impl<B, D> Wallet<B, D>
 where
     D: BatchDatabase,
 {
-    fn _new<E: ToWalletDescriptor>(
+    fn _new<E: IntoWalletDescriptor>(
         descriptor: E,
         change_descriptor: Option<E>,
         network: Network,
@@ -1247,7 +1247,7 @@ where
 {
     /// Create a new "online" wallet
     #[maybe_async]
-    pub fn new<E: ToWalletDescriptor>(
+    pub fn new<E: IntoWalletDescriptor>(
         descriptor: E,
         change_descriptor: Option<E>,
         network: Network,

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -134,7 +134,7 @@ where
     ) -> Result<Self, Error> {
         let secp = Secp256k1::new();
 
-        let (descriptor, keymap) = descriptor.to_wallet_descriptor(&secp, network)?;
+        let (descriptor, keymap) = descriptor.into_wallet_descriptor(&secp, network)?;
         database.check_descriptor_checksum(
             KeychainKind::External,
             get_checksum(&descriptor.to_string())?.as_bytes(),
@@ -143,7 +143,7 @@ where
         let (change_descriptor, change_signers) = match change_descriptor {
             Some(desc) => {
                 let (change_descriptor, change_keymap) =
-                    desc.to_wallet_descriptor(&secp, network)?;
+                    desc.into_wallet_descriptor(&secp, network)?;
                 database.check_descriptor_checksum(
                     KeychainKind::Internal,
                     get_checksum(&change_descriptor.to_string())?.as_bytes(),

--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -561,7 +561,7 @@ mod signers_container_tests {
     use super::*;
     use crate::descriptor;
     use crate::descriptor::IntoWalletDescriptor;
-    use crate::keys::{DescriptorKey, ToDescriptorKey};
+    use crate::keys::{DescriptorKey, IntoDescriptorKey};
     use bitcoin::secp256k1::{All, Secp256k1};
     use bitcoin::util::bip32;
     use bitcoin::util::psbt::PartiallySignedTransaction;

--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -560,7 +560,7 @@ impl Eq for SignersContainerKey {}
 mod signers_container_tests {
     use super::*;
     use crate::descriptor;
-    use crate::descriptor::ToWalletDescriptor;
+    use crate::descriptor::IntoWalletDescriptor;
     use crate::keys::{DescriptorKey, ToDescriptorKey};
     use bitcoin::secp256k1::{All, Secp256k1};
     use bitcoin::util::bip32;

--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -579,7 +579,9 @@ mod signers_container_tests {
         let (prvkey1, _, _) = setup_keys(TPRV0_STR);
         let (prvkey2, _, _) = setup_keys(TPRV1_STR);
         let desc = descriptor!(sh(multi(2, prvkey1, prvkey2))).unwrap();
-        let (_, keymap) = desc.to_wallet_descriptor(&secp, Network::Testnet).unwrap();
+        let (_, keymap) = desc
+            .into_wallet_descriptor(&secp, Network::Testnet)
+            .unwrap();
 
         let signers = SignersContainer::from(keymap);
         assert_eq!(signers.ids().len(), 2);
@@ -690,8 +692,8 @@ mod signers_container_tests {
         let tprv = bip32::ExtendedPrivKey::from_str(tprv).unwrap();
         let tpub = bip32::ExtendedPubKey::from_private(&secp, &tprv);
         let fingerprint = tprv.fingerprint(&secp);
-        let prvkey = (tprv, path.clone()).to_descriptor_key().unwrap();
-        let pubkey = (tpub, path).to_descriptor_key().unwrap();
+        let prvkey = (tprv, path.clone()).into_descriptor_key().unwrap();
+        let pubkey = (tpub, path).into_descriptor_key().unwrap();
 
         (prvkey, pubkey, fingerprint)
     }


### PR DESCRIPTION
### Description

Two new clippy warning are showing up with the new `stable` version of rust [`1.50.0`].

[`1.50.0`]: https://blog.rust-lang.org/2021/02/11/Rust-1.50.0.html

The first clippy warning [`unnecessary_wraps`] only required removing the unnecessary Result wrapper for the `policy::finalize()` and `compact_filters peer::_recv()` functions.

Slightly more changes were required for the second warning [`wrong_self_convention`] which requires renaming the `ToWalletDescriptor::to_wallet_descriptor()` function to `into_wallet_descriptor()` to satisfy the naming convention that `into_` methods take `self` and `to_` methods take `&self`.

[`unnecessary_wraps`]: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_wraps
[`wrong_self_convention`]: https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention

### Notes to the reviewers

Once this is merged to `master` I'll cherry pick it to the `release/0.4.0' branch.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`

#### Bugfixes:

* [x] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
