### PR TITLE
Turn on rustfmt merge_imports

### DIFF
--- a/examples/address_validator.rs
+++ b/examples/address_validator.rs
@@ -24,16 +24,15 @@
 
 use std::sync::Arc;
 
-use bdk::bitcoin;
-use bdk::database::MemoryDatabase;
-use bdk::descriptor::HDKeyPaths;
-use bdk::wallet::address_validator::{AddressValidator, AddressValidatorError};
-use bdk::KeychainKind;
-use bdk::Wallet;
+use bdk::{
+    bitcoin,
+    database::MemoryDatabase,
+    descriptor::HDKeyPaths,
+    wallet::address_validator::{AddressValidator, AddressValidatorError},
+    KeychainKind, Wallet,
+};
 
-use bitcoin::hashes::hex::FromHex;
-use bitcoin::util::bip32::Fingerprint;
-use bitcoin::{Network, Script};
+use bitcoin::{hashes::hex::FromHex, util::bip32::Fingerprint, Network, Script};
 
 #[derive(Debug)]
 struct DummyValidator;

--- a/examples/compact_filters_balance.rs
+++ b/examples/compact_filters_balance.rs
@@ -1,10 +1,10 @@
-use bdk::blockchain::compact_filters::*;
-use bdk::blockchain::noop_progress;
-use bdk::database::MemoryDatabase;
-use bdk::*;
+use bdk::{
+    blockchain::{compact_filters::*, noop_progress},
+    database::MemoryDatabase,
+    *,
+};
 use bitcoin::*;
-use blockchain::compact_filters::CompactFiltersBlockchain;
-use blockchain::compact_filters::CompactFiltersError;
+use blockchain::compact_filters::{CompactFiltersBlockchain, CompactFiltersError};
 use log::info;
 use std::sync::Arc;
 

--- a/examples/compiler.rs
+++ b/examples/compiler.rs
@@ -29,19 +29,16 @@ extern crate log;
 extern crate miniscript;
 extern crate serde_json;
 
-use std::error::Error;
-use std::str::FromStr;
+use std::{error::Error, str::FromStr};
 
 use log::info;
 
 use clap::{App, Arg};
 
 use bitcoin::Network;
-use miniscript::policy::Concrete;
-use miniscript::Descriptor;
+use miniscript::{policy::Concrete, Descriptor};
 
-use bdk::database::memory::MemoryDatabase;
-use bdk::{KeychainKind, Wallet};
+use bdk::{database::memory::MemoryDatabase, KeychainKind, Wallet};
 
 fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init_from_env(

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -27,8 +27,7 @@ extern crate quote;
 
 use proc_macro::TokenStream;
 
-use syn::spanned::Spanned;
-use syn::{parse, ImplItemMethod, ItemImpl, ItemTrait, Token};
+use syn::{parse, spanned::Spanned, ImplItemMethod, ItemImpl, ItemTrait, Token};
 
 fn add_async_trait(mut parsed: ItemTrait) -> TokenStream {
     let output = quote! {

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2018"
+merge_imports = true

--- a/src/blockchain/compact_filters/mod.rs
+++ b/src/blockchain/compact_filters/mod.rs
@@ -62,17 +62,20 @@
 //! # Ok::<(), CompactFiltersError>(())
 //! ```
 
-use std::collections::HashSet;
-use std::fmt;
-use std::path::Path;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::HashSet,
+    fmt,
+    path::Path,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc, Mutex,
+    },
+};
 
 #[allow(unused_imports)]
 use log::{debug, error, info, trace};
 
-use bitcoin::network::message_blockdata::Inventory;
-use bitcoin::{Network, OutPoint, Transaction, Txid};
+use bitcoin::{network::message_blockdata::Inventory, Network, OutPoint, Transaction, Txid};
 
 use rocksdb::{Options, SliceTransform, DB};
 
@@ -81,10 +84,12 @@ mod store;
 mod sync;
 
 use super::{Blockchain, Capability, ConfigurableBlockchain, Progress};
-use crate::database::{BatchDatabase, BatchOperations, DatabaseUtils};
-use crate::error::Error;
-use crate::types::{KeychainKind, TransactionDetails, UTXO};
-use crate::FeeRate;
+use crate::{
+    database::{BatchDatabase, BatchOperations, DatabaseUtils},
+    error::Error,
+    types::{KeychainKind, TransactionDetails, UTXO},
+    FeeRate,
+};
 
 use peer::*;
 use store::*;

--- a/src/blockchain/compact_filters/peer.rs
+++ b/src/blockchain/compact_filters/peer.rs
@@ -22,26 +22,32 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use std::collections::HashMap;
-use std::net::{TcpStream, ToSocketAddrs};
-use std::sync::{Arc, Condvar, Mutex, RwLock};
-use std::thread;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::{
+    collections::HashMap,
+    net::{TcpStream, ToSocketAddrs},
+    sync::{Arc, Condvar, Mutex, RwLock},
+    thread,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 
 use socks::{Socks5Stream, ToTargetAddr};
 
 use rand::{thread_rng, Rng};
 
-use bitcoin::consensus::Encodable;
-use bitcoin::hash_types::BlockHash;
-use bitcoin::network::constants::ServiceFlags;
-use bitcoin::network::message::{NetworkMessage, RawNetworkMessage};
-use bitcoin::network::message_blockdata::*;
-use bitcoin::network::message_filter::*;
-use bitcoin::network::message_network::VersionMessage;
-use bitcoin::network::stream_reader::StreamReader;
-use bitcoin::network::Address;
-use bitcoin::{Block, Network, Transaction, Txid, Wtxid};
+use bitcoin::{
+    consensus::Encodable,
+    hash_types::BlockHash,
+    network::{
+        constants::ServiceFlags,
+        message::{NetworkMessage, RawNetworkMessage},
+        message_blockdata::*,
+        message_filter::*,
+        message_network::VersionMessage,
+        stream_reader::StreamReader,
+        Address,
+    },
+    Block, Network, Transaction, Txid, Wtxid,
+};
 
 use super::CompactFiltersError;
 

--- a/src/blockchain/compact_filters/store.rs
+++ b/src/blockchain/compact_filters/store.rs
@@ -22,29 +22,26 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use std::convert::TryInto;
-use std::fmt;
-use std::io::{Read, Write};
-use std::marker::PhantomData;
-use std::ops::Deref;
-use std::sync::Arc;
-use std::sync::RwLock;
+use std::{
+    convert::TryInto,
+    fmt,
+    io::{Read, Write},
+    marker::PhantomData,
+    ops::Deref,
+    sync::{Arc, RwLock},
+};
 
-use rand::distributions::Alphanumeric;
-use rand::{thread_rng, Rng};
+use rand::{distributions::Alphanumeric, thread_rng, Rng};
 
 use rocksdb::{Direction, IteratorMode, ReadOptions, WriteBatch, DB};
 
-use bitcoin::consensus::{deserialize, encode::VarInt, serialize, Decodable, Encodable};
-use bitcoin::hash_types::{FilterHash, FilterHeader};
-use bitcoin::hashes::hex::FromHex;
-use bitcoin::hashes::Hash;
-use bitcoin::util::bip158::BlockFilter;
-use bitcoin::util::uint::Uint256;
-use bitcoin::Block;
-use bitcoin::BlockHash;
-use bitcoin::BlockHeader;
-use bitcoin::Network;
+use bitcoin::{
+    consensus::{deserialize, encode::VarInt, serialize, Decodable, Encodable},
+    hash_types::{FilterHash, FilterHeader},
+    hashes::{hex::FromHex, Hash},
+    util::{bip158::BlockFilter, uint::Uint256},
+    Block, BlockHash, BlockHeader, Network,
+};
 
 use super::CompactFiltersError;
 

--- a/src/blockchain/compact_filters/sync.rs
+++ b/src/blockchain/compact_filters/sync.rs
@@ -22,18 +22,19 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use std::collections::{BTreeMap, HashMap, VecDeque};
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::{
+    collections::{BTreeMap, HashMap, VecDeque},
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
-use bitcoin::hash_types::{BlockHash, FilterHeader};
-use bitcoin::network::message::NetworkMessage;
-use bitcoin::network::message_blockdata::GetHeadersMessage;
-use bitcoin::util::bip158::BlockFilter;
+use bitcoin::{
+    hash_types::{BlockHash, FilterHeader},
+    network::{message::NetworkMessage, message_blockdata::GetHeadersMessage},
+    util::bip158::BlockFilter,
+};
 
-use super::peer::*;
-use super::store::*;
-use super::CompactFiltersError;
+use super::{peer::*, store::*, CompactFiltersError};
 use crate::error::Error;
 
 pub(crate) const BURIED_CONFIRMATIONS: usize = 100;

--- a/src/blockchain/electrum.rs
+++ b/src/blockchain/electrum.rs
@@ -48,9 +48,7 @@ use electrum_client::{Client, ConfigBuilder, ElectrumApi, Socks5Config};
 
 use self::utils::{ELSGetHistoryRes, ElectrumLikeSync};
 use super::*;
-use crate::database::BatchDatabase;
-use crate::error::Error;
-use crate::FeeRate;
+use crate::{database::BatchDatabase, error::Error, FeeRate};
 
 /// Wrapper over an Electrum Client that implements the required blockchain traits
 ///

--- a/src/blockchain/esplora.rs
+++ b/src/blockchain/esplora.rs
@@ -35,8 +35,10 @@
 //! # Ok::<(), bdk::Error>(())
 //! ```
 
-use std::collections::{HashMap, HashSet};
-use std::fmt;
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+};
 
 use futures::stream::{self, FuturesOrdered, StreamExt, TryStreamExt};
 
@@ -47,17 +49,18 @@ use serde::Deserialize;
 
 use reqwest::{Client, StatusCode};
 
-use bitcoin::consensus::{self, deserialize, serialize};
-use bitcoin::hashes::hex::{FromHex, ToHex};
-use bitcoin::hashes::{sha256, Hash};
-use bitcoin::{BlockHash, BlockHeader, Script, Transaction, Txid};
+use bitcoin::{
+    consensus::{self, deserialize, serialize},
+    hashes::{
+        hex::{FromHex, ToHex},
+        sha256, Hash,
+    },
+    BlockHash, BlockHeader, Script, Transaction, Txid,
+};
 
 use self::utils::{ELSGetHistoryRes, ElectrumLikeSync};
 use super::*;
-use crate::database::BatchDatabase;
-use crate::error::Error;
-use crate::wallet::utils::ChunksIterator;
-use crate::FeeRate;
+use crate::{database::BatchDatabase, error::Error, wallet::utils::ChunksIterator, FeeRate};
 
 const DEFAULT_CONCURRENT_REQUESTS: u8 = 4;
 

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -29,16 +29,18 @@
 //! [Compact Filters/Neutrino](crate::blockchain::compact_filters), along with a generalized trait
 //! [`Blockchain`] that can be implemented to build customized backends.
 
-use std::collections::HashSet;
-use std::ops::Deref;
-use std::sync::mpsc::{channel, Receiver, Sender};
-use std::sync::Arc;
+use std::{
+    collections::HashSet,
+    ops::Deref,
+    sync::{
+        mpsc::{channel, Receiver, Sender},
+        Arc,
+    },
+};
 
 use bitcoin::{Transaction, Txid};
 
-use crate::database::BatchDatabase;
-use crate::error::Error;
-use crate::FeeRate;
+use crate::{database::BatchDatabase, error::Error, FeeRate};
 
 #[cfg(any(feature = "electrum", feature = "esplora"))]
 pub(crate) mod utils;

--- a/src/blockchain/utils.rs
+++ b/src/blockchain/utils.rs
@@ -26,17 +26,17 @@ use std::collections::{HashMap, HashSet};
 
 #[allow(unused_imports)]
 use log::{debug, error, info, trace};
-use rand::seq::SliceRandom;
-use rand::thread_rng;
+use rand::{seq::SliceRandom, thread_rng};
 
 use bitcoin::{BlockHeader, OutPoint, Script, Transaction, Txid};
 
 use super::*;
-use crate::database::{BatchDatabase, BatchOperations, DatabaseUtils};
-use crate::error::Error;
-use crate::types::{KeychainKind, TransactionDetails, UTXO};
-use crate::wallet::time::Instant;
-use crate::wallet::utils::ChunksIterator;
+use crate::{
+    database::{BatchDatabase, BatchOperations, DatabaseUtils},
+    error::Error,
+    types::{KeychainKind, TransactionDetails, UTXO},
+    wallet::{time::Instant, utils::ChunksIterator},
+};
 
 #[derive(Debug)]
 pub struct ELSGetHistoryRes {

--- a/src/database/keyvalue.rs
+++ b/src/database/keyvalue.rs
@@ -26,14 +26,17 @@ use std::convert::TryInto;
 
 use sled::{Batch, Tree};
 
-use bitcoin::consensus::encode::{deserialize, serialize};
-use bitcoin::hash_types::Txid;
-use bitcoin::{OutPoint, Script, Transaction};
+use bitcoin::{
+    consensus::encode::{deserialize, serialize},
+    hash_types::Txid,
+    OutPoint, Script, Transaction,
+};
 
-use crate::database::memory::MapKey;
-use crate::database::{BatchDatabase, BatchOperations, Database};
-use crate::error::Error;
-use crate::types::*;
+use crate::{
+    database::{memory::MapKey, BatchDatabase, BatchOperations, Database},
+    error::Error,
+    types::*,
+};
 
 macro_rules! impl_batch_operations {
     ( { $($after_insert:tt)* }, $process_delete:ident ) => {
@@ -396,8 +399,10 @@ impl BatchDatabase for Tree {
 
 #[cfg(test)]
 mod test {
-    use std::sync::{Arc, Condvar, Mutex, Once};
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::{
+        sync::{Arc, Condvar, Mutex, Once},
+        time::{SystemTime, UNIX_EPOCH},
+    };
 
     use sled::{Db, Tree};
 

--- a/src/database/memory.rs
+++ b/src/database/memory.rs
@@ -27,16 +27,22 @@
 //! This module defines an in-memory database type called [`MemoryDatabase`] that is based on a
 //! [`BTreeMap`].
 
-use std::collections::BTreeMap;
-use std::ops::Bound::{Excluded, Included};
+use std::{
+    collections::BTreeMap,
+    ops::Bound::{Excluded, Included},
+};
 
-use bitcoin::consensus::encode::{deserialize, serialize};
-use bitcoin::hash_types::Txid;
-use bitcoin::{OutPoint, Script, Transaction};
+use bitcoin::{
+    consensus::encode::{deserialize, serialize},
+    hash_types::Txid,
+    OutPoint, Script, Transaction,
+};
 
-use crate::database::{BatchDatabase, BatchOperations, ConfigurableDatabase, Database};
-use crate::error::Error;
-use crate::types::*;
+use crate::{
+    database::{BatchDatabase, BatchOperations, ConfigurableDatabase, Database},
+    error::Error,
+    types::*,
+};
 
 // path -> script       p{i,e}<path> -> script
 // script -> path       s<script> -> {i,e}<path>

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -37,11 +37,9 @@
 //!
 //! [`Wallet`]: crate::wallet::Wallet
 
-use bitcoin::hash_types::Txid;
-use bitcoin::{OutPoint, Script, Transaction, TxOut};
+use bitcoin::{hash_types::Txid, OutPoint, Script, Transaction, TxOut};
 
-use crate::error::Error;
-use crate::types::*;
+use crate::{error::Error, types::*};
 
 pub mod any;
 pub use any::{AnyDatabase, AnyDatabaseConfig};
@@ -206,9 +204,7 @@ impl<T: Database> DatabaseUtils for T {}
 pub mod test {
     use std::str::FromStr;
 
-    use bitcoin::consensus::encode::deserialize;
-    use bitcoin::hashes::hex::*;
-    use bitcoin::*;
+    use bitcoin::{consensus::encode::deserialize, hashes::hex::*, *};
 
     use super::*;
 

--- a/src/descriptor/derived.rs
+++ b/src/descriptor/derived.rs
@@ -24,17 +24,18 @@
 
 //! Derived descriptor keys
 
-use std::cmp::Ordering;
-use std::fmt;
-use std::hash::{Hash, Hasher};
-use std::ops::Deref;
+use std::{
+    cmp::Ordering,
+    fmt,
+    hash::{Hash, Hasher},
+    ops::Deref,
+};
 
-use bitcoin::hashes::hash160;
-use bitcoin::PublicKey;
+use bitcoin::{hashes::hash160, PublicKey};
 
 pub use miniscript::{
-    descriptor::KeyMap, descriptor::Wildcard, Descriptor, DescriptorPublicKey, Legacy, Miniscript,
-    ScriptContext, Segwitv0,
+    descriptor::{KeyMap, Wildcard},
+    Descriptor, DescriptorPublicKey, Legacy, Miniscript, ScriptContext, Segwitv0,
 };
 use miniscript::{MiniscriptKey, ToPublicKey, TranslatePk};
 

--- a/src/descriptor/dsl.rs
+++ b/src/descriptor/dsl.rs
@@ -677,18 +677,23 @@ macro_rules! fragment {
 
 #[cfg(test)]
 mod test {
-    use bitcoin::hashes::hex::ToHex;
-    use bitcoin::secp256k1::Secp256k1;
-    use miniscript::descriptor::{DescriptorPublicKey, DescriptorTrait, KeyMap};
-    use miniscript::{Descriptor, Legacy, Segwitv0};
+    use bitcoin::{hashes::hex::ToHex, secp256k1::Secp256k1};
+    use miniscript::{
+        descriptor::{DescriptorPublicKey, DescriptorTrait, KeyMap},
+        Descriptor, Legacy, Segwitv0,
+    };
 
     use std::str::FromStr;
 
-    use crate::descriptor::{DescriptorError, DescriptorMeta};
-    use crate::keys::{DescriptorKey, ToDescriptorKey, ValidNetworks};
-    use bitcoin::network::constants::Network::{Bitcoin, Regtest, Signet, Testnet};
-    use bitcoin::util::bip32;
-    use bitcoin::PrivateKey;
+    use crate::{
+        descriptor::{DescriptorError, DescriptorMeta},
+        keys::{DescriptorKey, ToDescriptorKey, ValidNetworks},
+    };
+    use bitcoin::{
+        network::constants::Network::{Bitcoin, Regtest, Signet, Testnet},
+        util::bip32,
+        PrivateKey,
+    };
 
     use crate::descriptor::derived::AsDerived;
 

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -27,18 +27,26 @@
 //! This module contains generic utilities to work with descriptors, plus some re-exported types
 //! from [`miniscript`].
 
-use std::collections::{BTreeMap, HashMap};
-use std::ops::Deref;
-
-use bitcoin::util::bip32::{
-    ChildNumber, DerivationPath, ExtendedPrivKey, ExtendedPubKey, Fingerprint, KeySource,
+use std::{
+    collections::{BTreeMap, HashMap},
+    ops::Deref,
 };
-use bitcoin::util::psbt;
-use bitcoin::{Network, PublicKey, Script, TxOut};
 
-use miniscript::descriptor::{DescriptorPublicKey, DescriptorType, DescriptorXKey, Wildcard};
+use bitcoin::{
+    util::{
+        bip32::{
+            ChildNumber, DerivationPath, ExtendedPrivKey, ExtendedPubKey, Fingerprint, KeySource,
+        },
+        psbt,
+    },
+    Network, PublicKey, Script, TxOut,
+};
+
 pub use miniscript::{descriptor::KeyMap, Descriptor, Legacy, Miniscript, ScriptContext, Segwitv0};
-use miniscript::{DescriptorTrait, ForEachKey, TranslatePk};
+use miniscript::{
+    descriptor::{DescriptorPublicKey, DescriptorType, DescriptorXKey, Wildcard},
+    DescriptorTrait, ForEachKey, TranslatePk,
+};
 
 pub mod checksum;
 pub(crate) mod derived;
@@ -48,15 +56,15 @@ pub mod error;
 pub mod policy;
 pub mod template;
 
-pub use self::checksum::get_checksum;
-use self::derived::AsDerived;
-pub use self::derived::DerivedDescriptorKey;
-pub use self::error::Error as DescriptorError;
-pub use self::policy::Policy;
-use self::template::DescriptorTemplateOut;
-use crate::keys::{KeyError, ToDescriptorKey};
-use crate::wallet::signer::SignersContainer;
-use crate::wallet::utils::SecpCtx;
+pub use self::{
+    checksum::get_checksum, derived::DerivedDescriptorKey, error::Error as DescriptorError,
+    policy::Policy,
+};
+use self::{derived::AsDerived, template::DescriptorTemplateOut};
+use crate::{
+    keys::{KeyError, ToDescriptorKey},
+    wallet::{signer::SignersContainer, utils::SecpCtx},
+};
 
 /// Alias for a [`Descriptor`] that can contain extended keys using [`DescriptorPublicKey`]
 pub type ExtendedDescriptor = Descriptor<DescriptorPublicKey>;
@@ -495,10 +503,12 @@ impl<'s> DerivedDescriptorMeta for DerivedDescriptor<'s> {
 mod test {
     use std::str::FromStr;
 
-    use bitcoin::consensus::encode::deserialize;
-    use bitcoin::hashes::hex::FromHex;
-    use bitcoin::secp256k1::Secp256k1;
-    use bitcoin::util::{bip32, psbt};
+    use bitcoin::{
+        consensus::encode::deserialize,
+        hashes::hex::FromHex,
+        secp256k1::Secp256k1,
+        util::{bip32, psbt},
+    };
 
     use super::*;
     use crate::psbt::PSBTUtils;

--- a/src/descriptor/policy.rs
+++ b/src/descriptor/policy.rs
@@ -47,30 +47,33 @@
 //! # Ok::<(), bdk::Error>(())
 //! ```
 
-use std::cmp::{max, Ordering};
-use std::collections::{BTreeMap, HashSet, VecDeque};
-use std::fmt;
+use std::{
+    cmp::{max, Ordering},
+    collections::{BTreeMap, HashSet, VecDeque},
+    fmt,
+};
 
-use serde::ser::SerializeMap;
-use serde::{Serialize, Serializer};
+use serde::{ser::SerializeMap, Serialize, Serializer};
 
-use bitcoin::hashes::*;
-use bitcoin::util::bip32::Fingerprint;
-use bitcoin::PublicKey;
+use bitcoin::{hashes::*, util::bip32::Fingerprint, PublicKey};
 
-use miniscript::descriptor::{DescriptorPublicKey, ShInner, SortedMultiVec, WshInner};
-use miniscript::{Descriptor, Miniscript, MiniscriptKey, ScriptContext, Terminal, ToPublicKey};
+use miniscript::{
+    descriptor::{DescriptorPublicKey, ShInner, SortedMultiVec, WshInner},
+    Descriptor, Miniscript, MiniscriptKey, ScriptContext, Terminal, ToPublicKey,
+};
 
 #[allow(unused_imports)]
 use log::{debug, error, info, trace};
 
-use crate::descriptor::{DerivedDescriptorKey, ExtractPolicy};
-use crate::wallet::signer::{SignerId, SignersContainer};
-use crate::wallet::utils::{self, SecpCtx};
+use crate::{
+    descriptor::{DerivedDescriptorKey, ExtractPolicy},
+    wallet::{
+        signer::{SignerId, SignersContainer},
+        utils::{self, SecpCtx},
+    },
+};
 
-use super::checksum::get_checksum;
-use super::error::Error;
-use super::XKeyUtils;
+use super::{checksum::get_checksum, error::Error, XKeyUtils};
 
 /// Raw public key or extended key fingerprint
 #[derive(Debug, Clone, Default, Serialize)]
@@ -889,18 +892,23 @@ impl ExtractPolicy for Descriptor<DescriptorPublicKey> {
 
 #[cfg(test)]
 mod test {
-    use crate::descriptor;
-    use crate::descriptor::{ExtractPolicy, ToWalletDescriptor};
+    use crate::{
+        descriptor,
+        descriptor::{ExtractPolicy, ToWalletDescriptor},
+    };
 
     use super::*;
-    use crate::descriptor::policy::SatisfiableItem::{Multisig, Signature, Thresh};
-    use crate::keys::{DescriptorKey, ToDescriptorKey};
-    use crate::wallet::signer::SignersContainer;
-    use bitcoin::secp256k1::{All, Secp256k1};
-    use bitcoin::util::bip32;
-    use bitcoin::Network;
-    use std::str::FromStr;
-    use std::sync::Arc;
+    use crate::{
+        descriptor::policy::SatisfiableItem::{Multisig, Signature, Thresh},
+        keys::{DescriptorKey, ToDescriptorKey},
+        wallet::signer::SignersContainer,
+    };
+    use bitcoin::{
+        secp256k1::{All, Secp256k1},
+        util::bip32,
+        Network,
+    };
+    use std::{str::FromStr, sync::Arc};
 
     const TPRV0_STR:&str = "tprv8ZgxMBicQKsPdZXrcHNLf5JAJWFAoJ2TrstMRdSKtEggz6PddbuSkvHKM9oKJyFgZV1B7rw8oChspxyYbtmEXYyg1AjfWbL3ho3XHDpHRZf";
     const TPRV1_STR:&str = "tprv8ZgxMBicQKsPdpkqS7Eair4YxjcuuvDPNYmKX3sCniCf16tHEVrjjiSXEkFRnUH77yXc6ZcwHHcLNfjdi5qUvw3VDfgYiH5mNsj5izuiu2N";

--- a/src/descriptor/template.rs
+++ b/src/descriptor/template.rs
@@ -27,16 +27,18 @@
 //! This module contains the definition of various common script templates that are ready to be
 //! used. See the documentation of each template for an example.
 
-use bitcoin::util::bip32;
-use bitcoin::Network;
+use bitcoin::{util::bip32, Network};
 
 use miniscript::{Legacy, Segwitv0};
 
 use super::{ExtendedDescriptor, KeyMap, ToWalletDescriptor};
-use crate::descriptor::DescriptorError;
-use crate::keys::{DerivableKey, ToDescriptorKey, ValidNetworks};
-use crate::wallet::utils::SecpCtx;
-use crate::{descriptor, KeychainKind};
+use crate::{
+    descriptor,
+    descriptor::DescriptorError,
+    keys::{DerivableKey, ToDescriptorKey, ValidNetworks},
+    wallet::utils::SecpCtx,
+    KeychainKind,
+};
 
 /// Type alias for the return type of [`DescriptorTemplate`], [`descriptor!`](crate::descriptor!) and others
 pub type DescriptorTemplateOut = (ExtendedDescriptor, KeyMap, ValidNetworks);
@@ -460,14 +462,17 @@ mod test {
     // test existing descriptor templates, make sure they are expanded to the right descriptors
 
     use super::*;
-    use crate::descriptor::derived::AsDerived;
-    use crate::descriptor::{DescriptorError, DescriptorMeta};
-    use crate::keys::ValidNetworks;
-    use bitcoin::hashes::core::str::FromStr;
-    use bitcoin::network::constants::Network::Regtest;
-    use bitcoin::secp256k1::Secp256k1;
-    use miniscript::descriptor::{DescriptorPublicKey, DescriptorTrait, KeyMap};
-    use miniscript::Descriptor;
+    use crate::{
+        descriptor::{derived::AsDerived, DescriptorError, DescriptorMeta},
+        keys::ValidNetworks,
+    };
+    use bitcoin::{
+        hashes::core::str::FromStr, network::constants::Network::Regtest, secp256k1::Secp256k1,
+    };
+    use miniscript::{
+        descriptor::{DescriptorPublicKey, DescriptorTrait, KeyMap},
+        Descriptor,
+    };
 
     // verify template descriptor generates expected address(es)
     fn check(

--- a/src/keys/bip39.rs
+++ b/src/keys/bip39.rs
@@ -27,8 +27,7 @@
 // TODO: maybe write our own implementation of bip39? Seems stupid to have an extra dependency for
 // something that should be fairly simple to re-implement.
 
-use bitcoin::util::bip32;
-use bitcoin::Network;
+use bitcoin::{util::bip32, Network};
 
 use miniscript::ScriptContext;
 

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -24,27 +24,28 @@
 
 //! Key formats
 
-use std::any::TypeId;
-use std::collections::HashSet;
-use std::marker::PhantomData;
-use std::ops::Deref;
-use std::str::FromStr;
+use std::{any::TypeId, collections::HashSet, marker::PhantomData, ops::Deref, str::FromStr};
 
 use bitcoin::secp256k1::{self, Secp256k1, Signing};
 
-use bitcoin::util::bip32;
-use bitcoin::{Network, PrivateKey, PublicKey};
+use bitcoin::{util::bip32, Network, PrivateKey, PublicKey};
 
-use miniscript::descriptor::{Descriptor, DescriptorXKey, Wildcard};
-pub use miniscript::descriptor::{
-    DescriptorPublicKey, DescriptorSecretKey, DescriptorSinglePriv, DescriptorSinglePub, KeyMap,
-    SortedMultiVec,
+use miniscript::{
+    descriptor::{Descriptor, DescriptorXKey, Wildcard},
+    Miniscript, Terminal,
 };
-pub use miniscript::ScriptContext;
-use miniscript::{Miniscript, Terminal};
+pub use miniscript::{
+    descriptor::{
+        DescriptorPublicKey, DescriptorSecretKey, DescriptorSinglePriv, DescriptorSinglePub,
+        KeyMap, SortedMultiVec,
+    },
+    ScriptContext,
+};
 
-use crate::descriptor::{CheckMiniscript, DescriptorError};
-use crate::wallet::utils::SecpCtx;
+use crate::{
+    descriptor::{CheckMiniscript, DescriptorError},
+    wallet::utils::SecpCtx,
+};
 
 #[cfg(feature = "keys-bip39")]
 #[cfg_attr(docsrs, doc(cfg(feature = "keys-bip39")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,14 +262,10 @@ pub(crate) mod psbt;
 pub(crate) mod types;
 pub mod wallet;
 
-pub use descriptor::template;
-pub use descriptor::HDKeyPaths;
+pub use descriptor::{template, HDKeyPaths};
 pub use error::Error;
 pub use types::*;
-pub use wallet::address_validator;
-pub use wallet::signer;
-pub use wallet::tx_builder::TxBuilder;
-pub use wallet::Wallet;
+pub use wallet::{address_validator, signer, tx_builder::TxBuilder, Wallet};
 
 /// Get the version of BDK at runtime
 pub fn version() -> &'static str {

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -22,8 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-use bitcoin::util::psbt::PartiallySignedTransaction as PSBT;
-use bitcoin::TxOut;
+use bitcoin::{util::psbt::PartiallySignedTransaction as PSBT, TxOut};
 
 pub trait PSBTUtils {
     fn get_utxo_for(&self, input_index: usize) -> Option<TxOut>;

--- a/src/types.rs
+++ b/src/types.rs
@@ -24,8 +24,10 @@
 
 use std::convert::AsRef;
 
-use bitcoin::blockdata::transaction::{OutPoint, Transaction, TxOut};
-use bitcoin::hash_types::Txid;
+use bitcoin::{
+    blockdata::transaction::{OutPoint, Transaction, TxOut},
+    hash_types::Txid,
+};
 
 use serde::{Deserialize, Serialize};
 

--- a/src/wallet/address_validator.rs
+++ b/src/wallet/address_validator.rs
@@ -79,8 +79,7 @@ use std::fmt;
 
 use bitcoin::Script;
 
-use crate::descriptor::HDKeyPaths;
-use crate::types::KeychainKind;
+use crate::{descriptor::HDKeyPaths, types::KeychainKind};
 
 /// Errors that can be returned to fail the validation of an address
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/wallet/coin_selection.rs
+++ b/src/wallet/coin_selection.rs
@@ -97,9 +97,11 @@
 //! # Ok::<(), bdk::Error>(())
 //! ```
 
-use crate::database::Database;
-use crate::error::Error;
-use crate::types::{FeeRate, UTXO};
+use crate::{
+    database::Database,
+    error::Error,
+    types::{FeeRate, UTXO},
+};
 
 use rand::seq::SliceRandom;
 #[cfg(not(test))]
@@ -526,12 +528,9 @@ mod test {
     use bitcoin::{OutPoint, Script, TxOut};
 
     use super::*;
-    use crate::database::MemoryDatabase;
-    use crate::types::*;
+    use crate::{database::MemoryDatabase, types::*};
 
-    use rand::rngs::StdRng;
-    use rand::seq::SliceRandom;
-    use rand::{Rng, SeedableRng};
+    use rand::{rngs::StdRng, seq::SliceRandom, Rng, SeedableRng};
 
     const P2WPKH_WITNESS_SIZE: usize = 73 + 33 + 2;
 

--- a/src/wallet/export.rs
+++ b/src/wallet/export.rs
@@ -76,11 +76,12 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
-use miniscript::descriptor::{ShInner, WshInner};
-use miniscript::{Descriptor, DescriptorPublicKey, ScriptContext, Terminal};
+use miniscript::{
+    descriptor::{ShInner, WshInner},
+    Descriptor, DescriptorPublicKey, ScriptContext, Terminal,
+};
 
-use crate::database::BatchDatabase;
-use crate::wallet::Wallet;
+use crate::{database::BatchDatabase, wallet::Wallet};
 
 /// Structure that contains the export of a wallet
 ///
@@ -222,9 +223,11 @@ mod test {
     use bitcoin::{Network, Txid};
 
     use super::*;
-    use crate::database::{memory::MemoryDatabase, BatchOperations};
-    use crate::types::TransactionDetails;
-    use crate::wallet::Wallet;
+    use crate::{
+        database::{memory::MemoryDatabase, BatchOperations},
+        types::TransactionDetails,
+        wallet::Wallet,
+    };
 
     fn get_test_db() -> MemoryDatabase {
         let mut db = MemoryDatabase::new();

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -26,22 +26,25 @@
 //!
 //! This module defines the [`Wallet`] structure.
 
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::collections::{BTreeMap, HashSet};
-use std::ops::{Deref, DerefMut};
-use std::sync::Arc;
+use std::{
+    cell::RefCell,
+    collections::{BTreeMap, HashMap, HashSet},
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
 
 use bitcoin::secp256k1::Secp256k1;
 
-use bitcoin::consensus::encode::serialize;
-use bitcoin::util::base58;
-use bitcoin::util::psbt::raw::Key as PSBTKey;
-use bitcoin::util::psbt::PartiallySignedTransaction as PSBT;
-use bitcoin::{Address, Network, OutPoint, Script, Transaction, TxOut, Txid};
+use bitcoin::{
+    consensus::encode::serialize,
+    util::{
+        base58,
+        psbt::{raw::Key as PSBTKey, PartiallySignedTransaction as PSBT},
+    },
+    Address, Network, OutPoint, Script, Transaction, TxOut, Txid,
+};
 
-use miniscript::descriptor::DescriptorTrait;
-use miniscript::psbt::PsbtInputSatisfier;
+use miniscript::{descriptor::DescriptorTrait, psbt::PsbtInputSatisfier};
 
 #[allow(unused_imports)]
 use log::{debug, error, info, trace};
@@ -62,16 +65,18 @@ use signer::{Signer, SignerOrdering, SignersContainer};
 use tx_builder::{BumpFee, CreateTx, FeePolicy, TxBuilder, TxParams};
 use utils::{check_nlocktime, check_nsequence_rbf, After, Older, SecpCtx, DUST_LIMIT_SATOSHI};
 
-use crate::blockchain::{Blockchain, Progress};
-use crate::database::{BatchDatabase, BatchOperations, DatabaseUtils};
-use crate::descriptor::derived::AsDerived;
-use crate::descriptor::{
-    get_checksum, DerivedDescriptor, DerivedDescriptorMeta, DescriptorMeta, DescriptorScripts,
-    ExtendedDescriptor, ExtractPolicy, Policy, ToWalletDescriptor, XKeyUtils,
+use crate::{
+    blockchain::{Blockchain, Progress},
+    database::{BatchDatabase, BatchOperations, DatabaseUtils},
+    descriptor::{
+        derived::AsDerived, get_checksum, DerivedDescriptor, DerivedDescriptorMeta, DescriptorMeta,
+        DescriptorScripts, ExtendedDescriptor, ExtractPolicy, Policy, ToWalletDescriptor,
+        XKeyUtils,
+    },
+    error::Error,
+    psbt::PSBTUtils,
+    types::*,
 };
-use crate::error::Error;
-use crate::psbt::PSBTUtils;
-use crate::types::*;
 
 const CACHE_ADDR_BATCH_SIZE: u32 = 100;
 
@@ -1349,9 +1354,10 @@ mod test {
 
     use bitcoin::Network;
 
-    use crate::database::memory::MemoryDatabase;
-    use crate::database::Database;
-    use crate::types::KeychainKind;
+    use crate::{
+        database::{memory::MemoryDatabase, Database},
+        types::KeychainKind,
+    };
 
     use super::*;
 
@@ -2212,9 +2218,10 @@ mod test {
 
     #[test]
     fn test_create_tx_global_xpubs_with_origin() {
-        use bitcoin::hashes::hex::FromHex;
-        use bitcoin::util::base58;
-        use bitcoin::util::psbt::raw::Key;
+        use bitcoin::{
+            hashes::hex::FromHex,
+            util::{base58, psbt::raw::Key},
+        };
 
         let (wallet, _, _) = get_funded_wallet("wpkh([73756c7f/48'/0'/0'/2']tpubDCKxNyM3bLgbEX13Mcd8mYxbVg9ajDkWXMh29hMWBurKfVmBfWAM96QVP3zaUcN51HvkZ3ar4VwP82kC8JZhhux8vFQoJintSpVBwpFvyU3/0/*)");
         let addr = wallet.get_new_address().unwrap();
@@ -2252,9 +2259,10 @@ mod test {
 
     #[test]
     fn test_create_tx_global_xpubs_master_without_origin() {
-        use bitcoin::hashes::hex::FromHex;
-        use bitcoin::util::base58;
-        use bitcoin::util::psbt::raw::Key;
+        use bitcoin::{
+            hashes::hex::FromHex,
+            util::{base58, psbt::raw::Key},
+        };
 
         let (wallet, _, _) = get_funded_wallet("wpkh(tpubD6NzVbkrYhZ4Y55A58Gv9RSNF5hy84b5AJqYy7sCcjFrkcLpPre8kmgfit6kY1Zs3BLgeypTDBZJM222guPpdz7Cup5yzaMu62u7mYGbwFL/0/*)");
         let addr = wallet.get_new_address().unwrap();

--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -95,22 +95,24 @@
 //! # Ok::<_, bdk::Error>(())
 //! ```
 
-use std::cmp::Ordering;
-use std::collections::BTreeMap;
-use std::fmt;
-use std::ops::Bound::Included;
-use std::sync::Arc;
+use std::{cmp::Ordering, collections::BTreeMap, fmt, ops::Bound::Included, sync::Arc};
 
-use bitcoin::blockdata::opcodes;
-use bitcoin::blockdata::script::Builder as ScriptBuilder;
-use bitcoin::hashes::{hash160, Hash};
-use bitcoin::secp256k1::{Message, Secp256k1};
-use bitcoin::util::bip32::{ExtendedPrivKey, Fingerprint};
-use bitcoin::util::{bip143, psbt};
-use bitcoin::{PrivateKey, Script, SigHash, SigHashType};
+use bitcoin::{
+    blockdata::{opcodes, script::Builder as ScriptBuilder},
+    hashes::{hash160, Hash},
+    secp256k1::{Message, Secp256k1},
+    util::{
+        bip143,
+        bip32::{ExtendedPrivKey, Fingerprint},
+        psbt,
+    },
+    PrivateKey, Script, SigHash, SigHashType,
+};
 
-use miniscript::descriptor::{DescriptorSecretKey, DescriptorSinglePriv, DescriptorXKey, KeyMap};
-use miniscript::{Legacy, MiniscriptKey, Segwitv0};
+use miniscript::{
+    descriptor::{DescriptorSecretKey, DescriptorSinglePriv, DescriptorXKey, KeyMap},
+    Legacy, MiniscriptKey, Segwitv0,
+};
 
 use super::utils::SecpCtx;
 use crate::descriptor::XKeyUtils;
@@ -559,13 +561,16 @@ impl Eq for SignersContainerKey {}
 #[cfg(test)]
 mod signers_container_tests {
     use super::*;
-    use crate::descriptor;
-    use crate::descriptor::ToWalletDescriptor;
-    use crate::keys::{DescriptorKey, ToDescriptorKey};
-    use bitcoin::secp256k1::{All, Secp256k1};
-    use bitcoin::util::bip32;
-    use bitcoin::util::psbt::PartiallySignedTransaction;
-    use bitcoin::Network;
+    use crate::{
+        descriptor,
+        descriptor::ToWalletDescriptor,
+        keys::{DescriptorKey, ToDescriptorKey},
+    };
+    use bitcoin::{
+        secp256k1::{All, Secp256k1},
+        util::{bip32, psbt::PartiallySignedTransaction},
+        Network,
+    };
     use miniscript::ScriptContext;
     use std::str::FromStr;
 

--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -49,21 +49,23 @@
 //! # Ok::<(), bdk::Error>(())
 //! ```
 
-use std::collections::BTreeMap;
-use std::collections::HashSet;
-use std::default::Default;
-use std::marker::PhantomData;
+use std::{
+    collections::{BTreeMap, HashSet},
+    default::Default,
+    marker::PhantomData,
+};
 
-use bitcoin::util::psbt::PartiallySignedTransaction as PSBT;
-use bitcoin::{OutPoint, Script, SigHashType, Transaction};
+use bitcoin::{
+    util::psbt::PartiallySignedTransaction as PSBT, OutPoint, Script, SigHashType, Transaction,
+};
 
 use miniscript::descriptor::DescriptorTrait;
 
 use super::coin_selection::{CoinSelectionAlgorithm, DefaultCoinSelectionAlgorithm};
-use crate::{database::BatchDatabase, Error, Wallet};
 use crate::{
+    database::BatchDatabase,
     types::{FeeRate, KeychainKind, UTXO},
-    TransactionDetails,
+    Error, TransactionDetails, Wallet,
 };
 /// Context in which the [`TxBuilder`] is valid
 pub trait TxBuilderContext: std::fmt::Debug + Default + Clone {}
@@ -642,8 +644,7 @@ mod test {
         };
     }
 
-    use bitcoin::consensus::deserialize;
-    use bitcoin::hashes::hex::FromHex;
+    use bitcoin::{consensus::deserialize, hashes::hex::FromHex};
 
     use super::*;
 

--- a/testutils-macros/src/lib.rs
+++ b/testutils-macros/src/lib.rs
@@ -27,8 +27,7 @@ extern crate quote;
 
 use proc_macro::TokenStream;
 
-use syn::spanned::Spanned;
-use syn::{parse, parse2, Ident, ReturnType};
+use syn::{parse, parse2, spanned::Spanned, Ident, ReturnType};
 
 #[proc_macro_attribute]
 pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream {

--- a/testutils/src/lib.rs
+++ b/testutils/src/lib.rs
@@ -27,27 +27,24 @@ extern crate serde_json;
 
 pub use serial_test::serial;
 
-use std::collections::HashMap;
-use std::env;
-use std::ops::Deref;
-use std::path::PathBuf;
-use std::str::FromStr;
-use std::time::Duration;
+use std::{collections::HashMap, env, ops::Deref, path::PathBuf, str::FromStr, time::Duration};
 
 #[allow(unused_imports)]
 use log::{debug, error, info, trace};
 
-use bitcoin::consensus::encode::{deserialize, serialize};
-use bitcoin::hashes::hex::{FromHex, ToHex};
-use bitcoin::hashes::sha256d;
-use bitcoin::secp256k1::{Secp256k1, Verification};
-use bitcoin::{Address, Amount, PublicKey, Script, Transaction, Txid};
+use bitcoin::{
+    consensus::encode::{deserialize, serialize},
+    hashes::{
+        hex::{FromHex, ToHex},
+        sha256d,
+    },
+    secp256k1::{Secp256k1, Verification},
+    Address, Amount, PublicKey, Script, Transaction, Txid,
+};
 
-use miniscript::descriptor::DescriptorPublicKey;
-use miniscript::{Descriptor, MiniscriptKey, TranslatePk};
+use miniscript::{descriptor::DescriptorPublicKey, Descriptor, MiniscriptKey, TranslatePk};
 
-pub use bitcoincore_rpc::bitcoincore_rpc_json::AddressType;
-pub use bitcoincore_rpc::{Auth, Client as RpcClient, RpcApi};
+pub use bitcoincore_rpc::{bitcoincore_rpc_json::AddressType, Auth, Client as RpcClient, RpcApi};
 
 pub use electrum_client::{Client as ElectrumClient, ElectrumApi};
 
@@ -422,10 +419,14 @@ impl TestClient {
     }
 
     pub fn generate_manually(&mut self, txs: Vec<Transaction>) -> String {
-        use bitcoin::blockdata::block::{Block, BlockHeader};
-        use bitcoin::blockdata::script::Builder;
-        use bitcoin::blockdata::transaction::{OutPoint, TxIn, TxOut};
-        use bitcoin::hash_types::{BlockHash, TxMerkleNode};
+        use bitcoin::{
+            blockdata::{
+                block::{Block, BlockHeader},
+                script::Builder,
+                transaction::{OutPoint, TxIn, TxOut},
+            },
+            hash_types::{BlockHash, TxMerkleNode},
+        };
 
         let block_template: serde_json::Value = self
             .call("getblocktemplate", &[json!({"rules": ["segwit"]})])


### PR DESCRIPTION
Was brought up here: https://github.com/bitcoindevkit/bdk/pull/279#r572591694

So I made  PR to see what it would look like and to see if we have overwhelming support for it. I think I prefer merge imports as it's easier to see what top level modules are being imported. It does add some more LoC funnily enough.

Voice your opinion. There are also other options we could turn on in rustfmt. See [here](https://rust-lang.github.io/rustfmt/?version=v1.4.36&search=) which could be added to the PR. 