### PR TITLE
126 clippy

### DIFF
--- a/examples/compiler.rs
+++ b/examples/compiler.rs
@@ -97,7 +97,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let network = matches
         .value_of("network")
-        .and_then(|n| Some(Network::from_str(n)))
+        .map(|n| Network::from_str(n))
         .transpose()
         .unwrap()
         .unwrap_or(Network::Testnet);

--- a/scripts/cargo-check.sh
+++ b/scripts/cargo-check.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Run various invocations of cargo check
+
+features=( "default" "compiler" "electrum" "esplora" "compact_filters" "key-value-db" "async-interface" "all-keys" "keys-bip39" )
+toolchains=( "+stable" "+1.45" "+nightly" )
+
+main() {
+    check_src
+    check_all_targets
+}
+
+# Check with all features, with various toolchains.
+check_src() {
+    for toolchain in "${toolchains[@]}"; do
+        cmd="cargo $toolchain clippy --all-targets --no-default-features"
+
+        for feature in "${features[@]}"; do
+            touch_files
+            $cmd --features "$feature"
+        done
+    done
+}
+
+# Touch files to prevent cached warnings from not showing up.
+touch_files() {
+    touch $(find . -name *.rs)
+}
+
+main
+exit 0

--- a/src/blockchain/compact_filters/mod.rs
+++ b/src/blockchain/compact_filters/mod.rs
@@ -239,6 +239,7 @@ impl Blockchain for CompactFiltersBlockchain {
         vec![Capability::FullHistory].into_iter().collect()
     }
 
+    #[allow(clippy::mutex_atomic)] // Mutex is easier to understand than a CAS loop.
     fn setup<D: BatchDatabase, P: 'static + Progress>(
         &self,
         _stop_gap: Option<usize>, // TODO: move to electrum and esplora only

--- a/src/blockchain/compact_filters/store.rs
+++ b/src/blockchain/compact_filters/store.rs
@@ -46,6 +46,8 @@ use bitcoin::BlockHash;
 use bitcoin::BlockHeader;
 use bitcoin::Network;
 
+use lazy_static::lazy_static;
+
 use super::CompactFiltersError;
 
 lazy_static! {

--- a/src/database/any.rs
+++ b/src/database/any.rs
@@ -312,24 +312,17 @@ impl BatchDatabase for AnyDatabase {
         }
     }
     fn commit_batch(&mut self, batch: Self::Batch) -> Result<(), Error> {
-        // TODO: refactor once `move_ref_pattern` is stable
-        #[allow(irrefutable_let_patterns)]
         match self {
-            AnyDatabase::Memory(db) => {
-                if let AnyBatch::Memory(batch) = batch {
-                    db.commit_batch(batch)
-                } else {
-                    unimplemented!()
-                }
-            }
+            AnyDatabase::Memory(db) => match batch {
+                AnyBatch::Memory(batch) => db.commit_batch(batch),
+                #[cfg(feature = "key-value-db")]
+                _ => unimplemented!("Sled batch shouldn't be used with Memory db."),
+            },
             #[cfg(feature = "key-value-db")]
-            AnyDatabase::Sled(db) => {
-                if let AnyBatch::Sled(batch) = batch {
-                    db.commit_batch(batch)
-                } else {
-                    unimplemented!()
-                }
-            }
+            AnyDatabase::Sled(db) => match batch {
+                AnyBatch::Sled(batch) => db.commit_batch(batch),
+                _ => unimplemented!("Memory batch shouldn't be used with Sled db."),
+            },
         }
     }
 }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -227,7 +227,7 @@ pub mod test {
         );
         assert_eq!(
             tree.get_path_from_script_pubkey(&script).unwrap(),
-            Some((keychain, path.clone()))
+            Some((keychain, path))
         );
     }
 
@@ -256,7 +256,7 @@ pub mod test {
         );
         assert_eq!(
             tree.get_path_from_script_pubkey(&script).unwrap(),
-            Some((keychain, path.clone()))
+            Some((keychain, path))
         );
     }
 

--- a/src/descriptor/dsl.rs
+++ b/src/descriptor/dsl.rs
@@ -968,7 +968,7 @@ mod test {
     fn test_valid_networks() {
         let xprv = bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPcx5nBGsR63Pe8KnRUqmbJNENAfGftF3yuXoMMoVJJcYeUw5eVkm9WBPjWYt6HMWYJNesB5HaNVBaFc1M6dRjWSYnmewUMYy").unwrap();
         let path = bip32::DerivationPath::from_str("m/0").unwrap();
-        let desc_key = (xprv, path.clone()).into_descriptor_key().unwrap();
+        let desc_key = (xprv, path).into_descriptor_key().unwrap();
 
         let (_desc, _key_map, valid_networks) = descriptor!(pkh(desc_key)).unwrap();
         assert_eq!(
@@ -978,7 +978,7 @@ mod test {
 
         let xprv = bip32::ExtendedPrivKey::from_str("xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi").unwrap();
         let path = bip32::DerivationPath::from_str("m/10/20/30/40").unwrap();
-        let desc_key = (xprv, path.clone()).into_descriptor_key().unwrap();
+        let desc_key = (xprv, path).into_descriptor_key().unwrap();
 
         let (_desc, _key_map, valid_networks) = descriptor!(wpkh(desc_key)).unwrap();
         assert_eq!(valid_networks, [Bitcoin].iter().cloned().collect());
@@ -1005,12 +1005,9 @@ mod test {
             descriptor!(sh(wsh(multi(2, desc_key1, desc_key2, desc_key3)))).unwrap();
         assert_eq!(key_map.len(), 3);
 
-        let desc_key1: DescriptorKey<Segwitv0> =
-            (xprv1, path1.clone()).into_descriptor_key().unwrap();
-        let desc_key2: DescriptorKey<Segwitv0> =
-            (xprv2, path2.clone()).into_descriptor_key().unwrap();
-        let desc_key3: DescriptorKey<Segwitv0> =
-            (xprv3, path3.clone()).into_descriptor_key().unwrap();
+        let desc_key1: DescriptorKey<Segwitv0> = (xprv1, path1).into_descriptor_key().unwrap();
+        let desc_key2: DescriptorKey<Segwitv0> = (xprv2, path2).into_descriptor_key().unwrap();
+        let desc_key3: DescriptorKey<Segwitv0> = (xprv3, path3).into_descriptor_key().unwrap();
 
         let (key1, _key_map, _valid_networks) = desc_key1.extract(&secp).unwrap();
         let (key2, _key_map, _valid_networks) = desc_key2.extract(&secp).unwrap();
@@ -1026,7 +1023,7 @@ mod test {
         // this compiles
         let xprv = bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPcx5nBGsR63Pe8KnRUqmbJNENAfGftF3yuXoMMoVJJcYeUw5eVkm9WBPjWYt6HMWYJNesB5HaNVBaFc1M6dRjWSYnmewUMYy").unwrap();
         let path = bip32::DerivationPath::from_str("m/0").unwrap();
-        let desc_key: DescriptorKey<Legacy> = (xprv, path.clone()).into_descriptor_key().unwrap();
+        let desc_key: DescriptorKey<Legacy> = (xprv, path).into_descriptor_key().unwrap();
 
         let (desc, _key_map, _valid_networks) = descriptor!(pkh(desc_key)).unwrap();
         assert_eq!(desc.to_string(), "pkh(tpubD6NzVbkrYhZ4WR7a4vY1VT3khMJMeAxVsfq9TBJyJWrNk247zCJtV7AWf6UJP7rAVsn8NNKdJi3gFyKPTmWZS9iukb91xbn2HbFSMQm2igY/0/*)#yrnz9pp2");

--- a/src/descriptor/dsl.rs
+++ b/src/descriptor/dsl.rs
@@ -228,10 +228,11 @@ macro_rules! impl_sortedmulti {
         use $crate::keys::IntoDescriptorKey;
         let secp = $crate::bitcoin::secp256k1::Secp256k1::new();
 
-        let mut keys = vec![];
-        $(
-            keys.push($key.into_descriptor_key());
-        )*
+        let keys = vec![
+            $(
+                $key.into_descriptor_key(),
+            )*
+        ];
 
         keys.into_iter().collect::<Result<Vec<_>, _>>()
             .map_err($crate::descriptor::DescriptorError::Key)
@@ -656,10 +657,11 @@ macro_rules! fragment {
         use $crate::keys::IntoDescriptorKey;
         let secp = $crate::bitcoin::secp256k1::Secp256k1::new();
 
-        let mut keys = vec![];
-        $(
-            keys.push($key.into_descriptor_key());
-        )*
+        let keys = vec![
+            $(
+                $key.into_descriptor_key(),
+            )*
+        ];
 
         keys.into_iter().collect::<Result<Vec<_>, _>>()
             .map_err($crate::descriptor::DescriptorError::Key)

--- a/src/descriptor/policy.rs
+++ b/src/descriptor/policy.rs
@@ -938,7 +938,7 @@ mod test {
             .unwrap();
 
         assert!(
-            matches!(&policy.item, Signature(pk_or_f) if &pk_or_f.fingerprint.unwrap() == &fingerprint)
+            matches!(&policy.item, Signature(pk_or_f) if pk_or_f.fingerprint.unwrap() == fingerprint)
         );
         assert!(matches!(&policy.contribution, Satisfaction::None));
 
@@ -953,7 +953,7 @@ mod test {
             .unwrap();
 
         assert!(
-            matches!(&policy.item, Signature(pk_or_f) if &pk_or_f.fingerprint.unwrap() == &fingerprint)
+            matches!(&policy.item, Signature(pk_or_f) if pk_or_f.fingerprint.unwrap() == fingerprint)
         );
         assert!(
             matches!(&policy.contribution, Satisfaction::Complete {condition} if condition.csv == None && condition.timelock == None)
@@ -1039,8 +1039,8 @@ mod test {
 
         assert!(
             matches!(&policy.item, Multisig { keys, threshold } if threshold == &1
-            && &keys[0].fingerprint.unwrap() == &fingerprint0
-            && &keys[1].fingerprint.unwrap() == &fingerprint1)
+            && keys[0].fingerprint.unwrap() == fingerprint0
+            && keys[1].fingerprint.unwrap() == fingerprint1)
         );
         assert!(
             matches!(&policy.contribution, Satisfaction::PartialComplete { n, m, items, conditions, .. } if n == &2
@@ -1071,8 +1071,8 @@ mod test {
 
         assert!(
             matches!(&policy.item, Multisig { keys, threshold } if threshold == &2
-            && &keys[0].fingerprint.unwrap() == &fingerprint0
-            && &keys[1].fingerprint.unwrap() == &fingerprint1)
+            && keys[0].fingerprint.unwrap() == fingerprint0
+            && keys[1].fingerprint.unwrap() == fingerprint1)
         );
 
         assert!(
@@ -1103,7 +1103,7 @@ mod test {
             .unwrap();
 
         assert!(
-            matches!(&policy.item, Signature(pk_or_f) if &pk_or_f.fingerprint.unwrap() == &fingerprint)
+            matches!(&policy.item, Signature(pk_or_f) if pk_or_f.fingerprint.unwrap() == fingerprint)
         );
         assert!(matches!(&policy.contribution, Satisfaction::None));
 
@@ -1119,7 +1119,7 @@ mod test {
             .unwrap();
 
         assert!(
-            matches!(&policy.item, Signature(pk_or_f) if &pk_or_f.fingerprint.unwrap() == &fingerprint)
+            matches!(&policy.item, Signature(pk_or_f) if pk_or_f.fingerprint.unwrap() == fingerprint)
         );
         assert!(
             matches!(&policy.contribution, Satisfaction::Complete {condition} if condition.csv == None && condition.timelock == None)
@@ -1147,8 +1147,8 @@ mod test {
 
         assert!(
             matches!(&policy.item, Multisig { keys, threshold } if threshold == &1
-            && &keys[0].fingerprint.unwrap() == &fingerprint0
-            && &keys[1].fingerprint.unwrap() == &fingerprint1)
+            && keys[0].fingerprint.unwrap() == fingerprint0
+            && keys[1].fingerprint.unwrap() == fingerprint1)
         );
         assert!(
             matches!(&policy.contribution, Satisfaction::PartialComplete { n, m, items, conditions, .. } if n == &2

--- a/src/descriptor/template.rs
+++ b/src/descriptor/template.rs
@@ -75,7 +75,7 @@ impl<T: DescriptorTemplate> IntoWalletDescriptor for T {
         secp: &SecpCtx,
         network: Network,
     ) -> Result<(ExtendedDescriptor, KeyMap), DescriptorError> {
-        Ok(self.build()?.into_wallet_descriptor(secp, network)?)
+        self.build()?.into_wallet_descriptor(secp, network)
     }
 }
 
@@ -108,7 +108,7 @@ pub struct P2PKH<K: IntoDescriptorKey<Legacy>>(pub K);
 
 impl<K: IntoDescriptorKey<Legacy>> DescriptorTemplate for P2PKH<K> {
     fn build(self) -> Result<DescriptorTemplateOut, DescriptorError> {
-        Ok(descriptor!(pkh(self.0))?)
+        descriptor!(pkh(self.0))
     }
 }
 
@@ -142,7 +142,7 @@ pub struct P2WPKH_P2SH<K: IntoDescriptorKey<Segwitv0>>(pub K);
 
 impl<K: IntoDescriptorKey<Segwitv0>> DescriptorTemplate for P2WPKH_P2SH<K> {
     fn build(self) -> Result<DescriptorTemplateOut, DescriptorError> {
-        Ok(descriptor!(sh(wpkh(self.0)))?)
+        descriptor!(sh(wpkh(self.0)))
     }
 }
 
@@ -175,7 +175,7 @@ pub struct P2WPKH<K: IntoDescriptorKey<Segwitv0>>(pub K);
 
 impl<K: IntoDescriptorKey<Segwitv0>> DescriptorTemplate for P2WPKH<K> {
     fn build(self) -> Result<DescriptorTemplateOut, DescriptorError> {
-        Ok(descriptor!(wpkh(self.0))?)
+        descriptor!(wpkh(self.0))
     }
 }
 
@@ -210,7 +210,7 @@ pub struct BIP44<K: DerivableKey<Legacy>>(pub K, pub KeychainKind);
 
 impl<K: DerivableKey<Legacy>> DescriptorTemplate for BIP44<K> {
     fn build(self) -> Result<DescriptorTemplateOut, DescriptorError> {
-        Ok(P2PKH(legacy::make_bipxx_private(44, self.0, self.1)?).build()?)
+        P2PKH(legacy::make_bipxx_private(44, self.0, self.1)?).build()
     }
 }
 
@@ -249,7 +249,7 @@ pub struct BIP44Public<K: DerivableKey<Legacy>>(pub K, pub bip32::Fingerprint, p
 
 impl<K: DerivableKey<Legacy>> DescriptorTemplate for BIP44Public<K> {
     fn build(self) -> Result<DescriptorTemplateOut, DescriptorError> {
-        Ok(P2PKH(legacy::make_bipxx_public(44, self.0, self.1, self.2)?).build()?)
+        P2PKH(legacy::make_bipxx_public(44, self.0, self.1, self.2)?).build()
     }
 }
 
@@ -284,7 +284,7 @@ pub struct BIP49<K: DerivableKey<Segwitv0>>(pub K, pub KeychainKind);
 
 impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for BIP49<K> {
     fn build(self) -> Result<DescriptorTemplateOut, DescriptorError> {
-        Ok(P2WPKH_P2SH(segwit_v0::make_bipxx_private(49, self.0, self.1)?).build()?)
+        P2WPKH_P2SH(segwit_v0::make_bipxx_private(49, self.0, self.1)?).build()
     }
 }
 
@@ -323,7 +323,7 @@ pub struct BIP49Public<K: DerivableKey<Segwitv0>>(pub K, pub bip32::Fingerprint,
 
 impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for BIP49Public<K> {
     fn build(self) -> Result<DescriptorTemplateOut, DescriptorError> {
-        Ok(P2WPKH_P2SH(segwit_v0::make_bipxx_public(49, self.0, self.1, self.2)?).build()?)
+        P2WPKH_P2SH(segwit_v0::make_bipxx_public(49, self.0, self.1, self.2)?).build()
     }
 }
 
@@ -358,7 +358,7 @@ pub struct BIP84<K: DerivableKey<Segwitv0>>(pub K, pub KeychainKind);
 
 impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for BIP84<K> {
     fn build(self) -> Result<DescriptorTemplateOut, DescriptorError> {
-        Ok(P2WPKH(segwit_v0::make_bipxx_private(84, self.0, self.1)?).build()?)
+        P2WPKH(segwit_v0::make_bipxx_private(84, self.0, self.1)?).build()
     }
 }
 
@@ -397,7 +397,7 @@ pub struct BIP84Public<K: DerivableKey<Segwitv0>>(pub K, pub bip32::Fingerprint,
 
 impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for BIP84Public<K> {
     fn build(self) -> Result<DescriptorTemplateOut, DescriptorError> {
-        Ok(P2WPKH(segwit_v0::make_bipxx_public(84, self.0, self.1, self.2)?).build()?)
+        P2WPKH(segwit_v0::make_bipxx_public(84, self.0, self.1, self.2)?).build()
     }
 }
 

--- a/src/descriptor/template.rs
+++ b/src/descriptor/template.rs
@@ -440,11 +440,11 @@ macro_rules! expand_make_bipxx {
                     KeychainKind::Internal => vec![bip32::ChildNumber::from_normal_idx(1)?].into(),
                 };
 
-                let mut source_path = Vec::with_capacity(3);
-                source_path.push(bip32::ChildNumber::from_hardened_idx(bip)?);
-                source_path.push(bip32::ChildNumber::from_hardened_idx(0)?);
-                source_path.push(bip32::ChildNumber::from_hardened_idx(0)?);
-                let source_path: bip32::DerivationPath = source_path.into();
+                let source_path = bip32::DerivationPath::from(vec![
+                    bip32::ChildNumber::from_hardened_idx(bip)?,
+                    bip32::ChildNumber::from_hardened_idx(0)?,
+                    bip32::ChildNumber::from_hardened_idx(0)?,
+                ]);
 
                 Ok((key, (parent_fingerprint, source_path), derivation_path))
             }

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -733,7 +733,7 @@ fn expand_multi_keys<Pk: IntoDescriptorKey<Ctx>, Ctx: ScriptContext>(
 ) -> Result<(Vec<DescriptorPublicKey>, KeyMap, ValidNetworks), KeyError> {
     let (pks, key_maps_networks): (Vec<_>, Vec<_>) = pks
         .into_iter()
-        .map(|key| Ok::<_, KeyError>(key.into_descriptor_key()?.extract(secp)?))
+        .map(|key| key.into_descriptor_key()?.extract(secp))
         .collect::<Result<Vec<_>, _>>()?
         .into_iter()
         .map(|(a, b, c)| (a, (b, c)))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,6 @@ extern crate async_trait;
 extern crate bdk_macros;
 
 #[cfg(feature = "compact_filters")]
-#[macro_use]
 extern crate lazy_static;
 
 #[cfg(feature = "electrum")]

--- a/src/wallet/coin_selection.rs
+++ b/src/wallet/coin_selection.rs
@@ -804,7 +804,7 @@ mod test {
             .coin_select(
                 &database,
                 vec![],
-                utxos.clone(),
+                utxos,
                 FeeRate::from_sat_per_vb(1.0),
                 99932, // first utxo's effective value
                 0.0,

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1942,7 +1942,7 @@ mod test {
 
         assert_eq!(psbt.inputs[0].bip32_derivation.len(), 1);
         assert_eq!(
-            psbt.inputs[0].bip32_derivation.values().nth(0).unwrap(),
+            psbt.inputs[0].bip32_derivation.values().next().unwrap(),
             &(
                 Fingerprint::from_str("d34db33f").unwrap(),
                 DerivationPath::from_str("m/44'/0'/0'/0/0").unwrap()
@@ -1968,7 +1968,7 @@ mod test {
 
         assert_eq!(psbt.outputs[0].bip32_derivation.len(), 1);
         assert_eq!(
-            psbt.outputs[0].bip32_derivation.values().nth(0).unwrap(),
+            psbt.outputs[0].bip32_derivation.values().next().unwrap(),
             &(
                 Fingerprint::from_str("d34db33f").unwrap(),
                 DerivationPath::from_str("m/44'/0'/0'/0/5").unwrap()

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -3220,15 +3220,18 @@ mod test {
         let (mut psbt, _) = builder.finish().unwrap();
 
         // add another input to the psbt that is at least passable.
-        let mut dud_input = bitcoin::util::psbt::Input::default();
-        dud_input.witness_utxo = Some(TxOut {
-            value: 100_000,
-            script_pubkey: miniscript::Descriptor::<bitcoin::PublicKey>::from_str(
-                "wpkh(025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee6357)",
-            )
-            .unwrap()
-            .script_pubkey(),
-        });
+        let dud_input = bitcoin::util::psbt::Input {
+            witness_utxo: Some(TxOut {
+                value: 100_000,
+                script_pubkey: miniscript::Descriptor::<bitcoin::PublicKey>::from_str(
+                    "wpkh(025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee6357)",
+                )
+                .unwrap()
+                .script_pubkey(),
+            }),
+            ..Default::default()
+        };
+
         psbt.inputs.push(dud_input);
         psbt.global.unsigned_tx.input.push(bitcoin::TxIn::default());
         let (psbt, is_final) = wallet.sign(psbt, None).unwrap();

--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -602,8 +602,9 @@ mod signers_container_tests {
         let signer2 = Arc::new(DummySigner { number: 2 });
         let signer3 = Arc::new(DummySigner { number: 3 });
 
-        signers.add_external(SignerId::Dummy(1), SignerOrdering(1), signer1.clone());
+        // Mixed order insertions verifies we are not inserting at head or tail.
         signers.add_external(SignerId::Dummy(2), SignerOrdering(2), signer2.clone());
+        signers.add_external(SignerId::Dummy(1), SignerOrdering(1), signer1.clone());
         signers.add_external(SignerId::Dummy(3), SignerOrdering(3), signer3.clone());
 
         // Check that signers are sorted from lowest to highest ordering

--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -630,11 +630,11 @@ impl ChangeSpendPolicy {
 #[cfg(test)]
 mod test {
     const ORDERING_TEST_TX: &str = "0200000003c26f3eb7932f7acddc5ddd26602b77e7516079b03090a16e2c2f54\
-                                            85d1fd600f0100000000ffffffffc26f3eb7932f7acddc5ddd26602b77e75160\
-                                            79b03090a16e2c2f5485d1fd600f0000000000ffffffff571fb3e02278217852\
-                                            dd5d299947e2b7354a639adc32ec1fa7b82cfb5dec530e0500000000ffffffff\
-                                            03e80300000000000002aaeee80300000000000001aa200300000000000001ff\
-                                            00000000";
+                                    85d1fd600f0100000000ffffffffc26f3eb7932f7acddc5ddd26602b77e75160\
+                                    79b03090a16e2c2f5485d1fd600f0000000000ffffffff571fb3e02278217852\
+                                    dd5d299947e2b7354a639adc32ec1fa7b82cfb5dec530e0500000000ffffffff\
+                                    03e80300000000000002aaeee80300000000000001aa200300000000000001ff\
+                                    00000000";
     macro_rules! ordering_test_tx {
         () => {
             deserialize::<bitcoin::Transaction>(&Vec::<u8>::from_hex(ORDERING_TEST_TX).unwrap())

--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -678,7 +678,7 @@ mod test {
         use std::str::FromStr;
 
         let original_tx = ordering_test_tx!();
-        let mut tx = original_tx.clone();
+        let mut tx = original_tx;
 
         TxOrdering::BIP69Lexicographic.sort_tx(&mut tx);
 

--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -736,9 +736,9 @@ mod test {
         let filtered = get_test_utxos()
             .into_iter()
             .filter(|u| change_spend_policy.is_satisfied_by(u))
-            .collect::<Vec<_>>();
+            .count();
 
-        assert_eq!(filtered.len(), 2);
+        assert_eq!(filtered, 2);
     }
 
     #[test]

--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -629,7 +629,7 @@ impl ChangeSpendPolicy {
 
 #[cfg(test)]
 mod test {
-    const ORDERING_TEST_TX: &'static str = "0200000003c26f3eb7932f7acddc5ddd26602b77e7516079b03090a16e2c2f54\
+    const ORDERING_TEST_TX: &str = "0200000003c26f3eb7932f7acddc5ddd26602b77e7516079b03090a16e2c2f54\
                                             85d1fd600f0100000000ffffffffc26f3eb7932f7acddc5ddd26602b77e75160\
                                             79b03090a16e2c2f5485d1fd600f0000000000ffffffff571fb3e02278217852\
                                             dd5d299947e2b7354a639adc32ec1fa7b82cfb5dec530e0500000000ffffffff\

--- a/src/wallet/utils.rs
+++ b/src/wallet/utils.rs
@@ -156,8 +156,8 @@ pub struct ChunksIterator<I: Iterator> {
     size: usize,
 }
 
+#[cfg(any(feature = "electrum", feature = "esplora"))]
 impl<I: Iterator> ChunksIterator<I> {
-    #[allow(dead_code)]
     pub fn new(iter: I, size: usize) -> Self {
         ChunksIterator { iter, size }
     }

--- a/testutils/src/lib.rs
+++ b/testutils/src/lib.rs
@@ -349,7 +349,7 @@ impl TestClient {
 
     pub fn receive(&mut self, meta_tx: TestIncomingTx) -> Txid {
         assert!(
-            meta_tx.output.len() > 0,
+            !meta_tx.output.is_empty(),
             "can't create a transaction with no outputs"
         );
 

--- a/testutils/src/lib.rs
+++ b/testutils/src/lib.rs
@@ -60,13 +60,13 @@ fn get_auth() -> Auth {
         ),
         _ => Auth::CookieFile(PathBuf::from(
             env::var("BDK_RPC_COOKIEFILE")
-                .unwrap_or("/home/user/.bitcoin/regtest/.cookie".to_string()),
+                .unwrap_or_else(|_| "/home/user/.bitcoin/regtest/.cookie".to_string()),
         )),
     }
 }
 
 pub fn get_electrum_url() -> String {
-    env::var("BDK_ELECTRUM_URL").unwrap_or("tcp://127.0.0.1:50001".to_string())
+    env::var("BDK_ELECTRUM_URL").unwrap_or_else(|_| "tcp://127.0.0.1:50001".to_string())
 }
 
 pub struct TestClient {
@@ -311,8 +311,8 @@ where
 
 impl TestClient {
     pub fn new() -> Self {
-        let url = env::var("BDK_RPC_URL").unwrap_or("127.0.0.1:18443".to_string());
-        let wallet = env::var("BDK_RPC_WALLET").unwrap_or("bdk-test".to_string());
+        let url = env::var("BDK_RPC_URL").unwrap_or_else(|_| "127.0.0.1:18443".to_string());
+        let wallet = env::var("BDK_RPC_WALLET").unwrap_or_else(|_| "bdk-test".to_string());
         let client =
             RpcClient::new(format!("http://{}/wallet/{}", url, wallet), get_auth()).unwrap();
         let electrum = ElectrumClient::new(&get_electrum_url()).unwrap();


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Fix clippy warnings, this includes those found using nightly. This PR does not remove _all_ clippy warnings. It doesn't do:

- the ones done in @notmandatory's PR #282.
- the float comparison ones in unit tests, I'm not sure about these ones yet - will think some more on them.
- the all caps ones (e.g. BIP32, UTXO) 
- the Rust 2021 ones (are we even in line with 2018 yet :)
- the 'use Default instead of new' one. Wasn't sure if that is a breaking API change or not so I left it out

I've tested the PR using a script that runs clippy for each of the toolchains `+stable`, `+1.45`, and `+nightly` to see none of the nightly suggestions break earlier toolchains. The final patch in this PR adds that script to `scritps/cargo-check.sh`. Can remove if not needed/wanted.

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

This PR includes patches first put forward in [this PR](https://github.com/bitcoindevkit/bdk/pull/241), seems I cannot re-open that one, sorry for breaking the thread.

There are going to be merge conflicts with #282, I'm happy for it to go in first and I'll rebase this one. 

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
