### PR TITLE
Fix/policy path multisig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Policy
 #### Changed
 - Removed unneeded `Result<(), PolicyError>` return type for `Satisfaction::finalize()`
+- Removed the `TooManyItemsSelected` policy error (see commit message for more details)
 
 ## [v0.3.0] - [v0.2.0]
 

--- a/src/descriptor/policy.rs
+++ b/src/descriptor/policy.rs
@@ -47,7 +47,7 @@
 //! # Ok::<(), bdk::Error>(())
 //! ```
 
-use std::cmp::{max, Ordering};
+use std::cmp::max;
 use std::collections::{BTreeMap, HashSet, VecDeque};
 use std::fmt;
 
@@ -510,8 +510,6 @@ impl Condition {
 pub enum PolicyError {
     /// Not enough items are selected to satisfy a [`SatisfiableItem::Thresh`]
     NotEnoughItemsSelected(String),
-    /// Too many items are selected to satisfy a [`SatisfiableItem::Thresh`]
-    TooManyItemsSelected(String),
     /// Index out of range for an item to satisfy a [`SatisfiableItem::Thresh`]
     IndexOutOfRange(usize),
     /// Can not add to an item that is [`Satisfaction::None`] or [`Satisfaction::Complete`]
@@ -668,14 +666,8 @@ impl Policy {
                 // if we have something, make sure we have enough items. note that the user can set
                 // an empty value for this step in case of n-of-n, because `selected` is set to all
                 // the elements above
-                match selected.len().cmp(threshold) {
-                    Ordering::Less => {
-                        return Err(PolicyError::NotEnoughItemsSelected(self.id.clone()))
-                    }
-                    Ordering::Greater => {
-                        return Err(PolicyError::TooManyItemsSelected(self.id.clone()))
-                    }
-                    Ordering::Equal => (),
+                if selected.len() < *threshold {
+                    return Err(PolicyError::NotEnoughItemsSelected(self.id.clone()));
                 }
 
                 // check the selected items, see if there are conflicting requirements

--- a/src/descriptor/policy.rs
+++ b/src/descriptor/policy.rs
@@ -506,11 +506,11 @@ impl Condition {
 }
 
 /// Errors that can happen while extracting and manipulating policies
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum PolicyError {
-    /// Not enough items are selected to satisfy a [`SatisfiableItem::Thresh`]
+    /// Not enough items are selected to satisfy a [`SatisfiableItem::Thresh`] or a [`SatisfiableItem::Multisig`]
     NotEnoughItemsSelected(String),
-    /// Index out of range for an item to satisfy a [`SatisfiableItem::Thresh`]
+    /// Index out of range for an item to satisfy a [`SatisfiableItem::Thresh`] or a [`SatisfiableItem::Multisig`]
     IndexOutOfRange(usize),
     /// Can not add to an item that is [`Satisfaction::None`] or [`Satisfaction::Complete`]
     AddOnLeaf,
@@ -642,10 +642,10 @@ impl Policy {
             SatisfiableItem::Thresh { items, threshold } if items.len() == *threshold => {
                 (0..*threshold).collect()
             }
+            SatisfiableItem::Multisig { keys, .. } => (0..keys.len()).collect(),
             _ => vec![],
         };
         let selected = match path.get(&self.id) {
-            _ if !default.is_empty() => &default,
             Some(arr) => arr,
             _ => &default,
         };
@@ -682,7 +682,16 @@ impl Policy {
 
                 Ok(requirements)
             }
-            _ if !selected.is_empty() => Err(PolicyError::TooManyItemsSelected(self.id.clone())),
+            SatisfiableItem::Multisig { keys, threshold } => {
+                if selected.len() < *threshold {
+                    return Err(PolicyError::NotEnoughItemsSelected(self.id.clone()));
+                }
+                if let Some(item) = selected.iter().find(|i| **i >= keys.len()) {
+                    return Err(PolicyError::IndexOutOfRange(*item));
+                }
+
+                Ok(Condition::default())
+            }
             SatisfiableItem::AbsoluteTimelock { value } => Ok(Condition {
                 csv: None,
                 timelock: Some(*value),
@@ -1249,4 +1258,50 @@ mod test {
     //
     //     // TODO how should this merge timelocks?
     // }
+
+    #[test]
+    fn test_get_condition_multisig() {
+        let secp = Secp256k1::gen_new();
+
+        let (_, pk0, _) = setup_keys(TPRV0_STR);
+        let (_, pk1, _) = setup_keys(TPRV1_STR);
+
+        let desc = descriptor!(wsh(multi(1, pk0, pk1))).unwrap();
+        let (wallet_desc, keymap) = desc
+            .into_wallet_descriptor(&secp, Network::Testnet)
+            .unwrap();
+        let signers = keymap.into();
+
+        let policy = wallet_desc
+            .extract_policy(&signers, &secp)
+            .unwrap()
+            .unwrap();
+
+        // no args, choose the default
+        let no_args = policy.get_condition(&vec![].into_iter().collect());
+        assert_eq!(no_args, Ok(Condition::default()));
+
+        // enough args
+        let eq_thresh =
+            policy.get_condition(&vec![(policy.id.clone(), vec![0])].into_iter().collect());
+        assert_eq!(eq_thresh, Ok(Condition::default()));
+
+        // more args, it doesn't really change anything
+        let gt_thresh =
+            policy.get_condition(&vec![(policy.id.clone(), vec![0, 1])].into_iter().collect());
+        assert_eq!(gt_thresh, Ok(Condition::default()));
+
+        // not enough args, error
+        let lt_thresh =
+            policy.get_condition(&vec![(policy.id.clone(), vec![])].into_iter().collect());
+        assert_eq!(
+            lt_thresh,
+            Err(PolicyError::NotEnoughItemsSelected(policy.id.clone()))
+        );
+
+        // index out of range
+        let out_of_range =
+            policy.get_condition(&vec![(policy.id.clone(), vec![5])].into_iter().collect());
+        assert_eq!(out_of_range, Err(PolicyError::IndexOutOfRange(5)));
+    }
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Opening against the relase branch, as this is a bugfix instead of a new feature. Once the release is done it'll get merged back into `master`.

#### [policy] Allow specifying a policy path for `Multisig`

While technically it's not required since there are no timelocks inside, it's still less confusing for the end user if we allow this instead of failing like we do currently.

#### [policy] Remove the `TooManyItemsSelected` error

The `TooManyItemsSelected` error has been removed, since it's not technically an error but potentailly more of an "over-constraint" over a tx: for instance, given a `thresh(3,pk(a),pk(b),older(10),older(20))` descriptor one could create a spending tx with the `[0,1,2]` items that would only be spendable after `10` blocks, or a tx with the `[0,2,3]` items that would be spendable after `20`.

In this case specifying more items than the threshold would create a tx with the maximum constraint possible, in this case the `20` blocks. This is not necessarily an error, so we should allow it without failing.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
