### PR TITLE
[descriptor] Perform additional checks before using a descriptor

### DIFF
--- a/src/descriptor/error.rs
+++ b/src/descriptor/error.rs
@@ -31,6 +31,8 @@ pub enum Error {
     InvalidHDKeyPath,
     /// The provided descriptor doesn't match its checksum
     InvalidDescriptorChecksum,
+    /// The descriptor contains hardened derivation steps on public extended keys
+    HardenedDerivationXpub,
 
     /// Error thrown while working with [`keys`](crate::keys)
     Key(crate::keys::KeyError),

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -66,8 +66,9 @@ use crate::blockchain::{Blockchain, Progress};
 use crate::database::{BatchDatabase, BatchOperations, DatabaseUtils};
 use crate::descriptor::derived::AsDerived;
 use crate::descriptor::{
-    get_checksum, DerivedDescriptor, DerivedDescriptorMeta, DescriptorMeta, DescriptorScripts,
-    ExtendedDescriptor, ExtractPolicy, IntoWalletDescriptor, Policy, XKeyUtils,
+    get_checksum, into_wallet_descriptor_checked, DerivedDescriptor, DerivedDescriptorMeta,
+    DescriptorMeta, DescriptorScripts, ExtendedDescriptor, ExtractPolicy, IntoWalletDescriptor,
+    Policy, XKeyUtils,
 };
 use crate::error::Error;
 use crate::psbt::PSBTUtils;
@@ -134,7 +135,7 @@ where
     ) -> Result<Self, Error> {
         let secp = Secp256k1::new();
 
-        let (descriptor, keymap) = descriptor.into_wallet_descriptor(&secp, network)?;
+        let (descriptor, keymap) = into_wallet_descriptor_checked(descriptor, &secp, network)?;
         database.check_descriptor_checksum(
             KeychainKind::External,
             get_checksum(&descriptor.to_string())?.as_bytes(),
@@ -143,7 +144,7 @@ where
         let (change_descriptor, change_signers) = match change_descriptor {
             Some(desc) => {
                 let (change_descriptor, change_keymap) =
-                    desc.into_wallet_descriptor(&secp, network)?;
+                    into_wallet_descriptor_checked(desc, &secp, network)?;
                 database.check_descriptor_checksum(
                     KeychainKind::Internal,
                     get_checksum(&change_descriptor.to_string())?.as_bytes(),


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Perform additional checks when loading a descriptor into a wallet.

Fixes #287 

### Notes to the reviewers

I decided to implement this as a separate (private) function because i didn't want people to potentially mess with this: alternatively this could have been implemented as a provided-method on the `IntoWalletDescriptor` trait, but this would allow people to override it externally, which we don't want.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
