### PR TITLE
[ci] Manually set rust stable version in CI pipeline

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - stable
+          - 1.50.0 # STABLE
           - 1.45.0 # MSRV
         features:
           - default
@@ -97,7 +97,7 @@ jobs:
       - name: Install rustup
         run: curl https://sh.rustup.rs -sSf | sh -s -- -y
       - name: Set default toolchain
-        run: $HOME/.cargo/bin/rustup default stable
+        run: $HOME/.cargo/bin/rustup default 1.50.0 # STABLE
       - name: Set profile
         run: $HOME/.cargo/bin/rustup set profile minimal
       - name: Update toolchain
@@ -130,7 +130,7 @@ jobs:
       - run: sudo apt-get update || exit 1
       - run: sudo apt-get install -y clang-10 libc6-dev-i386 || exit 1
       - name: Set default toolchain
-        run: rustup default stable
+        run: rustup default 1.50.0 # STABLE
       - name: Set profile
         run: rustup set profile minimal
       - name: Add target wasm32
@@ -147,7 +147,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set default toolchain
-        run: rustup default stable
+        run: rustup default 1.50.0 # STABLE
       - name: Set profile
         run: rustup set profile minimal
       - name: Add clippy


### PR DESCRIPTION
### Description

This PR sets the rust `stable` version in the CI pipeline to `1.50.0`. This value will  need to be updated manually when a new `stable` version of Rust :crab: is released. Any clippy or other fixes required by a new `stable` version should be fixed in the same PR.

Resolves discussion in #282 

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [x] I'm linking the issue being fixed by this PR
