### PR TITLE
reexport miniscript's use-serde feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Descriptor
+#### Added
+- Added `miniscript-serde` feature that reexports miniscript's `use-serde` feature.
 
 ## [v0.4.0] - [v0.3.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ key-value-db = ["sled"]
 async-interface = ["async-trait"]
 all-keys = ["keys-bip39"]
 keys-bip39 = ["tiny-bip39"]
+miniscript-serde = ["miniscript/use-serde"]
 
 # Debug/Test features
 debug-proc-macros = ["bdk-macros/debug", "bdk-testutils-macros/debug"]


### PR DESCRIPTION
### Description

Reexport miniscript's `use-serde` feature with new optional `miniscript-serde` feature. This allows me to derive `Serialize` / `Deserialize` for a `Descriptor<DescriptorPublicKey>`.

### Notes to the reviewers

Not making this default because bdk doesn't rely on this functionality.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`