### PR TITLE
Make constructor functions on `FeeRate` const

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 - Updated `electrum-client` to version `0.7`
 
+### Wallet
+#### Changed
+- `FeeRate` constructors `from_sat_per_vb` and `default_min_relay_fee` are now `const` functions
+
 ## [v0.4.0] - [v0.3.0]
 
 ### Keys

--- a/src/types.rs
+++ b/src/types.rs
@@ -69,12 +69,12 @@ impl FeeRate {
     }
 
     /// Create a new instance of [`FeeRate`] given a float fee rate in satoshi/vbyte
-    pub fn from_sat_per_vb(sat_per_vb: f32) -> Self {
+    pub const fn from_sat_per_vb(sat_per_vb: f32) -> Self {
         FeeRate(sat_per_vb)
     }
 
     /// Create a new [`FeeRate`] with the default min relay fee value
-    pub fn default_min_relay_fee() -> Self {
+    pub const fn default_min_relay_fee() -> Self {
         FeeRate(1.0)
     }
 
@@ -178,4 +178,15 @@ pub struct TransactionDetails {
     pub fees: u64,
     /// Confirmed in block height, `None` means unconfirmed
     pub height: Option<u32>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_store_feerate_in_const() {
+        const _MY_RATE: FeeRate = FeeRate::from_sat_per_vb(10.0);
+        const _MIN_RELAY: FeeRate = FeeRate::default_min_relay_fee();
+    }
 }


### PR DESCRIPTION
This allows `FeeRate`s to be stored inside `const`s.

For example:

```rust
const MY_FEE_RATE: FeeRate = FeeRate::from_sat_per_vb(10.0);
```

Unfortunately, floating point maths inside const expressions is unstable, hence we cannot make `from_btc_per_kvb` const.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [ ] ~I've added docs for the new feature~
* [x] I've updated `CHANGELOG.md`
