### PR TITLE
add `get_psbt_input` function to Wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ final transaction is created by calling `finish` on the builder.
 - Added `WeightedUtxo` to replace floating `(UTXO, usize)`.
 - Added `Utxo` enum to incorporate both local utxos and foreign utxos
 - Added `TxBuilder::add_foreign_utxo` which allows adding a utxo external to the wallet.
+- Added `Wallet::get_psbt_input` for sharing, e.g. for joint transactions
 
 ### CLI
 #### Changed

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -24,8 +24,9 @@ use bitcoin::secp256k1::Secp256k1;
 use bitcoin::consensus::encode::serialize;
 use bitcoin::util::base58;
 use bitcoin::util::psbt::raw::Key as PSBTKey;
+use bitcoin::util::psbt::Input;
 use bitcoin::util::psbt::PartiallySignedTransaction as PSBT;
-use bitcoin::{Address, Network, OutPoint, Script, Transaction, TxOut, Txid};
+use bitcoin::{Address, Network, OutPoint, Script, SigHashType, Transaction, TxOut, Txid};
 
 use miniscript::descriptor::DescriptorTrait;
 use miniscript::psbt::PsbtInputSatisfier;
@@ -1144,41 +1145,21 @@ where
                 None => continue,
             };
 
-            // Only set it if the params has a custom one, otherwise leave blank which defaults to
-            // SIGHASH_ALL
-            if let Some(sighash_type) = params.sighash {
-                psbt_input.sighash_type = Some(sighash_type);
-            }
-
             match utxo {
                 Utxo::Local(utxo) => {
-                    // Try to find the prev_script in our db to figure out if this is internal or external,
-                    // and the derivation index
-                    let (keychain, child) = match self
-                        .database
-                        .borrow()
-                        .get_path_from_script_pubkey(&utxo.txout.script_pubkey)?
-                    {
-                        Some(x) => x,
-                        None => continue,
-                    };
-
-                    let desc = self.get_descriptor_for_keychain(keychain);
-                    let derived_descriptor = desc.as_derived(child, &self.secp);
-                    psbt_input.bip32_derivation = derived_descriptor.get_hd_keypaths(&self.secp)?;
-
-                    psbt_input.redeem_script = derived_descriptor.psbt_redeem_script();
-                    psbt_input.witness_script = derived_descriptor.psbt_witness_script();
-
-                    let prev_output = input.previous_output;
-                    if let Some(prev_tx) = self.database.borrow().get_raw_tx(&prev_output.txid)? {
-                        if desc.is_witness() {
-                            psbt_input.witness_utxo =
-                                Some(prev_tx.output[prev_output.vout as usize].clone());
-                        }
-                        if !desc.is_witness() || params.force_non_witness_utxo {
-                            psbt_input.non_witness_utxo = Some(prev_tx);
-                        }
+                    *psbt_input = match self.get_psbt_input(
+                        utxo,
+                        params.sighash,
+                        params.force_non_witness_utxo,
+                    ) {
+                        Ok(psbt_input) => psbt_input,
+                        Err(e) => match e {
+                            Error::UnknownUTXO => Input {
+                                sighash_type: params.sighash,
+                                ..Input::default()
+                            },
+                            _ => return Err(e),
+                        },
                     }
                 }
                 Utxo::Foreign {
@@ -1224,6 +1205,48 @@ where
         }
 
         Ok(psbt)
+    }
+
+    /// get the corresponding PSBT Input for a LocalUtxo
+    pub fn get_psbt_input(
+        &self,
+        utxo: LocalUtxo,
+        sighash_type: Option<SigHashType>,
+        force_non_witness_utxo: bool,
+    ) -> Result<Input, Error> {
+        // Try to find the prev_script in our db to figure out if this is internal or external,
+        // and the derivation index
+        let (keychain, child) = match self
+            .database
+            .borrow()
+            .get_path_from_script_pubkey(&utxo.txout.script_pubkey)?
+        {
+            Some(x) => x,
+            None => return Err(Error::UnknownUTXO),
+        };
+
+        let mut psbt_input = Input {
+            sighash_type,
+            ..Input::default()
+        };
+
+        let desc = self.get_descriptor_for_keychain(keychain);
+        let derived_descriptor = desc.as_derived(child, &self.secp);
+        psbt_input.bip32_derivation = derived_descriptor.get_hd_keypaths(&self.secp)?;
+
+        psbt_input.redeem_script = derived_descriptor.psbt_redeem_script();
+        psbt_input.witness_script = derived_descriptor.psbt_witness_script();
+
+        let prev_output = utxo.outpoint;
+        if let Some(prev_tx) = self.database.borrow().get_raw_tx(&prev_output.txid)? {
+            if desc.is_witness() {
+                psbt_input.witness_utxo = Some(prev_tx.output[prev_output.vout as usize].clone());
+            }
+            if !desc.is_witness() || force_non_witness_utxo {
+                psbt_input.non_witness_utxo = Some(prev_tx);
+            }
+        }
+        Ok(psbt_input)
     }
 
     fn add_input_hd_keypaths(&self, psbt: &mut PSBT) -> Result<(), Error> {
@@ -2430,6 +2453,16 @@ mod test {
                 builder.finish().is_ok(),
                 "psbt_input with non_witness_utxo should succeed with force_non_witness_utxo"
             );
+        }
+    }
+
+    #[test]
+    fn test_get_psbt_input() {
+        // this should grab a known good utxo and set the input
+        let (wallet, _, _) = get_funded_wallet(get_test_wpkh());
+        for utxo in wallet.list_unspent().unwrap() {
+            let psbt_input = wallet.get_psbt_input(utxo, None, false).unwrap();
+            assert!(psbt_input.witness_utxo.is_some() || psbt_input.non_witness_utxo.is_some());
         }
     }
 


### PR DESCRIPTION
### Description
This PR factors out some code as a public function
```
Wallet<B, D>::get_psbt_input(
    &self,  
    local_utxo: LocalUtxo,
    sighash_type: Option<SigHashType>,
    force_non_witness_utxo: bool
) -> Result<Input, Error>
```
to facilitate access to psbt inputs, e.g. for sharing with others to use with `add_foreign_utxo`.

### Notes to the reviewers
I replaced the factored out code with a call to the new function. The function returns an `Error::UnknownUTXO` if there is no matching script pubkey in the db for the utxo, but maybe that could be a different error type.

The test I wrote fails because of [this issue](https://github.com/bitcoindevkit/bdk/issues/303).

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`