### PR TITLE
[ci] Manually install 'libclang-common-10-dev' to 'check-wasm' job

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -129,7 +129,7 @@ jobs:
       - run: wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - || exit 1
       - run: sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main" || exit 1
       - run: sudo apt-get update || exit 1
-      - run: sudo apt-get install -y clang-10 libc6-dev-i386 || exit 1
+      - run: sudo apt-get install -y libclang-common-10-dev clang-10 libc6-dev-i386 || exit 1
       - name: Set default toolchain
         run: rustup default 1.50.0 # STABLE
       - name: Set profile


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Github actions changed the default packages in their `ubuntu-16.04` image causing the `check-wasm` job to fail. This PR manually installs the missing dependency `libclang-common-10-dev`. 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
