### PR TITLE
Pin hyper version to =0.14.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,8 @@ tiny-bip39 = { version = "^0.8", optional = true }
 # Platform-specific dependencies
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", features = ["rt"] }
+# pin hyper version to prevent update to socket2 0.4.0 which isn't supported for MSRV 1.45.0
+hyper = { version = "=0.14.4" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 async-trait = "0.1"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Our `request` `0.11` dependency depends on `hyper` `^0.14`, and the recent `hyper` `0.14.5` version updated its `socket2` dependency to `0.4.0` which breaks compatibility with our minimum supported rust version `1.45.0`. To fix this problem I've pinned the version of `hyper` to  `0.14.4`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing