### PR TITLE
[ci] update MSRV to 1.46.0

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         rust:
           - 1.50.0 # STABLE
-          - 1.45.0 # MSRV
+          - 1.46.0 # MSRV
         features:
           - default
           - minimal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Misc
+#### Changed
+- New minimum supported rust version is 1.46.0
+
 ### Descriptor
 #### Added
 - Added ability to analyze a `PSBT` to check which and how many signatures are already available

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Every new feature should be covered by functional tests where possible.
 When refactoring, structure your PR to make it easy to review and don't
 hesitate to split it into multiple small, focused PRs.
 
-The Minimal Supported Rust Version is 1.45 (enforced by our CI).
+The Minimal Supported Rust Version is 1.46 (enforced by our CI).
 
 Commits should cover both the issue fixed and the solution's rationale.
 These [guidelines](https://chris.beams.io/posts/git-commit/) should be kept in mind.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,6 @@ tiny-bip39 = { version = "^0.8", optional = true }
 # Platform-specific dependencies
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "1", features = ["rt"] }
-# pin hyper version to prevent update to socket2 0.4.0 which isn't supported for MSRV 1.45.0
-hyper = { version = "=0.14.4" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 async-trait = "0.1"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
     <a href="https://github.com/bitcoindevkit/bdk/actions?query=workflow%3ACI"><img alt="CI Status" src="https://github.com/bitcoindevkit/bdk/workflows/CI/badge.svg"></a>
     <a href="https://codecov.io/gh/bitcoindevkit/bdk"><img src="https://codecov.io/gh/bitcoindevkit/bdk/branch/master/graph/badge.svg"/></a>
     <a href="https://docs.rs/bdk"><img alt="API Docs" src="https://img.shields.io/badge/docs.rs-bdk-green"/></a>
-    <a href="https://blog.rust-lang.org/2020/07/16/Rust-1.45.0.html"><img alt="Rustc Version 1.45+" src="https://img.shields.io/badge/rustc-1.45%2B-lightgrey.svg"/></a>
+    <a href="https://blog.rust-lang.org/2020/08/27/Rust-1.46.0.html"><img alt="Rustc Version 1.46+" src="https://img.shields.io/badge/rustc-1.46%2B-lightgrey.svg"/></a>
     <a href="https://discord.gg/d7NkDKm"><img alt="Chat on Discord" src="https://img.shields.io/discord/753336465005608961?logo=discord"></a>
   </p>
 

--- a/scripts/cargo-check.sh
+++ b/scripts/cargo-check.sh
@@ -3,7 +3,7 @@
 # Run various invocations of cargo check
 
 features=( "default" "compiler" "electrum" "esplora" "compact_filters" "key-value-db" "async-interface" "all-keys" "keys-bip39" )
-toolchains=( "+stable" "+1.45" "+nightly" )
+toolchains=( "+stable" "+1.46" "+nightly" )
 
 main() {
     check_src


### PR DESCRIPTION
### Description

This change increases BDKs minimum supported rust version to `1.46.0`. This will fix a problem with a recently updated version of `hyper` which breaks our CI build with the current MSRV `1.45.0`.   

### Notes to the reviewers

Since rust `1.45.0` is already five versions back I think it's reasonable to increment it now. Our other option is to pin the `hyper` version to `0.14.4` (see #316) but that change breaks our `check-wasm` CI job. I don't think we need to go down that rabbit hole since we shouldn't have any users who can't update to at least `1.46.0`. 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
