### PR TITLE
Avoid over-/underflow error in coin_select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `get_address(AddressIndex::Reset(u32))` which returns a derived address for a specified descriptor index and resets current index to the given value
 - Added `get_psbt_input` to create the corresponding psbt input for a local utxo.
 
+#### Fixed
+- Fixed `coin_select` calculation for UTXOs where `value < fee` that caused over-/underflow errors.
+
 ## [v0.5.1] - [v0.5.0]
 
 ### Misc


### PR DESCRIPTION
Fix edge-cases for small UTXOs (where value < fee) in the `coin_select` calculation. 
Before this change the coin-select would panic with overflow/underflow errors.

Bitcoin is lmited to 21*(10^6) so any Bitcoin amount fits into i64.
Using i64 avoids panic in calculations with small UTXOs.
