### PR TITLE
Policy refactor, with timelocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Policy
+#### Changed
+Removed `fill_satisfaction` method in favor of enum parameter in `extract_policy` method
+
+#### Added
+Timelocks are considered (optionally) in building the `satisfaction` field
+
 ## [v0.6.0] - [v0.5.1]
 
 ### Misc

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -27,6 +27,8 @@ use miniscript::descriptor::{DescriptorPublicKey, DescriptorType, DescriptorXKey
 pub use miniscript::{descriptor::KeyMap, Descriptor, Legacy, Miniscript, ScriptContext, Segwitv0};
 use miniscript::{DescriptorTrait, ForEachKey, TranslatePk};
 
+use crate::descriptor::policy::BuildSatisfaction;
+
 pub mod checksum;
 pub(crate) mod derived;
 #[doc(hidden)]
@@ -255,6 +257,7 @@ pub trait ExtractPolicy {
     fn extract_policy(
         &self,
         signers: &SignersContainer,
+        psbt: BuildSatisfaction,
         secp: &SecpCtx,
     ) -> Result<Option<Policy>, DescriptorError>;
 }

--- a/src/descriptor/policy.rs
+++ b/src/descriptor/policy.rs
@@ -767,8 +767,8 @@ fn signature_in_psbt(psbt: &PSBT, key: &DescriptorPublicKey, secp: &SecpCtx) -> 
             let pubkey = input
                 .bip32_derivation
                 .iter()
-                .find(|s| s.1 .0 == xpub.root_fingerprint(secp))
-                .map(|f| f.0);
+                .find(|(_, (f, _))| *f == xpub.root_fingerprint(secp))
+                .map(|(p, _)| p);
             //TODO check actual derivation matches
             match pubkey {
                 Some(pubkey) => input.partial_sigs.contains_key(pubkey),

--- a/src/descriptor/policy.rs
+++ b/src/descriptor/policy.rs
@@ -920,7 +920,7 @@ pub enum BuildSatisfaction<'a> {
     Psbt(&'a PSBT),
     /// Like `Psbt` variant and also check for expired timelocks
     PsbtTimelocks {
-        /// give PSBT
+        /// Given PSBT
         psbt: &'a PSBT,
         /// Current blockchain height
         current_height: u32,
@@ -1465,7 +1465,7 @@ mod test {
             .extract_policy(&signers_container, BuildSatisfaction::Psbt(&psbt), &secp)
             .unwrap()
             .unwrap();
-        println!("{}", serde_json::to_string(&policy_alice_psbt).unwrap());
+        //println!("{}", serde_json::to_string(&policy_alice_psbt).unwrap());
 
         assert!(
             matches!(&policy_alice_psbt.satisfaction, Satisfaction::Partial { n, m, items, .. } if n == &2
@@ -1548,8 +1548,7 @@ mod test {
              && items.is_empty()
             )
         );
-
-        println!("{}", serde_json::to_string(&policy).unwrap());
+        //println!("{}", serde_json::to_string(&policy).unwrap());
 
         let build_sat_expired = BuildSatisfaction::PsbtTimelocks {
             psbt: &psbt,
@@ -1567,8 +1566,7 @@ mod test {
              && items == &vec![0]
             )
         );
-
-        println!("{}", serde_json::to_string(&policy_expired).unwrap());
+        //println!("{}", serde_json::to_string(&policy_expired).unwrap());
 
         let psbt_signed: PSBT =
             deserialize(&base64::decode(PSBT_POLICY_CONSIDER_TIMELOCK_EXPIRED_SIGNED).unwrap())
@@ -1590,7 +1588,6 @@ mod test {
              && items == &vec![0, 1]
             )
         );
-
-        println!("{}", serde_json::to_string(&policy_expired_signed).unwrap());
+        //println!("{}", serde_json::to_string(&policy_expired_signed).unwrap());
     }
 }


### PR DESCRIPTION
### Description

Optionally consider timelocks in policy if providing relative information (current height and prevout confirmation height)

### Notes to the reviewers

The `fill_satisfaction` method previously introduced to check signatures present in a PSBT has been removed and now everything is optionally calculated in the `extract_policy` method (also considering nested conditions).
To achieve this another enum parameter has been added `BuildSatisfaction`, using the variant None is equivalent as before (will not build satisfaction).

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`
