### PR TITLE
making the rbf functions also available when bumping the fee

### DIFF
--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -2712,7 +2712,7 @@ mod test {
             .unwrap();
 
         let mut builder = wallet.build_fee_bump(txid).unwrap();
-        builder.fee_rate(FeeRate::from_sat_per_vb(2.5));
+        builder.fee_rate(FeeRate::from_sat_per_vb(2.5)).enable_rbf();
         let (psbt, details) = builder.finish().unwrap();
 
         assert_eq!(details.sent, original_details.sent);
@@ -2773,6 +2773,7 @@ mod test {
 
         let mut builder = wallet.build_fee_bump(txid).unwrap();
         builder.fee_absolute(200);
+        builder.enable_rbf();
         let (psbt, details) = builder.finish().unwrap();
 
         assert_eq!(details.sent, original_details.sent);

--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -528,7 +528,7 @@ impl<'a, B, D: BatchDatabase, Cs: CoinSelectionAlgorithm<D>, Ctx: TxBuilderConte
     ///
     /// This will use the default nSequence value of `0xFFFFFFFD`.
     pub fn enable_rbf(&mut self) -> &mut Self {
-        self.params.rbf = Some(RBFValue::Default);
+        self.params.rbf = Some(RbfValue::Default);
         self
     }
 
@@ -540,7 +540,7 @@ impl<'a, B, D: BatchDatabase, Cs: CoinSelectionAlgorithm<D>, Ctx: TxBuilderConte
     /// If the `nsequence` is higher than `0xFFFFFFFD` an error will be thrown, since it would not
     /// be a valid nSequence to signal RBF.
     pub fn enable_rbf_with_sequence(&mut self, nsequence: u32) -> &mut Self {
-        self.params.rbf = Some(RBFValue::Value(nsequence));
+        self.params.rbf = Some(RbfValue::Value(nsequence));
         self
     }
 }

--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -523,6 +523,26 @@ impl<'a, B, D: BatchDatabase, Cs: CoinSelectionAlgorithm<D>, Ctx: TxBuilderConte
     pub fn finish(self) -> Result<(PSBT, TransactionDetails), Error> {
         self.wallet.create_tx(self.coin_selection, self.params)
     }
+
+    /// Enable signaling RBF
+    ///
+    /// This will use the default nSequence value of `0xFFFFFFFD`.
+    pub fn enable_rbf(&mut self) -> &mut Self {
+        self.params.rbf = Some(RBFValue::Default);
+        self
+    }
+
+    /// Enable signaling RBF with a specific nSequence value
+    ///
+    /// This can cause conflicts if the wallet's descriptors contain an "older" (OP_CSV) operator
+    /// and the given `nsequence` is lower than the CSV value.
+    ///
+    /// If the `nsequence` is higher than `0xFFFFFFFD` an error will be thrown, since it would not
+    /// be a valid nSequence to signal RBF.
+    pub fn enable_rbf_with_sequence(&mut self, nsequence: u32) -> &mut Self {
+        self.params.rbf = Some(RBFValue::Value(nsequence));
+        self
+    }
 }
 
 impl<'a, B, D: BatchDatabase, Cs: CoinSelectionAlgorithm<D>> TxBuilder<'a, B, D, Cs, CreateTx> {
@@ -556,26 +576,6 @@ impl<'a, B, D: BatchDatabase, Cs: CoinSelectionAlgorithm<D>> TxBuilder<'a, B, D,
         self.params.single_recipient = Some(recipient);
         self.params.recipients.clear();
 
-        self
-    }
-
-    /// Enable signaling RBF
-    ///
-    /// This will use the default nSequence value of `0xFFFFFFFD`.
-    pub fn enable_rbf(&mut self) -> &mut Self {
-        self.params.rbf = Some(RBFValue::Default);
-        self
-    }
-
-    /// Enable signaling RBF with a specific nSequence value
-    ///
-    /// This can cause conflicts if the wallet's descriptors contain an "older" (OP_CSV) operator
-    /// and the given `nsequence` is lower than the CSV value.
-    ///
-    /// If the `nsequence` is higher than `0xFFFFFFFD` an error will be thrown, since it would not
-    /// be a valid nSequence to signal RBF.
-    pub fn enable_rbf_with_sequence(&mut self, nsequence: u32) -> &mut Self {
-        self.params.rbf = Some(RBFValue::Value(nsequence));
         self
     }
 }


### PR DESCRIPTION
### Description

Allow setting RBF when bumping the fee of a transaction. This enables to further bump the fee.
Fixes https://github.com/bitcoindevkit/bdk/issues/315