### PR TITLE
[ci] Update 'Build docs' job to use nightly-2021-03-23

### DIFF
--- a/.github/workflows/nightly_docs.yml
+++ b/.github/workflows/nightly_docs.yml
@@ -17,17 +17,14 @@ jobs:
             ~/.cargo/git
             target
           key: nightly-docs-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
-      - name: Install nightly toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+      - name: Set default toolchain
+        run: rustup default nightly-2021-03-23
+      - name: Set profile
+        run: rustup set profile minimal
+      - name: Update toolchain
+        run: rustup update
       - name: Build docs
-        uses: actions-rs/cargo@v1
-        with:
-          command: rustdoc
-          args: --verbose --features=compiler,electrum,esplora,compact_filters,key-value-db,all-keys -- --cfg docsrs -Dwarnings
+        run: cargo rustdoc --verbose --features=compiler,electrum,esplora,compact_filters,key-value-db,all-keys -- --cfg docsrs -Dwarnings
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
### Description

This change is required because latest nightly (2021-04-11) rustdoc is showing what appear to be invalid errors like:

```
error[E0642]: patterns aren't allowed in methods without bodies
Error:     --> /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/clang-sys-0.29.3/src/lib.rs:2186:46
     |
2186 |     pub fn clang_VerbatimLineComment_getText(comment: CXComment) -> CXString;
     |                                              ^^^^^^^
     |
help: give this argument a name or use an underscore to ignore it
     |
2186 |     pub fn clang_VerbatimLineComment_getText(_: CXComment) -> CXString;
     |  
```

### Notes to the reviewers

There may also be a way to exclude building docs for `clang-sys` but I'd rather setup our CI to depend on fixed tool chain versions anyway so that we don't get random failures like this. 

I also replaced `actions-rs/toolchain` and `actions-rs/cargo` with the equivalent `run:` commands, which is what we are already doing in our build-test CI jobs.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

