### PR TITLE
[ci] Revert fixed nightly-2021-03-23, use actual nightly

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set default toolchain
-        run: rustup default nightly-2021-03-23
+        run: rustup default nightly
       - name: Set profile
         run: rustup set profile minimal
 

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -65,7 +65,7 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-test-md-docs-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
       - name: Set default toolchain
-        run: rustup default nightly-2021-03-23
+        run: rustup default nightly
       - name: Set profile
         run: rustup set profile minimal
       - name: Update toolchain

--- a/.github/workflows/nightly_docs.yml
+++ b/.github/workflows/nightly_docs.yml
@@ -18,7 +18,7 @@ jobs:
             target
           key: nightly-docs-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
       - name: Set default toolchain
-        run: rustup default nightly-2021-03-23
+        run: rustup default nightly
       - name: Set profile
         run: rustup set profile minimal
       - name: Update toolchain


### PR DESCRIPTION
### Description

Due to a [regression in rust nightly 2021-04-11] which [broke clang-sys] our CI 'Build docs' job also broke. I hard coded this and other jobs that rely on +nightly to use `+nightly-2021-03-23` instead, see #326. But docs.rs always uses +nightly so when we published `0.6.0` our docs there were still broken.

This issue is fixed in `+nightly-2021-04-15` so in order to keep our CI 'Build docs' job in sync with how they will build on docs.rs I've changed back to using the actual +nightly.

[regression in rust nightly 2021-04-11]: https://github.com/rust-lang/rust/pull/84130
[broke clang-sys]: https://github.com/rust-lang/rust/issues/84162

### Notes to the reviewers

I've also requested build `0.6.0` docs be rebuilt with the new latest +nightly, see https://github.com/rust-lang/docs.rs/issues/1356.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)