### PR TITLE
Use `non_witness_utxo` when making SegWit signatures to mitigate the "SegWit bug"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Timelocks are considered (optionally) in building the `satisfaction` field
 
 - Changed `Wallet::{sign, finalize_psbt}` now take a `&mut psbt` rather than consuming it.
 - Require and validate `non_witness_utxo` for SegWit signatures by default, can be adjusted with `SignOptions`
+- Replace the opt-in builder option `force_non_witness_utxo` with the opposite `only_witness_utxo`. From now on we will provide the `non_witness_utxo`, unless explicitly asked not to.
 
 ## [v0.6.0] - [v0.5.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Timelocks are considered (optionally) in building the `satisfaction` field
 ### Wallet
 
 - Changed `Wallet::{sign, finalize_psbt}` now take a `&mut psbt` rather than consuming it.
+- Require and validate `non_witness_utxo` for SegWit signatures by default, can be adjusted with `SignOptions`
 
 ## [v0.6.0] - [v0.5.1]
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ fn main() -> Result<(), bdk::Error> {
 ### Sign a transaction
 
 ```rust,no_run
-use bdk::{Wallet, database::MemoryDatabase};
+use bdk::{Wallet, SignOptions, database::MemoryDatabase};
 
 use bitcoin::consensus::deserialize;
 
@@ -145,7 +145,7 @@ fn main() -> Result<(), bdk::Error> {
     let psbt = "...";
     let mut psbt = deserialize(&base64::decode(psbt).unwrap())?;
 
-    let finalized = wallet.sign(&mut psbt, None)?;
+    let finalized = wallet.sign(&mut psbt, SignOptions::default())?;
 
     Ok(())
 }

--- a/src/descriptor/template.rs
+++ b/src/descriptor/template.rs
@@ -455,11 +455,12 @@ expand_make_bipxx!(segwit_v0, Segwitv0);
 mod test {
     // test existing descriptor templates, make sure they are expanded to the right descriptors
 
+    use std::str::FromStr;
+
     use super::*;
     use crate::descriptor::derived::AsDerived;
     use crate::descriptor::{DescriptorError, DescriptorMeta};
     use crate::keys::ValidNetworks;
-    use bitcoin::hashes::core::str::FromStr;
     use bitcoin::network::constants::Network::Regtest;
     use bitcoin::secp256k1::Secp256k1;
     use miniscript::descriptor::{DescriptorPublicKey, DescriptorTrait, KeyMap};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,6 +256,7 @@ pub use error::Error;
 pub use types::*;
 pub use wallet::address_validator;
 pub use wallet::signer;
+pub use wallet::signer::SignOptions;
 pub use wallet::tx_builder::TxBuilder;
 pub use wallet::Wallet;
 

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -862,12 +862,10 @@ where
 
         // If we aren't allowed to use `witness_utxo`, ensure that every input has the
         // `non_witness_utxo`
-        if !sign_options.trust_witness_utxo {
-            for input in &psbt.inputs {
-                if input.non_witness_utxo.is_none() {
-                    return Err(Error::Signer(signer::SignerError::MissingNonWitnessUtxo));
-                }
-            }
+        if !sign_options.trust_witness_utxo
+            && psbt.inputs.iter().any(|i| i.non_witness_utxo.is_none())
+        {
+            return Err(Error::Signer(signer::SignerError::MissingNonWitnessUtxo));
         }
 
         for signer in self

--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -498,7 +498,7 @@ impl ComputeSighash for Segwitv0 {
         let witness_utxo = psbt_input
             .witness_utxo
             .as_ref()
-            .ok_or(SignerError::MissingNonWitnessUtxo)?;
+            .ok_or(SignerError::MissingWitnessUtxo)?;
         let value = witness_utxo.value;
 
         let script = match psbt_input.witness_script {

--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -427,6 +427,43 @@ impl SignersContainer {
     }
 }
 
+/// Options for a software signer
+///
+/// Adjust the behavior of our software signers and the way a transaction is finalized
+#[derive(Debug, Clone)]
+pub struct SignOptions {
+    /// Whether the signer should trust the `witness_utxo`, if the `non_witness_utxo` hasn't been
+    /// provided
+    ///
+    /// Defaults to `false` to mitigate the "SegWit bug" which chould trick the wallet into
+    /// paying a fee larger than expected.
+    ///
+    /// Some wallets, especially if relatively old, might not provide the `non_witness_utxo` for
+    /// SegWit transactions in the PSBT they generate: in those cases setting this to `true`
+    /// should correctly produce a signature, at the expense of an increased trust in the creator
+    /// of the PSBT.
+    ///
+    /// For more details see: <https://blog.trezor.io/details-of-firmware-updates-for-trezor-one-version-1-9-1-and-trezor-model-t-version-2-3-1-1eba8f60f2dd>
+    pub trust_witness_utxo: bool,
+
+    /// Whether the wallet should assume a specific height has been reached when trying to finalize
+    /// a transaction
+    ///
+    /// The wallet will only "use" a timelock to satisfy the spending policy of an input if the
+    /// timelock height has already been reached. This option allows overriding the "current height" to let the
+    /// wallet use timelocks in the future to spend a coin.
+    pub assume_height: Option<u32>,
+}
+
+impl Default for SignOptions {
+    fn default() -> Self {
+        SignOptions {
+            trust_witness_utxo: false,
+            assume_height: None,
+        }
+    }
+}
+
 pub(crate) trait ComputeSighash {
     fn sighash(
         psbt: &psbt::PartiallySignedTransaction,
@@ -492,20 +529,37 @@ impl ComputeSighash for Segwitv0 {
         }
 
         let psbt_input = &psbt.inputs[input_index];
+        let tx_input = &psbt.global.unsigned_tx.input[input_index];
 
         let sighash = psbt_input.sighash_type.unwrap_or(SigHashType::All);
 
-        let witness_utxo = psbt_input
-            .witness_utxo
-            .as_ref()
-            .ok_or(SignerError::MissingWitnessUtxo)?;
-        let value = witness_utxo.value;
+        // Always try first with the non-witness utxo
+        let utxo = if let Some(prev_tx) = &psbt_input.non_witness_utxo {
+            // Check the provided prev-tx
+            if prev_tx.txid() != tx_input.previous_output.txid {
+                return Err(SignerError::InvalidNonWitnessUtxo);
+            }
+
+            // The output should be present, if it's missing the `non_witness_utxo` is invalid
+            prev_tx
+                .output
+                .get(tx_input.previous_output.vout as usize)
+                .ok_or(SignerError::InvalidNonWitnessUtxo)?
+        } else if let Some(witness_utxo) = &psbt_input.witness_utxo {
+            // Fallback to the witness_utxo. If we aren't allowed to use it, signing should fail
+            // before we get to this point
+            witness_utxo
+        } else {
+            // Nothing has been provided
+            return Err(SignerError::MissingNonWitnessUtxo);
+        };
+        let value = utxo.value;
 
         let script = match psbt_input.witness_script {
             Some(ref witness_script) => witness_script.clone(),
             None => {
-                if witness_utxo.script_pubkey.is_v0_p2wpkh() {
-                    p2wpkh_script_code(&witness_utxo.script_pubkey)
+                if utxo.script_pubkey.is_v0_p2wpkh() {
+                    p2wpkh_script_code(&utxo.script_pubkey)
                 } else if psbt_input
                     .redeem_script
                     .as_ref()

--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -146,7 +146,7 @@ pub(crate) struct TxParams {
     pub(crate) rbf: Option<RbfValue>,
     pub(crate) version: Option<Version>,
     pub(crate) change_policy: ChangeSpendPolicy,
-    pub(crate) force_non_witness_utxo: bool,
+    pub(crate) only_witness_utxo: bool,
     pub(crate) add_global_xpubs: bool,
     pub(crate) include_output_redeem_witness_script: bool,
     pub(crate) bumping_fee: Option<PreviousFee>,
@@ -336,10 +336,10 @@ impl<'a, B, D: BatchDatabase, Cs: CoinSelectionAlgorithm<D>, Ctx: TxBuilderConte
     /// 1. The `psbt_input` does not contain a `witness_utxo` or `non_witness_utxo`.
     /// 2. The data in `non_witness_utxo` does not match what is in `outpoint`.
     ///
-    /// Note if you set [`force_non_witness_utxo`] any `psbt_input` you pass to this method must
+    /// Note unless you set [`only_witness_utxo`] any `psbt_input` you pass to this method must
     /// have `non_witness_utxo` set otherwise you will get an error when [`finish`] is called.
     ///
-    /// [`force_non_witness_utxo`]: Self::force_non_witness_utxo
+    /// [`only_witness_utxo`]: Self::only_witness_utxo
     /// [`finish`]: Self::finish
     /// [`max_satisfaction_weight`]: miniscript::Descriptor::max_satisfaction_weight
     pub fn add_foreign_utxo(
@@ -464,12 +464,13 @@ impl<'a, B, D: BatchDatabase, Cs: CoinSelectionAlgorithm<D>, Ctx: TxBuilderConte
         self
     }
 
-    /// Fill-in the [`psbt::Input::non_witness_utxo`](bitcoin::util::psbt::Input::non_witness_utxo) field even if the wallet only has SegWit
-    /// descriptors.
+    /// Only Fill-in the [`psbt::Input::witness_utxo`](bitcoin::util::psbt::Input::witness_utxo) field when spending from
+    /// SegWit descriptors.
     ///
-    /// This is useful for signers which always require it, like Trezor hardware wallets.
-    pub fn force_non_witness_utxo(&mut self) -> &mut Self {
-        self.params.force_non_witness_utxo = true;
+    /// This reduces the size of the PSBT, but some signers might reject them due to the lack of
+    /// the `non_witness_utxo`.
+    pub fn only_witness_utxo(&mut self) -> &mut Self {
+        self.params.only_witness_utxo = true;
         self
     }
 

--- a/testutils-macros/src/lib.rs
+++ b/testutils-macros/src/lib.rs
@@ -298,7 +298,7 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     let mut builder = wallet.build_tx();
                     builder.add_recipient(node_addr.script_pubkey(), 25_000);
                     let (mut psbt, details) = builder.finish().unwrap();
-                    let finalized = wallet.sign(&mut psbt, None).unwrap();
+                    let finalized = wallet.sign(&mut psbt, Default::default()).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     let tx = psbt.extract_tx();
                     println!("{}", bitcoin::consensus::encode::serialize_hex(&tx));
@@ -327,7 +327,7 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     let mut builder = wallet.build_tx();
                     builder.add_recipient(node_addr.script_pubkey(), 25_000);
                     let (mut psbt, details) = builder.finish().unwrap();
-                    let finalized = wallet.sign(&mut psbt, None).unwrap();
+                    let finalized = wallet.sign(&mut psbt, Default::default()).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     let sent_txid = wallet.broadcast(psbt.extract_tx()).unwrap();
 
@@ -368,7 +368,7 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                         let mut builder = wallet.build_tx();
                         builder.add_recipient(node_addr.script_pubkey(), 5_000);
                         let (mut psbt, details) = builder.finish().unwrap();
-                        let finalized = wallet.sign(&mut psbt, None).unwrap();
+                        let finalized = wallet.sign(&mut psbt, Default::default()).unwrap();
                         assert!(finalized, "Cannot finalize transaction");
                         wallet.broadcast(psbt.extract_tx()).unwrap();
 
@@ -402,7 +402,7 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     let mut builder = wallet.build_tx();
                     builder.add_recipient(node_addr.script_pubkey().clone(), 5_000).enable_rbf();
                     let (mut psbt, details) = builder.finish().unwrap();
-                    let finalized = wallet.sign(&mut psbt, None).unwrap();
+                    let finalized = wallet.sign(&mut psbt, Default::default()).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(psbt.extract_tx()).unwrap();
                     wallet.sync(noop_progress(), None).unwrap();
@@ -412,7 +412,7 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     let mut builder = wallet.build_fee_bump(details.txid).unwrap();
                     builder.fee_rate(FeeRate::from_sat_per_vb(2.1));
                     let (mut new_psbt, new_details) = builder.finish().unwrap();
-                    let finalized = wallet.sign(&mut new_psbt, None).unwrap();
+                    let finalized = wallet.sign(&mut new_psbt, Default::default()).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(new_psbt.extract_tx()).unwrap();
                     wallet.sync(noop_progress(), None).unwrap();
@@ -438,7 +438,7 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     let mut builder = wallet.build_tx();
                     builder.add_recipient(node_addr.script_pubkey().clone(), 49_000).enable_rbf();
                     let (mut psbt, details) = builder.finish().unwrap();
-                    let finalized = wallet.sign(&mut psbt, None).unwrap();
+                    let finalized = wallet.sign(&mut psbt, Default::default()).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(psbt.extract_tx()).unwrap();
                     wallet.sync(noop_progress(), None).unwrap();
@@ -448,7 +448,7 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     let mut builder = wallet.build_fee_bump(details.txid).unwrap();
                     builder.fee_rate(FeeRate::from_sat_per_vb(5.0));
                     let (mut new_psbt, new_details) = builder.finish().unwrap();
-                    let finalized = wallet.sign(&mut new_psbt, None).unwrap();
+                    let finalized = wallet.sign(&mut new_psbt, Default::default()).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(new_psbt.extract_tx()).unwrap();
                     wallet.sync(noop_progress(), None).unwrap();
@@ -474,7 +474,7 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     let mut builder = wallet.build_tx();
                     builder.add_recipient(node_addr.script_pubkey().clone(), 49_000).enable_rbf();
                     let (mut psbt, details) = builder.finish().unwrap();
-                    let finalized = wallet.sign(&mut psbt, None).unwrap();
+                    let finalized = wallet.sign(&mut psbt, Default::default()).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(psbt.extract_tx()).unwrap();
                     wallet.sync(noop_progress(), None).unwrap();
@@ -484,7 +484,7 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     let mut builder = wallet.build_fee_bump(details.txid).unwrap();
                     builder.fee_rate(FeeRate::from_sat_per_vb(10.0));
                     let (mut new_psbt, new_details) = builder.finish().unwrap();
-                    let finalized = wallet.sign(&mut new_psbt, None).unwrap();
+                    let finalized = wallet.sign(&mut new_psbt, Default::default()).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(new_psbt.extract_tx()).unwrap();
                     wallet.sync(noop_progress(), None).unwrap();
@@ -508,7 +508,7 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     let mut builder = wallet.build_tx();
                     builder.add_recipient(node_addr.script_pubkey().clone(), 49_000).enable_rbf();
                     let (mut psbt, details) = builder.finish().unwrap();
-                    let finalized = wallet.sign(&mut psbt, None).unwrap();
+                    let finalized = wallet.sign(&mut psbt, Default::default()).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(psbt.extract_tx()).unwrap();
                     wallet.sync(noop_progress(), None).unwrap();
@@ -520,7 +520,7 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     let (mut new_psbt, new_details) = builder.finish().unwrap();
                     println!("{:#?}", new_details);
 
-                    let finalized = wallet.sign(&mut new_psbt, None).unwrap();
+                    let finalized = wallet.sign(&mut new_psbt, Default::default()).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(new_psbt.extract_tx()).unwrap();
                     wallet.sync(noop_progress(), None).unwrap();


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Unless explicitly asked not to (by enabling a signer option), we will now by default require the presence of the `non_witness_utxo` when signing SegWit transactions as well, to mitigate the risk of an attacker tricking the wallet into paying more fees than it expects.

The `force_non_witness_utxo` option which was off by default has been replaced with `only_witness_utxo` which is also disabled by default, but since it's basically the opposite of the one we had previously, it effectively inverts the default behavior from not including the `non_witness_utxo` to providing it.

### Notes to the reviewers

This needed a bit of refactoring in the signing part to introduce some options that can be provided to tweak the behavior of the signer. I don't particularly like having that extra method on our `Signer` trait, but I couldn't come up with a better alternative.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`
* [x] This pull request breaks the existing API
