### PR TITLE
Added grcov based code coverage reporting in github action

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -3,25 +3,35 @@ on: [push]
 name: Code Coverage
 
 jobs:
-  tarpaulin-codecov:
-    name: Tarpaulin to codecov.io
+
+  Codecov:
+    name: Code Coverage
     runs-on: ubuntu-latest
+    env:
+      CARGO_INCREMENTAL: '0'
+      RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
+      RUSTDOCFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
+      - name: Install rustup
+        run: curl https://sh.rustup.rs -sSf | sh -s -- -y
       - name: Set default toolchain
         run: rustup default nightly
       - name: Set profile
         run: rustup set profile minimal
+      - name: Update toolchain
+        run: rustup update
+      - name: Test
+        run: cargo test --features all-keys,compiler,esplora,compact_filters --no-default-features
+                    
+      - id: coverage
+        name: Generate coverage
+        uses: actions-rs/grcov@v0.1.5
 
-      - name: Install tarpaulin
-        run: cargo install cargo-tarpaulin
-      - name: Tarpaulin
-        run: cargo tarpaulin --features all-keys,compiler,esplora,compact_filters --run-types Tests,Doctests --exclude-files "testutils/*" --out Xml
-
-      - name: Publish to codecov.io
-        uses: codecov/codecov-action@v1.0.15
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
         with:
-          fail_ci_if_error: true
-          file: ./cobertura.xml
+          file: ${{ steps.coverage.outputs.report }}
+          directory: ./coverage/reports/

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,13 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        base: auto
+        informational: false
+    patch:
+      default:
+        target: auto
+        threshold: 100%
+        base: auto


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

This PR adds `grcov` based code coveraging using a market-place github action `actions-rs/grcov@v0.1.5` and replaces the existing `Tarpaulin` coverages. It could be written with raw `grcov` commands but the market-place action seems to be working good. 

### Notes to the reviewers

Note that the coverage report currently being produced by the CI does not include the blockchain tests that run with `--features test-electrum`. So the report will not show coverage of those modules. This was true even with `Tarpaulin` previously. 

The blockchain tests are run here with docker containers and they don't produce coverages. https://github.com/bitcoindevkit/bdk/blob/00f07818f9f3b54752b92784af884eb1c79918de/.github/workflows/cont_integration.yml#L76

So one easy way is to include the `test-electrum` runs within the code coverage action and then upload the entire coverage report to codecov.

Once we agree on the approach I can modify this PR accordingly before merge.

### Notes to the maintainers
To see the coverage report attaching to each PR install the github codecov app https://github.com/marketplace/codecov and give permission to bdk repository.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR