### PR TITLE
Make wallet methods take &mut psbt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Removed `fill_satisfaction` method in favor of enum parameter in `extract_policy
 #### Added
 Timelocks are considered (optionally) in building the `satisfaction` field
 
+### Wallet
+
+- Changed `Wallet::{sign, finalize_psbt}` now take a `&mut psbt` rather than consuming it.
+
 ## [v0.6.0] - [v0.5.1]
 
 ### Misc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ test-md-docs = ["electrum"]
 
 [dev-dependencies]
 bdk-testutils = "0.4"
-bdk-testutils-macros = "0.5"
+bdk-testutils-macros = { path = "testutils-macros"}
 serial_test = "0.4"
 lazy_static = "1.4"
 env_logger = "0.7"

--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ fn main() -> Result<(), bdk::Error> {
     )?;
 
     let psbt = "...";
-    let psbt = deserialize(&base64::decode(psbt).unwrap())?;
+    let mut psbt = deserialize(&base64::decode(psbt).unwrap())?;
 
-    let (signed_psbt, finalized) = wallet.sign(psbt, None)?;
+    let finalized = wallet.sign(&mut psbt, None)?;
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,9 +158,9 @@
 //!     )?;
 //!
 //!     let psbt = "...";
-//!     let psbt = deserialize(&base64::decode(psbt).unwrap())?;
+//!     let mut psbt = deserialize(&base64::decode(psbt).unwrap())?;
 //!
-//!     let (signed_psbt, finalized) = wallet.sign(psbt, None)?;
+//!     let finalized = wallet.sign(&mut psbt, None)?;
 //!
 //!     Ok(())
 //! }

--- a/testutils-macros/src/lib.rs
+++ b/testutils-macros/src/lib.rs
@@ -297,8 +297,8 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
 
                     let mut builder = wallet.build_tx();
                     builder.add_recipient(node_addr.script_pubkey(), 25_000);
-                    let (psbt, details) = builder.finish().unwrap();
-                    let (psbt, finalized) = wallet.sign(psbt, None).unwrap();
+                    let (mut psbt, details) = builder.finish().unwrap();
+                    let finalized = wallet.sign(&mut psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     let tx = psbt.extract_tx();
                     println!("{}", bitcoin::consensus::encode::serialize_hex(&tx));
@@ -326,8 +326,8 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
 
                     let mut builder = wallet.build_tx();
                     builder.add_recipient(node_addr.script_pubkey(), 25_000);
-                    let (psbt, details) = builder.finish().unwrap();
-                    let (psbt, finalized) = wallet.sign(psbt, None).unwrap();
+                    let (mut psbt, details) = builder.finish().unwrap();
+                    let finalized = wallet.sign(&mut psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     let sent_txid = wallet.broadcast(psbt.extract_tx()).unwrap();
 
@@ -367,8 +367,8 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
                     for _ in 0..5 {
                         let mut builder = wallet.build_tx();
                         builder.add_recipient(node_addr.script_pubkey(), 5_000);
-                        let (psbt, details) = builder.finish().unwrap();
-                        let (psbt, finalized) = wallet.sign(psbt, None).unwrap();
+                        let (mut psbt, details) = builder.finish().unwrap();
+                        let finalized = wallet.sign(&mut psbt, None).unwrap();
                         assert!(finalized, "Cannot finalize transaction");
                         wallet.broadcast(psbt.extract_tx()).unwrap();
 
@@ -401,8 +401,8 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
 
                     let mut builder = wallet.build_tx();
                     builder.add_recipient(node_addr.script_pubkey().clone(), 5_000).enable_rbf();
-                    let (psbt, details) = builder.finish().unwrap();
-                    let (psbt, finalized) = wallet.sign(psbt, None).unwrap();
+                    let (mut psbt, details) = builder.finish().unwrap();
+                    let finalized = wallet.sign(&mut psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(psbt.extract_tx()).unwrap();
                     wallet.sync(noop_progress(), None).unwrap();
@@ -411,8 +411,8 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
 
                     let mut builder = wallet.build_fee_bump(details.txid).unwrap();
                     builder.fee_rate(FeeRate::from_sat_per_vb(2.1));
-                    let (new_psbt, new_details) = builder.finish().unwrap();
-                    let (new_psbt, finalized) = wallet.sign(new_psbt, None).unwrap();
+                    let (mut new_psbt, new_details) = builder.finish().unwrap();
+                    let finalized = wallet.sign(&mut new_psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(new_psbt.extract_tx()).unwrap();
                     wallet.sync(noop_progress(), None).unwrap();
@@ -437,8 +437,8 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
 
                     let mut builder = wallet.build_tx();
                     builder.add_recipient(node_addr.script_pubkey().clone(), 49_000).enable_rbf();
-                    let (psbt, details) = builder.finish().unwrap();
-                    let (psbt, finalized) = wallet.sign(psbt, None).unwrap();
+                    let (mut psbt, details) = builder.finish().unwrap();
+                    let finalized = wallet.sign(&mut psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(psbt.extract_tx()).unwrap();
                     wallet.sync(noop_progress(), None).unwrap();
@@ -447,8 +447,8 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
 
                     let mut builder = wallet.build_fee_bump(details.txid).unwrap();
                     builder.fee_rate(FeeRate::from_sat_per_vb(5.0));
-                    let (new_psbt, new_details) = builder.finish().unwrap();
-                    let (new_psbt, finalized) = wallet.sign(new_psbt, None).unwrap();
+                    let (mut new_psbt, new_details) = builder.finish().unwrap();
+                    let finalized = wallet.sign(&mut new_psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(new_psbt.extract_tx()).unwrap();
                     wallet.sync(noop_progress(), None).unwrap();
@@ -473,8 +473,8 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
 
                     let mut builder = wallet.build_tx();
                     builder.add_recipient(node_addr.script_pubkey().clone(), 49_000).enable_rbf();
-                    let (psbt, details) = builder.finish().unwrap();
-                    let (psbt, finalized) = wallet.sign(psbt, None).unwrap();
+                    let (mut psbt, details) = builder.finish().unwrap();
+                    let finalized = wallet.sign(&mut psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(psbt.extract_tx()).unwrap();
                     wallet.sync(noop_progress(), None).unwrap();
@@ -483,8 +483,8 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
 
                     let mut builder = wallet.build_fee_bump(details.txid).unwrap();
                     builder.fee_rate(FeeRate::from_sat_per_vb(10.0));
-                    let (new_psbt, new_details) = builder.finish().unwrap();
-                    let (new_psbt, finalized) = wallet.sign(new_psbt, None).unwrap();
+                    let (mut new_psbt, new_details) = builder.finish().unwrap();
+                    let finalized = wallet.sign(&mut new_psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(new_psbt.extract_tx()).unwrap();
                     wallet.sync(noop_progress(), None).unwrap();
@@ -507,8 +507,8 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
 
                     let mut builder = wallet.build_tx();
                     builder.add_recipient(node_addr.script_pubkey().clone(), 49_000).enable_rbf();
-                    let (psbt, details) = builder.finish().unwrap();
-                    let (psbt, finalized) = wallet.sign(psbt, None).unwrap();
+                    let (mut psbt, details) = builder.finish().unwrap();
+                    let finalized = wallet.sign(&mut psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(psbt.extract_tx()).unwrap();
                     wallet.sync(noop_progress(), None).unwrap();
@@ -517,10 +517,10 @@ pub fn bdk_blockchain_tests(attr: TokenStream, item: TokenStream) -> TokenStream
 
                     let mut builder = wallet.build_fee_bump(details.txid).unwrap();
                     builder.fee_rate(FeeRate::from_sat_per_vb(123.0));
-                    let (new_psbt, new_details) = builder.finish().unwrap();
+                    let (mut new_psbt, new_details) = builder.finish().unwrap();
                     println!("{:#?}", new_details);
 
-                    let (new_psbt, finalized) = wallet.sign(new_psbt, None).unwrap();
+                    let finalized = wallet.sign(&mut new_psbt, None).unwrap();
                     assert!(finalized, "Cannot finalize transaction");
                     wallet.broadcast(new_psbt.extract_tx()).unwrap();
                     wallet.sync(noop_progress(), None).unwrap();


### PR DESCRIPTION
Rather than consuming it because that is not ergonomic. It is very annoying to successively sign with different wallets for example.

### Notes to the reviewers

I had to make it depend on the local testutils (agian).

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [x] I've updated `CHANGELOG.md`
* [x] This pull request breaks the existing API

