### PR TITLE
Use `default: D` mirroring Rust documentation

### DIFF
--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -164,14 +164,14 @@ pub(crate) trait DatabaseUtils: Database {
             .map(|o| o.is_some())
     }
 
-    fn get_raw_tx_or<F>(&self, txid: &Txid, f: F) -> Result<Option<Transaction>, Error>
+    fn get_raw_tx_or<D>(&self, txid: &Txid, default: D) -> Result<Option<Transaction>, Error>
     where
-        F: FnOnce() -> Result<Option<Transaction>, Error>,
+        D: FnOnce() -> Result<Option<Transaction>, Error>,
     {
         self.get_tx(txid, true)?
             .map(|t| t.transaction)
             .flatten()
-            .map_or_else(f, |t| Ok(Some(t)))
+            .map_or_else(default, |t| Ok(Some(t)))
     }
 
     fn get_previous_output(&self, outpoint: &OutPoint) -> Result<Option<TxOut>, Error> {


### PR DESCRIPTION
### Description

Currently we use `F: f` for the argument that is the default function passed to `map_or_else` and pass a closure for the second argument. This bent my brain while reading the documentation because the docs use `default: D` for the first and `f: F` for the second. Although this is totally trivial it makes deciphering the combinator chain easier if we name the arguments the same way the Rust docs do.

Use `default: D` for the identifier of the default function passed into `map_or_else`.

ref: https://doc.rust-lang.org/std/result/enum.Result.html#method.map_or_else
```
pub fn map_or_else<U, D, F>(self, default: D, f: F) -> U where
    F: FnOnce(T) -> U,
    D: FnOnce(E) -> U, 
```

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
