### PR TITLE
Fix nightly Clippy warnings

### DIFF
--- a/src/descriptor/dsl.rs
+++ b/src/descriptor/dsl.rs
@@ -535,9 +535,7 @@ macro_rules! fragment_internal {
     ( @t , $( $tail:tt )* ) => ({
         $crate::fragment_internal!( @t $( $tail )* )
     });
-    ( @t ) => ({
-        ()
-    });
+    ( @t ) => ({});
 
     // Fallback to calling `fragment!()`
     ( $( $tokens:tt )* ) => ({

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -17,6 +17,7 @@ pub trait PsbtUtils {
 }
 
 impl PsbtUtils for Psbt {
+    #[allow(clippy::all)] // We want to allow `manual_map` but it is too new.
     fn get_utxo_for(&self, input_index: usize) -> Option<TxOut> {
         let tx = &self.global.unsigned_tx;
 

--- a/src/wallet/coin_selection.rs
+++ b/src/wallet/coin_selection.rs
@@ -255,8 +255,8 @@ impl OutputGroup {
         let effective_value = weighted_utxo.utxo.txout().value as i64 - fee.ceil() as i64;
         OutputGroup {
             weighted_utxo,
-            effective_value,
             fee,
+            effective_value,
         }
     }
 }

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1166,11 +1166,11 @@ where
         //    must_spend <- manually selected utxos
         //    may_spend  <- all other available utxos
         let mut may_spend = self.get_available_utxos()?;
+
         may_spend.retain(|may_spend| {
-            manually_selected
+            !manually_selected
                 .iter()
-                .find(|manually_selected| manually_selected.utxo.outpoint() == may_spend.0.outpoint)
-                .is_none()
+                .any(|manually_selected| manually_selected.utxo.outpoint() == may_spend.0.outpoint)
         });
         let mut must_spend = manually_selected;
 

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -3514,7 +3514,7 @@ pub(crate) mod test {
         let (mut psbt, _) = builder.finish().unwrap();
 
         let finalized = wallet.sign(&mut psbt, Default::default()).unwrap();
-        assert_eq!(finalized, true);
+        assert!(finalized);
 
         let extracted = psbt.extract_tx();
         assert_eq!(extracted.input[0].witness.len(), 2);
@@ -3531,7 +3531,7 @@ pub(crate) mod test {
         let (mut psbt, _) = builder.finish().unwrap();
 
         let finalized = wallet.sign(&mut psbt, Default::default()).unwrap();
-        assert_eq!(finalized, true);
+        assert!(finalized);
 
         let extracted = psbt.extract_tx();
         assert_eq!(extracted.input[0].witness.len(), 2);
@@ -3548,7 +3548,7 @@ pub(crate) mod test {
         let (mut psbt, _) = builder.finish().unwrap();
 
         let finalized = wallet.sign(&mut psbt, Default::default()).unwrap();
-        assert_eq!(finalized, true);
+        assert!(finalized);
 
         let extracted = psbt.extract_tx();
         assert_eq!(extracted.input[0].witness.len(), 2);
@@ -3565,7 +3565,7 @@ pub(crate) mod test {
         let (mut psbt, _) = builder.finish().unwrap();
 
         let finalized = wallet.sign(&mut psbt, Default::default()).unwrap();
-        assert_eq!(finalized, true);
+        assert!(finalized);
 
         let extracted = psbt.extract_tx();
         assert_eq!(extracted.input[0].witness.len(), 2);
@@ -3583,7 +3583,7 @@ pub(crate) mod test {
         let (mut psbt, _) = builder.finish().unwrap();
 
         let finalized = wallet.sign(&mut psbt, Default::default()).unwrap();
-        assert_eq!(finalized, true);
+        assert!(finalized);
 
         let extracted = psbt.extract_tx();
         assert_eq!(extracted.input[0].witness.len(), 2);
@@ -3603,7 +3603,7 @@ pub(crate) mod test {
         assert_eq!(psbt.inputs[0].bip32_derivation.len(), 0);
 
         let finalized = wallet.sign(&mut psbt, Default::default()).unwrap();
-        assert_eq!(finalized, true);
+        assert!(finalized);
 
         let extracted = psbt.extract_tx();
         assert_eq!(extracted.input[0].witness.len(), 2);

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -424,9 +424,8 @@ where
             })
             .transpose()?;
 
-        let requirements = external_requirements
-            .clone()
-            .merge(&internal_requirements.unwrap_or_default())?;
+        let requirements =
+            external_requirements.merge(&internal_requirements.unwrap_or_default())?;
         debug!("Policy requirements: {:?}", requirements);
 
         let version = match params.version {

--- a/src/wallet/utils.rs
+++ b/src/wallet/utils.rs
@@ -201,31 +201,31 @@ mod test {
     #[test]
     fn test_check_nsequence_rbf_msb_set() {
         let result = check_nsequence_rbf(0x80000000, 5000);
-        assert_eq!(result, false);
+        assert!(!result);
     }
 
     #[test]
     fn test_check_nsequence_rbf_lt_csv() {
         let result = check_nsequence_rbf(4000, 5000);
-        assert_eq!(result, false);
+        assert!(!result);
     }
 
     #[test]
     fn test_check_nsequence_rbf_different_unit() {
         let result = check_nsequence_rbf(SEQUENCE_LOCKTIME_TYPE_FLAG + 5000, 5000);
-        assert_eq!(result, false);
+        assert!(!result);
     }
 
     #[test]
     fn test_check_nsequence_rbf_mask() {
         let result = check_nsequence_rbf(0x3f + 10_000, 5000);
-        assert_eq!(result, true);
+        assert!(result);
     }
 
     #[test]
     fn test_check_nsequence_rbf_same_unit_blocks() {
         let result = check_nsequence_rbf(10_000, 5000);
-        assert_eq!(result, true);
+        assert!(result);
     }
 
     #[test]
@@ -234,25 +234,25 @@ mod test {
             SEQUENCE_LOCKTIME_TYPE_FLAG + 10_000,
             SEQUENCE_LOCKTIME_TYPE_FLAG + 5000,
         );
-        assert_eq!(result, true);
+        assert!(result);
     }
 
     #[test]
     fn test_check_nlocktime_lt_cltv() {
         let result = check_nlocktime(4000, 5000);
-        assert_eq!(result, false);
+        assert!(!result);
     }
 
     #[test]
     fn test_check_nlocktime_different_unit() {
         let result = check_nlocktime(BLOCKS_TIMELOCK_THRESHOLD + 5000, 5000);
-        assert_eq!(result, false);
+        assert!(!result);
     }
 
     #[test]
     fn test_check_nlocktime_same_unit_blocks() {
         let result = check_nlocktime(10_000, 5000);
-        assert_eq!(result, true);
+        assert!(result);
     }
 
     #[test]
@@ -261,6 +261,6 @@ mod test {
             BLOCKS_TIMELOCK_THRESHOLD + 10_000,
             BLOCKS_TIMELOCK_THRESHOLD + 5000,
         );
-        assert_eq!(result, true);
+        assert!(result);
     }
 }


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

Checking `bdk` with the nightly toolchain throws a bunch of warnings, ~all are trivial to fix~. Turns out one of them is not, the final patch of this PR may or may not be deemed an improvement, please review and I can drop if required.

Fix warnings emitted by Clippy when using nightly toolchain.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

While bdk does not appear to explicitly rely on nightly features I like to use nightly so I can pass `-Zunstable-options` to clippy. I do this so that Clippy doesn't hide warnings after the first time showing them, instead throwing warnings every check. 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

