### PR TITLE
Lowercase PSBT

### DIFF
--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -9,14 +9,14 @@
 // You may not use this file except in accordance with one or both of these
 // licenses.
 
-use bitcoin::util::psbt::PartiallySignedTransaction as PSBT;
+use bitcoin::util::psbt::PartiallySignedTransaction as Psbt;
 use bitcoin::TxOut;
 
 pub trait PsbtUtils {
     fn get_utxo_for(&self, input_index: usize) -> Option<TxOut>;
 }
 
-impl PsbtUtils for PSBT {
+impl PsbtUtils for Psbt {
     fn get_utxo_for(&self, input_index: usize) -> Option<TxOut> {
         let tx = &self.global.unsigned_tx;
 
@@ -42,7 +42,7 @@ impl PsbtUtils for PSBT {
 mod test {
     use crate::bitcoin::consensus::deserialize;
     use crate::bitcoin::TxIn;
-    use crate::psbt::PSBT;
+    use crate::psbt::Psbt;
     use crate::wallet::test::{get_funded_wallet, get_test_wpkh};
     use crate::wallet::AddressIndex;
     use crate::SignOptions;
@@ -53,7 +53,7 @@ mod test {
     #[test]
     #[should_panic(expected = "InputIndexOutOfRange")]
     fn test_psbt_malformed_psbt_input_legacy() {
-        let psbt_bip: PSBT = deserialize(&base64::decode(PSBT_STR).unwrap()).unwrap();
+        let psbt_bip: Psbt = deserialize(&base64::decode(PSBT_STR).unwrap()).unwrap();
         let (wallet, _, _) = get_funded_wallet(get_test_wpkh());
         let send_to = wallet.get_address(AddressIndex::New).unwrap();
         let mut builder = wallet.build_tx();
@@ -70,7 +70,7 @@ mod test {
     #[test]
     #[should_panic(expected = "InputIndexOutOfRange")]
     fn test_psbt_malformed_psbt_input_segwit() {
-        let psbt_bip: PSBT = deserialize(&base64::decode(PSBT_STR).unwrap()).unwrap();
+        let psbt_bip: Psbt = deserialize(&base64::decode(PSBT_STR).unwrap()).unwrap();
         let (wallet, _, _) = get_funded_wallet(get_test_wpkh());
         let send_to = wallet.get_address(AddressIndex::New).unwrap();
         let mut builder = wallet.build_tx();
@@ -102,7 +102,7 @@ mod test {
 
     #[test]
     fn test_psbt_sign_with_finalized() {
-        let psbt_bip: PSBT = deserialize(&base64::decode(PSBT_STR).unwrap()).unwrap();
+        let psbt_bip: Psbt = deserialize(&base64::decode(PSBT_STR).unwrap()).unwrap();
         let (wallet, _, _) = get_funded_wallet(get_test_wpkh());
         let send_to = wallet.get_address(AddressIndex::New).unwrap();
         let mut builder = wallet.build_tx();

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -25,7 +25,7 @@ use bitcoin::consensus::encode::serialize;
 use bitcoin::util::base58;
 use bitcoin::util::psbt::raw::Key as PSBTKey;
 use bitcoin::util::psbt::Input;
-use bitcoin::util::psbt::PartiallySignedTransaction as PSBT;
+use bitcoin::util::psbt::PartiallySignedTransaction as Psbt;
 use bitcoin::{Address, Network, OutPoint, Script, SigHashType, Transaction, TxOut, Txid};
 
 use miniscript::descriptor::DescriptorTrait;
@@ -371,7 +371,7 @@ where
         &self,
         coin_selection: Cs,
         params: TxParams,
-    ) -> Result<(PSBT, TransactionDetails), Error> {
+    ) -> Result<(Psbt, TransactionDetails), Error> {
         let external_policy = self
             .descriptor
             .extract_policy(&self.signers, BuildSatisfaction::None, &self.secp)?
@@ -857,7 +857,7 @@ where
     /// let  finalized = wallet.sign(&mut psbt, SignOptions::default())?;
     /// assert!(finalized, "we should have signed all the inputs");
     /// # Ok::<(), bdk::Error>(())
-    pub fn sign(&self, psbt: &mut PSBT, sign_options: SignOptions) -> Result<bool, Error> {
+    pub fn sign(&self, psbt: &mut Psbt, sign_options: SignOptions) -> Result<bool, Error> {
         // this helps us doing our job later
         self.add_input_hd_keypaths(psbt)?;
 
@@ -927,7 +927,7 @@ where
     /// Try to finalize a PSBT
     ///
     /// The [`SignOptions`] can be used to tweak the behavior of the finalizer.
-    pub fn finalize_psbt(&self, psbt: &mut PSBT, sign_options: SignOptions) -> Result<bool, Error> {
+    pub fn finalize_psbt(&self, psbt: &mut Psbt, sign_options: SignOptions) -> Result<bool, Error> {
         let tx = &psbt.global.unsigned_tx;
         let mut finished = true;
 
@@ -1228,10 +1228,10 @@ where
         tx: Transaction,
         selected: Vec<Utxo>,
         params: TxParams,
-    ) -> Result<PSBT, Error> {
+    ) -> Result<Psbt, Error> {
         use bitcoin::util::psbt::serialize::Serialize;
 
-        let mut psbt = PSBT::from_unsigned_tx(tx)?;
+        let mut psbt = Psbt::from_unsigned_tx(tx)?;
 
         if params.add_global_xpubs {
             let mut all_xpubs = self.descriptor.get_extended_keys()?;
@@ -1371,7 +1371,7 @@ where
         Ok(psbt_input)
     }
 
-    fn add_input_hd_keypaths(&self, psbt: &mut PSBT) -> Result<(), Error> {
+    fn add_input_hd_keypaths(&self, psbt: &mut Psbt) -> Result<(), Error> {
         let mut input_utxos = Vec::with_capacity(psbt.inputs.len());
         for n in 0..psbt.inputs.len() {
             input_utxos.push(psbt.get_utxo_for(n).clone());

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -23,7 +23,7 @@ use bitcoin::secp256k1::Secp256k1;
 
 use bitcoin::consensus::encode::serialize;
 use bitcoin::util::base58;
-use bitcoin::util::psbt::raw::Key as PSBTKey;
+use bitcoin::util::psbt::raw::Key as PsbtKey;
 use bitcoin::util::psbt::Input;
 use bitcoin::util::psbt::PartiallySignedTransaction as Psbt;
 use bitcoin::{Address, Network, OutPoint, Script, SigHashType, Transaction, TxOut, Txid};
@@ -1242,7 +1242,7 @@ where
             for xpub in all_xpubs {
                 let serialized_xpub = base58::from_check(&xpub.xkey.to_string())
                     .expect("Internal serialization error");
-                let key = PSBTKey {
+                let key = PsbtKey {
                     type_value: 0x01,
                     key: serialized_xpub,
                 };

--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -41,7 +41,7 @@ use std::collections::HashSet;
 use std::default::Default;
 use std::marker::PhantomData;
 
-use bitcoin::util::psbt::{self, PartiallySignedTransaction as PSBT};
+use bitcoin::util::psbt::{self, PartiallySignedTransaction as Psbt};
 use bitcoin::{OutPoint, Script, SigHashType, Transaction};
 
 use miniscript::descriptor::DescriptorTrait;
@@ -521,7 +521,7 @@ impl<'a, B, D: BatchDatabase, Cs: CoinSelectionAlgorithm<D>, Ctx: TxBuilderConte
     /// Returns the [`BIP174`] "PSBT" and summary details about the transaction.
     ///
     /// [`BIP174`]: https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki
-    pub fn finish(self) -> Result<(PSBT, TransactionDetails), Error> {
+    pub fn finish(self) -> Result<(Psbt, TransactionDetails), Error> {
         self.wallet.create_tx(self.coin_selection, self.params)
     }
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Idiomatic Rust uses lowercase for acronyms for all characters after the first e.g. `std::net::TcpStream`. PSBT (Partially Signed Bitcoin Transaction) should be rendered `Psbt` in Rust code if we want to write idiomatic Rust. Likewise for `PSBTKey` -> `PsbtKey`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
