### PR TITLE
Remove stale comments

### DIFF
--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -119,9 +119,6 @@ impl TxBuilderContext for BumpFee {}
 #[derive(Debug)]
 pub struct TxBuilder<'a, B, D, Cs, Ctx> {
     pub(crate) wallet: &'a Wallet<B, D>,
-    // params and coin_selection are Options not becasue they are optionally set (they are always
-    // there) but because `.finish()` uses `Option::take` to get an owned value from a &mut self.
-    // They are only `None` after `.finish()` is called.
     pub(crate) params: TxParams,
     pub(crate) coin_selection: Cs,
     pub(crate) phantom: PhantomData<Ctx>,


### PR DESCRIPTION

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

The two fields this comment references are not `Option` type. This
comment seems to be stale.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
