### PR TITLE
Return AddressInfo from get_address to allow access to index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Wallet
 - Added an option that must be explicitly enabled to allow signing using non-`SIGHASH_ALL` sighashes (#350)
+#### Changed
+`get_address` now returns an `AddressInfo` struct that includes the index and derefs to `Address`.
 
 ## [v0.7.0] - [v0.6.0]
 

--- a/src/testutils/blockchain_tests.rs
+++ b/src/testutils/blockchain_tests.rs
@@ -815,7 +815,7 @@ macro_rules! bdk_blockchain_tests {
             #[serial]
             fn test_sync_receive_coinbase() {
                 let (wallet, _, mut test_client) = init_single_sig();
-                let wallet_addr = wallet.get_address(New).unwrap();
+                let wallet_addr = wallet.get_address(New).unwrap().address;
 
                 wallet.sync(noop_progress(), None).unwrap();
                 assert_eq!(wallet.get_balance().unwrap(), 0);


### PR DESCRIPTION
This adds an `AddressInfo` struct that derefs to `Address` so that wallet's `get_address` method can return both an index and an address without breaking existing code (hopefully!).

The motivation is to be able to produce descriptors to pass to HWI for purpose of verifying an address. Without BDK telling me the index I would have to keep track of that state on my own.

This was discussed on Discord as preferable to creating an additional method (something like `get_address_and_index`) just for this purpose.

An even nicer outcome would be the ability to query the database for a list of previously seen addresses and indexes, but that will involve a lot of database stuff that I'm not familiar with.

### Notes to the reviewers

I'm a little uncertain on how verbose to be with documenting this struct.

Also I got two unrelated clippy errors. Not sure if I should fix those or rebase once they're fixed elsewhere.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`