### PR TITLE
[signer] Add an option to explicitly allow using non-`ALL` sighashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Wallet
+- Added an option that must be explicitly enabled to allow signing using non-`SIGHASH_ALL` sighashes (#350)
+
 ## [v0.7.0] - [v0.6.0]
 
 ### Policy

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -63,7 +63,7 @@ mod test {
         psbt.inputs.push(psbt_bip.inputs[0].clone());
         let options = SignOptions {
             trust_witness_utxo: true,
-            assume_height: None,
+            ..Default::default()
         };
         let _ = wallet.sign(&mut psbt, options).unwrap();
     }
@@ -80,7 +80,7 @@ mod test {
         psbt.inputs.push(psbt_bip.inputs[1].clone());
         let options = SignOptions {
             trust_witness_utxo: true,
-            assume_height: None,
+            ..Default::default()
         };
         let _ = wallet.sign(&mut psbt, options).unwrap();
     }
@@ -96,7 +96,7 @@ mod test {
         psbt.global.unsigned_tx.input.push(TxIn::default());
         let options = SignOptions {
             trust_witness_utxo: true,
-            assume_height: None,
+            ..Default::default()
         };
         let _ = wallet.sign(&mut psbt, options).unwrap();
     }

--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -147,6 +147,12 @@ pub enum SignerError {
     MissingWitnessScript,
     /// The fingerprint and derivation path are missing from the psbt input
     MissingHdKeypath,
+    /// The psbt contains a non-`SIGHASH_ALL` sighash in one of its input and the user hasn't
+    /// explicitly allowed them
+    ///
+    /// To enable signing transactions with non-standard sighashes set
+    /// [`SignOptions::allow_all_sighashes`] to `true`.
+    NonStandardSighash,
 }
 
 impl fmt::Display for SignerError {
@@ -465,6 +471,12 @@ pub struct SignOptions {
     /// timelock height has already been reached. This option allows overriding the "current height" to let the
     /// wallet use timelocks in the future to spend a coin.
     pub assume_height: Option<u32>,
+
+    /// Whether the signer should use the `sighash_type` set in the PSBT when signing, no matter
+    /// what its value is
+    ///
+    /// Defaults to `false` which will only allow signing using `SIGHASH_ALL`.
+    pub allow_all_sighashes: bool,
 }
 
 impl Default for SignOptions {
@@ -472,6 +484,7 @@ impl Default for SignOptions {
         SignOptions {
             trust_witness_utxo: false,
             assume_height: None,
+            allow_all_sighashes: false,
         }
     }
 }


### PR DESCRIPTION
### Description

Instead of blindly using the `sighash_type` set in a psbt input, we now only sign `SIGHASH_ALL` inputs by default, and require the user to explicitly opt-in to using other sighashes if they desire to do so.

Fixes #350

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`
