### PR TITLE
Remove redundant borrows

### DIFF
--- a/src/blockchain/utils.rs
+++ b/src/blockchain/utils.rs
@@ -158,7 +158,7 @@ pub trait ElectrumLikeSync {
                 }
             } else {
                 save_transaction_details_and_utxos(
-                    &txid,
+                    txid,
                     db,
                     timestamp,
                     height,
@@ -171,7 +171,7 @@ pub trait ElectrumLikeSync {
         // remove any tx details in db but not in history_txs_id
         for txid in txs_details_in_db.keys() {
             if !history_txs_id.contains(txid) {
-                batch.del_tx(&txid, false)?;
+                batch.del_tx(txid, false)?;
             }
         }
 
@@ -329,7 +329,7 @@ fn save_transaction_details_and_utxos<D: BatchDatabase>(
 
         // removes conflicting UTXO if any (generated from same inputs, like for example RBF)
         if let Some(outpoint) = utxo_deps.get(&input.previous_output) {
-            updates.del_utxo(&outpoint)?;
+            updates.del_utxo(outpoint)?;
         }
     }
 

--- a/src/database/keyvalue.rs
+++ b/src/database/keyvalue.rs
@@ -320,7 +320,7 @@ impl Database for Tree {
             .map(|b| -> Result<_, Error> {
                 let mut txdetails: TransactionDetails = serde_json::from_slice(&b)?;
                 if include_raw {
-                    txdetails.transaction = self.get_raw_tx(&txid)?;
+                    txdetails.transaction = self.get_raw_tx(txid)?;
                 }
 
                 Ok(txdetails)

--- a/src/database/memory.rs
+++ b/src/database/memory.rs
@@ -394,7 +394,7 @@ impl Database for MemoryDatabase {
         Ok(self.map.get(&key).map(|b| {
             let mut txdetails: TransactionDetails = b.downcast_ref().cloned().unwrap();
             if include_raw {
-                txdetails.transaction = self.get_raw_tx(&txid).unwrap();
+                txdetails.transaction = self.get_raw_tx(txid).unwrap();
             }
 
             txdetails

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -128,11 +128,11 @@ impl IntoWalletDescriptor for (ExtendedDescriptor, KeyMap) {
             let (pk, _, networks) = if self.0.is_witness() {
                 let desciptor_key: DescriptorKey<miniscript::Segwitv0> =
                     pk.clone().into_descriptor_key()?;
-                desciptor_key.extract(&secp)?
+                desciptor_key.extract(secp)?
             } else {
                 let desciptor_key: DescriptorKey<miniscript::Legacy> =
                     pk.clone().into_descriptor_key()?;
-                desciptor_key.extract(&secp)?
+                desciptor_key.extract(secp)?
             };
 
             if networks.contains(&network) {

--- a/src/descriptor/policy.rs
+++ b/src/descriptor/policy.rs
@@ -336,7 +336,7 @@ impl Satisfaction {
                         items.push(inner_index);
                         let conditions_set = other_conditions
                             .values()
-                            .fold(HashSet::new(), |set, i| set.union(&i).cloned().collect());
+                            .fold(HashSet::new(), |set, i| set.union(i).cloned().collect());
                         conditions.insert(inner_index, conditions_set);
                     }
                 }
@@ -1031,8 +1031,8 @@ mod test {
     ) -> (DescriptorKey<Ctx>, DescriptorKey<Ctx>, Fingerprint) {
         let path = bip32::DerivationPath::from_str(path).unwrap();
         let tprv = bip32::ExtendedPrivKey::from_str(tprv).unwrap();
-        let tpub = bip32::ExtendedPubKey::from_private(&secp, &tprv);
-        let fingerprint = tprv.fingerprint(&secp);
+        let tpub = bip32::ExtendedPubKey::from_private(secp, &tprv);
+        let fingerprint = tprv.fingerprint(secp);
         let prvkey = (tprv, path.clone()).into_descriptor_key().unwrap();
         let pubkey = (tpub, path).into_descriptor_key().unwrap();
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -139,7 +139,7 @@ impl Utxo {
                 }
 
                 if let Some(txout) = &psbt_input.witness_utxo {
-                    return &txout;
+                    return txout;
                 }
 
                 unreachable!("Foreign UTXOs will always have one of these set")

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -398,7 +398,7 @@ where
     /// [`TxBuilder`]: crate::TxBuilder
     pub fn build_tx(&self) -> TxBuilder<'_, B, D, DefaultCoinSelectionAlgorithm, CreateTx> {
         TxBuilder {
-            wallet: &self,
+            wallet: self,
             params: TxParams::default(),
             coin_selection: DefaultCoinSelectionAlgorithm::default(),
             phantom: core::marker::PhantomData,
@@ -861,7 +861,7 @@ where
         };
 
         Ok(TxBuilder {
-            wallet: &self,
+            wallet: self,
             params,
             coin_selection: DefaultCoinSelectionAlgorithm::default(),
             phantom: core::marker::PhantomData,
@@ -1031,7 +1031,7 @@ where
                     match desc.satisfy(
                         &mut tmp_input,
                         (
-                            PsbtInputSatisfier::new(&psbt, n),
+                            PsbtInputSatisfier::new(psbt, n),
                             After::new(current_height, false),
                             Older::new(current_height, create_height, false),
                         ),

--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -222,7 +222,7 @@ impl Signer for DescriptorXKey<ExtendedPrivKey> {
             .bip32_derivation
             .iter()
             .filter_map(|(pk, &(fingerprint, ref path))| {
-                if self.matches(&(fingerprint, path.clone()), &secp).is_some() {
+                if self.matches(&(fingerprint, path.clone()), secp).is_some() {
                     Some((pk, path))
                 } else {
                     None
@@ -240,12 +240,12 @@ impl Signer for DescriptorXKey<ExtendedPrivKey> {
                     &full_path.into_iter().cloned().collect::<Vec<ChildNumber>>()
                         [origin_path.len()..],
                 );
-                self.xkey.derive_priv(&secp, &deriv_path).unwrap()
+                self.xkey.derive_priv(secp, &deriv_path).unwrap()
             }
-            None => self.xkey.derive_priv(&secp, &full_path).unwrap(),
+            None => self.xkey.derive_priv(secp, &full_path).unwrap(),
         };
 
-        if &derived_key.private_key.public_key(&secp) != public_key {
+        if &derived_key.private_key.public_key(secp) != public_key {
             Err(SignerError::InvalidKey)
         } else {
             derived_key.private_key.sign(psbt, Some(input_index), secp)
@@ -257,7 +257,7 @@ impl Signer for DescriptorXKey<ExtendedPrivKey> {
     }
 
     fn id(&self, secp: &SecpCtx) -> SignerId {
-        SignerId::from(self.root_fingerprint(&secp))
+        SignerId::from(self.root_fingerprint(secp))
     }
 
     fn descriptor_secret_key(&self) -> Option<DescriptorSecretKey> {
@@ -283,7 +283,7 @@ impl Signer for PrivateKey {
             return Ok(());
         }
 
-        let pubkey = self.public_key(&secp);
+        let pubkey = self.public_key(secp);
         if psbt.inputs[input_index].partial_sigs.contains_key(&pubkey) {
             return Ok(());
         }
@@ -591,7 +591,7 @@ impl ComputeSighash for Segwitv0 {
                     .map(Script::is_v0_p2wpkh)
                     .unwrap_or(false)
                 {
-                    p2wpkh_script_code(&psbt_input.redeem_script.as_ref().unwrap())
+                    p2wpkh_script_code(psbt_input.redeem_script.as_ref().unwrap())
                 } else {
                     return Err(SignerError::MissingWitnessScript);
                 }


### PR DESCRIPTION
### Description

Clippy emits:

  warning: this expression borrows a reference

As suggested remove the borrows from the front of vars that are already references.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->



### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
