### PR TITLE
Add maybe_async attribute to CompactFiltersBlockchain

### DIFF
--- a/src/blockchain/compact_filters/mod.rs
+++ b/src/blockchain/compact_filters/mod.rs
@@ -221,6 +221,7 @@ impl CompactFiltersBlockchain {
     }
 }
 
+#[maybe_async]
 impl Blockchain for CompactFiltersBlockchain {
     fn get_capabilities(&self) -> HashSet<Capability> {
         vec![Capability::FullHistory].into_iter().collect()


### PR DESCRIPTION
### Description

Currently we cannot build `bdk` using the following build command:

```
cargo check --no-default-features \
--features  async-interface,esplora,compact_filters
```

This is because the `maybe_async` attribute is missing from the `Blockchain` impl block for `CompactFiltersBlockchain`.

Add maybe_async attribute to CompactFiltersBlockchain `Blockchain` impl block.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
