### PR TITLE
Add `InitWallet` structure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ test-esplora = ["esplora"]
 test-md-docs = ["electrum"]
 
 [dev-dependencies]
+anyhow = "1.0"
 lazy_static = "1.4"
 env_logger = "0.7"
 clap = "2.33"

--- a/examples/init_wallet.rs
+++ b/examples/init_wallet.rs
@@ -11,10 +11,10 @@
 use anyhow::Result;
 use bitcoin::Network;
 
-use bdk::blockchain::{ElectrumBlockchain, NoopProgress};
+use bdk::blockchain::ElectrumBlockchain;
 use bdk::database::MemoryDatabase;
 use bdk::electrum_client::Client;
-use bdk::Wallet;
+use bdk::InitWallet;
 
 const ELECTRUM_URL: &str = "ssl://electrum.blockstream.info:60002";
 const DESC: &str = "wpkh(tprv8ZgxMBicQKsPdT8dRdm7Ae7ZxLTCKNPaZwt7aBWNRyxUCMvY7xhjRG4iBLerk2FTBv6zrzMMw18M3LwJEvn9QhbzsiYJefwUmzcUXcAPDmt/0/*)";
@@ -22,20 +22,16 @@ const CHANGE_DESC: &str = "wpkh(tprv8ZgxMBicQKsPdT8dRdm7Ae7ZxLTCKNPaZwt7aBWNRyxU
 
 /// This demonstrates simple initialisation of an online wallet.
 fn main() -> Result<()> {
-    let wallet = wallet()?;
-    wallet.sync(NoopProgress, None)?;
-    Ok(())
-}
-
-fn wallet() -> Result<Wallet<ElectrumBlockchain, MemoryDatabase>> {
     let client = Client::new(ELECTRUM_URL)?;
-    let wallet = Wallet::new(
+    let wallet = InitWallet::new(
         DESC,
         Some(CHANGE_DESC),
         Network::Testnet,
         MemoryDatabase::default(),
         ElectrumBlockchain::from(client),
     )?;
+    // Equivalent to `wallet.sync(NoopProgress, None)`.
+    let _wallet = wallet.init()?;
 
-    Ok(wallet)
+    Ok(())
 }

--- a/examples/init_wallet.rs
+++ b/examples/init_wallet.rs
@@ -1,0 +1,41 @@
+// Bitcoin Dev Kit
+// Written in 2020 by Alekos Filini <alekos.filini@gmail.com>
+//
+// Copyright (c) 2020-2021 Bitcoin Dev Kit Developers
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+use anyhow::Result;
+use bitcoin::Network;
+
+use bdk::blockchain::{ElectrumBlockchain, NoopProgress};
+use bdk::database::MemoryDatabase;
+use bdk::electrum_client::Client;
+use bdk::Wallet;
+
+const ELECTRUM_URL: &str = "ssl://electrum.blockstream.info:60002";
+const DESC: &str = "wpkh(tprv8ZgxMBicQKsPdT8dRdm7Ae7ZxLTCKNPaZwt7aBWNRyxUCMvY7xhjRG4iBLerk2FTBv6zrzMMw18M3LwJEvn9QhbzsiYJefwUmzcUXcAPDmt/0/*)";
+const CHANGE_DESC: &str = "wpkh(tprv8ZgxMBicQKsPdT8dRdm7Ae7ZxLTCKNPaZwt7aBWNRyxUCMvY7xhjRG4iBLerk2FTBv6zrzMMw18M3LwJEvn9QhbzsiYJefwUmzcUXcAPDmt/1/*)";
+
+/// This demonstrates simple initialisation of an online wallet.
+fn main() -> Result<()> {
+    let wallet = wallet()?;
+    wallet.sync(NoopProgress, None)?;
+    Ok(())
+}
+
+fn wallet() -> Result<Wallet<ElectrumBlockchain, MemoryDatabase>> {
+    let client = Client::new(ELECTRUM_URL)?;
+    let wallet = Wallet::new(
+        DESC,
+        Some(CHANGE_DESC),
+        Network::Testnet,
+        MemoryDatabase::default(),
+        ElectrumBlockchain::from(client),
+    )?;
+
+    Ok(wallet)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,7 +261,7 @@ pub use wallet::address_validator;
 pub use wallet::signer;
 pub use wallet::signer::SignOptions;
 pub use wallet::tx_builder::TxBuilder;
-pub use wallet::Wallet;
+pub use wallet::{InitWallet, Wallet};
 
 /// Get the version of BDK at runtime
 pub fn version() -> &'static str {


### PR DESCRIPTION
### Description

Currently when creating a `Wallet` there is a hard requirement that users call `wallet.sync()` before using the wallet.

In an effort to make the bdk library more intuitive add a new type `InitWallet` that wraps the `Wallet` and exposes a only three simple methods. A constructor, a `sync` method, and a `init` method that is a helper method calling `sync` for simple usage. `sync` consumes `self` and returns the inner `Wallet`.

Idea based on suggestion by @RCasatta in issue #354.

Fixes #354

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

Draft because this is not necessarily a good idea, its a breaking API change, and it makes a lot of current documentation stale. This PR does not include all the docs fixes, would be done before raising non-draft PR. Are there many docs online in other places that this is going to make stale? Is that a consideration?

Also, adds an example usage in `bdk/examples/init_wallet.rs`. Done as two commits, the first adding the example with the current `Wallet::new` workflow and then, when we add the `InitWallet` in patch 2, includes modifications to the example.

I didn't think that hard about whether or not this is a good change, it just seemed like a fun thing to hack on late one evening, feel free to nack it :)

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`
