### PR TITLE
Mark the RPC backend as experimental, build its documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,6 @@ required-features = ["compiler"]
 [workspace]
 members = ["macros"]
 [package.metadata.docs.rs]
-features = ["compiler", "electrum", "esplora", "compact_filters", "key-value-db", "all-keys", "verify"]
+features = ["compiler", "electrum", "esplora", "compact_filters", "rpc", "key-value-db", "all-keys", "verify"]
 # defines the configuration attribute `docsrs`
 rustdoc-args = ["--cfg", "docsrs"]

--- a/src/blockchain/rpc.rs
+++ b/src/blockchain/rpc.rs
@@ -13,6 +13,8 @@
 //!
 //! Backend that gets blockchain data from Bitcoin Core RPC
 //!
+//! This is an **EXPERIMENTAL** feature, API and other major changes are expected.
+//!
 //! ## Example
 //!
 //! ```no_run


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Mark the RPC backend as experimental, since we are still missing a few things like:
- SOCKS5 proxies ( #373 )
- Support in `AnyBlockchain` ( https://github.com/rust-bitcoin/rust-bitcoincore-rpc/pull/181 )

Also build the feature on `docs.rs`, otherwise the docs would be missing

### Notes to the reviewers

I'm opening this PR to let the CI run before merging to `master`, but I will also merge this to the release branch

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
