### PR TITLE
[rpc] Show in the docs that the RPC APIs are feature-gated

### DIFF
--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -44,6 +44,7 @@ pub use self::electrum::ElectrumBlockchain;
 pub use self::electrum::ElectrumBlockchainConfig;
 
 #[cfg(feature = "rpc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "rpc")))]
 pub mod rpc;
 #[cfg(feature = "rpc")]
 pub use self::rpc::RpcBlockchain;


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Show in the docs that in order to use the API under the `blockchain::rpc` module the `rpc` feature has to be enabled.

Not sure if it's worth doing a patch-level release just to fix this, I don't think it's that big of an issue.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing