### PR TITLE
[test] add tests to verify support for sending to bech32m address

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,10 @@ test-rpc = ["rpc", "electrsd/electrs_0_8_10", "test-blockchains"]
 test-esplora = ["electrsd/legacy", "electrsd/esplora_a33e97e1", "test-blockchains"]
 test-md-docs = ["electrum"]
 
+[patch.crates-io]
+core-rpc = { git="https://github.com/sandipndev/rust-bitcoincore-rpc", branch="bech32m-support" }
+bitcoind = { git="https://github.com/sandipndev/bitcoind", branch="create-wallet-updates" }
+
 [dev-dependencies]
 lazy_static = "1.4"
 env_logger = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,15 +90,11 @@ test-rpc = ["rpc", "electrsd/electrs_0_8_10", "test-blockchains"]
 test-esplora = ["electrsd/legacy", "electrsd/esplora_a33e97e1", "test-blockchains"]
 test-md-docs = ["electrum"]
 
-[patch.crates-io]
-core-rpc = { git="https://github.com/sandipndev/rust-bitcoincore-rpc", branch="bech32m-support" }
-bitcoind = { git="https://github.com/sandipndev/bitcoind", branch="create-wallet-updates" }
-
 [dev-dependencies]
 lazy_static = "1.4"
 env_logger = "0.7"
 clap = "2.33"
-electrsd = { version= "0.12", features = ["trigger", "bitcoind_0_21_1"] }
+electrsd = { version= "0.12", features = ["trigger", "bitcoind_22_0"] }
 
 [[example]]
 name = "address_validator"

--- a/src/blockchain/rpc.rs
+++ b/src/blockchain/rpc.rs
@@ -370,7 +370,7 @@ impl ConfigurableBlockchain for RpcBlockchain {
                 client.load_wallet(&wallet_name)?;
                 debug!("wallet loaded {:?}", wallet_name);
             } else {
-                client.create_wallet(&wallet_name, Some(true), None, None, None)?;
+                client.create_wallet(&wallet_name, Some(true), None, None, None, None)?;
                 debug!("wallet created {:?}", wallet_name);
             }
         }
@@ -445,7 +445,7 @@ where
 }
 
 /// return the wallets available in default wallet directory
-//TODO use bitcoincore_rpc method when PR #179 lands
+//TODO use core_rpc method when PR #179 lands
 fn list_wallet_dir(client: &Client) -> Result<Vec<String>, Error> {
     #[derive(Deserialize)]
     struct Name {

--- a/src/blockchain/rpc.rs
+++ b/src/blockchain/rpc.rs
@@ -370,7 +370,7 @@ impl ConfigurableBlockchain for RpcBlockchain {
                 client.load_wallet(&wallet_name)?;
                 debug!("wallet loaded {:?}", wallet_name);
             } else {
-                client.create_wallet(&wallet_name, Some(true), None, None, None, None)?;
+                client.create_wallet(&wallet_name, Some(true), None, None, None)?;
                 debug!("wallet created {:?}", wallet_name);
             }
         }
@@ -445,7 +445,7 @@ where
 }
 
 /// return the wallets available in default wallet directory
-//TODO use core_rpc method when PR #179 lands
+//TODO use bitcoincore_rpc method when PR #179 lands
 fn list_wallet_dir(client: &Client) -> Result<Vec<String>, Error> {
     #[derive(Deserialize)]
     struct Name {

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -3994,4 +3994,15 @@ pub(crate) mod test {
             }
         );
     }
+
+    #[test]
+    fn test_sending_to_bip350_bech32m_address() {
+        let (wallet, _, _) = get_funded_wallet(get_test_wpkh());
+        let addr =
+            Address::from_str("tb1pqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesf3hn0c")
+                .unwrap();
+        let mut builder = wallet.build_tx();
+        builder.add_recipient(addr.script_pubkey(), 45_000);
+        builder.finish().unwrap();
+    }
 }


### PR DESCRIPTION
### Description

This PR is in reference to #396 
It adds some tests to confirm sending transactions to Bech32m addresses, introduced in [BIP350](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki)

**Note:** This change requires `bitcoin-core` `v22.0` to be incorporated into bitcoind.

### Checklists

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for Bech32m adoption by `rust-bitcoin`
