### PR TITLE
Update electrsd dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,7 @@ test-md-docs = ["electrum"]
 lazy_static = "1.4"
 env_logger = "0.7"
 clap = "2.33"
-electrsd = { version= "0.6", features = ["trigger", "bitcoind_0_21_1"] }
+electrsd = { version= "0.8", features = ["trigger", "bitcoind_0_21_1"] }
 
 [[example]]
 name = "address_validator"

--- a/src/testutils/blockchain_tests.rs
+++ b/src/testutils/blockchain_tests.rs
@@ -7,7 +7,7 @@ pub use bitcoincore_rpc::bitcoincore_rpc_json::AddressType;
 pub use bitcoincore_rpc::{Auth, Client as RpcClient, RpcApi};
 use core::str::FromStr;
 use electrsd::bitcoind::BitcoinD;
-use electrsd::{bitcoind, ElectrsD};
+use electrsd::{bitcoind, Conf, ElectrsD};
 pub use electrum_client::{Client as ElectrumClient, ElectrumApi};
 #[allow(unused_imports)]
 use log::{debug, error, info, trace};
@@ -28,7 +28,11 @@ impl TestClient {
 
         let http_enabled = cfg!(feature = "test-esplora");
 
-        let electrsd = ElectrsD::new(electrs_exe, &bitcoind, false, http_enabled).unwrap();
+        let conf = Conf {
+            http_enabled,
+            ..Default::default()
+        };
+        let electrsd = ElectrsD::with_conf(electrs_exe, &bitcoind, &conf).unwrap();
 
         let node_address = bitcoind.client.get_new_address(None, None).unwrap();
         bitcoind


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

I noticed there is some log output in blockchain tests caused by a leftover `eprintln` in electrsd, this dep upgrade solve this


### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

