### PR TITLE
Add flush method to Database trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added `RpcBlockchain` in the `AnyBlockchain` struct to allow using Rpc backend where `AnyBlockchain` is used (eg `bdk-cli`)
 - Removed hard dependency on `tokio`.
+- Added `flush` method to the `Database` trait to explicitly flush to disk latest changes on the db.
 
 ### Wallet
 

--- a/src/database/any.rs
+++ b/src/database/any.rs
@@ -233,6 +233,10 @@ impl Database for AnyDatabase {
     fn increment_last_index(&mut self, keychain: KeychainKind) -> Result<u32, Error> {
         impl_inner_method!(AnyDatabase, self, increment_last_index, keychain)
     }
+
+    fn flush(&mut self) -> Result<(), Error> {
+        impl_inner_method!(AnyDatabase, self, flush)
+    }
 }
 
 impl BatchOperations for AnyBatch {

--- a/src/database/keyvalue.rs
+++ b/src/database/keyvalue.rs
@@ -367,6 +367,10 @@ impl Database for Tree {
             Ok(val)
         })
     }
+
+    fn flush(&mut self) -> Result<(), Error> {
+        Ok(Tree::flush(self).map(|_| ())?)
+    }
 }
 
 impl BatchDatabase for Tree {

--- a/src/database/memory.rs
+++ b/src/database/memory.rs
@@ -419,6 +419,10 @@ impl Database for MemoryDatabase {
 
         Ok(*value)
     }
+
+    fn flush(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 impl BatchDatabase for MemoryDatabase {

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -134,6 +134,9 @@ pub trait Database: BatchOperations {
     ///
     /// It should insert and return `0` if not present in the database
     fn increment_last_index(&mut self, keychain: KeychainKind) -> Result<u32, Error>;
+
+    /// Force changes to be written to disk, returning the number of bytes written
+    fn flush(&mut self) -> Result<(), Error>;
 }
 
 /// Trait for a database that supports batch operations

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -135,7 +135,7 @@ pub trait Database: BatchOperations {
     /// It should insert and return `0` if not present in the database
     fn increment_last_index(&mut self, keychain: KeychainKind) -> Result<u32, Error>;
 
-    /// Force changes to be written to disk, returning the number of bytes written
+    /// Force changes to be written to disk
     fn flush(&mut self) -> Result<(), Error>;
 }
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Expose `flush` method in the `Database` trait to explicitly flush db changes to disk

A step toward fixing https://github.com/bitcoindevkit/bdk/issues/391.

Following steps are
- [ ] Add call to flush from JNI
- [ ] Call the flush method from the app (ideally in a App Destructor callback or if not possible at the end of sync)

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`
