### PR TITLE
exposing get_funded_wallet

### DIFF
--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -43,8 +43,8 @@ impl PsbtUtils for Psbt {
 mod test {
     use crate::bitcoin::TxIn;
     use crate::psbt::Psbt;
-    use crate::wallet::test::{get_funded_wallet, get_test_wpkh};
     use crate::wallet::AddressIndex;
+    use crate::wallet::{get_funded_wallet, test::get_test_wpkh};
     use crate::SignOptions;
     use std::str::FromStr;
 

--- a/src/wallet/address_validator.rs
+++ b/src/wallet/address_validator.rs
@@ -115,8 +115,8 @@ mod test {
     use std::sync::Arc;
 
     use super::*;
-    use crate::wallet::test::{get_funded_wallet, get_test_wpkh};
     use crate::wallet::AddressIndex::New;
+    use crate::wallet::{get_funded_wallet, test::get_test_wpkh};
 
     #[derive(Debug)]
     struct TestValidator;


### PR DESCRIPTION
* moving get_funded_wallet out of the test section to make it available for https://github.com/ulrichard/bdk-reserves
* moving the wallet::network() getter function to make it more accessable for https://github.com/ulrichard/bdk-reserves

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
