### PR TITLE
Add testutils and test-wallet features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,17 +62,20 @@ rpc = ["bitcoincore-rpc"]
 
 
 # Debug/Test features
+testutils = []
 test-blockchains = ["bitcoincore-rpc", "electrum-client"]
 test-electrum = ["electrum", "electrsd/electrs_0_8_10", "test-blockchains"]
 test-rpc = ["rpc", "electrsd/electrs_0_8_10", "test-blockchains"]
 test-esplora = ["esplora", "electrsd/legacy", "electrsd/esplora_a33e97e1", "test-blockchains"]
 test-md-docs = ["electrum"]
+test-wallet = []
 
 [dev-dependencies]
 lazy_static = "1.4"
 env_logger = "0.7"
 clap = "2.33"
 electrsd = { version= "0.8", features = ["trigger", "bitcoind_0_21_1"] }
+bdk = { path = ".", default-features = false, features = ["testutils", "test-wallet"] }
 
 [[example]]
 name = "address_validator"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,9 +262,7 @@ pub fn version() -> &'static str {
     env!("CARGO_PKG_VERSION", "unknown")
 }
 
-// We should consider putting this under a feature flag but we need the macro in doctets so we need
-// to wait until https://github.com/rust-lang/rust/issues/67295 is fixed.
-//
+#[cfg(feature = "testutils")]
 // Stuff in here is too rough to document atm
 #[doc(hidden)]
 pub mod testutils;

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -43,8 +43,8 @@ impl PsbtUtils for Psbt {
 mod test {
     use crate::bitcoin::TxIn;
     use crate::psbt::Psbt;
-    use crate::wallet::test::{get_funded_wallet, get_test_wpkh};
     use crate::wallet::AddressIndex;
+    use crate::wallet::{get_funded_wallet, test::get_test_wpkh};
     use crate::SignOptions;
     use std::str::FromStr;
 

--- a/src/wallet/address_validator.rs
+++ b/src/wallet/address_validator.rs
@@ -115,8 +115,8 @@ mod test {
     use std::sync::Arc;
 
     use super::*;
-    use crate::wallet::test::{get_funded_wallet, get_test_wpkh};
     use crate::wallet::AddressIndex::New;
+    use crate::wallet::{get_funded_wallet, test::get_test_wpkh};
 
     #[derive(Debug)]
     struct TestValidator;

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -18,7 +18,6 @@ use std::collections::HashMap;
 use std::collections::{BTreeMap, HashSet};
 use std::fmt;
 use std::ops::{Deref, DerefMut};
-use std::str::FromStr;
 use std::sync::Arc;
 
 use bitcoin::secp256k1::Secp256k1;
@@ -56,7 +55,6 @@ use tx_builder::{BumpFee, CreateTx, FeePolicy, TxBuilder, TxParams};
 use utils::{check_nlocktime, check_nsequence_rbf, After, Older, SecpCtx, DUST_LIMIT_SATOSHI};
 
 use crate::blockchain::{Blockchain, Progress};
-use crate::database::memory::MemoryDatabase;
 use crate::database::{BatchDatabase, BatchOperations, DatabaseUtils};
 use crate::descriptor::derived::AsDerived;
 use crate::descriptor::policy::BuildSatisfaction;
@@ -68,7 +66,6 @@ use crate::descriptor::{
 use crate::error::Error;
 use crate::psbt::PsbtUtils;
 use crate::signer::SignerError;
-use crate::testutils;
 use crate::types::*;
 
 const CACHE_ADDR_BATCH_SIZE: u32 = 100;
@@ -1551,6 +1548,11 @@ where
     }
 }
 
+#[cfg(feature = "test-wallet")]
+use crate::database::memory::MemoryDatabase;
+
+#[cfg(feature = "test-wallet")]
+#[doc(hidden)]
 /// Return a fake wallet that appears to be funded for testing.
 pub fn get_funded_wallet(
     descriptor: &str,
@@ -1559,6 +1561,9 @@ pub fn get_funded_wallet(
     (String, Option<String>),
     bitcoin::Txid,
 ) {
+    use crate::testutils;
+    use std::str::FromStr;
+
     let descriptors = testutils!(@descriptors (descriptor));
     let wallet = Wallet::new_offline(
         &descriptors.0,
@@ -1606,6 +1611,9 @@ pub(crate) mod test {
     use super::*;
     use crate::signer::{SignOptions, SignerError};
     use crate::wallet::AddressIndex::{LastUnused, New, Peek, Reset};
+
+    use crate::testutils;
+    use std::str::FromStr;
 
     #[test]
     fn test_cache_addresses_fixed() {


### PR DESCRIPTION

### Description

This PR creates two new feature flags, `testutils` to enable the testutils module, and `test-wallet` to enable the now exposed `wallet::get_funded_wallet()`  function. Exposing the `wallet::get_funded_wallet()` function and moving the  `Wallet::network()` function are needed to make testing easier for supporting projects like `bdk-reserves` without including this functionality in non-test builds.

### Notes to the reviewers

All doctests should work with the new `testutils` feature without having this module exposed for non-test builds.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
