### PR TITLE
Fix esplora integration test runner

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,8 @@ esplora = []
 test-blockchains = ["core-rpc", "electrum-client"]
 test-electrum = ["electrum", "electrsd/electrs_0_8_10", "test-blockchains"]
 test-rpc = ["rpc", "electrsd/electrs_0_8_10", "test-blockchains"]
-test-esplora = ["esplora", "ureq", "electrsd/legacy", "electrsd/esplora_a33e97e1", "test-blockchains"]
+# Requires one of `use-esplora-ureq` or `use-esplora-reqwest` to run integration tests.
+test-esplora = ["electrsd/legacy", "electrsd/esplora_a33e97e1", "test-blockchains"]
 test-md-docs = ["electrum"]
 
 [dev-dependencies]

--- a/src/blockchain/esplora/mod.rs
+++ b/src/blockchain/esplora/mod.rs
@@ -141,3 +141,11 @@ impl_error!(io::Error, Io, EsploraError);
 impl_error!(std::num::ParseIntError, Parsing, EsploraError);
 impl_error!(consensus::encode::Error, BitcoinEncoding, EsploraError);
 impl_error!(bitcoin::hashes::hex::Error, Hex, EsploraError);
+
+#[cfg(test)]
+#[cfg(feature = "test-esplora")]
+crate::bdk_blockchain_tests! {
+    fn test_instance(test_client: &TestClient) -> EsploraBlockchain {
+        EsploraBlockchain::new(&format!("http://{}",test_client.electrsd.esplora_url.as_ref().unwrap()), 20)
+    }
+}

--- a/src/blockchain/esplora/reqwest.rs
+++ b/src/blockchain/esplora/reqwest.rs
@@ -350,11 +350,3 @@ impl ConfigurableBlockchain for EsploraBlockchain {
         Ok(blockchain)
     }
 }
-
-#[cfg(test)]
-#[cfg(feature = "test-esplora")]
-crate::bdk_blockchain_tests! {
-    fn test_instance(test_client: &TestClient) -> EsploraBlockchain {
-        EsploraBlockchain::new(&format!("http://{}",test_client.electrsd.esplora_url.as_ref().unwrap()), None, 20)
-    }
-}


### PR DESCRIPTION
### Description

Recently we added sub-modules to the `esplora` module for different HTTP
backends. We (Tobin) failed to update the integration test runner.

Modify the test running macro so that the backend is explicitly
selected:

  `cargo test --no-default-features --features=use-esplora-ureq,test-esplora`


### Notes to the reviewers

I can't actually get the integration tests to run to completion. They all (test-rpc, test-electrum, test-esplora) hang
```
$ echo $BITCOIND_EXE                                                                                                        ✘ 130 
/opt/bitcoin/bin/bitcoind
$ echo $ELECTRS_EXE
/home/tobin/.cargo/bin/electrs
$ cargo test --no-default-features --features=use-esplora-ureq,test-esplora
test blockchain::esplora::bdk_blockchain_tests::test_sync_address_reuse has been running for over 60 seconds
test blockchain::esplora::bdk_blockchain_tests::test_sync_after_send has been running for over 60 seconds
test blockchain::esplora::bdk_blockchain_tests::test_sync_before_and_after_receive has been running for over 60 seconds
test blockchain::esplora::bdk_blockchain_tests::test_sync_bump_fee_add_input_no_change has been running for over 60 seconds
```

However without this patch the integration tests do not run at all for esplora so I believe this is still correct. And it seems like a good way to ask if I am doing something wrong with how I'm trying to run the integration tests? Any suggestions please?

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
