### PR TITLE
Fix typo in spelling of 'features'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ reqwest = { version = "0.11", optional = true, features = ["json"] }
 ureq = { version = "2.1", default-features = false, features = ["json"], optional = true }
 futures = { version = "0.3", optional = true }
 async-trait = { version = "0.1", optional = true }
-rocksdb = { version = "0.14", default-features = false, fetures = ["snappy"], optional = true }
+rocksdb = { version = "0.14", default-features = false, features = ["snappy"], optional = true }
 cc = { version = ">=1.0.64", optional = true }
 socks = { version = "0.3", optional = true }
 lazy_static = { version = "1.4", optional = true }


### PR DESCRIPTION
### Description

Recently we disabled default features for `rocksdb` and attempted to
enable the `snappy` feature. Somehow 'features' got misspelled.

Fix typo in spelling of 'fetures' -> 'features'.

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

How sad to find a bug in the tip of HEAD only to find that I introduced it myself.

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
