### PR TITLE
[esplora] Support proxies in EsploraBlockchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [v0.11.0] - [v0.10.0]
 
 - Added `flush` method to the `Database` trait to explicitly flush to disk latest changes on the db.
+- Add support for proxies in `EsploraBlockchain`
 
 ## [v0.10.0] - [v0.9.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,8 +77,8 @@ rpc = ["core-rpc"]
 async-interface = ["async-trait"]
 electrum = ["electrum-client"]
 # MUST ALSO USE `--no-default-features`.
-use-esplora-reqwest = ["esplora", "reqwest", "futures"]
-use-esplora-ureq = ["esplora", "ureq"]
+use-esplora-reqwest = ["esplora", "reqwest", "reqwest/socks", "futures"]
+use-esplora-ureq = ["esplora", "ureq", "ureq/socks"]
 # Typical configurations will not need to use `esplora` feature directly.
 esplora = []
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Add support for http/socks proxies in Esplora

### Notes to the reviewers

Opening this as a draft, since I think it's gonna break for wasm32.

This is also technically an API break, which according to the new updated guidelines shouldn't happen. On the other hand, I can't think of a better way to do this. Am I supposed to make a different `EsploraBlockchainConfig` struct with the new field added and only deprecate the current one?

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`
* [x] This pull request breaks the existing API
