### PR TITLE
Fix esplora testing

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -84,9 +84,9 @@ jobs:
       fail-fast: false
       matrix:
         blockchain:
+          # We test Esplora separately below.
           - name: electrum
           - name: rpc
-          - name: esplora
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -105,6 +105,34 @@ jobs:
           override: true
       - name: Test
         run: cargo test --features test-${{ matrix.blockchain.name }} ${{ matrix.blockchain.name }}::bdk_blockchain_tests
+
+  test-blockchains-esplora:
+    name: Test esplora-${{ matrix.backend.name }}
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        backend:
+          - name: ureq
+          - name: reqwest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ github.job }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
+      - name: Setup rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+      - name: Test
+        run: cargo test --no-default-features --features test-esplora,use-esplora-${{ matrix.backend.name }} esplora::bdk_blockchain_tests
 
   check-wasm:
     name: Check WASM

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ esplora = []
 test-blockchains = ["core-rpc", "electrum-client"]
 test-electrum = ["electrum", "electrsd/electrs_0_8_10", "test-blockchains"]
 test-rpc = ["rpc", "electrsd/electrs_0_8_10", "test-blockchains"]
-test-esplora = ["esplora", "ureq", "electrsd/legacy", "electrsd/esplora_a33e97e1", "test-blockchains"]
+test-esplora = ["electrsd/legacy", "electrsd/esplora_a33e97e1", "test-blockchains"]
 test-md-docs = ["electrum"]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ lazy_static = "1.4"
 env_logger = "0.7"
 clap = "2.33"
 electrsd = { version= "0.10", features = ["trigger", "bitcoind_0_21_1"] }
+tokio = { version = "1", features = ["macros", "rt"] }
 
 [[example]]
 name = "address_validator"

--- a/src/blockchain/esplora/reqwest.rs
+++ b/src/blockchain/esplora/reqwest.rs
@@ -355,6 +355,6 @@ impl ConfigurableBlockchain for EsploraBlockchain {
 #[cfg(feature = "test-esplora")]
 crate::bdk_blockchain_tests! {
     fn test_instance(test_client: &TestClient) -> EsploraBlockchain {
-        EsploraBlockchain::new(&format!("http://{}",test_client.electrsd.esplora_url.as_ref().unwrap()), None, 20)
+        EsploraBlockchain::new(&format!("http://{}",test_client.electrsd.esplora_url.as_ref().unwrap()), 20)
     }
 }

--- a/src/blockchain/esplora/ureq.rs
+++ b/src/blockchain/esplora/ureq.rs
@@ -377,3 +377,11 @@ impl ConfigurableBlockchain for EsploraBlockchain {
         Ok(EsploraBlockchain::new(config.base_url.as_str(), config.stop_gap).with_agent(agent))
     }
 }
+
+#[cfg(test)]
+#[cfg(feature = "test-esplora")]
+crate::bdk_blockchain_tests! {
+    fn test_instance(test_client: &TestClient) -> EsploraBlockchain {
+        EsploraBlockchain::new(&format!("http://{}",test_client.electrsd.esplora_url.as_ref().unwrap()), 20)
+    }
+}


### PR DESCRIPTION
### Description

Currently testing of esplora/reqwest is broken because of incorrect usage of, or lack of, `async`.

Enable testing of esplora/reqwest by using `maybe_await!` macro in tests and declaring all unit tests in `blockchain_tests.rs` to be async. This adds a dev dependency on `tokio`.

With this patch applied one can successfully run:
```
cargo test --features=test-esplora,use-esplora-reqwest --no-default-features
```

### Notes to the reviewers

This is, in my opinion, a better fix to https://github.com/bitcoindevkit/bdk/issues/431 than https://github.com/bitcoindevkit/bdk/pull/430 (i.e., supercedes #430) 

The primary advantage of this PR over #430 is it does not introduce a hard dependency on `tokio`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
