### PR TITLE
Fix `extract_policy()` on `pk_h()` operands

### DIFF
--- a/src/descriptor/dsl.rs
+++ b/src/descriptor/dsl.rs
@@ -571,8 +571,9 @@ macro_rules! fragment {
     ( pk ( $key:expr ) ) => ({
         $crate::fragment!(c:pk_k ( $key ))
     });
-    ( pk_h ( $key_hash:expr ) ) => ({
-        $crate::impl_leaf_opcode_value!(PkH, $key_hash)
+    ( pk_h ( $key:expr ) ) => ({
+        let secp = $crate::bitcoin::secp256k1::Secp256k1::new();
+        $crate::keys::make_pkh($key, &secp)
     });
     ( after ( $value:expr ) ) => ({
         $crate::impl_leaf_opcode_value!(After, $value)

--- a/src/descriptor/dsl.rs
+++ b/src/descriptor/dsl.rs
@@ -602,6 +602,9 @@ macro_rules! fragment {
     ( and_or ( $( $inner:tt )* ) ) => ({
         $crate::impl_node_opcode_three!(AndOr, $( $inner )*)
     });
+    ( andor ( $( $inner:tt )* ) ) => ({
+        $crate::impl_node_opcode_three!(AndOr, $( $inner )*)
+    });
     ( or_b ( $( $inner:tt )* ) ) => ({
         $crate::impl_node_opcode_two!(OrB, $( $inner )*)
     });

--- a/src/descriptor/policy.rs
+++ b/src/descriptor/policy.rs
@@ -47,14 +47,12 @@ use bitcoin::util::bip32::Fingerprint;
 use bitcoin::PublicKey;
 
 use miniscript::descriptor::{DescriptorPublicKey, ShInner, SortedMultiVec, WshInner};
-use miniscript::{
-    Descriptor, Miniscript, MiniscriptKey, Satisfier, ScriptContext, Terminal, ToPublicKey,
-};
+use miniscript::{Descriptor, Miniscript, MiniscriptKey, Satisfier, ScriptContext, Terminal};
 
 #[allow(unused_imports)]
 use log::{debug, error, info, trace};
 
-use crate::descriptor::{DerivedDescriptorKey, ExtractPolicy};
+use crate::descriptor::ExtractPolicy;
 use crate::wallet::signer::{SignerId, SignersContainer};
 use crate::wallet::utils::{self, After, Older, SecpCtx};
 
@@ -86,13 +84,6 @@ impl PkOrF {
                 fingerprint: Some(xpub.root_fingerprint(secp)),
                 ..Default::default()
             },
-        }
-    }
-
-    fn from_key_hash(k: hash160::Hash) -> Self {
-        PkOrF {
-            pubkey_hash: Some(k),
-            ..Default::default()
         }
     }
 }
@@ -779,25 +770,6 @@ fn signature_in_psbt(psbt: &Psbt, key: &DescriptorPublicKey, secp: &SecpCtx) -> 
     })
 }
 
-fn signature_key(
-    key: &<DescriptorPublicKey as MiniscriptKey>::Hash,
-    signers: &SignersContainer,
-    secp: &SecpCtx,
-) -> Policy {
-    let key_hash = DerivedDescriptorKey::new(key.clone(), secp)
-        .to_public_key()
-        .to_pubkeyhash();
-    let mut policy: Policy = SatisfiableItem::Signature(PkOrF::from_key_hash(key_hash)).into();
-
-    if signers.find(SignerId::PkHash(key_hash)).is_some() {
-        policy.contribution = Satisfaction::Complete {
-            condition: Default::default(),
-        }
-    }
-
-    policy
-}
-
 impl<Ctx: ScriptContext> ExtractPolicy for Miniscript<DescriptorPublicKey, Ctx> {
     fn extract_policy(
         &self,
@@ -809,7 +781,7 @@ impl<Ctx: ScriptContext> ExtractPolicy for Miniscript<DescriptorPublicKey, Ctx> 
             // Leaves
             Terminal::True | Terminal::False => None,
             Terminal::PkK(pubkey) => Some(signature(pubkey, signers, build_sat, secp)),
-            Terminal::PkH(pubkey_hash) => Some(signature_key(pubkey_hash, signers, secp)),
+            Terminal::PkH(pubkey_hash) => Some(signature(pubkey_hash, signers, build_sat, secp)),
             Terminal::After(value) => {
                 let mut policy: Policy = SatisfiableItem::AbsoluteTimelock { value: *value }.into();
                 policy.contribution = Satisfaction::Complete {

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -753,6 +753,20 @@ pub fn make_pk<Pk: IntoDescriptorKey<Ctx>, Ctx: ScriptContext>(
     Ok((minisc, key_map, valid_networks))
 }
 
+// Used internally by `bdk::fragment!` to build `pk_h()` fragments
+#[doc(hidden)]
+pub fn make_pkh<Pk: IntoDescriptorKey<Ctx>, Ctx: ScriptContext>(
+    descriptor_key: Pk,
+    secp: &SecpCtx,
+) -> Result<(Miniscript<DescriptorPublicKey, Ctx>, KeyMap, ValidNetworks), DescriptorError> {
+    let (key, key_map, valid_networks) = descriptor_key.into_descriptor_key()?.extract(secp)?;
+    let minisc = Miniscript::from_ast(Terminal::PkH(key))?;
+
+    minisc.check_minsicript()?;
+
+    Ok((minisc, key_map, valid_networks))
+}
+
 // Used internally by `bdk::fragment!` to build `multi()` fragments
 #[doc(hidden)]
 pub fn make_multi<Pk: IntoDescriptorKey<Ctx>, Ctx: ScriptContext>(


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

It looks like we didn't have any test covering the `pk_h()` operand in our policy module, and sure enough there was a bug in there that basically made it work only with WIF keys, not extended keys.

While fixing this issue I noticed that:

1. We forgot to update the `descriptor!()` macro when we switched to the `IntoDescriptorKey` trait, so the `pk_h()` operand was only working with `DescriptorPublicKey` but not other key types that implement the conversion trait, so I fixed it as well.
2. The macro also didn't support `andor()` because we call it `and_or()`. To avoid breaking existing code I just added `andor()` as an alias, so both can be used. 

Finally I added a test that calls `extract_policy()` on a descriptor that contains `pk_h()`.

This issue was reported on discord: https://discord.com/channels/753336465005608961/753336465005608964/886978803690246206

### Notes to the reviewers

None I guess

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
