### PR TITLE
[fix-build] Fix version of zeroize_derive < 1.2.0

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -113,7 +113,7 @@ jobs:
   
   check-wasm:
     name: Check WASM
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       CC: clang-10
       CFLAGS: -I/usr/include
@@ -130,7 +130,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ github.job }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
         # Install a recent version of clang that supports wasm32
       - run: wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - || exit 1
-      - run: sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main" || exit 1
+      - run: sudo apt-add-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-10 main" || exit 1
       - run: sudo apt-get update || exit 1
       - run: sudo apt-get install -y libclang-common-10-dev clang-10 libc6-dev-i386 || exit 1
       - name: Set default toolchain

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,9 @@ socks = { version = "0.3", optional = true }
 lazy_static = { version = "1.4", optional = true }
 tiny-bip39 = { version = "^0.8", optional = true }
 zeroize = { version = "<1.4.0", optional = true }
+# 1.2 broke something so fix this until https://github.com/maciejhirsz/tiny-bip39/pull/29 is merged.
+# (or we get rid of the tiny-bip39 dependency https://github.com/bitcoindevkit/bdk/issues/399)
+zeroize_derive = { version = "~1.1.0", optional = true }
 bitcoinconsensus = { version = "0.19.0-3", optional = true }
 
 # Needed by bdk_blockchain_tests macro
@@ -55,7 +58,7 @@ default = ["key-value-db", "electrum"]
 compact_filters = ["rocksdb", "socks", "lazy_static", "cc"]
 key-value-db = ["sled"]
 all-keys = ["keys-bip39"]
-keys-bip39 = ["tiny-bip39", "zeroize"]
+keys-bip39 = ["tiny-bip39", "zeroize", "zeroize_derive"]
 rpc = ["core-rpc"]
 
 # We currently provide mulitple implementations of `Blockchain`, all are


### PR DESCRIPTION
zeroize_derive minor version bump 1.2 introduced a breaking change somehow. Fix it below until we figure out what to do! We already fix `zeroize` so this should not be a big deal.

update: For some reason I have to fix it exactly with `~1.1.0` for it to work otherwise cargo decides to use `1.0.0` which we can't have!