### PR TITLE
Pin ahash version to 0.7.4 for sqlite feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ rand = "^0.7"
 sled = { version = "0.34", optional = true }
 electrum-client = { version = "0.8", optional = true }
 rusqlite = { version = "0.25.3", optional = true }
+ahash = { version = "=0.7.4", optional = true }
 reqwest = { version = "0.11", optional = true, features = ["json"] }
 ureq = { version = "2.1", features = ["json"], optional = true }
 futures = { version = "0.3", optional = true }
@@ -57,7 +58,7 @@ minimal = []
 compiler = ["miniscript/compiler"]
 verify = ["bitcoinconsensus"]
 default = ["key-value-db", "electrum"]
-sqlite = ["rusqlite"]
+sqlite = ["rusqlite", "ahash"]
 compact_filters = ["rocksdb", "socks", "lazy_static", "cc"]
 key-value-db = ["sled"]
 all-keys = ["keys-bip39"]


### PR DESCRIPTION
### Description

The `ahash` crate is used by the `sqlite` feature but the latest update (0.7.5)
breaks compatibility with our current MSRV 1.46.0. See also:
https://github.com/tkaitchuck/aHash/issues/99

### Notes to the reviewers

To reproduce the issue locally before applying this patch:
```shell
cargo update
cargo +1.46.0 build --features sqlite
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
