### PR TITLE
Update MSRV to 1.51, enable cargo resolver = "2"

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         rust:
           - 1.56.0 # STABLE
-          - 1.46.0 # MSRV
+          - 1.51.0 # MSRV
         features:
           - default
           - minimal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- New minimum supported rust version is 1.51.0 to support `resolver = "2"`
 
 ## [v0.12.0] - [v0.11.0]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Every new feature should be covered by functional tests where possible.
 When refactoring, structure your PR to make it easy to review and don't
 hesitate to split it into multiple small, focused PRs.
 
-The Minimal Supported Rust Version is 1.46 (enforced by our CI).
+The Minimal Supported Rust Version is 1.51 (enforced by our CI).
 
 Commits should cover both the issue fixed and the solution's rationale.
 These [guidelines](https://chris.beams.io/posts/git-commit/) should be kept in mind.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ description = "A modern, lightweight, descriptor-based wallet library"
 keywords = ["bitcoin", "wallet", "descriptor", "psbt"]
 readme = "README.md"
 license = "MIT OR Apache-2.0"
+resolver = "2"
 
 [dependencies]
 bdk-macros = "^0.6"
@@ -24,9 +25,9 @@ rand = "^0.7"
 sled = { version = "0.34", optional = true }
 electrum-client = { version = "0.8", optional = true }
 rusqlite = { version = "0.25.3", optional = true }
-ahash = { version = "=0.7.4", optional = true }
+ahash = { version = "0.7", optional = true }
 reqwest = { version = "0.11", optional = true, features = ["json"] }
-ureq = { version = "~2.2.0", features = ["json"], optional = true }
+ureq = { version = "2.1", features = ["json"], optional = true }
 futures = { version = "0.3", optional = true }
 async-trait = { version = "0.1", optional = true }
 rocksdb = { version = "0.14", default-features = false, features = ["snappy"], optional = true }
@@ -34,13 +35,7 @@ cc = { version = ">=1.0.64", optional = true }
 socks = { version = "0.3", optional = true }
 lazy_static = { version = "1.4", optional = true }
 
-# the latest 0.8 version of tiny-bip39 depends on zeroize_derive 1.2 which has MSRV 1.51 and our 
-# MSRV is 1.46, to fix this until we update our MSRV or replace the tiny-bip39 
-# dependency https://github.com/bitcoindevkit/bdk/issues/399 we can only use an older version
-tiny-bip39 = { version = "< 0.8", optional = true }
-# backtrace > 0.3.61 includes object v0.27 which doesn't compile on 1.46. this is used by
-# tiny-bip39
-backtrace = { version = "=0.3.61", optional = true }
+tiny-bip39 = { version = "0.8", optional = true }
 
 bitcoinconsensus = { version = "0.19.0-3", optional = true }
 
@@ -65,7 +60,7 @@ sqlite = ["rusqlite", "ahash"]
 compact_filters = ["rocksdb", "socks", "lazy_static", "cc"]
 key-value-db = ["sled"]
 all-keys = ["keys-bip39"]
-keys-bip39 = ["tiny-bip39", "backtrace"]
+keys-bip39 = ["tiny-bip39"]
 rpc = ["core-rpc"]
 
 # We currently provide mulitple implementations of `Blockchain`, all are

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
     <a href="https://github.com/bitcoindevkit/bdk/actions?query=workflow%3ACI"><img alt="CI Status" src="https://github.com/bitcoindevkit/bdk/workflows/CI/badge.svg"></a>
     <a href="https://codecov.io/gh/bitcoindevkit/bdk"><img src="https://codecov.io/gh/bitcoindevkit/bdk/branch/master/graph/badge.svg"/></a>
     <a href="https://docs.rs/bdk"><img alt="API Docs" src="https://img.shields.io/badge/docs.rs-bdk-green"/></a>
-    <a href="https://blog.rust-lang.org/2020/08/27/Rust-1.46.0.html"><img alt="Rustc Version 1.46+" src="https://img.shields.io/badge/rustc-1.46%2B-lightgrey.svg"/></a>
+    <a href="https://blog.rust-lang.org/2020/08/27/Rust-1.51.0.html"><img alt="Rustc Version 1.51+" src="https://img.shields.io/badge/rustc-1.51%2B-lightgrey.svg"/></a>
     <a href="https://discord.gg/d7NkDKm"><img alt="Chat on Discord" src="https://img.shields.io/discord/753336465005608961?logo=discord"></a>
   </p>
 


### PR DESCRIPTION
### Description

This is required to keep using dependencies that have switched to MSRV 1.51 which requires the resolver version 2: tiny-bip39, ahash, and object.

### Notes to the reviewers

Current Debian stable (bullseye) includes Rust 1.48.0, and testing (bookworm) includes Rust 1.50.0. If this is a concern I'm open to other suggestions on how to avoid running into the resolver errors we've been getting  hit with lately. 

Prior to merging this PR our branch checks will need to be updated to require the 1.51.0 tests instead of the ones for 1.48.0.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've updated `CHANGELOG.md`

#### Bugfixes:

* [x] This pull request breaks the existing API,  **Requires update to Rust 1.51+**
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
