### PR TITLE
Store the last sync time and block height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - BIP39 implementation dependency, in `keys::bip39` changed from tiny-bip39 to rust-bip39.
 - Add new method on the `TxBuilder` to embed data in the transaction via `OP_RETURN`. To allow that a fix to check the dust only on spendable output has been introduced.
 - Update the `Database` trait to store the last sync timestamp and block height
+- Rename `ConfirmationTime` to `BlockTime`
 
 ## [v0.13.0] - [v0.12.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - BIP39 implementation dependency, in `keys::bip39` changed from tiny-bip39 to rust-bip39.
 - Add new method on the `TxBuilder` to embed data in the transaction via `OP_RETURN`. To allow that a fix to check the dust only on spendable output has been introduced.
+- Update the `Database` trait to store the last sync timestamp and block height
 
 ## [v0.13.0] - [v0.12.0]
 

--- a/src/blockchain/compact_filters/mod.rs
+++ b/src/blockchain/compact_filters/mod.rs
@@ -71,7 +71,7 @@ use super::{Blockchain, Capability, ConfigurableBlockchain, Progress};
 use crate::database::{BatchDatabase, BatchOperations, DatabaseUtils};
 use crate::error::Error;
 use crate::types::{KeychainKind, LocalUtxo, TransactionDetails};
-use crate::{ConfirmationTime, FeeRate};
+use crate::{BlockTime, FeeRate};
 
 use peer::*;
 use store::*;
@@ -206,7 +206,7 @@ impl CompactFiltersBlockchain {
                 transaction: Some(tx.clone()),
                 received: incoming,
                 sent: outgoing,
-                confirmation_time: ConfirmationTime::new(height, timestamp),
+                confirmation_time: BlockTime::new(height, timestamp),
                 verified: height.is_some(),
                 fee: Some(inputs_sum.saturating_sub(outputs_sum)),
             };

--- a/src/blockchain/rpc.rs
+++ b/src/blockchain/rpc.rs
@@ -37,7 +37,7 @@ use crate::blockchain::{Blockchain, Capability, ConfigurableBlockchain, Progress
 use crate::database::{BatchDatabase, DatabaseUtils};
 use crate::descriptor::{get_checksum, IntoWalletDescriptor};
 use crate::wallet::utils::SecpCtx;
-use crate::{ConfirmationTime, Error, FeeRate, KeychainKind, LocalUtxo, TransactionDetails};
+use crate::{BlockTime, Error, FeeRate, KeychainKind, LocalUtxo, TransactionDetails};
 use bitcoincore_rpc::json::{
     GetAddressInfoResultLabel, ImportMultiOptions, ImportMultiRequest,
     ImportMultiRequestScriptPubkey, ImportMultiRescanSince,
@@ -230,7 +230,7 @@ impl Blockchain for RpcBlockchain {
             list_txs_ids.insert(txid);
             if let Some(mut known_tx) = known_txs.get_mut(&txid) {
                 let confirmation_time =
-                    ConfirmationTime::new(tx_result.info.blockheight, tx_result.info.blocktime);
+                    BlockTime::new(tx_result.info.blockheight, tx_result.info.blocktime);
                 if confirmation_time != known_tx.confirmation_time {
                     // reorg may change tx height
                     debug!(
@@ -266,7 +266,7 @@ impl Blockchain for RpcBlockchain {
                 let td = TransactionDetails {
                     transaction: Some(tx),
                     txid: tx_result.info.txid,
-                    confirmation_time: ConfirmationTime::new(
+                    confirmation_time: BlockTime::new(
                         tx_result.info.blockheight,
                         tx_result.info.blocktime,
                     ),

--- a/src/blockchain/utils.rs
+++ b/src/blockchain/utils.rs
@@ -21,7 +21,7 @@ use bitcoin::{BlockHeader, OutPoint, Script, Transaction, Txid};
 use super::*;
 use crate::database::{BatchDatabase, BatchOperations, DatabaseUtils};
 use crate::error::Error;
-use crate::types::{ConfirmationTime, KeychainKind, LocalUtxo, TransactionDetails};
+use crate::types::{BlockTime, KeychainKind, LocalUtxo, TransactionDetails};
 use crate::wallet::time::Instant;
 use crate::wallet::utils::ChunksIterator;
 
@@ -151,7 +151,7 @@ pub trait ElectrumLikeSync {
                 // check if tx height matches, otherwise updates it. timestamp is not in the if clause
                 // because we are not asking headers for confirmed tx we know about
                 if tx_details.confirmation_time.as_ref().map(|c| c.height) != height {
-                    let confirmation_time = ConfirmationTime::new(height, timestamp);
+                    let confirmation_time = BlockTime::new(height, timestamp);
                     let mut new_tx_details = tx_details.clone();
                     new_tx_details.confirmation_time = confirmation_time;
                     batch.set_tx(&new_tx_details)?;
@@ -359,7 +359,7 @@ fn save_transaction_details_and_utxos<D: BatchDatabase>(
         transaction: Some(tx),
         received: incoming,
         sent: outgoing,
-        confirmation_time: ConfirmationTime::new(height, timestamp),
+        confirmation_time: BlockTime::new(height, timestamp),
         fee: Some(inputs_sum.saturating_sub(outputs_sum)), /* if the tx is a coinbase, fees would be negative */
         verified: height.is_some(),
     };

--- a/src/database/any.rs
+++ b/src/database/any.rs
@@ -144,8 +144,8 @@ impl BatchOperations for AnyDatabase {
     fn set_last_index(&mut self, keychain: KeychainKind, value: u32) -> Result<(), Error> {
         impl_inner_method!(AnyDatabase, self, set_last_index, keychain, value)
     }
-    fn set_last_sync_time(&mut self, last_sync_time: BlockTime) -> Result<(), Error> {
-        impl_inner_method!(AnyDatabase, self, set_last_sync_time, last_sync_time)
+    fn set_sync_time(&mut self, sync_time: SyncTime) -> Result<(), Error> {
+        impl_inner_method!(AnyDatabase, self, set_sync_time, sync_time)
     }
 
     fn del_script_pubkey_from_path(
@@ -183,8 +183,8 @@ impl BatchOperations for AnyDatabase {
     fn del_last_index(&mut self, keychain: KeychainKind) -> Result<Option<u32>, Error> {
         impl_inner_method!(AnyDatabase, self, del_last_index, keychain)
     }
-    fn del_last_sync_time(&mut self) -> Result<Option<BlockTime>, Error> {
-        impl_inner_method!(AnyDatabase, self, del_last_sync_time)
+    fn del_sync_time(&mut self) -> Result<Option<SyncTime>, Error> {
+        impl_inner_method!(AnyDatabase, self, del_sync_time)
     }
 }
 
@@ -247,8 +247,8 @@ impl Database for AnyDatabase {
     fn get_last_index(&self, keychain: KeychainKind) -> Result<Option<u32>, Error> {
         impl_inner_method!(AnyDatabase, self, get_last_index, keychain)
     }
-    fn get_last_sync_time(&self) -> Result<Option<BlockTime>, Error> {
-        impl_inner_method!(AnyDatabase, self, get_last_sync_time)
+    fn get_sync_time(&self) -> Result<Option<SyncTime>, Error> {
+        impl_inner_method!(AnyDatabase, self, get_sync_time)
     }
 
     fn increment_last_index(&mut self, keychain: KeychainKind) -> Result<u32, Error> {
@@ -281,8 +281,8 @@ impl BatchOperations for AnyBatch {
     fn set_last_index(&mut self, keychain: KeychainKind, value: u32) -> Result<(), Error> {
         impl_inner_method!(AnyBatch, self, set_last_index, keychain, value)
     }
-    fn set_last_sync_time(&mut self, last_sync_time: BlockTime) -> Result<(), Error> {
-        impl_inner_method!(AnyBatch, self, set_last_sync_time, last_sync_time)
+    fn set_sync_time(&mut self, sync_time: SyncTime) -> Result<(), Error> {
+        impl_inner_method!(AnyBatch, self, set_sync_time, sync_time)
     }
 
     fn del_script_pubkey_from_path(
@@ -314,8 +314,8 @@ impl BatchOperations for AnyBatch {
     fn del_last_index(&mut self, keychain: KeychainKind) -> Result<Option<u32>, Error> {
         impl_inner_method!(AnyBatch, self, del_last_index, keychain)
     }
-    fn del_last_sync_time(&mut self) -> Result<Option<BlockTime>, Error> {
-        impl_inner_method!(AnyBatch, self, del_last_sync_time)
+    fn del_sync_time(&mut self) -> Result<Option<SyncTime>, Error> {
+        impl_inner_method!(AnyBatch, self, del_sync_time)
     }
 }
 

--- a/src/database/any.rs
+++ b/src/database/any.rs
@@ -144,6 +144,9 @@ impl BatchOperations for AnyDatabase {
     fn set_last_index(&mut self, keychain: KeychainKind, value: u32) -> Result<(), Error> {
         impl_inner_method!(AnyDatabase, self, set_last_index, keychain, value)
     }
+    fn set_last_sync_time(&mut self, last_sync_time: ConfirmationTime) -> Result<(), Error> {
+        impl_inner_method!(AnyDatabase, self, set_last_sync_time, last_sync_time)
+    }
 
     fn del_script_pubkey_from_path(
         &mut self,
@@ -179,6 +182,9 @@ impl BatchOperations for AnyDatabase {
     }
     fn del_last_index(&mut self, keychain: KeychainKind) -> Result<Option<u32>, Error> {
         impl_inner_method!(AnyDatabase, self, del_last_index, keychain)
+    }
+    fn del_last_sync_time(&mut self) -> Result<Option<ConfirmationTime>, Error> {
+        impl_inner_method!(AnyDatabase, self, del_last_sync_time)
     }
 }
 
@@ -241,6 +247,9 @@ impl Database for AnyDatabase {
     fn get_last_index(&self, keychain: KeychainKind) -> Result<Option<u32>, Error> {
         impl_inner_method!(AnyDatabase, self, get_last_index, keychain)
     }
+    fn get_last_sync_time(&self) -> Result<Option<ConfirmationTime>, Error> {
+        impl_inner_method!(AnyDatabase, self, get_last_sync_time)
+    }
 
     fn increment_last_index(&mut self, keychain: KeychainKind) -> Result<u32, Error> {
         impl_inner_method!(AnyDatabase, self, increment_last_index, keychain)
@@ -272,6 +281,9 @@ impl BatchOperations for AnyBatch {
     fn set_last_index(&mut self, keychain: KeychainKind, value: u32) -> Result<(), Error> {
         impl_inner_method!(AnyBatch, self, set_last_index, keychain, value)
     }
+    fn set_last_sync_time(&mut self, last_sync_time: ConfirmationTime) -> Result<(), Error> {
+        impl_inner_method!(AnyBatch, self, set_last_sync_time, last_sync_time)
+    }
 
     fn del_script_pubkey_from_path(
         &mut self,
@@ -301,6 +313,9 @@ impl BatchOperations for AnyBatch {
     }
     fn del_last_index(&mut self, keychain: KeychainKind) -> Result<Option<u32>, Error> {
         impl_inner_method!(AnyBatch, self, del_last_index, keychain)
+    }
+    fn del_last_sync_time(&mut self) -> Result<Option<ConfirmationTime>, Error> {
+        impl_inner_method!(AnyBatch, self, del_last_sync_time)
     }
 }
 

--- a/src/database/any.rs
+++ b/src/database/any.rs
@@ -144,7 +144,7 @@ impl BatchOperations for AnyDatabase {
     fn set_last_index(&mut self, keychain: KeychainKind, value: u32) -> Result<(), Error> {
         impl_inner_method!(AnyDatabase, self, set_last_index, keychain, value)
     }
-    fn set_last_sync_time(&mut self, last_sync_time: ConfirmationTime) -> Result<(), Error> {
+    fn set_last_sync_time(&mut self, last_sync_time: BlockTime) -> Result<(), Error> {
         impl_inner_method!(AnyDatabase, self, set_last_sync_time, last_sync_time)
     }
 
@@ -183,7 +183,7 @@ impl BatchOperations for AnyDatabase {
     fn del_last_index(&mut self, keychain: KeychainKind) -> Result<Option<u32>, Error> {
         impl_inner_method!(AnyDatabase, self, del_last_index, keychain)
     }
-    fn del_last_sync_time(&mut self) -> Result<Option<ConfirmationTime>, Error> {
+    fn del_last_sync_time(&mut self) -> Result<Option<BlockTime>, Error> {
         impl_inner_method!(AnyDatabase, self, del_last_sync_time)
     }
 }
@@ -247,7 +247,7 @@ impl Database for AnyDatabase {
     fn get_last_index(&self, keychain: KeychainKind) -> Result<Option<u32>, Error> {
         impl_inner_method!(AnyDatabase, self, get_last_index, keychain)
     }
-    fn get_last_sync_time(&self) -> Result<Option<ConfirmationTime>, Error> {
+    fn get_last_sync_time(&self) -> Result<Option<BlockTime>, Error> {
         impl_inner_method!(AnyDatabase, self, get_last_sync_time)
     }
 
@@ -281,7 +281,7 @@ impl BatchOperations for AnyBatch {
     fn set_last_index(&mut self, keychain: KeychainKind, value: u32) -> Result<(), Error> {
         impl_inner_method!(AnyBatch, self, set_last_index, keychain, value)
     }
-    fn set_last_sync_time(&mut self, last_sync_time: ConfirmationTime) -> Result<(), Error> {
+    fn set_last_sync_time(&mut self, last_sync_time: BlockTime) -> Result<(), Error> {
         impl_inner_method!(AnyBatch, self, set_last_sync_time, last_sync_time)
     }
 
@@ -314,7 +314,7 @@ impl BatchOperations for AnyBatch {
     fn del_last_index(&mut self, keychain: KeychainKind) -> Result<Option<u32>, Error> {
         impl_inner_method!(AnyBatch, self, del_last_index, keychain)
     }
-    fn del_last_sync_time(&mut self) -> Result<Option<ConfirmationTime>, Error> {
+    fn del_last_sync_time(&mut self) -> Result<Option<BlockTime>, Error> {
         impl_inner_method!(AnyBatch, self, del_last_sync_time)
     }
 }

--- a/src/database/keyvalue.rs
+++ b/src/database/keyvalue.rs
@@ -82,7 +82,7 @@ macro_rules! impl_batch_operations {
             Ok(())
         }
 
-        fn set_last_sync_time(&mut self, ct: ConfirmationTime) -> Result<(), Error> {
+        fn set_last_sync_time(&mut self, ct: BlockTime) -> Result<(), Error> {
             let key = MapKey::LastSyncTime.as_map_key();
             self.insert(key, serde_json::to_vec(&ct)?)$($after_insert)*;
 
@@ -176,7 +176,7 @@ macro_rules! impl_batch_operations {
             }
         }
 
-        fn del_last_sync_time(&mut self) -> Result<Option<ConfirmationTime>, Error> {
+        fn del_last_sync_time(&mut self) -> Result<Option<BlockTime>, Error> {
             let key = MapKey::LastSyncTime.as_map_key();
             let res = self.remove(key);
             let res = $process_delete!(res);
@@ -357,7 +357,7 @@ impl Database for Tree {
             .transpose()
     }
 
-    fn get_last_sync_time(&self) -> Result<Option<ConfirmationTime>, Error> {
+    fn get_last_sync_time(&self) -> Result<Option<BlockTime>, Error> {
         let key = MapKey::LastSyncTime.as_map_key();
         Ok(self
             .get(key)?

--- a/src/database/keyvalue.rs
+++ b/src/database/keyvalue.rs
@@ -18,7 +18,7 @@ use bitcoin::hash_types::Txid;
 use bitcoin::{OutPoint, Script, Transaction};
 
 use crate::database::memory::MapKey;
-use crate::database::{BatchDatabase, BatchOperations, Database};
+use crate::database::{BatchDatabase, BatchOperations, Database, SyncTime};
 use crate::error::Error;
 use crate::types::*;
 
@@ -82,9 +82,9 @@ macro_rules! impl_batch_operations {
             Ok(())
         }
 
-        fn set_last_sync_time(&mut self, ct: BlockTime) -> Result<(), Error> {
-            let key = MapKey::LastSyncTime.as_map_key();
-            self.insert(key, serde_json::to_vec(&ct)?)$($after_insert)*;
+        fn set_sync_time(&mut self, data: SyncTime) -> Result<(), Error> {
+            let key = MapKey::SyncTime.as_map_key();
+            self.insert(key, serde_json::to_vec(&data)?)$($after_insert)*;
 
             Ok(())
         }
@@ -176,8 +176,8 @@ macro_rules! impl_batch_operations {
             }
         }
 
-        fn del_last_sync_time(&mut self) -> Result<Option<BlockTime>, Error> {
-            let key = MapKey::LastSyncTime.as_map_key();
+        fn del_sync_time(&mut self) -> Result<Option<SyncTime>, Error> {
+            let key = MapKey::SyncTime.as_map_key();
             let res = self.remove(key);
             let res = $process_delete!(res);
 
@@ -357,8 +357,8 @@ impl Database for Tree {
             .transpose()
     }
 
-    fn get_last_sync_time(&self) -> Result<Option<BlockTime>, Error> {
-        let key = MapKey::LastSyncTime.as_map_key();
+    fn get_sync_time(&self) -> Result<Option<SyncTime>, Error> {
+        let key = MapKey::SyncTime.as_map_key();
         Ok(self
             .get(key)?
             .map(|b| serde_json::from_slice(&b))
@@ -495,7 +495,7 @@ mod test {
     }
 
     #[test]
-    fn test_last_sync_time() {
-        crate::database::test::test_last_sync_time(get_tree());
+    fn test_sync_time() {
+        crate::database::test::test_sync_time(get_tree());
     }
 }

--- a/src/database/memory.rs
+++ b/src/database/memory.rs
@@ -183,7 +183,7 @@ impl BatchOperations for MemoryDatabase {
 
         Ok(())
     }
-    fn set_last_sync_time(&mut self, ct: ConfirmationTime) -> Result<(), Error> {
+    fn set_last_sync_time(&mut self, ct: BlockTime) -> Result<(), Error> {
         let key = MapKey::LastSyncTime.as_map_key();
         self.map.insert(key, Box::new(ct));
 
@@ -279,7 +279,7 @@ impl BatchOperations for MemoryDatabase {
             Some(b) => Ok(Some(*b.downcast_ref().unwrap())),
         }
     }
-    fn del_last_sync_time(&mut self) -> Result<Option<ConfirmationTime>, Error> {
+    fn del_last_sync_time(&mut self) -> Result<Option<BlockTime>, Error> {
         let key = MapKey::LastSyncTime.as_map_key();
         let res = self.map.remove(&key);
         self.deleted_keys.push(key);
@@ -423,7 +423,7 @@ impl Database for MemoryDatabase {
         Ok(self.map.get(&key).map(|b| *b.downcast_ref().unwrap()))
     }
 
-    fn get_last_sync_time(&self) -> Result<Option<ConfirmationTime>, Error> {
+    fn get_last_sync_time(&self) -> Result<Option<BlockTime>, Error> {
         let key = MapKey::LastSyncTime.as_map_key();
         Ok(self
             .map
@@ -505,7 +505,7 @@ macro_rules! populate_test_db {
         let txid = tx.txid();
         let confirmation_time = tx_meta
             .min_confirmations
-            .map(|conf| $crate::ConfirmationTime {
+            .map(|conf| $crate::BlockTime {
                 height: current_height.unwrap().checked_sub(conf as u32).unwrap(),
                 timestamp: 0,
             });

--- a/src/database/memory.rs
+++ b/src/database/memory.rs
@@ -33,6 +33,7 @@ use crate::types::*;
 // transactions         t<txid> -> tx details
 // deriv indexes        c{i,e} -> u32
 // descriptor checksum  d{i,e} -> vec<u8>
+// last sync time       l -> { height, timestamp }
 
 pub(crate) enum MapKey<'a> {
     Path((Option<KeychainKind>, Option<u32>)),
@@ -41,6 +42,7 @@ pub(crate) enum MapKey<'a> {
     RawTx(Option<&'a Txid>),
     Transaction(Option<&'a Txid>),
     LastIndex(KeychainKind),
+    LastSyncTime,
     DescriptorChecksum(KeychainKind),
 }
 
@@ -59,6 +61,7 @@ impl MapKey<'_> {
             MapKey::RawTx(_) => b"r".to_vec(),
             MapKey::Transaction(_) => b"t".to_vec(),
             MapKey::LastIndex(st) => [b"c", st.as_ref()].concat(),
+            MapKey::LastSyncTime => b"l".to_vec(),
             MapKey::DescriptorChecksum(st) => [b"d", st.as_ref()].concat(),
         }
     }
@@ -180,6 +183,12 @@ impl BatchOperations for MemoryDatabase {
 
         Ok(())
     }
+    fn set_last_sync_time(&mut self, ct: ConfirmationTime) -> Result<(), Error> {
+        let key = MapKey::LastSyncTime.as_map_key();
+        self.map.insert(key, Box::new(ct));
+
+        Ok(())
+    }
 
     fn del_script_pubkey_from_path(
         &mut self,
@@ -269,6 +278,13 @@ impl BatchOperations for MemoryDatabase {
             None => Ok(None),
             Some(b) => Ok(Some(*b.downcast_ref().unwrap())),
         }
+    }
+    fn del_last_sync_time(&mut self) -> Result<Option<ConfirmationTime>, Error> {
+        let key = MapKey::LastSyncTime.as_map_key();
+        let res = self.map.remove(&key);
+        self.deleted_keys.push(key);
+
+        Ok(res.map(|b| b.downcast_ref().cloned().unwrap()))
     }
 }
 
@@ -405,6 +421,14 @@ impl Database for MemoryDatabase {
     fn get_last_index(&self, keychain: KeychainKind) -> Result<Option<u32>, Error> {
         let key = MapKey::LastIndex(keychain).as_map_key();
         Ok(self.map.get(&key).map(|b| *b.downcast_ref().unwrap()))
+    }
+
+    fn get_last_sync_time(&self) -> Result<Option<ConfirmationTime>, Error> {
+        let key = MapKey::LastSyncTime.as_map_key();
+        Ok(self
+            .map
+            .get(&key)
+            .map(|b| b.downcast_ref().cloned().unwrap()))
     }
 
     // inserts 0 if not present
@@ -589,5 +613,10 @@ mod test {
     #[test]
     fn test_last_index() {
         crate::database::test::test_last_index(get_tree());
+    }
+
+    #[test]
+    fn test_last_sync_time() {
+        crate::database::test::test_last_sync_time(get_tree());
     }
 }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -65,7 +65,7 @@ pub trait BatchOperations {
     /// Store the last derivation index for a given keychain.
     fn set_last_index(&mut self, keychain: KeychainKind, value: u32) -> Result<(), Error>;
     /// Store the sync time in terms of block height and timestamp
-    fn set_last_sync_time(&mut self, last_sync_time: ConfirmationTime) -> Result<(), Error>;
+    fn set_last_sync_time(&mut self, last_sync_time: BlockTime) -> Result<(), Error>;
 
     /// Delete a script_pubkey given the keychain and its child number.
     fn del_script_pubkey_from_path(
@@ -94,7 +94,7 @@ pub trait BatchOperations {
     /// Reset the last sync time to `None`
     ///
     /// Returns the removed value
-    fn del_last_sync_time(&mut self) -> Result<Option<ConfirmationTime>, Error>;
+    fn del_last_sync_time(&mut self) -> Result<Option<BlockTime>, Error>;
 }
 
 /// Trait for reading data from a database
@@ -141,7 +141,7 @@ pub trait Database: BatchOperations {
     /// Return the last defivation index for a keychain.
     fn get_last_index(&self, keychain: KeychainKind) -> Result<Option<u32>, Error>;
     /// Return the last sync time, if present
-    fn get_last_sync_time(&self) -> Result<Option<ConfirmationTime>, Error>;
+    fn get_last_sync_time(&self) -> Result<Option<BlockTime>, Error>;
 
     /// Increment the last derivation index for a keychain and return it
     ///
@@ -333,7 +333,7 @@ pub mod test {
             received: 1337,
             sent: 420420,
             fee: Some(140),
-            confirmation_time: Some(ConfirmationTime {
+            confirmation_time: Some(BlockTime {
                 timestamp: 123456,
                 height: 1000,
             }),
@@ -388,7 +388,7 @@ pub mod test {
     pub fn test_last_sync_time<D: Database>(mut tree: D) {
         assert!(tree.get_last_sync_time().unwrap().is_none());
 
-        tree.set_last_sync_time(ConfirmationTime {
+        tree.set_last_sync_time(BlockTime {
             height: 100,
             timestamp: 1000,
         })

--- a/src/database/sqlite.rs
+++ b/src/database/sqlite.rs
@@ -206,7 +206,7 @@ impl SqliteDatabase {
         Ok(())
     }
 
-    fn update_last_sync_time(&self, ct: ConfirmationTime) -> Result<i64, Error> {
+    fn update_last_sync_time(&self, ct: BlockTime) -> Result<i64, Error> {
         let mut statement = self.connection.prepare_cached(
             "INSERT INTO last_sync_time (id, height, timestamp) VALUES (0, :height, :timestamp) ON CONFLICT(id) DO UPDATE SET height=:height, timestamp=:timestamp WHERE id = 0",
         )?;
@@ -389,7 +389,7 @@ impl SqliteDatabase {
             };
 
             let confirmation_time = match (height, timestamp) {
-                (Some(height), Some(timestamp)) => Some(ConfirmationTime { height, timestamp }),
+                (Some(height), Some(timestamp)) => Some(BlockTime { height, timestamp }),
                 _ => None,
             };
 
@@ -423,7 +423,7 @@ impl SqliteDatabase {
             let verified: bool = row.get(6)?;
 
             let confirmation_time = match (height, timestamp) {
-                (Some(height), Some(timestamp)) => Some(ConfirmationTime { height, timestamp }),
+                (Some(height), Some(timestamp)) => Some(BlockTime { height, timestamp }),
                 _ => None,
             };
 
@@ -466,7 +466,7 @@ impl SqliteDatabase {
                 };
 
                 let confirmation_time = match (height, timestamp) {
-                    (Some(height), Some(timestamp)) => Some(ConfirmationTime { height, timestamp }),
+                    (Some(height), Some(timestamp)) => Some(BlockTime { height, timestamp }),
                     _ => None,
                 };
 
@@ -501,12 +501,12 @@ impl SqliteDatabase {
         }
     }
 
-    fn select_last_sync_time(&self) -> Result<Option<ConfirmationTime>, Error> {
+    fn select_last_sync_time(&self) -> Result<Option<BlockTime>, Error> {
         let mut statement = self
             .connection
             .prepare_cached("SELECT height, timestamp FROM last_sync_time WHERE id = 0")?;
         let mut rows = statement.query_map([], |row| {
-            Ok(ConfirmationTime {
+            Ok(BlockTime {
                 height: row.get(0)?,
                 timestamp: row.get(1)?,
             })
@@ -658,7 +658,7 @@ impl BatchOperations for SqliteDatabase {
         Ok(())
     }
 
-    fn set_last_sync_time(&mut self, ct: ConfirmationTime) -> Result<(), Error> {
+    fn set_last_sync_time(&mut self, ct: BlockTime) -> Result<(), Error> {
         self.update_last_sync_time(ct)?;
         Ok(())
     }
@@ -749,7 +749,7 @@ impl BatchOperations for SqliteDatabase {
         }
     }
 
-    fn del_last_sync_time(&mut self) -> Result<Option<ConfirmationTime>, Error> {
+    fn del_last_sync_time(&mut self) -> Result<Option<BlockTime>, Error> {
         match self.select_last_sync_time()? {
             Some(value) => {
                 self.delete_last_sync_time()?;
@@ -870,7 +870,7 @@ impl Database for SqliteDatabase {
         Ok(value)
     }
 
-    fn get_last_sync_time(&self) -> Result<Option<ConfirmationTime>, Error> {
+    fn get_last_sync_time(&self) -> Result<Option<BlockTime>, Error> {
         self.select_last_sync_time()
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -210,7 +210,7 @@ pub struct TransactionDetails {
     pub fee: Option<u64>,
     /// If the transaction is confirmed, contains height and timestamp of the block containing the
     /// transaction, unconfirmed transaction contains `None`.
-    pub confirmation_time: Option<ConfirmationTime>,
+    pub confirmation_time: Option<BlockTime>,
     /// Whether the tx has been verified against the consensus rules
     ///
     /// Confirmed txs are considered "verified" by default, while unconfirmed txs are checked to
@@ -222,20 +222,26 @@ pub struct TransactionDetails {
     pub verified: bool,
 }
 
-/// Block height and timestamp of the block containing the confirmed transaction
+/// Block height and timestamp of a block
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default)]
-pub struct ConfirmationTime {
+pub struct BlockTime {
     /// confirmation block height
     pub height: u32,
     /// confirmation block timestamp
     pub timestamp: u64,
 }
 
-impl ConfirmationTime {
-    /// Returns `Some` `ConfirmationTime` if both `height` and `timestamp` are `Some`
+/// **DEPRECATED**: Confirmation time of a transaction
+///
+/// The structure has been renamed to `BlockTime`
+#[deprecated(note = "This structure has been renamed to `BlockTime`")]
+pub type ConfirmationTime = BlockTime;
+
+impl BlockTime {
+    /// Returns `Some` `BlockTime` if both `height` and `timestamp` are `Some`
     pub fn new(height: Option<u32>, timestamp: Option<u64>) -> Option<Self> {
         match (height, timestamp) {
-            (Some(height), Some(timestamp)) => Some(ConfirmationTime { height, timestamp }),
+            (Some(height), Some(timestamp)) => Some(BlockTime { height, timestamp }),
             _ => None,
         }
     }

--- a/src/wallet/export.rs
+++ b/src/wallet/export.rs
@@ -212,7 +212,7 @@ mod test {
     use crate::database::{memory::MemoryDatabase, BatchOperations};
     use crate::types::TransactionDetails;
     use crate::wallet::Wallet;
-    use crate::ConfirmationTime;
+    use crate::BlockTime;
 
     fn get_test_db() -> MemoryDatabase {
         let mut db = MemoryDatabase::new();
@@ -226,7 +226,7 @@ mod test {
             received: 100_000,
             sent: 0,
             fee: Some(500),
-            confirmation_time: Some(ConfirmationTime {
+            confirmation_time: Some(BlockTime {
                 timestamp: 12345678,
                 height: 5000,
             }),

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -57,7 +57,7 @@ use utils::{check_nlocktime, check_nsequence_rbf, After, Older, SecpCtx, DUST_LI
 
 use crate::blockchain::{Blockchain, Progress};
 use crate::database::memory::MemoryDatabase;
-use crate::database::{BatchDatabase, BatchOperations, DatabaseUtils};
+use crate::database::{BatchDatabase, BatchOperations, DatabaseUtils, SyncTime};
 use crate::descriptor::derived::AsDerived;
 use crate::descriptor::policy::BuildSatisfaction;
 use crate::descriptor::{
@@ -1554,14 +1554,14 @@ where
             }
         }
 
-        let last_sync_time = BlockTime {
-            height: maybe_await!(self.client.get_height())?,
-            timestamp: time::get_timestamp(),
+        let sync_time = SyncTime {
+            block_time: BlockTime {
+                height: maybe_await!(self.client.get_height())?,
+                timestamp: time::get_timestamp(),
+            },
         };
-        debug!("Saving `last_sync_time` = {:?}", last_sync_time);
-        self.database
-            .borrow_mut()
-            .set_last_sync_time(last_sync_time)?;
+        debug!("Saving `sync_time` = {:?}", sync_time);
+        self.database.borrow_mut().set_sync_time(sync_time)?;
 
         Ok(())
     }

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1447,6 +1447,11 @@ where
 
         Ok(())
     }
+
+    /// Return an immutable reference to the internal database
+    pub fn database(&self) -> impl std::ops::Deref<Target = D> + '_ {
+        self.database.borrow()
+    }
 }
 
 impl<B, D> Wallet<B, D>

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1554,6 +1554,15 @@ where
             }
         }
 
+        let last_sync_time = ConfirmationTime {
+            height: maybe_await!(self.client.get_height())?,
+            timestamp: time::get_timestamp(),
+        };
+        debug!("Saving `last_sync_time` = {:?}", last_sync_time);
+        self.database
+            .borrow_mut()
+            .set_last_sync_time(last_sync_time)?;
+
         Ok(())
     }
 

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1554,7 +1554,7 @@ where
             }
         }
 
-        let last_sync_time = ConfirmationTime {
+        let last_sync_time = BlockTime {
             height: maybe_await!(self.client.get_height())?,
             timestamp: time::get_timestamp(),
         };
@@ -2792,7 +2792,7 @@ pub(crate) mod test {
         let txid = tx.txid();
         // skip saving the utxos, we know they can't be used anyways
         details.transaction = Some(tx);
-        details.confirmation_time = Some(ConfirmationTime {
+        details.confirmation_time = Some(BlockTime {
             timestamp: 12345678,
             height: 42,
         });


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Update the `Database` trait to allow storing the block height and timestamp of the last `sync` of a `Wallet`. This will allow having a rough estimation of the "current" height, even in parts of the code that don't have network access (tx creation, computing the balance, etc), at least in non-airgapped wallets that are periodically synced.

After this is ready I'm planning to work on a PR to close #413, essentially making BDK aware of what can be spent and what is still not "mature" (initially only for coinbase UTXOs which are trivial, later on ideally also for any UTXO that has a timelock, which is a lot trickier).

Closes #455.

### Notes to the reviewers

Opening this in draft mode, since it includes some commits from #454.

Random open points:

1. I was thinking about renaming `ConfirmationTime` because that name doesn't really make sense in this context, but I couldn't come up with a decent alternative. I'm open to suggestions if you have any. 
2. I'm not sure what I've done with the sqlite database is ideal, let me know if you think I could use a better structure. Initially I used to add an entry in the table for every `sync`, and then I would only return the latest one. That seemed pretty inefficient, considering that I was storing stuff that were by definition never read, so I changed it to the current structure.. but this feels more NoSQL-like so I still don't know which one I like best.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`

#### Bugfixes:

* [x] This pull request breaks the existing API
* [x] I'm linking the issue being fixed by this PR
