### PR TITLE
Use rust-bip39 instead of tiny-bip39

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,6 @@ socks = { version = "0.3", optional = true }
 lazy_static = { version = "1.4", optional = true }
 
 bip39 = { version = "1.0.1", optional = true }
-# backtrace > 0.3.61 includes object v0.27 which doesn't compile on 1.46. this is used by
-# tiny-bip39
-backtrace = { version = "=0.3.61", optional = true }
-
 bitcoinconsensus = { version = "0.19.0-3", optional = true }
 
 # Needed by bdk_blockchain_tests macro

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,7 @@ cc = { version = ">=1.0.64", optional = true }
 socks = { version = "0.3", optional = true }
 lazy_static = { version = "1.4", optional = true }
 
-# the latest 0.8 version of tiny-bip39 depends on zeroize_derive 1.2 which has MSRV 1.51 and our 
-# MSRV is 1.46, to fix this until we update our MSRV or replace the tiny-bip39 
-# dependency https://github.com/bitcoindevkit/bdk/issues/399 we can only use an older version
-tiny-bip39 = { version = "< 0.8", optional = true }
+bip39 = { version = "1.0.1", optional = true }
 # backtrace > 0.3.61 includes object v0.27 which doesn't compile on 1.46. this is used by
 # tiny-bip39
 backtrace = { version = "=0.3.61", optional = true }
@@ -65,7 +62,7 @@ sqlite = ["rusqlite", "ahash"]
 compact_filters = ["rocksdb", "socks", "lazy_static", "cc"]
 key-value-db = ["sled"]
 all-keys = ["keys-bip39"]
-keys-bip39 = ["tiny-bip39", "backtrace"]
+keys-bip39 = ["bip39"]
 rpc = ["core-rpc"]
 
 # We currently provide mulitple implementations of `Blockchain`, all are

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -460,9 +460,9 @@ use bdk::keys::bip39::{Mnemonic, Language};
 
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
 let xkey: ExtendedKey =
-    Mnemonic::from_phrase(
+    Mnemonic::parse_in(
+        Language::English,
         "jelly crash boy whisper mouse ecology tuna soccer memory million news short",
-        Language::English
     )?
     .into_extended_key()?;
 let xprv = xkey.into_xprv(Network::Bitcoin).unwrap();


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Fixes #399. This can solve the current version conflict issues of `tiny-bip39` dependencies and replace that with `rust-bip39`. 

Few small refactoring changes were required for that.

`rust-bip39` doesn't have dedicated `MnemonicType` enum to denote mnemonic entropy (aka word count). To make the impl consistent with existing traits I have wrote a simple `WordCount` enum to capture that.   

### Notes to the reviewers

All previous tests are passing.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing