### PR TITLE
Disable reqwest's default features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Unify ureq and reqwest esplora backends to have the same configuration parameters. This means reqwest now has a timeout parameter and ureq has a concurrency parameter.
 - Fixed esplora fee estimation.
 - Fixed generating WIF in the correct network format.
+- Disable `reqwest` default features.
+- Added `reqwest-default-tls` feature: Use this to restore the TLS defaults of reqwest if you don't want to add a dependency to it in your own manifest.
 
 ## [v0.14.0] - [v0.13.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ sled = { version = "0.34", optional = true }
 electrum-client = { version = "0.8", optional = true }
 rusqlite = { version = "0.25.3", optional = true }
 ahash = { version = "=0.7.4", optional = true }
-reqwest = { version = "0.11", optional = true, features = ["json"] }
+reqwest = { version = "0.11", optional = true, default-features = false, features = ["json"] }
 ureq = { version = "~2.2.0", features = ["json"], optional = true }
 futures = { version = "0.3", optional = true }
 async-trait = { version = "0.1", optional = true }
@@ -82,6 +82,8 @@ use-esplora-ureq = ["esplora", "ureq", "ureq/socks"]
 # Typical configurations will not need to use `esplora` feature directly.
 esplora = []
 
+# Use below feature with `use-esplora-reqwest` to enable reqwest default TLS support
+reqwest-default-tls = ["reqwest/default-tls"]
 
 # Debug/Test features
 test-blockchains = ["bitcoincore-rpc", "electrum-client"]


### PR DESCRIPTION
### Description

﻿﻿By default, reqwest uses openssl for TLS. Any consumer wanting to use
rustls will thus pull in unnecessary dependencies.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* ~[ ] I've added tests for the new feature~
* ~[ ] I've added docs for the new feature~
* [x] I've updated `CHANGELOG.md`

#### Bugfixes:

* ~[ ] This pull request breaks the existing API~
* ~[ ] I've added tests to reproduce the issue which are now passing~
* ~[ ] I'm linking the issue being fixed by this PR~
