### PR TITLE
Only run clippy for the stable rust version

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -10,8 +10,9 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.56.0 # STABLE
-          - 1.46.0 # MSRV
+          - version: 1.56.0 # STABLE
+            clippy: true
+          - version: 1.46.0 # MSRV
         features:
           - default
           - minimal
@@ -31,7 +32,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: Generate cache key
-        run: echo "${{ matrix.rust }} ${{ matrix.features }}" | tee .cache_key
+        run: echo "${{ matrix.rust.version }} ${{ matrix.features }}" | tee .cache_key
       - name: cache
         uses: actions/cache@v2
         with:
@@ -41,16 +42,18 @@ jobs:
             target
           key: ${{ runner.os }}-cargo-${{ hashFiles('.cache_key') }}-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
       - name: Set default toolchain
-        run: rustup default ${{ matrix.rust }}
+        run: rustup default ${{ matrix.rust.version }}
       - name: Set profile
         run: rustup set profile minimal
       - name: Add clippy
+        if: ${{ matrix.rust.clippy }}
         run: rustup component add clippy
       - name: Update toolchain
         run: rustup update
       - name: Build
         run: cargo build --features ${{ matrix.features }} --no-default-features
       - name: Clippy
+        if: ${{ matrix.rust.clippy }}
         run: cargo clippy --all-targets --features ${{ matrix.features }} --no-default-features -- -D warnings
       - name: Test
         run: cargo test --features ${{ matrix.features }} --no-default-features


### PR DESCRIPTION
### Description

It was decided during the team call today (2021-12-14)  to only run clippy for the stable rust version.

### Notes to the reviewers

This is required to fix the below build issues when running clippy on rust version 1.46.0.

```shell
cargo clippy --all-targets --features async-interface --no-default-features -- -D warnings
```

```text
...

Checking bitcoincore-rpc v0.14.0
error: unknown clippy lint: clippy::no_effect_underscore_binding
  --> src/blockchain/mod.rs:88:1
   |
88 | #[maybe_async]
   | ^^^^^^^^^^^^^^
   |
   = note: `-D clippy::unknown-clippy-lints` implied by `-D warnings`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unknown_clippy_lints
   = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)

error: unknown clippy lint: clippy::no_effect_underscore_binding
   --> src/blockchain/mod.rs:220:1
    |
220 | #[maybe_async]
    | ^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unknown_clippy_lints
    = note: this error originates in an attribute macro (in Nightly builds, run with -Z macro-backtrace for more info)
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

