### PR TITLE
Refactor verification logic

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -89,13 +89,13 @@ jobs:
       matrix:
         blockchain:
           - name: electrum
-            features: test-electrum
+            features: test-electrum,verify
           - name: rpc
             features: test-rpc
           - name: esplora
-            features: test-esplora,use-esplora-reqwest
+            features: test-esplora,use-esplora-reqwest,verify
           - name: esplora
-            features: test-esplora,use-esplora-ureq    
+            features: test-esplora,use-esplora-ureq,verify
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Removed default verification from `wallet::sync`. sync-time verification is added in `script_sync` and is activated by `verify` feature flag.
+- `verify` flag removed from `TransactionDetails`.
+
 ## [v0.16.0] - [v0.15.0]
 
 - Disable `reqwest` default features.
@@ -18,12 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Overhauled sync logic for electrum and esplora.
 - Unify ureq and reqwest esplora backends to have the same configuration parameters. This means reqwest now has a timeout parameter and ureq has a concurrency parameter.
 - Fixed esplora fee estimation.
-- Fixed generating WIF in the correct network format.
-- Disable `reqwest` default features.
-- Added `reqwest-default-tls` feature: Use this to restore the TLS defaults of reqwest if you don't want to add a dependency to it in your own manifest.
-- Removed default verification from `wallet::sync`. `sync` verification is added only for `electrum` and
-`esplora` blockchains. No `sync` verification for `rpc`. `verify_tx()` is refactored as an wallet api.
-`verify` flag removed from `TransactionDetails`.
 
 ## [v0.14.0] - [v0.13.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Overhauled sync logic for electrum and esplora.
 - Unify ureq and reqwest esplora backends to have the same configuration parameters. This means reqwest now has a timeout parameter and ureq has a concurrency parameter.
 - Fixed esplora fee estimation.
+- Fixed generating WIF in the correct network format.
+- Disable `reqwest` default features.
+- Added `reqwest-default-tls` feature: Use this to restore the TLS defaults of reqwest if you don't want to add a dependency to it in your own manifest.
+- Removed default verification from `wallet::sync`. `sync` verification is added only for `electrum` and
+`esplora` blockchains. No `sync` verification for `rpc`. `verify_tx()` is refactored as an wallet api.
+`verify` flag removed from `TransactionDetails`.
 
 ## [v0.14.0] - [v0.13.0]
 

--- a/src/blockchain/compact_filters/mod.rs
+++ b/src/blockchain/compact_filters/mod.rs
@@ -207,7 +207,6 @@ impl CompactFiltersBlockchain {
                 received: incoming,
                 sent: outgoing,
                 confirmation_time: BlockTime::new(height, timestamp),
-                verified: height.is_some(),
                 fee: Some(inputs_sum.saturating_sub(outputs_sum)),
             };
 

--- a/src/blockchain/electrum.rs
+++ b/src/blockchain/electrum.rs
@@ -190,19 +190,6 @@ impl Blockchain for ElectrumBlockchain {
                                         .output
                                         .get(input.previous_output.vout as usize)
                                         .ok_or_else(electrum_goof)?;
-                                    // Verify this input if requested via feature flag
-                                    #[cfg(feature = "verify")]
-                                    {
-                                        use crate::wallet::verify::VerifyError;
-                                        let serialized_tx = bitcoin::consensus::serialize(&tx);
-                                        bitcoinconsensus::verify(
-                                            txout.script_pubkey.to_bytes().as_ref(),
-                                            txout.value,
-                                            &serialized_tx,
-                                            input_index,
-                                        )
-                                        .map_err(|e| VerifyError::from(e))?;
-                                    }
                                     input_index += 1;
                                     Ok(Some(txout.clone()))
                                 })

--- a/src/blockchain/electrum.rs
+++ b/src/blockchain/electrum.rs
@@ -175,6 +175,7 @@ impl Blockchain for ElectrumBlockchain {
                     let full_details = full_transactions
                         .into_iter()
                         .map(|tx| {
+                            let mut input_index = 0usize;
                             let prev_outputs = tx
                                 .input
                                 .iter()
@@ -189,6 +190,20 @@ impl Blockchain for ElectrumBlockchain {
                                         .output
                                         .get(input.previous_output.vout as usize)
                                         .ok_or_else(electrum_goof)?;
+                                    // Verify this input if requested via feature flag
+                                    #[cfg(feature = "verify")]
+                                    {
+                                        use crate::wallet::verify::VerifyError;
+                                        let serialized_tx = bitcoin::consensus::serialize(&tx);
+                                        bitcoinconsensus::verify(
+                                            txout.script_pubkey.to_bytes().as_ref(),
+                                            txout.value,
+                                            &serialized_tx,
+                                            input_index,
+                                        )
+                                        .map_err(|e| VerifyError::from(e))?;
+                                    }
+                                    input_index += 1;
                                     Ok(Some(txout.clone()))
                                 })
                                 .collect::<Result<Vec<_>, Error>>()?;

--- a/src/blockchain/esplora/reqwest.rs
+++ b/src/blockchain/esplora/reqwest.rs
@@ -167,9 +167,27 @@ impl Blockchain for EsploraBlockchain {
                         .request()
                         .map(|txid| {
                             let tx = tx_index.get(txid).expect("must be in index");
-                            (tx.previous_outputs(), tx.to_tx())
+                            // Verify this transaction if requested via feature flag
+                            #[cfg(feature = "verify")]
+                            {
+                                use crate::wallet::verify::VerifyError;
+                                let prev_outs = tx.previous_outputs();
+                                let tx_bytes = serialize(&tx.to_tx());
+                                for (index, output) in prev_outs.iter().enumerate() {
+                                    if let Some(output) = output {
+                                        bitcoinconsensus::verify(
+                                            output.script_pubkey.to_bytes().as_ref(),
+                                            output.value,
+                                            &tx_bytes,
+                                            index,
+                                        )
+                                        .map_err(|e| VerifyError::from(e))?;
+                                    }
+                                }
+                            }
+                            Ok((tx.previous_outputs(), tx.to_tx()))
                         })
-                        .collect();
+                        .collect::<Result<_, Error>>()?;
                     tx_req.satisfy(full_txs)?
                 }
                 Request::Finish(batch_update) => break batch_update,

--- a/src/blockchain/esplora/reqwest.rs
+++ b/src/blockchain/esplora/reqwest.rs
@@ -167,24 +167,6 @@ impl Blockchain for EsploraBlockchain {
                         .request()
                         .map(|txid| {
                             let tx = tx_index.get(txid).expect("must be in index");
-                            // Verify this transaction if requested via feature flag
-                            #[cfg(feature = "verify")]
-                            {
-                                use crate::wallet::verify::VerifyError;
-                                let prev_outs = tx.previous_outputs();
-                                let tx_bytes = serialize(&tx.to_tx());
-                                for (index, output) in prev_outs.iter().enumerate() {
-                                    if let Some(output) = output {
-                                        bitcoinconsensus::verify(
-                                            output.script_pubkey.to_bytes().as_ref(),
-                                            output.value,
-                                            &tx_bytes,
-                                            index,
-                                        )
-                                        .map_err(|e| VerifyError::from(e))?;
-                                    }
-                                }
-                            }
                             Ok((tx.previous_outputs(), tx.to_tx()))
                         })
                         .collect::<Result<_, Error>>()?;

--- a/src/blockchain/esplora/ureq.rs
+++ b/src/blockchain/esplora/ureq.rs
@@ -166,24 +166,6 @@ impl Blockchain for EsploraBlockchain {
                         .request()
                         .map(|txid| {
                             let tx = tx_index.get(txid).expect("must be in index");
-                            // Verify this transaction if requested via feature flag
-                            #[cfg(feature = "verify")]
-                            {
-                                use crate::wallet::verify::VerifyError;
-                                let prev_outs = tx.previous_outputs();
-                                let tx_bytes = serialize(&tx.to_tx());
-                                for (index, output) in prev_outs.iter().enumerate() {
-                                    if let Some(output) = output {
-                                        bitcoinconsensus::verify(
-                                            output.script_pubkey.to_bytes().as_ref(),
-                                            output.value,
-                                            &tx_bytes,
-                                            index,
-                                        )
-                                        .map_err(|e| VerifyError::from(e))?;
-                                    }
-                                }
-                            }
                             Ok((tx.previous_outputs(), tx.to_tx()))
                         })
                         .collect::<Result<_, Error>>()?;

--- a/src/blockchain/rpc.rs
+++ b/src/blockchain/rpc.rs
@@ -271,7 +271,6 @@ impl Blockchain for RpcBlockchain {
                     received,
                     sent,
                     fee: tx_result.fee.map(|f| f.as_sat().abs() as u64),
-                    verified: true,
                 };
                 debug!(
                     "saving tx: {} tx_result.fee:{:?} td.fees:{:?}",

--- a/src/blockchain/script_sync.rs
+++ b/src/blockchain/script_sync.rs
@@ -214,7 +214,6 @@ impl<'a, D: BatchDatabase> TxReq<'a, D> {
                     // we're going to fill this in later
                     confirmation_time: None,
                     fee: Some(fee),
-                    verified: false,
                 })
             })
             .collect::<Result<Vec<_>, _>>()?;

--- a/src/blockchain/script_sync.rs
+++ b/src/blockchain/script_sync.rs
@@ -178,7 +178,9 @@ impl<'a, D: BatchDatabase> TxReq<'a, D> {
                 let mut inputs_sum: u64 = 0;
                 let mut outputs_sum: u64 = 0;
 
-                for (txout, input) in vout.into_iter().zip(tx.input.iter()) {
+                for (txout, (_input_index, input)) in
+                    vout.into_iter().zip(tx.input.iter().enumerate())
+                {
                     let txout = match txout {
                         Some(txout) => txout,
                         None => {
@@ -190,7 +192,19 @@ impl<'a, D: BatchDatabase> TxReq<'a, D> {
                             continue;
                         }
                     };
-
+                    // Verify this input if requested via feature flag
+                    #[cfg(feature = "verify")]
+                    {
+                        use crate::wallet::verify::VerifyError;
+                        let serialized_tx = bitcoin::consensus::serialize(&tx);
+                        bitcoinconsensus::verify(
+                            txout.script_pubkey.to_bytes().as_ref(),
+                            txout.value,
+                            &serialized_tx,
+                            _input_index,
+                        )
+                        .map_err(VerifyError::from)?;
+                    }
                     inputs_sum += txout.value;
                     if self.state.db.is_mine(&txout.script_pubkey)? {
                         sent += txout.value;

--- a/src/database/memory.rs
+++ b/src/database/memory.rs
@@ -515,7 +515,6 @@ macro_rules! populate_test_db {
             received: 0,
             sent: 0,
             confirmation_time,
-            verified: current_height.is_some(),
         };
 
         db.set_tx(&tx_details).unwrap();

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -348,7 +348,6 @@ pub mod test {
                 timestamp: 123456,
                 height: 1000,
             }),
-            verified: true,
         };
 
         tree.set_tx(&tx_details).unwrap();

--- a/src/database/sqlite.rs
+++ b/src/database/sqlite.rs
@@ -29,7 +29,7 @@ static MIGRATIONS: &[&str] = &[
     "CREATE INDEX idx_txid_vout ON utxos(txid, vout);",
     "CREATE TABLE transactions (txid BLOB, raw_tx BLOB);",
     "CREATE INDEX idx_txid ON transactions(txid);",
-    "CREATE TABLE transaction_details (txid BLOB, timestamp INTEGER, received INTEGER, sent INTEGER, fee INTEGER, height INTEGER, verified INTEGER DEFAULT 0);",
+    "CREATE TABLE transaction_details (txid BLOB, timestamp INTEGER, received INTEGER, sent INTEGER, fee INTEGER, height INTEGER);",
     "CREATE INDEX idx_txdetails_txid ON transaction_details(txid);",
     "CREATE TABLE last_derivation_indices (keychain TEXT, value INTEGER);",
     "CREATE UNIQUE INDEX idx_indices_keychain ON last_derivation_indices(keychain);",
@@ -127,7 +127,7 @@ impl SqliteDatabase {
 
         let txid: &[u8] = &transaction.txid;
 
-        let mut statement = self.connection.prepare_cached("INSERT INTO transaction_details (txid, timestamp, received, sent, fee, height, verified) VALUES (:txid, :timestamp, :received, :sent, :fee, :height, :verified)")?;
+        let mut statement = self.connection.prepare_cached("INSERT INTO transaction_details (txid, timestamp, received, sent, fee, height) VALUES (:txid, :timestamp, :received, :sent, :fee, :height)")?;
 
         statement.execute(named_params! {
             ":txid": txid,
@@ -136,7 +136,6 @@ impl SqliteDatabase {
             ":sent": transaction.sent,
             ":fee": transaction.fee,
             ":height": height,
-            ":verified": transaction.verified
         })?;
 
         Ok(self.connection.last_insert_rowid())
@@ -153,7 +152,7 @@ impl SqliteDatabase {
 
         let txid: &[u8] = &transaction.txid;
 
-        let mut statement = self.connection.prepare_cached("UPDATE transaction_details SET timestamp=:timestamp, received=:received, sent=:sent, fee=:fee, height=:height, verified=:verified WHERE txid=:txid")?;
+        let mut statement = self.connection.prepare_cached("UPDATE transaction_details SET timestamp=:timestamp, received=:received, sent=:sent, fee=:fee, height=:height WHERE txid=:txid")?;
 
         statement.execute(named_params! {
             ":txid": txid,
@@ -162,7 +161,6 @@ impl SqliteDatabase {
             ":sent": transaction.sent,
             ":fee": transaction.fee,
             ":height": height,
-            ":verified": transaction.verified,
         })?;
 
         Ok(())
@@ -367,7 +365,7 @@ impl SqliteDatabase {
     }
 
     fn select_transaction_details_with_raw(&self) -> Result<Vec<TransactionDetails>, Error> {
-        let mut statement = self.connection.prepare_cached("SELECT transaction_details.txid, transaction_details.timestamp, transaction_details.received, transaction_details.sent, transaction_details.fee, transaction_details.height, transaction_details.verified, transactions.raw_tx FROM transaction_details, transactions WHERE transaction_details.txid = transactions.txid")?;
+        let mut statement = self.connection.prepare_cached("SELECT transaction_details.txid, transaction_details.timestamp, transaction_details.received, transaction_details.sent, transaction_details.fee, transaction_details.height, transactions.raw_tx FROM transaction_details, transactions WHERE transaction_details.txid = transactions.txid")?;
         let mut transaction_details: Vec<TransactionDetails> = vec![];
         let mut rows = statement.query([])?;
         while let Some(row) = rows.next()? {
@@ -378,7 +376,6 @@ impl SqliteDatabase {
             let sent: u64 = row.get(3)?;
             let fee: Option<u64> = row.get(4)?;
             let height: Option<u32> = row.get(5)?;
-            let verified: bool = row.get(6)?;
             let raw_tx: Option<Vec<u8>> = row.get(7)?;
             let tx: Option<Transaction> = match raw_tx {
                 Some(raw_tx) => {
@@ -400,7 +397,6 @@ impl SqliteDatabase {
                 sent,
                 fee,
                 confirmation_time,
-                verified,
             });
         }
         Ok(transaction_details)
@@ -408,7 +404,7 @@ impl SqliteDatabase {
 
     fn select_transaction_details(&self) -> Result<Vec<TransactionDetails>, Error> {
         let mut statement = self.connection.prepare_cached(
-            "SELECT txid, timestamp, received, sent, fee, height, verified FROM transaction_details",
+            "SELECT txid, timestamp, received, sent, fee, height FROM transaction_details",
         )?;
         let mut transaction_details: Vec<TransactionDetails> = vec![];
         let mut rows = statement.query([])?;
@@ -420,7 +416,6 @@ impl SqliteDatabase {
             let sent: u64 = row.get(3)?;
             let fee: Option<u64> = row.get(4)?;
             let height: Option<u32> = row.get(5)?;
-            let verified: bool = row.get(6)?;
 
             let confirmation_time = match (height, timestamp) {
                 (Some(height), Some(timestamp)) => Some(BlockTime { height, timestamp }),
@@ -434,7 +429,6 @@ impl SqliteDatabase {
                 sent,
                 fee,
                 confirmation_time,
-                verified,
             });
         }
         Ok(transaction_details)
@@ -444,7 +438,7 @@ impl SqliteDatabase {
         &self,
         txid: &[u8],
     ) -> Result<Option<TransactionDetails>, Error> {
-        let mut statement = self.connection.prepare_cached("SELECT transaction_details.timestamp, transaction_details.received, transaction_details.sent, transaction_details.fee, transaction_details.height, transaction_details.verified, transactions.raw_tx FROM transaction_details, transactions WHERE transaction_details.txid=transactions.txid AND transaction_details.txid=:txid")?;
+        let mut statement = self.connection.prepare_cached("SELECT transaction_details.timestamp, transaction_details.received, transaction_details.sent, transaction_details.fee, transaction_details.height, transactions.raw_tx FROM transaction_details, transactions WHERE transaction_details.txid=transactions.txid AND transaction_details.txid=:txid")?;
         let mut rows = statement.query(named_params! { ":txid": txid })?;
 
         match rows.next()? {
@@ -454,9 +448,8 @@ impl SqliteDatabase {
                 let sent: u64 = row.get(2)?;
                 let fee: Option<u64> = row.get(3)?;
                 let height: Option<u32> = row.get(4)?;
-                let verified: bool = row.get(5)?;
 
-                let raw_tx: Option<Vec<u8>> = row.get(6)?;
+                let raw_tx: Option<Vec<u8>> = row.get(5)?;
                 let tx: Option<Transaction> = match raw_tx {
                     Some(raw_tx) => {
                         let tx: Transaction = deserialize(&raw_tx)?;
@@ -477,7 +470,6 @@ impl SqliteDatabase {
                     sent,
                     fee,
                     confirmation_time,
-                    verified,
                 }))
             }
             None => Ok(None),

--- a/src/database/sqlite.rs
+++ b/src/database/sqlite.rs
@@ -29,13 +29,17 @@ static MIGRATIONS: &[&str] = &[
     "CREATE INDEX idx_txid_vout ON utxos(txid, vout);",
     "CREATE TABLE transactions (txid BLOB, raw_tx BLOB);",
     "CREATE INDEX idx_txid ON transactions(txid);",
-    "CREATE TABLE transaction_details (txid BLOB, timestamp INTEGER, received INTEGER, sent INTEGER, fee INTEGER, height INTEGER);",
+    "CREATE TABLE transaction_details (txid BLOB, timestamp INTEGER, received INTEGER, sent INTEGER, fee INTEGER, height INTEGER, verified INTEGER DEFAULT 0);",
     "CREATE INDEX idx_txdetails_txid ON transaction_details(txid);",
     "CREATE TABLE last_derivation_indices (keychain TEXT, value INTEGER);",
     "CREATE UNIQUE INDEX idx_indices_keychain ON last_derivation_indices(keychain);",
     "CREATE TABLE checksums (keychain TEXT, checksum BLOB);",
     "CREATE INDEX idx_checksums_keychain ON checksums(keychain);",
-    "CREATE TABLE sync_time (id INTEGER PRIMARY KEY, height INTEGER, timestamp INTEGER);"
+    "CREATE TABLE sync_time (id INTEGER PRIMARY KEY, height INTEGER, timestamp INTEGER);",
+    "ALTER TABLE transaction_details RENAME TO transaction_details_old;",
+    "CREATE TABLE transaction_details (txid BLOB, timestamp INTEGER, received INTEGER, sent INTEGER, fee INTEGER, height INTEGER);",
+    "INSERT INTO transaction_details SELECT txid, timestamp, received, sent, fee, height FROM transaction_details_old;",
+    "DROP TABLE transaction_details_old;",
 ];
 
 /// Sqlite database stored on filesystem

--- a/src/types.rs
+++ b/src/types.rs
@@ -211,15 +211,6 @@ pub struct TransactionDetails {
     /// If the transaction is confirmed, contains height and timestamp of the block containing the
     /// transaction, unconfirmed transaction contains `None`.
     pub confirmation_time: Option<BlockTime>,
-    /// Whether the tx has been verified against the consensus rules
-    ///
-    /// Confirmed txs are considered "verified" by default, while unconfirmed txs are checked to
-    /// ensure an unstrusted [`Blockchain`](crate::blockchain::Blockchain) backend can't trick the
-    /// wallet into using an invalid tx as an RBF template.
-    ///
-    /// The check is only performed when the `verify` feature is enabled.
-    #[serde(default = "bool::default")] // default to `false` if not specified
-    pub verified: bool,
 }
 
 /// Block height and timestamp of a block

--- a/src/wallet/export.rs
+++ b/src/wallet/export.rs
@@ -230,7 +230,6 @@ mod test {
                 timestamp: 12345678,
                 height: 5000,
             }),
-            verified: true,
         })
         .unwrap();
 

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -712,7 +712,6 @@ where
             received,
             sent,
             fee: Some(fee_amount),
-            verified: true,
         };
 
         Ok((psbt, transaction_details))

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1537,23 +1537,6 @@ where
                 .sync(self.database.borrow_mut().deref_mut(), progress_update,))?;
         }
 
-        #[cfg(feature = "verify")]
-        {
-            debug!("Verifying transactions...");
-            for mut tx in self.database.borrow().iter_txs(true)? {
-                if !tx.verified {
-                    verify::verify_tx(
-                        tx.transaction.as_ref().ok_or(Error::TransactionNotFound)?,
-                        self.database.borrow().deref(),
-                        &self.client,
-                    )?;
-
-                    tx.verified = true;
-                    self.database.borrow_mut().set_tx(&tx)?;
-                }
-            }
-        }
-
         let sync_time = SyncTime {
             block_time: BlockTime {
                 height: maybe_await!(self.client.get_height())?,


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

As discussed in https://github.com/bitcoindevkit/bdk/issues/498 and also in team call,
 - default verification from wallet sync is removed
 - `verify_tx` refactored as an wallet API
 - in `sync` verification added for electrum and esplora backends, gated by `verify` flag.
 - `verify` flag is removed from `TransactionDetails`.

### Notes to the reviewers

I haven't looked into `comapct_filters` to see how verification can fit there, but that will probably be required in future.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Wallet API change:

* [x] I've updated `CHANGELOG.md`