### PR TITLE
[ci] Fix publish_docs job

### DIFF
--- a/.github/workflows/nightly_docs.yml
+++ b/.github/workflows/nightly_docs.yml
@@ -44,14 +44,14 @@ jobs:
           repository: bitcoindevkit/bitcoindevkit.org
           ref: master
       - name: Create directories
-        run: mkdir -p ./static/docs-rs/bdk/nightly
+        run: mkdir -p ./docs/.vuepress/public/docs-rs/bdk/nightly
       - name: Remove old latest
-        run: rm -rf ./static/docs-rs/bdk/nightly/latest
+        run: rm -rf ./docs/.vuepress/public/docs-rs/bdk/nightly/latest
       - name: Download built docs
         uses: actions/download-artifact@v1
         with:
           name: built-docs
-          path: ./static/docs-rs/bdk/nightly/latest
+          path: ./docs/.vuepress/public/docs-rs/bdk/nightly/latest
       - name: Configure git
         run: git config user.email "github-actions@github.com" && git config user.name "github-actions"
       - name: Commit


### PR DESCRIPTION
### Description

Update the `nightly_docs.yml` github actions pipeline that publishes nightly docs to the bitcoindevkit.org site repo. This directory to put nightly docs in changed when we changed the website builder tool from Hugo to Vuepress.

### Notes to the reviewers

After this goes in I'll do a PR on the bitcoindevkit.org repo to remove the old `./static` directory. https://github.com/bitcoindevkit/bitcoindevkit.org/pull/73

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
