### PR TITLE
Change the visibility of the `derived` module and of the `AsDerived` trait

### DIFF
--- a/src/descriptor/derived.rs
+++ b/src/descriptor/derived.rs
@@ -119,7 +119,7 @@ impl<'s> ToPublicKey for DerivedDescriptorKey<'s> {
     }
 }
 
-pub(crate) trait AsDerived {
+pub trait AsDerived {
     // Derive a descriptor and transform all of its keys to `DerivedDescriptorKey`
     fn as_derived<'s>(&self, index: u32, secp: &'s SecpCtx)
         -> Descriptor<DerivedDescriptorKey<'s>>;

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -30,7 +30,7 @@ use miniscript::{DescriptorTrait, ForEachKey, TranslatePk};
 use crate::descriptor::policy::BuildSatisfaction;
 
 pub mod checksum;
-pub(crate) mod derived;
+pub mod derived;
 #[doc(hidden)]
 pub mod dsl;
 pub mod error;


### PR DESCRIPTION
There is currently no way to retrieve change addresses, so this PR changes the visibility of the `derived` module and the `AsDerived` trait.

With this change, the addresses can be retrieved using the function below, for example:

```rust
use bdk::descriptor::derived::AsDerived;

// ...

fn peek_change_address(&self, wallet: &Wallet<ElectrumBlockchain, MemoryDatabase>, index: u32) -> Result<AddressInfo, Error> {

        let result_descriptor = wallet.get_descriptor_for_keychain(bdk::KeychainKind::Internal);

        result_descriptor
            .as_derived(index, wallet.secp_ctx())
            .address(wallet.network())
            .map(|address| AddressInfo { index, address })
            .map_err(|_| Error::ScriptDoesntHaveAddressForm)
    }
```