### PR TITLE
Use u64 in blockheight parameter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,7 @@ test-md-docs = ["electrum"]
 lazy_static = "1.4"
 env_logger = "0.7"
 clap = "2.33"
-electrsd = { version= "0.13", features = ["trigger", "bitcoind_22_0"] }
+electrsd = { version= "0.14", features = ["trigger", "bitcoind_22_0"] }
 
 [[example]]
 name = "address_validator"

--- a/src/blockchain/any.rs
+++ b/src/blockchain/any.rs
@@ -155,7 +155,7 @@ impl Blockchain for AnyBlockchain {
         maybe_await!(impl_inner_method!(self, broadcast, tx))
     }
 
-    fn get_height(&self) -> Result<u32, Error> {
+    fn get_height(&self) -> Result<u64, Error> {
         maybe_await!(impl_inner_method!(self, get_height))
     }
     fn estimate_fee(&self, target: usize) -> Result<FeeRate, Error> {

--- a/src/blockchain/compact_filters/mod.rs
+++ b/src/blockchain/compact_filters/mod.rs
@@ -444,8 +444,8 @@ impl Blockchain for CompactFiltersBlockchain {
         Ok(())
     }
 
-    fn get_height(&self) -> Result<u32, Error> {
-        Ok(self.headers.get_height()? as u32)
+    fn get_height(&self) -> Result<u64, Error> {
+        Ok(self.headers.get_height()? as u64)
     }
 
     fn estimate_fee(&self, _target: usize) -> Result<FeeRate, Error> {

--- a/src/blockchain/electrum.rs
+++ b/src/blockchain/electrum.rs
@@ -214,13 +214,13 @@ impl Blockchain for ElectrumBlockchain {
         Ok(self.client.transaction_broadcast(tx).map(|_| ())?)
     }
 
-    fn get_height(&self) -> Result<u32, Error> {
+    fn get_height(&self) -> Result<u64, Error> {
         // TODO: unsubscribe when added to the client, or is there a better call to use here?
 
         Ok(self
             .client
             .block_headers_subscribe()
-            .map(|data| data.height as u32)?)
+            .map(|data| data.height as u64)?)
     }
 
     fn estimate_fee(&self, target: usize) -> Result<FeeRate, Error> {

--- a/src/blockchain/esplora/reqwest.rs
+++ b/src/blockchain/esplora/reqwest.rs
@@ -189,7 +189,7 @@ impl Blockchain for EsploraBlockchain {
         Ok(await_or_block!(self.url_client._broadcast(tx))?)
     }
 
-    fn get_height(&self) -> Result<u32, Error> {
+    fn get_height(&self) -> Result<u64, Error> {
         Ok(await_or_block!(self.url_client._get_height())?)
     }
 
@@ -258,7 +258,7 @@ impl UrlClient {
         Ok(())
     }
 
-    async fn _get_height(&self) -> Result<u32, EsploraError> {
+    async fn _get_height(&self) -> Result<u64, EsploraError> {
         let req = self
             .client
             .get(&format!("{}/blocks/tip/height", self.url))

--- a/src/blockchain/esplora/ureq.rs
+++ b/src/blockchain/esplora/ureq.rs
@@ -189,7 +189,7 @@ impl Blockchain for EsploraBlockchain {
         Ok(())
     }
 
-    fn get_height(&self) -> Result<u32, Error> {
+    fn get_height(&self) -> Result<u64, Error> {
         Ok(self.url_client._get_height()?)
     }
 
@@ -266,7 +266,7 @@ impl UrlClient {
         }
     }
 
-    fn _get_height(&self) -> Result<u32, EsploraError> {
+    fn _get_height(&self) -> Result<u64, EsploraError> {
         let resp = self
             .agent
             .get(&format!("{}/blocks/tip/height", self.url))

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -138,7 +138,7 @@ pub trait Blockchain {
     fn broadcast(&self, tx: &Transaction) -> Result<(), Error>;
 
     /// Return the current height
-    fn get_height(&self) -> Result<u32, Error>;
+    fn get_height(&self) -> Result<u64, Error>;
     /// Estimate the fee rate required to confirm a transaction in a given `target` of blocks
     fn estimate_fee(&self, target: usize) -> Result<FeeRate, Error>;
 }
@@ -246,7 +246,7 @@ impl<T: Blockchain> Blockchain for Arc<T> {
         maybe_await!(self.deref().broadcast(tx))
     }
 
-    fn get_height(&self) -> Result<u32, Error> {
+    fn get_height(&self) -> Result<u64, Error> {
         maybe_await!(self.deref().get_height())
     }
     fn estimate_fee(&self, target: usize) -> Result<FeeRate, Error> {

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1556,7 +1556,7 @@ where
 
         let sync_time = SyncTime {
             block_time: BlockTime {
-                height: maybe_await!(self.client.get_height())?,
+                height: maybe_await!(self.client.get_height())? as u32,
                 timestamp: time::get_timestamp(),
             },
         };


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Fixes #513. 

Note that the wallet internal blockheight values are still `u32`. So we still need to convert the `u64` to `u32` in `wallet.mod`. This PR turns the height values to `u64` in `blockhain` module only to make it compatible with height values returned by `bitcoincore-rpc`.

Not sure how effective of a change is this. Opening it up for discussion.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing


