### PR TITLE
[ci] Pin nightly docs workflow rust version to nightly-2022-01-25

### DIFF
--- a/.github/workflows/nightly_docs.yml
+++ b/.github/workflows/nightly_docs.yml
@@ -18,7 +18,7 @@ jobs:
             target
           key: nightly-docs-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
       - name: Set default toolchain
-        run: rustup default nightly
+        run: rustup default nightly-2022-01-25
       - name: Set profile
         run: rustup set profile minimal
       - name: Update toolchain


### PR DESCRIPTION
### Description

Pin nightly docs workflow rust version to `nightly-2022-01-25` to fix #538 . 

### Notes to the reviewers

The nightly docs should be changed to the `stable` version once it supports `feature(doc_cfg)`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### Bugfixes:

* [x] I'm linking the issue being fixed by this PR
