### PR TITLE
Update `electrsd` to v0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ test-md-docs = ["electrum"]
 lazy_static = "1.4"
 env_logger = "0.7"
 clap = "2.33"
-electrsd = { version= "0.13", features = ["trigger", "bitcoind_22_0"] }
+electrsd = { version= "0.15", features = ["trigger", "bitcoind_22_0"] }
 
 [[example]]
 name = "address_validator"

--- a/src/testutils/blockchain_tests.rs
+++ b/src/testutils/blockchain_tests.rs
@@ -320,7 +320,7 @@ impl Default for TestClient {
     fn default() -> Self {
         let bitcoind_exe = env::var("BITCOIND_EXE")
             .ok()
-            .or(bitcoind::downloaded_exe_path())
+            .or(bitcoind::downloaded_exe_path().ok())
             .expect(
                 "you should provide env var BITCOIND_EXE or specifiy a bitcoind version feature",
             );


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

PR RCasatta/electrsd#33 has been merged and the new changes released as part of `v0.15.0`: the PR allows setting an env variable (`ELECTRSD_EXE`) to use a custom electrsd binary, which can be useful when the one that is downloaded automatically doesn't work for whatever reason.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
