### PR TITLE
AddressIndex improvements: LastUnused, FirstUnused, and get_batch_unused_addresses()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `get_internal_address` to allow you to get internal addresses just as you get external addresses.
 - added `ensure_addresses_cached` to `Wallet` to let offline wallets load and cache addresses in their database
 - Add `is_spent` field to `LocalUtxo`; when we notice that a utxo has been spent we set `is_spent` field to true instead of deleting it from the db.
+- Changed `AddressIndex::LastUnused` to look back further than `current_index`, and only return a new address if all have been used.
+- Add `AddressIndex::FirstUnused` to get unused addresses from the beginning of the keychain.
+- Add `wallet.get_batch_unused_addresses` to return vector of N unused addresses, populating any remaining with new addresses.
 
 ### Sync API change
 


### PR DESCRIPTION
### Description
* Change `AddressIndex::LastUnused` to look back further than current_index
* Add `AddressIndex::FirstUnused`
* Add `get_batch_unused_addresses`

### Notes to the reviewers
Builds upon https://github.com/bitcoindevkit/bdk/pull/522

Currently BDK supports address indexing via `LastUnused`, which will return the address with `current_index` if it is unused, otherwise it will return a New address.

With this current logic, if you get two new addresses A1 and A2 and use A2, then `LastUnused` will give you a `New` address rather than the unused A1.

In order to more consistently utilize unused addresses i've added a new function `get_unused_key_indexes(keychain)` which returns a vector of indexes for the unused addresses in that keychain. Making use of this function, `LastUnused` now returns the most recent address that has not yet been used, and New if all addresses have been used.

In some cases it may be desirable to utilize unused addresses that reside earlier in the keychain. i.e. `AddressIndex::FirstUnused` in this PR. 

`FirstUnused` has the same caveat as LastUnused: that if the wallet has not yet detected an address has been used, it could return a used address.

Additionally a new public function `get_batch_unused_addresses` allows for retrieval of `N` unused addresses at once. Prioritizing unused addresses first, then populating the remaining with New addresses (like `FirstUnused`).

For example: if a wallet builds a transaction involving many `New` internal addresses but that transaction is never broadcast, then all of these addresses can now easily be used in a later transaction via `get_batch_unused_addresses`.


### Checklists

#### All Submissions:

* [X] I've signed all my commits
* [X] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [X] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [X] I've added tests for the new feature
* [X] I've added docs for the new feature
* [X] I've updated `CHANGELOG.md`