### PR TITLE
Document MSRV policy and change MSRV to 1.49.0

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -10,9 +10,9 @@ jobs:
     strategy:
       matrix:
         rust:
-          - version: 1.56.0 # STABLE
+          - version: stable # STABLE
             clippy: true
-          - version: 1.46.0 # MSRV
+          - version: 1.49.0 # MSRV
         features:
           - default
           - minimal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Increase project MSRV from 1.46.0 to 1.49.0, see new policy in README
+
 ## [v0.16.0] - [v0.15.0]
 
 - Disable `reqwest` default features.

--- a/README.md
+++ b/README.md
@@ -170,6 +170,16 @@ cargo test --features test-electrum
 The other options are `test-esplora` or `test-rpc`.
 Note that `electrs` and `bitcoind` binaries are automatically downloaded (on mac and linux), to specify you already have installed binaries you must use `--no-default-features` and provide `BITCOIND_EXE` and `ELECTRS_EXE` as environment variables.
 
+## Supported Rust Versions
+
+The BDK MSRV (minimum supported rust version) will be as low as possible to support required 
+dependencies and no higher than the [rustc](https://tracker.debian.org/pkg/rustc) version packaged 
+with the Debian ["testing"] release, and if possible the ["stable"] release. We will only increase 
+the BDK MSRV with a new MINOR release, never a PATCH release.
+
+["testing"]: https://www.debian.org/releases/testing/
+["stable"]: https://www.debian.org/releases/stable/
+
 ## License
 
 Licensed under either of

--- a/examples/compiler.rs
+++ b/examples/compiler.rs
@@ -85,7 +85,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let network = matches
         .value_of("network")
-        .map(|n| Network::from_str(n))
+        .map(Network::from_str)
         .transpose()
         .unwrap()
         .unwrap_or(Network::Testnet);

--- a/src/blockchain/any.rs
+++ b/src/blockchain/any.rs
@@ -108,6 +108,7 @@ macro_rules! impl_inner_method {
 /// It allows switching backend at runtime
 ///
 /// See [this module](crate::blockchain::any)'s documentation for a usage example.
+#[allow(clippy::large_enum_variant)] // TODO fix https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
 pub enum AnyBlockchain {
     #[cfg(feature = "electrum")]
     #[cfg_attr(docsrs, doc(cfg(feature = "electrum")))]

--- a/src/blockchain/compact_filters/peer.rs
+++ b/src/blockchain/compact_filters/peer.rs
@@ -115,7 +115,7 @@ pub struct Peer {
     writer: Arc<Mutex<TcpStream>>,
     responses: Arc<RwLock<ResponsesMap>>,
 
-    reader_thread: thread::JoinHandle<()>,
+    _reader_thread: thread::JoinHandle<()>,
     connected: Arc<RwLock<bool>>,
 
     mempool: Arc<Mempool>,
@@ -228,7 +228,7 @@ impl Peer {
         Ok(Peer {
             writer,
             responses,
-            reader_thread,
+            _reader_thread: reader_thread,
             connected,
             mempool,
             version,

--- a/src/blockchain/rpc.rs
+++ b/src/blockchain/rpc.rs
@@ -55,7 +55,7 @@ pub struct RpcBlockchain {
     /// Rpc client to the node, includes the wallet name
     client: Client,
     /// Network used
-    network: Network,
+    _network: Network,
     /// Blockchain capabilities, cached here at startup
     capabilities: HashSet<Capability>,
     /// Skip this many blocks of the blockchain at the first rescan, if None the rescan is done from the genesis block
@@ -405,7 +405,7 @@ impl ConfigurableBlockchain for RpcBlockchain {
 
         Ok(RpcBlockchain {
             client,
-            network,
+            _network: network,
             capabilities,
             _storage_address: storage_address,
             skip_blocks: config.skip_blocks,

--- a/src/wallet/export.rs
+++ b/src/wallet/export.rs
@@ -95,6 +95,7 @@ impl FromStr for WalletExport {
     }
 }
 
+#[allow(clippy::manual_split_once)]
 fn remove_checksum(s: String) -> String {
     s.splitn(2, '#').next().map(String::from).unwrap()
 }

--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -448,7 +448,7 @@ impl SignersContainer {
 /// Options for a software signer
 ///
 /// Adjust the behavior of our software signers and the way a transaction is finalized
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct SignOptions {
     /// Whether the signer should trust the `witness_utxo`, if the `non_witness_utxo` hasn't been
     /// provided
@@ -477,16 +477,6 @@ pub struct SignOptions {
     ///
     /// Defaults to `false` which will only allow signing using `SIGHASH_ALL`.
     pub allow_all_sighashes: bool,
-}
-
-impl Default for SignOptions {
-    fn default() -> Self {
-        SignOptions {
-            trust_witness_utxo: false,
-            assume_height: None,
-            allow_all_sighashes: false,
-        }
-    }
 }
 
 pub(crate) trait ComputeSighash {


### PR DESCRIPTION
### Description

Set MSRV policy to be at most Debian "testing" release version of rustc. Update `build-test` CI job matrix to use the current latest stable version and MSRV ~~1.56.0~~ 1.49.0.

Fixes #331
Fixes #496 

### Notes to the reviewers

Fixes CI error caused by tokio MSRV changing to 1.49.0, see #522.

I also changed from a fixed stable version (was `1.56.0`) to the latest `stable` because we haven't been updating it manually and this will ensure we're always testing against current `stable` rust.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
