### PR TITLE
Release/0.16.1

### DIFF
--- a/.github/workflows/nightly_docs.yml
+++ b/.github/workflows/nightly_docs.yml
@@ -18,7 +18,7 @@ jobs:
             target
           key: nightly-docs-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
       - name: Set default toolchain
-        run: rustup default nightly
+        run: rustup default nightly-2022-01-25
       - name: Set profile
         run: rustup set profile minimal
       - name: Update toolchain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.16.1] - [v0.16.0]
+
 - Pin tokio dependency version to ~1.14 to prevent errors due to their new MSRV 1.49.0
 
 ## [v0.16.0] - [v0.15.0]
@@ -414,3 +416,4 @@ final transaction is created by calling `finish` on the builder.
 [v0.14.0]: https://github.com/bitcoindevkit/bdk/compare/v0.13.0...v0.14.0
 [v0.15.0]: https://github.com/bitcoindevkit/bdk/compare/v0.14.0...v0.15.0
 [v0.16.0]: https://github.com/bitcoindevkit/bdk/compare/v0.15.0...v0.16.0
+[v0.16.1]: https://github.com/bitcoindevkit/bdk/compare/v0.16.0...v0.16.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Pin tokio dependency version to ~1.14 to prevent errors due to their new MSRV 1.49.0
+
 ## [v0.16.0] - [v0.15.0]
 
 - Disable `reqwest` default features.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ bitcoincore-rpc = { version = "0.14", optional = true }
 
 # Platform-specific dependencies
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1", features = ["rt"] }
+tokio = { version = "~1.14", features = ["rt"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 async-trait = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk"
-version = "0.16.1"
+version = "0.16.2-dev"
 edition = "2018"
 authors = ["Alekos Filini <alekos.filini@gmail.com>", "Riccardo Casatta <riccardo@casatta.it>"]
 homepage = "https://bitcoindevkit.org"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk"
-version = "0.16.1-dev"
+version = "0.16.1"
 edition = "2018"
 authors = ["Alekos Filini <alekos.filini@gmail.com>", "Riccardo Casatta <riccardo@casatta.it>"]
 homepage = "https://bitcoindevkit.org"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 //! interact with the bitcoin P2P network.
 //!
 //! ```toml
-//! bdk = "0.16.0"
+//! bdk = "0.16.1"
 //! ```
 #![cfg_attr(
     feature = "electrum",


### PR DESCRIPTION
### Description

This is a bug fix release. Cherry picked #539 and #550 so projects using bdk `^0.16` like `bdk-cli` will be able to do a `cargo update` and not be broken. Also need this since our `0.17.0` release is running late.

### Notes to the reviewers

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
