### PR TITLE
Fix hierarchy of headers on docs landing page

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,12 +46,13 @@
 //! ```toml
 //! bdk = "0.16.1"
 //! ```
+//!
+//! # Examples
 #![cfg_attr(
     feature = "electrum",
     doc = r##"
 ## Sync the balance of a descriptor
 
-### Example
 ```no_run
 use bdk::Wallet;
 use bdk::database::MemoryDatabase;
@@ -80,7 +81,6 @@ fn main() -> Result<(), bdk::Error> {
 //!
 //! ## Generate a few addresses
 //!
-//! ### Example
 //! ```
 //! use bdk::{Wallet};
 //! use bdk::database::MemoryDatabase;
@@ -106,7 +106,6 @@ fn main() -> Result<(), bdk::Error> {
     doc = r##"
 ## Create a transaction
 
-### Example
 ```no_run
 use bdk::{FeeRate, Wallet};
 use bdk::database::MemoryDatabase;
@@ -150,7 +149,6 @@ fn main() -> Result<(), bdk::Error> {
 //!
 //! ## Sign a transaction
 //!
-//! ### Example
 //! ```no_run
 //! use std::str::FromStr;
 //!
@@ -192,7 +190,7 @@ fn main() -> Result<(), bdk::Error> {
 //! * `async-interface`: async functions in bdk traits
 //! * `keys-bip39`: [BIP-39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) mnemonic codes for generating deterministic keys
 //!
-//! ## Internal features
+//! # Internal features
 //!
 //! These features do not expose any new API, but influence internal implementation aspects of
 //! BDK.


### PR DESCRIPTION
### Description

This PR fixes the hierarchy of headers on the lib.rs docs. I noticed it as I was reading through the docs. The new hierarchy is the following:

- About (h1)
- A tour of BDK (h1)
- Examples (h1)
  - Sync the balance of a descriptor (h2)
  - Generate a few addresses (h2)
  - Create a transaction (h2)
  - Sign a transaction (h2)
- Feature flags (h1)
- Internal features (h1)

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
