### PR TITLE
Add support for custom sorting and deprecate BIP69

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed default verification from `wallet::sync`. sync-time verification is added in `script_sync` and is activated by `verify` feature flag.
 - `verify` flag removed from `TransactionDetails`.
+- Deprecated `TxOrdering::Bip69Lexicographic` and added `TxOrdering::Custom`.
 
 ## [v0.16.1] - [v0.16.0]
 

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -2145,6 +2145,7 @@ pub(crate) mod test {
         let (wallet, _, _) = get_funded_wallet(get_test_wpkh());
         let addr = wallet.get_address(New).unwrap();
         let mut builder = wallet.build_tx();
+        #[allow(deprecated)]
         builder
             .add_recipient(addr.script_pubkey(), 30_000)
             .add_recipient(addr.script_pubkey(), 10_000)


### PR DESCRIPTION
### Description

Resolves #534.

This PR adds a way to add custom sorting functions for both inputs and outputs. BIP69 is permanently deprecated.

### Notes to the reviewers

`Fn` was used instead of `FnMut` to reduce complexity, since it's inside an `Arc`. We can try supporting `FnMut` but that would also require us to use a `Mutex` and I'm not sure whether it's worth the added complexity.

Additionally, I cannot decide what kind of test will be good for this. Should I implement just a simple sort (like `a.value.cmp(&b.value)`) and test if it's in proper order?

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
