### PR TITLE
Add waste metric for coin selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- added `OldestFirstCoinSelection` impl to `CoinSelectionAlgorithm`
+- Added `OldestFirstCoinSelection` impl to `CoinSelectionAlgorithm`
 - New MSRV set to `1.56`
 - Unpinned tokio to `1`
 - Add traits to reuse `Blockchain`s across multiple wallets (`BlockchainFactory` and `StatelessBlockchain`).
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Signing Taproot PSBTs (key spend and script spend)
   - Support for `tr()` descriptors in the `descriptor!()` macro
 - Add support for Bitcoin Core 23.0 when using the `rpc` blockchain
+- Added `Waste` struct to `coinselection` module, with impl of
+  `Waste::calculate` to compute waste metric for coin selection algorithms.
+- Added `_cost_of_change` parameter for `CoinSelectionAlgorithm::coin_select`
+  to pass the cost of generating change to calculate the waste metric for each
+  algorithm.
+- Changed `OutputGroup` owned `weighted_utxo` value to borrowed one.
 
 ## [v0.18.0] - [v0.17.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for Bitcoin Core 23.0 when using the `rpc` blockchain
 - Added `Waste` struct to `coinselection` module, with impl of
   `Waste::calculate` to compute waste metric for coin selection algorithms.
-- Added `_cost_of_change` parameter for `CoinSelectionAlgorithm::coin_select`
-  to pass the cost of generating change to calculate the waste metric for each
-  algorithm.
+- Added new type `WeightedTxOut`. It joins a TxOut with the satisfaction weight
+  needed to spend it in the future.
+- Added new field `drain_output` to struct `CoinSelectionResult`. It'll hold
+  the created change output if needed.
+- Added `weighted_drain_output` parameter for
+  `CoinSelectionAlgorithm::coin_select` to pass the TxOut to drain the change
+  joined with the satisfaction weight to spend it in the future.
 - Changed `OutputGroup` owned `weighted_utxo` value to borrowed one.
 
 ## [v0.18.0] - [v0.17.0]

--- a/src/types.rs
+++ b/src/types.rs
@@ -147,6 +147,19 @@ pub struct WeightedUtxo {
     pub utxo: Utxo,
 }
 
+/// A [`TxOut`] with its `satisfaction_weight`, if it were spend by the wallet owning the produced
+/// UTXO from this TxOut.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WeightedTxOut {
+    /// The weight of the witness data and `scriptSig` expressed in [weight units]. This is used to
+    /// properly compute the cost of change for waste metric.
+    ///
+    /// [weight units]: https://en.bitcoin.it/wiki/Weight_units
+    pub satisfaction_weight: usize,
+    /// The TxOut
+    pub txout: TxOut,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 /// An unspent transaction output (UTXO).
 pub enum Utxo {

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -756,6 +756,8 @@ where
             fee_rate,
             outgoing,
             fee_amount,
+            // REVIEW: Add cost_of_change to TxParams
+            None,
         )?;
         let mut fee_amount = coin_selection.fee_amount;
 

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -749,6 +749,14 @@ where
             params.bumping_fee.is_some(), // we mandate confirmed transactions if we're bumping the fee
         )?;
 
+        let weighted_drain_txout = WeightedTxOut {
+            txout: TxOut {
+                value: 0,
+                script_pubkey: Script::new(),
+            },
+            satisfaction_weight: 0,
+        };
+
         let coin_selection = coin_selection.coin_select(
             self.database.borrow().deref(),
             required_utxos,
@@ -756,8 +764,7 @@ where
             fee_rate,
             outgoing,
             fee_amount,
-            // REVIEW: Add cost_of_change to TxParams
-            None,
+            weighted_drain_txout,
         )?;
         let mut fee_amount = coin_selection.fee_amount;
 


### PR DESCRIPTION
### Description

Waste is a metric introduced by the BnB algorithm as part of its bounding
procedure. Later, it was included as a high level function to use in comparison
of different coin selection algorithms in bitcoin/bitcoin#22009.

This implementations considers waste as the sum of two values:
* Timing cost
* Creation cost
> waste = timing_cost + creation_cost

---

**Timing cost** is the cost associated to the current fee rate and some long
term fee rate used as a treshold to consolidate UTXOs.
> timing_cost = txin_size * current_fee_rate - txin_size * long_term_fee_rate

Timing cost can be negative if the `current_fee_rate` is cheaper than the
`long_term_fee_rate`, or zero if they are equal.

The name of this cost is derived from the action of making bets against some
kind of market (in this case the fee market) to gain profits using the
interpretation of the future behaviour of that market based on a partial
information game.

---

**Creation cost** is the cost associated to the surplus of coins besides the
transaction amount and transaction fees. It can happen in the form of a change
output or in the form of excess fees paid to the miner.

Change cost is derived from the cost of adding the extra output to the
transaction and spending that output in the future.
> change_cost = current_fee_rate * change_output_size + long_term_feerate * change_spend_size

Excess happens when there is not change, and the surplus of coins is spend as
part of the fees to the miner:
> excess = tx_total_value - tx_fees - target

Where _target_ is the desired amount to send.

Creation cost can be zero if there is a perfect match as result of the coin
selection algorithm.

---

So, waste can be zero or negative if the creation cost is zero and the timing
cost is less than or equal to zero

Later this can be used in the wallet to select the most optimal coin selection
algorithm.

This PR continues the work initiated by @benthecarman in #435 and address some
of the features described in #483.

The current PR is based mainly in the following sources:
- [GetSelectionWaste](https://github.com/bitcoin/bitcoin/blob/master/src/wallet/coinselection.h#L201) from Bitcoin Core.
- Draft PR #435.
- Bitcoin Core PR Review Club [#22009](https://bitcoincore.reviews/22009).


<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

While running `cargo clippy` some warnings may arise due to the lack of
documentation of the new functions, those will be resolved once the code
changes are finished. The same applies for the `CHANGELOG.md` file.

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`
