### PR TITLE
Fix pre-segwit inputs with esplora

### DIFF
--- a/src/blockchain/esplora/api.rs
+++ b/src/blockchain/esplora/api.rs
@@ -17,7 +17,7 @@ pub struct Vin {
     // None if coinbase
     pub prevout: Option<PrevOut>,
     pub scriptsig: Script,
-    #[serde(deserialize_with = "deserialize_witness")]
+    #[serde(deserialize_with = "deserialize_witness", default)]
     pub witness: Vec<Vec<u8>>,
     pub sequence: u32,
     pub is_coinbase: bool,


### PR DESCRIPTION
Unexpectedly pre-segwit inputs have an empty JSON witness field in esplora.

Fixes #570 

* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
