### PR TITLE
updating tokio to 1.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ bitcoincore-rpc = { version = "0.14", optional = true }
 
 # Platform-specific dependencies
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "~1.14", features = ["rt"] }
+tokio = { version = "~1.17", features = ["rt"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 async-trait = "0.1"


### PR DESCRIPTION
### Description

updating tokio to 1.17

### Notes to the reviewers

We recently upgraded all our other stuff to 1.17 and it worked well with bdk up to 0.16. 
Now I tried upgrading bdk to 0.17 and got conflicts.
I'm not really keen on downgrading our application to use an older version of tokio. I couldn't observe any downsides or problems in bdk when using the newer version of tokio.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)