### PR TITLE
Deprecate Database::flush() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `sqlite-bundled` feature for deployments that need a bundled version of sqlite, ie. for mobile platforms.
 - Added `Wallet::get_signers()`, `Wallet::descriptor_checksum()` and `Wallet::get_address_validators()`, exposed the `AsDerived` trait.
+- Deprecate `database::Database::flush()`, the function is only needed for the sled database on mobile, instead for mobile use the sqlite database.
 
 ## [v0.17.0] - [v0.16.1]
 

--- a/src/database/any.rs
+++ b/src/database/any.rs
@@ -61,6 +61,7 @@ macro_rules! impl_from {
 
 macro_rules! impl_inner_method {
     ( $enum_name:ident, $self:expr, $name:ident $(, $args:expr)* ) => {
+        #[allow(deprecated)]
         match $self {
             $enum_name::Memory(inner) => inner.$name( $($args, )* ),
             #[cfg(feature = "key-value-db")]

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -159,6 +159,10 @@ pub trait Database: BatchOperations {
     /// It should insert and return `0` if not present in the database
     fn increment_last_index(&mut self, keychain: KeychainKind) -> Result<u32, Error>;
 
+    #[deprecated(
+        since = "0.18.0",
+        note = "The flush function is only needed for the sled database on mobile, instead for mobile use the sqlite database."
+    )]
     /// Force changes to be written to disk
     fn flush(&mut self) -> Result<(), Error>;
 }


### PR DESCRIPTION
### Description

The Database::flush() function is only needed for the sled database on mobile, instead for mobile use the sqlite database.

### Notes to the reviewers

This PR is in preparation for removing the Database::flush() function. See https://github.com/bitcoindevkit/bdk/pull/575#issuecomment-1082916667.

After the `release/0.18.0` feature freeze branch is created then #575 should be merged.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`

