### PR TITLE
Expose bip39::Error

### DIFF
--- a/src/keys/bip39.rs
+++ b/src/keys/bip39.rs
@@ -19,7 +19,7 @@ use bitcoin::Network;
 
 use miniscript::ScriptContext;
 
-pub use bip39::{Language, Mnemonic};
+pub use bip39::{Error, Language, Mnemonic};
 
 type Seed = [u8; 64];
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Expose `bip39::Error` (fixes #581 )

### Notes to the reviewers

I am aware that the `bip39` module plans to be rewritten (as per #561 ), however this seems like a rather straightforward and quick change that may be useful in the short/mid term.

### Checklists

#### Bugfixes:

* [x] Expose `bip39::Error`

