### PR TITLE
Caravan export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix hang when `ElectrumBlockchainConfig::stop_gap` is zero.
 - Set coin type in BIP44, BIP49, and BIP84 templates
 - Get block hash given a block height - A `get_block_hash` method is now defined on the `GetBlockHash` trait and implemented on every blockchain backend. This method expects a block height and returns the corresponding block hash. 
+- Add wallet::export::caravan module for importing and exporting Caravan configurations
 
 ## [v0.19.0] - [v0.18.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ lazy_static = "1.4"
 env_logger = "0.7"
 clap = "2.33"
 electrsd = "0.19.1"
+assert-json-diff = "2.0"
 
 [[example]]
 name = "address_validator"

--- a/src/wallet/export/caravan.rs
+++ b/src/wallet/export/caravan.rs
@@ -1,7 +1,7 @@
 // Bitcoin Dev Kit
 // Written in 2020 by Alekos Filini <alekos.filini@gmail.com>
 //
-// Copyright (c) 2020-2021 Bitcoin Dev Kit Developers
+// Copyright (c) 2020-2022 Bitcoin Dev Kit Developers
 //
 // This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
 // or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -9,7 +9,7 @@
 // You may not use this file except in accordance with one or both of these
 // licenses.
 
-//! Wallet export
+//! Caravan Wallet export
 //!
 //! This modules implements the wallet export format used by Unchained Capitals's [Caravan](https://github.com/unchained-capital/caravan).
 //!
@@ -53,8 +53,8 @@
 //!
 //! let import = CaravanExport::from_str(import)?;
 //! let wallet = Wallet::new(
-//!     import.descriptor()?,
-//!     None,
+//!     import.descriptor(KeychainKind::External)?,
+//!     Some(import.descriptor(KeychainKind::Internal)?),
 //!     import.network(),
 //!     MemoryDatabase::default(),
 //! )?;
@@ -69,7 +69,7 @@
 //! # use bdk::*;
 //! let wallet = Wallet::new(
 //!     "wsh(sortedmulti(2,[f57ec65d/48'/1'/100'/2']tpubDFc9Mm4tw6EkgR4YTC1GrU6CGEd9yw7KSBnSssL4LXAXh89D4uMZigRyv3csdXbeU3BhLQc4vWKTLewboA1Pt8Fu6fbHKu81MZ6VGdc32eM/0/*,[efa5d916/48'/1'/100'/2']tpubDErWN5qfdLwYE94mh12oWr4uURDDNKCjKVhCEcAgZ7jKnnAwq5tcTF2iEk3VuznkJuk2G8SCHft9gS6aKbBd18ptYWPqKLRSTRQY7e2rrDj/0/*))#nv5k65uf",
-//!     None,
+//!     Some("wsh(sortedmulti(2,[f57ec65d/48'/1'/100'/2']tpubDFc9Mm4tw6EkgR4YTC1GrU6CGEd9yw7KSBnSssL4LXAXh89D4uMZigRyv3csdXbeU3BhLQc4vWKTLewboA1Pt8Fu6fbHKu81MZ6VGdc32eM/1/*,[efa5d916/48'/1'/100'/2']tpubDErWN5qfdLwYE94mh12oWr4uURDDNKCjKVhCEcAgZ7jKnnAwq5tcTF2iEk3VuznkJuk2G8SCHft9gS6aKbBd18ptYWPqKLRSTRQY7e2rrDj/1/*))"),
 //!     Network::Testnet,
 //!     MemoryDatabase::default()
 //! )?;
@@ -136,21 +136,24 @@ impl CaravanExport {
         }
     }
     /// Get the descriptor value
-    pub fn descriptor(&self) -> Result<Descriptor<DescriptorPublicKey>, Error> {
+    pub fn descriptor(
+        &self,
+        keychain: KeychainKind,
+    ) -> Result<Descriptor<DescriptorPublicKey>, Error> {
         let required = self.quorum.required_signers;
         let network: Network = self.network();
 
         let result = match self.address_type {
             CaravanAddressType::P2sh => {
-                let keys: Vec<DescriptorKey<Legacy>> = self.descriptor_keys()?;
+                let keys: Vec<DescriptorKey<Legacy>> = self.descriptor_keys(keychain)?;
                 descriptor! { sh ( sortedmulti_vec(required, keys) ) }
             }
             CaravanAddressType::P2shP2wsh => {
-                let keys: Vec<DescriptorKey<Segwitv0>> = self.descriptor_keys()?;
+                let keys: Vec<DescriptorKey<Segwitv0>> = self.descriptor_keys(keychain)?;
                 descriptor! { sh ( wsh ( sortedmulti_vec(required, keys) ) ) }
             }
             CaravanAddressType::P2wsh => {
-                let keys: Vec<DescriptorKey<Segwitv0>> = self.descriptor_keys()?;
+                let keys: Vec<DescriptorKey<Segwitv0>> = self.descriptor_keys(keychain)?;
                 descriptor! { wsh ( sortedmulti_vec(required, keys) ) }
             }
         }
@@ -173,6 +176,7 @@ impl CaravanExport {
 
     fn descriptor_keys<Ctx: ScriptContext>(
         &self,
+        keychain: KeychainKind,
     ) -> Result<Vec<DescriptorKey<Ctx>>, DescriptorError> {
         let result = self
             .extended_public_keys
@@ -181,25 +185,16 @@ impl CaravanExport {
                 let fingerprint = k.xfp;
                 let key_path = k.bip32_path.clone();
                 let key_source = fingerprint.zip(key_path);
-                let derivation_path =
-                    DerivationPath::master().child(ChildNumber::Normal { index: 0 });
+                let keychain_index = keychain as u32;
+                let derivation_path = DerivationPath::master().child(ChildNumber::Normal {
+                    index: keychain_index,
+                });
                 k.xpub
                     .into_descriptor_key(key_source, derivation_path)
                     .map_err(|e| DescriptorError::Key(e))
             })
             .collect();
         result
-    }
-
-    fn parse_sorted_multi<Pk: MiniscriptKey, Ctx: ScriptContext>(
-        sorted_multi: &SortedMultiVec<Pk, Ctx>,
-    ) -> (Quorum, &[Pk]) {
-        let quorum = Quorum {
-            required_signers: sorted_multi.k,
-            total_signers: sorted_multi.pks.len(),
-        };
-        let extended_public_keys = sorted_multi.pks.as_slice();
-        (quorum, extended_public_keys)
     }
 
     /// Export BDK wallet configuration as a Caravan configuration
@@ -209,99 +204,182 @@ impl CaravanExport {
         client_type: String,
     ) -> Result<Self, Error> {
         let network = wallet.network;
-        let descriptor = wallet.get_descriptor_for_keychain(KeychainKind::External);
-        if wallet.change_descriptor.is_none() {
-            Self::export(network, descriptor, name, client_type)
-        } else {
-            Err(Error::Generic(
-                "Can not export a wallet with a change descriptor to Caravan.".to_string(),
-            ))
+        let external_descriptor = wallet.get_descriptor_for_keychain(KeychainKind::External);
+        match &wallet.change_descriptor {
+            None => Err(Error::Generic(
+                "Wallet must have an internal descriptor".to_string(),
+            )),
+            Some(internal_descriptor) => {
+                Self::export(
+                    network,
+                    external_descriptor,
+                    internal_descriptor,
+                    name,
+                    client_type,
+                )
+            }
         }
     }
 
     /// Export BDK wallet network and descriptor as a Caravan configuration
     pub fn export(
         network: Network,
-        descriptor: &Descriptor<DescriptorPublicKey>,
+        external_descriptor: &Descriptor<DescriptorPublicKey>,
+        internal_descriptor: &Descriptor<DescriptorPublicKey>,
         name: String,
         client_type: String,
     ) -> Result<Self, Error> {
-        let (address_type, quorum, descriptor_public_keys) = match descriptor {
-            Descriptor::Sh(sh) => match sh.as_inner() {
-                ShInner::SortedMulti(smv) => {
-                    let (quorum, extended_public_keys) = CaravanExport::parse_sorted_multi(smv);
-                    Ok((CaravanAddressType::P2sh, quorum, extended_public_keys))
-                }
-                ShInner::Wsh(wsh) => match wsh.as_inner() {
-                    WshInner::SortedMulti(smv) => {
-                        let (quorum, extended_public_keys) = CaravanExport::parse_sorted_multi(smv);
-                        Ok((CaravanAddressType::P2shP2wsh, quorum, extended_public_keys))
-                    }
-                    _ => Err(Error::Generic(
-                        "Unsupported sh(wsh()) inner descriptor.".to_string(),
-                    )),
-                },
-                _ => Err(Error::Generic(
-                    "Unsupported sh() inner descriptor.".to_string(),
-                )),
-            },
-            Descriptor::Wsh(sh) => match sh.as_inner() {
-                WshInner::SortedMulti(smv) => {
-                    let (quorum, extended_public_keys) = CaravanExport::parse_sorted_multi(smv);
-                    Ok((CaravanAddressType::P2wsh, quorum, extended_public_keys))
-                }
-                _ => Err(Error::Generic(
-                    "Unsupported wsh() inner descriptor.".to_string(),
-                )),
-            },
-            _ => Err(Error::Generic(
-                "Unsupported top level descriptor.".to_string(),
-            )),
-        }?;
+        let (external_address_type, external_quorum, external_public_keys) =
+            parse_descriptor(external_descriptor)?;
+        let (internal_address_type, internal_quorum, internal_public_keys) =
+            parse_descriptor(internal_descriptor)?;
+
+        // verify external and internal address types match
+        if external_address_type != internal_address_type {
+            return Err(Error::Generic(
+                "External and internal descriptor address type configs don't match.".to_string(),
+            ));
+        }
+
+        // verify external and internal descriptor configs match
+        if external_quorum != internal_quorum {
+            return Err(Error::Generic(
+                "External and internal descriptor quorum configs don't match.".to_string(),
+            ));
+        }
+
+        // verify internal and external descriptor keys match except ends with m/(0|1)/*
+        for (external_key, internal_key) in
+            external_public_keys.iter().zip(internal_public_keys.iter())
+        {
+            let ex_caravan_key = parse_key(external_key)?;
+            let in_caravan_key = parse_key(internal_key)?;
+            if ex_caravan_key.bip32_path != in_caravan_key.bip32_path {
+                return Err(Error::Generic(
+                    "External and internal keys have different bip32_path".to_string(),
+                ));
+            }
+            if ex_caravan_key.xfp != in_caravan_key.xfp {
+                return Err(Error::Generic(
+                    "External and internal keys have different xfp".to_string(),
+                ));
+            }
+            if ex_caravan_key.xpub_last_index != 0 {
+                return Err(Error::Generic(
+                    "External keys last normal index must be 0".to_string(),
+                ));
+            }
+            if in_caravan_key.xpub_last_index != 1 {
+                return Err(Error::Generic(
+                    "Internal keys last normal index must be 0".to_string(),
+                ));
+            }
+        }
 
         let network = match network {
             Network::Bitcoin => CaravanNetwork::Mainnet,
             _ => CaravanNetwork::Testnet,
         };
         let client = CaravanClient { value: client_type };
-        let extended_public_keys = descriptor_public_keys
+        let extended_public_keys = external_public_keys
             .iter()
-            .map(|k| match k {
-                DescriptorPublicKey::SinglePub(_) => {
-                    Err(Error::Generic("Unsupported single pub key.".to_string()))
-                }
-                DescriptorPublicKey::XPub(xpub) => {
-                    let mut xfp = None;
-                    let mut bip32_path = None;
-                    if let Some((s_xfp, s_bip32_path)) = xpub.clone().origin {
-                        xfp = Some(s_xfp);
-                        bip32_path = Some(s_bip32_path);
-                    }
-                    Ok(CaravanExtendedPublicKey {
-                        name: xpub.xkey.fingerprint().to_string(),
-                        bip32_path,
-                        xpub: xpub.xkey,
-                        xfp,
-                    })
-                }
-            })
+            .map(|pubkey| parse_key(pubkey))
             .flatten()
             .collect();
 
         Ok(Self {
             name,
-            address_type,
+            address_type: external_address_type,
             network,
             client,
-            quorum,
+            quorum: external_quorum,
             extended_public_keys,
             starting_address_index: 0,
         })
     }
 }
 
+fn parse_sorted_multi<Pk: MiniscriptKey, Ctx: ScriptContext>(
+    sorted_multi: &SortedMultiVec<Pk, Ctx>,
+) -> (Quorum, &[Pk]) {
+    let quorum = Quorum {
+        required_signers: sorted_multi.k,
+        total_signers: sorted_multi.pks.len(),
+    };
+    let extended_public_keys = sorted_multi.pks.as_slice();
+    (quorum, extended_public_keys)
+}
+
+fn parse_descriptor(
+    descriptor: &Descriptor<DescriptorPublicKey>,
+) -> Result<(CaravanAddressType, Quorum, &[DescriptorPublicKey]), Error> {
+    match descriptor {
+        Descriptor::Sh(sh) => match sh.as_inner() {
+            ShInner::SortedMulti(sorted_multi) => {
+                let (quorum, extended_public_keys) = parse_sorted_multi(sorted_multi);
+                Ok((CaravanAddressType::P2sh, quorum, extended_public_keys))
+            }
+            ShInner::Wsh(wsh) => match wsh.as_inner() {
+                WshInner::SortedMulti(sorted_multi) => {
+                    let (quorum, extended_public_keys) = parse_sorted_multi(sorted_multi);
+                    Ok((CaravanAddressType::P2shP2wsh, quorum, extended_public_keys))
+                }
+                _ => Err(Error::Generic(
+                    "Unsupported sh(wsh()) inner descriptor.".to_string(),
+                )),
+            },
+            _ => Err(Error::Generic(
+                "Unsupported sh() inner descriptor.".to_string(),
+            )),
+        },
+        Descriptor::Wsh(sh) => match sh.as_inner() {
+            WshInner::SortedMulti(smv) => {
+                let (quorum, extended_public_keys) = parse_sorted_multi(smv);
+                Ok((CaravanAddressType::P2wsh, quorum, extended_public_keys))
+            }
+            _ => Err(Error::Generic(
+                "Unsupported wsh() inner descriptor.".to_string(),
+            )),
+        },
+        _ => Err(Error::Generic(
+            "Unsupported top level descriptor.".to_string(),
+        )),
+    }
+}
+
+fn parse_key(pubkey: &DescriptorPublicKey) -> Result<CaravanExtendedPublicKey, Error> {
+    match pubkey {
+        DescriptorPublicKey::SinglePub(_) => {
+            Err(Error::Generic("Unsupported single pub key.".to_string()))
+        }
+        DescriptorPublicKey::XPub(xpub) => {
+            let mut xfp = None;
+            let mut bip32_path = None;
+            if let Some((s_xfp, s_bip32_path)) = xpub.origin.clone() {
+                xfp = Some(s_xfp);
+                bip32_path = Some(s_bip32_path);
+            }
+            let xpub_index = xpub.derivation_path.len() - 1;
+            let xpub_last_child = xpub.derivation_path[xpub_index];
+            let xpub_last_index = match xpub_last_child {
+                ChildNumber::Normal { index } => index,
+                ChildNumber::Hardened { .. } => {
+                    return Err(Error::Generic("Last key index must be normal.".to_string()))
+                }
+            };
+            Ok(CaravanExtendedPublicKey {
+                name: xpub.xkey.fingerprint().to_string(),
+                bip32_path,
+                xpub: xpub.xkey,
+                xfp,
+                xpub_last_index,
+            })
+        }
+    }
+}
+
 /// The address types supported by Caravan
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub enum CaravanAddressType {
     /// P2SH
     #[serde(rename = "P2SH")]
@@ -331,7 +409,7 @@ pub struct CaravanClient {
 }
 
 /// The quorum of signers required and total signers
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct Quorum {
     #[serde(rename = "requiredSigners")]
     required_signers: usize,
@@ -347,6 +425,8 @@ pub struct CaravanExtendedPublicKey {
     bip32_path: Option<DerivationPath>,
     xpub: ExtendedPubKey,
     xfp: Option<Fingerprint>,
+    #[serde(skip, default)]
+    xpub_last_index: u32,
 }
 
 impl ToString for CaravanExport {
@@ -377,12 +457,22 @@ mod test {
 
     fn test_import(import_json: &str, expected_addresses: Vec<&str>) {
         let import = CaravanExport::from_str(import_json).expect("import");
-        let descriptor = import.descriptor().expect("descriptor");
+        let external_descriptor = import
+            .descriptor(KeychainKind::External)
+            .expect("external descriptor");
+        println!("external descriptor: {}", external_descriptor);
+        let internal_descriptor = import
+            .descriptor(KeychainKind::Internal)
+            .expect("internal descriptor");
+        println!("internal descriptor: {}", internal_descriptor);
 
-        println!("descriptor: {}", descriptor);
-
-        let wallet =
-            Wallet::new(descriptor, None, import.network(), MemoryDatabase::new()).expect("wallet");
+        let wallet = Wallet::new(
+            external_descriptor,
+            Some(internal_descriptor),
+            import.network(),
+            MemoryDatabase::new(),
+        )
+        .expect("wallet");
 
         for (index, expected_address) in expected_addresses.iter().enumerate() {
             let expected_address = Address::from_str(expected_address).expect("address");
@@ -396,9 +486,20 @@ mod test {
         }
     }
 
-    fn test_export(network: Network, descriptor: &str, name: &str, expected_export_json: &str) {
-        let wallet =
-            Wallet::new(descriptor, None, network, MemoryDatabase::default()).expect("wallet");
+    fn test_export(
+        network: Network,
+        external_descriptor: &str,
+        internal_descriptor: &str,
+        name: &str,
+        expected_export_json: &str,
+    ) {
+        let wallet = Wallet::new(
+            external_descriptor,
+            Some(internal_descriptor),
+            network,
+            MemoryDatabase::default(),
+        )
+        .expect("wallet");
 
         let export = CaravanExport::export_wallet(&wallet, name.to_string(), "public".to_string())
             .expect("export");
@@ -453,7 +554,9 @@ mod test {
 
     #[test]
     fn test_export_p2sh_m() {
-        let descriptor = "sh(sortedmulti(2,[f57ec65d/45'/0'/100']xpub6CCHViYn5VzPfSR7baop9FtGcbm3UnqHwa54Z2eNvJnRFCJCdo9HtCYoLJKZCoATMLUowDDA1BMGfQGauY3fDYU3HyMzX4NDkoLYCSkLpbH/0/*,[efa5d916/45'/0'/100']xpub6Ca5CwTgRASgkXbXE5TeddTP9mPCbYHreCpmGt9dhz9y6femstHGCoFESHHKKRcm414xMKnuLjP9LDS7TwaJC9n5gxua6XB1rwPcC6hqDub/0/*))#uxj9xxul";
+        let external_descriptor = "sh(sortedmulti(2,[f57ec65d/45'/0'/100']xpub6CCHViYn5VzPfSR7baop9FtGcbm3UnqHwa54Z2eNvJnRFCJCdo9HtCYoLJKZCoATMLUowDDA1BMGfQGauY3fDYU3HyMzX4NDkoLYCSkLpbH/0/*,[efa5d916/45'/0'/100']xpub6Ca5CwTgRASgkXbXE5TeddTP9mPCbYHreCpmGt9dhz9y6femstHGCoFESHHKKRcm414xMKnuLjP9LDS7TwaJC9n5gxua6XB1rwPcC6hqDub/0/*))#uxj9xxul";
+        let internal_descriptor = "sh(sortedmulti(2,[f57ec65d/45'/0'/100']xpub6CCHViYn5VzPfSR7baop9FtGcbm3UnqHwa54Z2eNvJnRFCJCdo9HtCYoLJKZCoATMLUowDDA1BMGfQGauY3fDYU3HyMzX4NDkoLYCSkLpbH/1/*,[efa5d916/45'/0'/100']xpub6Ca5CwTgRASgkXbXE5TeddTP9mPCbYHreCpmGt9dhz9y6femstHGCoFESHHKKRcm414xMKnuLjP9LDS7TwaJC9n5gxua6XB1rwPcC6hqDub/1/*))#3hxf9z66";
+
         let name = "P2SH-M";
 
         // NOTE: .extendedPublicKeys[].name fields are set to key hash and are not expected
@@ -483,7 +586,13 @@ mod test {
           "startingAddressIndex": 0
         }"#;
 
-        test_export(Network::Bitcoin, descriptor, name, expected_export_json);
+        test_export(
+            Network::Bitcoin,
+            external_descriptor,
+            internal_descriptor,
+            name,
+            expected_export_json,
+        );
     }
 
     #[test]
@@ -528,7 +637,8 @@ mod test {
 
     #[test]
     fn test_export_p2sh_t() {
-        let descriptor = "sh(sortedmulti(2,[efa5d916/45'/1'/100']tpubDDinbKDXyddTUKcX6mv936Ux5utCJteq5S6EEKhfpM8CqN2rMAcccv6GecsB3cPt8eGL4e4K2eaZ9Jis9TGf7mbwBsRTN7ngnFR7yJZxBKC/0/*,[f57ec65d/45'/1'/100']tpubDDQubdBx9cbwQtdcRTisKF7wVCwHgHewhU7wh77VzCi62Q9q81qyQeLoZjKWZ62FnQbWU8k7CuKo2A21pAWaFtPGDHP9WuhtAx4smcCxqn1/0/*))#e4qrgzdy";
+        let external_descriptor = "sh(sortedmulti(2,[efa5d916/45'/1'/100']tpubDDinbKDXyddTUKcX6mv936Ux5utCJteq5S6EEKhfpM8CqN2rMAcccv6GecsB3cPt8eGL4e4K2eaZ9Jis9TGf7mbwBsRTN7ngnFR7yJZxBKC/0/*,[f57ec65d/45'/1'/100']tpubDDQubdBx9cbwQtdcRTisKF7wVCwHgHewhU7wh77VzCi62Q9q81qyQeLoZjKWZ62FnQbWU8k7CuKo2A21pAWaFtPGDHP9WuhtAx4smcCxqn1/0/*))#e4qrgzdy";
+        let internal_descriptor = "sh(sortedmulti(2,[efa5d916/45'/1'/100']tpubDDinbKDXyddTUKcX6mv936Ux5utCJteq5S6EEKhfpM8CqN2rMAcccv6GecsB3cPt8eGL4e4K2eaZ9Jis9TGf7mbwBsRTN7ngnFR7yJZxBKC/1/*,[f57ec65d/45'/1'/100']tpubDDQubdBx9cbwQtdcRTisKF7wVCwHgHewhU7wh77VzCi62Q9q81qyQeLoZjKWZ62FnQbWU8k7CuKo2A21pAWaFtPGDHP9WuhtAx4smcCxqn1/1/*))#5y50txtp";
         let name = "P2SH-T";
 
         // NOTE: .extendedPublicKeys[].name fields are set to key hash and are not expected
@@ -558,7 +668,13 @@ mod test {
           "startingAddressIndex": 0
         }"#;
 
-        test_export(Network::Testnet, descriptor, name, expected_export_json);
+        test_export(
+            Network::Testnet,
+            external_descriptor,
+            internal_descriptor,
+            name,
+            expected_export_json,
+        );
     }
 
     #[test]
@@ -603,7 +719,8 @@ mod test {
 
     #[test]
     fn test_export_p2sh_p2wsh_m() {
-        let descriptor = "sh(wsh(sortedmulti(2,[efa5d916/48'/0'/100'/1']xpub6EwJjKaiocGvo9f7XSGXGwzo1GLB1URxSZ5Ccp1wqdxNkhrSoqNQkC2CeMsU675urdmFJLHSX62xz56HGcnn6u21wRy6uipovmzaE65PfBp/0/*,[f57ec65d/48'/0'/100'/1']xpub6DcqYQxnbefzEBJF6osEuT5yXoHVZu1YCCsS5YkATvqD2h7tdMBgdBrUXk26FrJwawDGX6fHKPvhhZxKc5b8dPAPb8uANDhsjAPMJqTFDjH/0/*)))#jeqfd8lr";
+        let external_descriptor = "sh(wsh(sortedmulti(2,[efa5d916/48'/0'/100'/1']xpub6EwJjKaiocGvo9f7XSGXGwzo1GLB1URxSZ5Ccp1wqdxNkhrSoqNQkC2CeMsU675urdmFJLHSX62xz56HGcnn6u21wRy6uipovmzaE65PfBp/0/*,[f57ec65d/48'/0'/100'/1']xpub6DcqYQxnbefzEBJF6osEuT5yXoHVZu1YCCsS5YkATvqD2h7tdMBgdBrUXk26FrJwawDGX6fHKPvhhZxKc5b8dPAPb8uANDhsjAPMJqTFDjH/0/*)))#jeqfd8lr";
+        let internal_descriptor = "sh(wsh(sortedmulti(2,[efa5d916/48'/0'/100'/1']xpub6EwJjKaiocGvo9f7XSGXGwzo1GLB1URxSZ5Ccp1wqdxNkhrSoqNQkC2CeMsU675urdmFJLHSX62xz56HGcnn6u21wRy6uipovmzaE65PfBp/1/*,[f57ec65d/48'/0'/100'/1']xpub6DcqYQxnbefzEBJF6osEuT5yXoHVZu1YCCsS5YkATvqD2h7tdMBgdBrUXk26FrJwawDGX6fHKPvhhZxKc5b8dPAPb8uANDhsjAPMJqTFDjH/1/*)))#j58fg4ec";
         let name = "P2SH-P2WSH-M";
 
         // NOTE: .extendedPublicKeys[].name fields are set to key hash and are not expected
@@ -633,7 +750,13 @@ mod test {
           "startingAddressIndex": 0
         }"#;
 
-        test_export(Network::Bitcoin, descriptor, name, expected_export_json);
+        test_export(
+            Network::Bitcoin,
+            external_descriptor,
+            internal_descriptor,
+            name,
+            expected_export_json,
+        );
     }
 
     #[test]
@@ -678,7 +801,8 @@ mod test {
 
     #[test]
     fn test_export_p2sh_p2wsh_t() {
-        let descriptor = "sh(wsh(sortedmulti(2,[f57ec65d/48'/1'/100'/1']tpubDFc9Mm4tw6EkdXuk24MnQYRrDsdKEFh498vFffqa2KJmxytpcHbWrcFYwTKAdLxkSWpadzb5M5VVZ7PDAUjDjymvUmQ7pBbRecz2FM952Am/0/*,[efa5d916/48'/1'/100'/1']tpubDErWN5qfdLwY9ZJo9HWpxjcuEFuEBVHSbQbPqF35LQr3etWNGirKcgAa93DZ4DmtHm36p2gTf4aj6KybLqHaS3UePM5LtPqtb3d3dYVDs2F/0/*)))#j7jzgtur";
+        let external_descriptor = "sh(wsh(sortedmulti(2,[f57ec65d/48'/1'/100'/1']tpubDFc9Mm4tw6EkdXuk24MnQYRrDsdKEFh498vFffqa2KJmxytpcHbWrcFYwTKAdLxkSWpadzb5M5VVZ7PDAUjDjymvUmQ7pBbRecz2FM952Am/0/*,[efa5d916/48'/1'/100'/1']tpubDErWN5qfdLwY9ZJo9HWpxjcuEFuEBVHSbQbPqF35LQr3etWNGirKcgAa93DZ4DmtHm36p2gTf4aj6KybLqHaS3UePM5LtPqtb3d3dYVDs2F/0/*)))#j7jzgtur";
+        let internal_descriptor = "sh(wsh(sortedmulti(2,[f57ec65d/48'/1'/100'/1']tpubDFc9Mm4tw6EkdXuk24MnQYRrDsdKEFh498vFffqa2KJmxytpcHbWrcFYwTKAdLxkSWpadzb5M5VVZ7PDAUjDjymvUmQ7pBbRecz2FM952Am/1/*,[efa5d916/48'/1'/100'/1']tpubDErWN5qfdLwY9ZJo9HWpxjcuEFuEBVHSbQbPqF35LQr3etWNGirKcgAa93DZ4DmtHm36p2gTf4aj6KybLqHaS3UePM5LtPqtb3d3dYVDs2F/1/*)))#jn4zde6c";
         let name = "P2SH-P2WSH-T";
 
         // NOTE: .extendedPublicKeys[].name fields are set to key hash and are not expected
@@ -708,7 +832,13 @@ mod test {
           "startingAddressIndex": 0
         }"#;
 
-        test_export(Network::Testnet, descriptor, name, expected_export_json);
+        test_export(
+            Network::Testnet,
+            external_descriptor,
+            internal_descriptor,
+            name,
+            expected_export_json,
+        );
     }
 
     #[test]
@@ -753,7 +883,8 @@ mod test {
 
     #[test]
     fn test_export_p2wsh_m() {
-        let descriptor = "wsh(sortedmulti(2,[efa5d916/48'/0'/100'/2']xpub6EwJjKaiocGvqSuM2jRZSuQ9HEddiFUFu9RdjE47zG7kXVNDQpJ3GyvskwYiLmvU4SBTNZyv8UH53QcmFEE23YwozE61V3dwzZJEFQr6H2b/0/*,[f57ec65d/48'/0'/100'/2']xpub6DcqYQxnbefzFkaRBK63FSE2GzNuNnNhFGw1xV9RioVG7av6r3JDf1aELqBSq5gt5487CtNxvVtaiJjQU2HQWzgG5NzLyTPbYav6otW8qEc/0/*))#decr929e";
+        let external_descriptor = "wsh(sortedmulti(2,[efa5d916/48'/0'/100'/2']xpub6EwJjKaiocGvqSuM2jRZSuQ9HEddiFUFu9RdjE47zG7kXVNDQpJ3GyvskwYiLmvU4SBTNZyv8UH53QcmFEE23YwozE61V3dwzZJEFQr6H2b/0/*,[f57ec65d/48'/0'/100'/2']xpub6DcqYQxnbefzFkaRBK63FSE2GzNuNnNhFGw1xV9RioVG7av6r3JDf1aELqBSq5gt5487CtNxvVtaiJjQU2HQWzgG5NzLyTPbYav6otW8qEc/0/*))#decr929e";
+        let internal_descriptor = "wsh(sortedmulti(2,[efa5d916/48'/0'/100'/2']xpub6EwJjKaiocGvqSuM2jRZSuQ9HEddiFUFu9RdjE47zG7kXVNDQpJ3GyvskwYiLmvU4SBTNZyv8UH53QcmFEE23YwozE61V3dwzZJEFQr6H2b/1/*,[f57ec65d/48'/0'/100'/2']xpub6DcqYQxnbefzFkaRBK63FSE2GzNuNnNhFGw1xV9RioVG7av6r3JDf1aELqBSq5gt5487CtNxvVtaiJjQU2HQWzgG5NzLyTPbYav6otW8qEc/1/*))#wj94h3at";
         let name = "P2WSH-M";
 
         // NOTE: .extendedPublicKeys[].name fields are set to key hash and are not expected
@@ -783,7 +914,13 @@ mod test {
           "startingAddressIndex": 0
         }"#;
 
-        test_export(Network::Bitcoin, descriptor, name, expected_export_json);
+        test_export(
+            Network::Bitcoin,
+            external_descriptor,
+            internal_descriptor,
+            name,
+            expected_export_json,
+        );
     }
 
     #[test]
@@ -828,7 +965,8 @@ mod test {
 
     #[test]
     fn test_export_p2wsh_t() {
-        let descriptor = "wsh(sortedmulti(2,[f57ec65d/48'/1'/100'/2']tpubDFc9Mm4tw6EkgR4YTC1GrU6CGEd9yw7KSBnSssL4LXAXh89D4uMZigRyv3csdXbeU3BhLQc4vWKTLewboA1Pt8Fu6fbHKu81MZ6VGdc32eM/0/*,[efa5d916/48'/1'/100'/2']tpubDErWN5qfdLwYE94mh12oWr4uURDDNKCjKVhCEcAgZ7jKnnAwq5tcTF2iEk3VuznkJuk2G8SCHft9gS6aKbBd18ptYWPqKLRSTRQY7e2rrDj/0/*))#nv5k65uf";
+        let external_descriptor = "wsh(sortedmulti(2,[f57ec65d/48'/1'/100'/2']tpubDFc9Mm4tw6EkgR4YTC1GrU6CGEd9yw7KSBnSssL4LXAXh89D4uMZigRyv3csdXbeU3BhLQc4vWKTLewboA1Pt8Fu6fbHKu81MZ6VGdc32eM/0/*,[efa5d916/48'/1'/100'/2']tpubDErWN5qfdLwYE94mh12oWr4uURDDNKCjKVhCEcAgZ7jKnnAwq5tcTF2iEk3VuznkJuk2G8SCHft9gS6aKbBd18ptYWPqKLRSTRQY7e2rrDj/0/*))#nv5k65uf";
+        let internal_descriptor = "wsh(sortedmulti(2,[f57ec65d/48'/1'/100'/2']tpubDFc9Mm4tw6EkgR4YTC1GrU6CGEd9yw7KSBnSssL4LXAXh89D4uMZigRyv3csdXbeU3BhLQc4vWKTLewboA1Pt8Fu6fbHKu81MZ6VGdc32eM/1/*,[efa5d916/48'/1'/100'/2']tpubDErWN5qfdLwYE94mh12oWr4uURDDNKCjKVhCEcAgZ7jKnnAwq5tcTF2iEk3VuznkJuk2G8SCHft9gS6aKbBd18ptYWPqKLRSTRQY7e2rrDj/1/*))#s8fqg0ym";
         let name = "P2WSH-T";
 
         // NOTE: .extendedPublicKeys[].name fields are set to key hash and are not expected
@@ -858,6 +996,12 @@ mod test {
           "startingAddressIndex": 0
         }"#;
 
-        test_export(Network::Testnet, descriptor, name, expected_export_json);
+        test_export(
+            Network::Testnet,
+            external_descriptor,
+            internal_descriptor,
+            name,
+            expected_export_json,
+        );
     }
 }

--- a/src/wallet/export/caravan.rs
+++ b/src/wallet/export/caravan.rs
@@ -11,7 +11,7 @@
 
 //! Wallet export
 //!
-//! This modules implements the wallet export format used by [FullyNoded](https://github.com/Fonta1n3/FullyNoded/blob/10b7808c8b929b171cca537fb50522d015168ac9/Docs/Wallets/Wallet-Export-Spec.md).
+//! This modules implements the wallet export format used by Unchained Capitals's [Caravan](https://github.com/unchained-capital/caravan).
 //!
 //! ## Examples
 //!
@@ -21,19 +21,41 @@
 //! # use std::str::FromStr;
 //! # use bitcoin::*;
 //! # use bdk::database::*;
-//! # use bdk::wallet::fully_noded::*;
+//! # use bdk::wallet::export::caravan::*;
 //! # use bdk::*;
 //! let import = r#"{
-//!     "descriptor": "wpkh([c258d2e4\/84h\/1h\/0h]tpubDD3ynpHgJQW8VvWRzQ5WFDCrs4jqVFGHB3vLC3r49XHJSqP8bHKdK4AriuUKLccK68zfzowx7YhmDN8SiSkgCDENUFx9qVw65YyqM78vyVe\/0\/*)",
-//!     "blockheight":1782088,
-//!     "label":"testnet"
+//!   "name": "P2WSH-T",
+//!   "addressType": "P2WSH",
+//!   "network": "testnet",
+//!   "client":  {
+//!     "type": "public"
+//!   },
+//!   "quorum": {
+//!     "requiredSigners": 2,
+//!     "totalSigners": 2
+//!   },
+//!   "extendedPublicKeys": [
+//!     {
+//!         "name": "osw",
+//!         "bip32Path": "m/48'/1'/100'/2'",
+//!         "xpub": "tpubDFc9Mm4tw6EkgR4YTC1GrU6CGEd9yw7KSBnSssL4LXAXh89D4uMZigRyv3csdXbeU3BhLQc4vWKTLewboA1Pt8Fu6fbHKu81MZ6VGdc32eM",
+//!         "xfp" : "f57ec65d"
+//!       },
+//!     {
+//!         "name": "d",
+//!         "bip32Path": "m/48'/1'/100'/2'",
+//!         "xpub": "tpubDErWN5qfdLwYE94mh12oWr4uURDDNKCjKVhCEcAgZ7jKnnAwq5tcTF2iEk3VuznkJuk2G8SCHft9gS6aKbBd18ptYWPqKLRSTRQY7e2rrDj",
+//!         "xfp" : "efa5d916"
+//!       }
+//!   ],
+//!   "startingAddressIndex": 0
 //! }"#;
 //!
-//! let import = FullyNodedExport::from_str(import)?;
+//! let import = CaravanExport::from_str(import)?;
 //! let wallet = Wallet::new(
-//!     &import.descriptor(),
-//!     import.change_descriptor().as_ref(),
-//!     Network::Testnet,
+//!     import.descriptor()?,
+//!     None,
+//!     import.network(),
 //!     MemoryDatabase::default(),
 //! )?;
 //! # Ok::<_, bdk::Error>(())
@@ -43,17 +65,21 @@
 //! ```
 //! # use bitcoin::*;
 //! # use bdk::database::*;
-//! # use bdk::wallet::fully_noded::*;
+//! # use bdk::wallet::export::caravan::*;
 //! # use bdk::*;
 //! let wallet = Wallet::new(
-//!     "wpkh([c258d2e4/84h/1h/0h]tpubDD3ynpHgJQW8VvWRzQ5WFDCrs4jqVFGHB3vLC3r49XHJSqP8bHKdK4AriuUKLccK68zfzowx7YhmDN8SiSkgCDENUFx9qVw65YyqM78vyVe/0/*)",
-//!     Some("wpkh([c258d2e4/84h/1h/0h]tpubDD3ynpHgJQW8VvWRzQ5WFDCrs4jqVFGHB3vLC3r49XHJSqP8bHKdK4AriuUKLccK68zfzowx7YhmDN8SiSkgCDENUFx9qVw65YyqM78vyVe/1/*)"),
+//!     "wsh(sortedmulti(2,[f57ec65d/48'/1'/100'/2']tpubDFc9Mm4tw6EkgR4YTC1GrU6CGEd9yw7KSBnSssL4LXAXh89D4uMZigRyv3csdXbeU3BhLQc4vWKTLewboA1Pt8Fu6fbHKu81MZ6VGdc32eM/0/*,[efa5d916/48'/1'/100'/2']tpubDErWN5qfdLwYE94mh12oWr4uURDDNKCjKVhCEcAgZ7jKnnAwq5tcTF2iEk3VuznkJuk2G8SCHft9gS6aKbBd18ptYWPqKLRSTRQY7e2rrDj/0/*))#nv5k65uf",
+//!     None,
 //!     Network::Testnet,
 //!     MemoryDatabase::default()
 //! )?;
-//! let export = FullyNodedExport::export_wallet(&wallet, "exported wallet", true)
-//!     .map_err(ToString::to_string)
-//!     .map_err(bdk::Error::Generic)?;
+//!
+//! let name = "P2WSH-T".to_string();
+//! let client = "public".to_string();
+//! let network = wallet.network();
+//! let descriptor = wallet.get_descriptor_for_keychain(KeychainKind::External);
+//!
+//! let export = CaravanExport::export(name, client, network, &descriptor)?;
 //!
 //! println!("Exported: {}", export.to_string());
 //! # Ok::<_, bdk::Error>(())
@@ -63,12 +89,16 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
-use miniscript::descriptor::{ShInner, WshInner};
-use miniscript::{Descriptor, ScriptContext, Terminal};
+use crate::bitcoin::util::bip32::{ChildNumber, DerivationPath, ExtendedPubKey, Fingerprint};
+use crate::bitcoin::Network;
+use miniscript::{Descriptor, ScriptContext};
 
-use crate::database::BatchDatabase;
-use crate::types::KeychainKind;
-use crate::wallet::Wallet;
+use crate::descriptor;
+use crate::descriptor::{DescriptorError, DescriptorPublicKey, Legacy, Segwitv0};
+use crate::error::Error;
+use crate::keys::{DerivableKey, DescriptorKey, SortedMultiVec};
+use crate::miniscript::descriptor::{ShInner, WshInner};
+use crate::miniscript::MiniscriptKey;
 
 /// Alias for [`FullyNodedExport`]
 #[deprecated(since = "0.18.0", note = "Please use [`FullyNodedExport`] instead")]
@@ -76,23 +106,226 @@ pub type WalletExport = FullyNodedExport;
 
 /// Structure that contains the export of a wallet
 ///
-/// For a usage example see [this module](crate::wallet::export)'s documentation.
+/// For a usage example see [this module](crate::wallet::export::caravan)'s documentation.
 #[derive(Debug, Serialize, Deserialize)]
-pub struct FullyNodedExport {
-    descriptor: String,
-    /// Earliest block to rescan when looking for the wallet's transactions
-    pub blockheight: u32,
-    /// Arbitrary label for the wallet
-    pub label: String,
+pub struct CaravanExport {
+    pub name: String,
+    #[serde(rename = "addressType")]
+    pub address_type: CaravanAddressType,
+    network: CaravanNetwork,
+    pub client: CaravanClient,
+    pub quorum: Quorum,
+    #[serde(rename = "extendedPublicKeys")]
+    pub extended_public_keys: Vec<CaravanExtendedPublicKey>,
+    #[serde(rename = "startingAddressIndex")]
+    pub starting_address_index: u32,
 }
 
-impl ToString for FullyNodedExport {
+impl CaravanExport {
+    pub fn network(&self) -> Network {
+        match self.network {
+            CaravanNetwork::Mainnet => Network::Bitcoin,
+            CaravanNetwork::Testnet => Network::Testnet,
+        }
+    }
+
+    pub fn descriptor(&self) -> Result<Descriptor<DescriptorPublicKey>, Error> {
+        let required = self.quorum.required_signers;
+        let network: Network = self.network();
+
+        let result = match self.address_type {
+            CaravanAddressType::P2sh => {
+                let keys: Vec<DescriptorKey<Legacy>> = self.descriptor_keys()?;
+                descriptor! { sh ( sortedmulti_vec(required, keys) ) }
+            }
+            CaravanAddressType::P2shP2wsh => {
+                let keys: Vec<DescriptorKey<Segwitv0>> = self.descriptor_keys()?;
+                descriptor! { sh ( wsh ( sortedmulti_vec(required, keys) ) ) }
+            }
+            CaravanAddressType::P2wsh => {
+                let keys: Vec<DescriptorKey<Segwitv0>> = self.descriptor_keys()?;
+                descriptor! { wsh ( sortedmulti_vec(required, keys) ) }
+            }
+        }
+        .map_err(|e| Error::Descriptor(e));
+
+        match result {
+            Ok((d, _, n)) => {
+                if n.contains(&network) {
+                    Ok(d)
+                } else {
+                    Err(Error::InvalidNetwork {
+                        requested: network,
+                        found: *n.iter().last().expect("network"),
+                    })
+                }
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    fn descriptor_keys<Ctx: ScriptContext>(
+        &self,
+    ) -> Result<Vec<DescriptorKey<Ctx>>, DescriptorError> {
+        let result = self
+            .extended_public_keys
+            .iter()
+            .map(|k| {
+                let fingerprint = k.xfp;
+                let key_path = k.clone().bip32_path;
+                let mut key_source = None;
+                if let (Some(fp), Some(kp)) = (fingerprint, key_path) {
+                    key_source = Some((fp, kp))
+                };
+                let derivation_path =
+                    DerivationPath::master().child(ChildNumber::Normal { index: 0 });
+                k.xpub
+                    .into_descriptor_key(key_source, derivation_path)
+                    .map_err(|e| DescriptorError::Key(e))
+            })
+            .collect();
+        result
+    }
+
+    fn parse_sorted_multi<Pk: MiniscriptKey, Ctx: ScriptContext>(
+        sorted_multi: &SortedMultiVec<Pk, Ctx>,
+    ) -> (Quorum, Vec<Pk>) {
+        let quorum = Quorum {
+            required_signers: sorted_multi.k,
+            total_signers: sorted_multi.pks.len(),
+        };
+        let extended_public_keys = sorted_multi.pks.clone();
+        (quorum, extended_public_keys)
+    }
+
+    pub fn export(
+        name: String,
+        client_type: String,
+        network: Network,
+        descriptor: &Descriptor<DescriptorPublicKey>,
+    ) -> Result<Self, Error> {
+        let (address_type, quorum, descriptor_public_keys) = match descriptor {
+            Descriptor::Sh(sh) => match sh.as_inner() {
+                ShInner::SortedMulti(smv) => {
+                    let (quorum, extended_public_keys) = CaravanExport::parse_sorted_multi(smv);
+                    Ok((CaravanAddressType::P2sh, quorum, extended_public_keys))
+                }
+                ShInner::Wsh(wsh) => match wsh.as_inner() {
+                    WshInner::SortedMulti(smv) => {
+                        let (quorum, extended_public_keys) = CaravanExport::parse_sorted_multi(smv);
+                        Ok((CaravanAddressType::P2shP2wsh, quorum, extended_public_keys))
+                    }
+                    _ => Err(Error::Generic(
+                        "Unsupported sh(wsh()) inner descriptor.".to_string(),
+                    )),
+                },
+                _ => Err(Error::Generic(
+                    "Unsupported sh() inner descriptor.".to_string(),
+                )),
+            },
+            Descriptor::Wsh(sh) => match sh.as_inner() {
+                WshInner::SortedMulti(smv) => {
+                    let (quorum, extended_public_keys) = CaravanExport::parse_sorted_multi(smv);
+                    Ok((CaravanAddressType::P2wsh, quorum, extended_public_keys))
+                }
+                _ => Err(Error::Generic(
+                    "Unsupported wsh() inner descriptor.".to_string(),
+                )),
+            },
+            _ => Err(Error::Generic(
+                "Unsupported top level descriptor.".to_string(),
+            )),
+        }?;
+
+        let network = match network {
+            Network::Bitcoin => CaravanNetwork::Mainnet,
+            _ => CaravanNetwork::Testnet,
+        };
+        let client = CaravanClient { value: client_type };
+        let extended_public_keys: Vec<CaravanExtendedPublicKey> = descriptor_public_keys
+            .iter()
+            .map(|k| match k {
+                DescriptorPublicKey::SinglePub(_) => {
+                    Err(Error::Generic("Unsupported single pub key.".to_string()))
+                }
+                DescriptorPublicKey::XPub(xpub) => {
+                    let mut xfp = None;
+                    let mut bip32_path = None;
+                    if let Some((s_xfp, s_bip32_path)) = xpub.clone().origin {
+                        xfp = Some(s_xfp);
+                        bip32_path = Some(s_bip32_path);
+                    }
+                    Ok(CaravanExtendedPublicKey {
+                        name: xpub.xkey.fingerprint().to_string(),
+                        bip32_path,
+                        xpub: xpub.xkey,
+                        xfp,
+                    })
+                }
+            })
+            .flatten()
+            .collect::<Vec<CaravanExtendedPublicKey>>();
+
+        Ok(Self {
+            name,
+            address_type,
+            network,
+            client,
+            quorum,
+            extended_public_keys,
+            starting_address_index: 0,
+        })
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum CaravanAddressType {
+    #[serde(rename = "P2SH")]
+    P2sh,
+    #[serde(rename = "P2SH-P2WSH")]
+    P2shP2wsh,
+    #[serde(rename = "P2WSH")]
+    P2wsh,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+enum CaravanNetwork {
+    #[serde(rename = "mainnet")]
+    Mainnet,
+    #[serde(rename = "testnet")]
+    Testnet,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CaravanClient {
+    #[serde(rename = "type")]
+    value: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Quorum {
+    #[serde(rename = "requiredSigners")]
+    required_signers: usize,
+    #[serde(rename = "totalSigners")]
+    total_signers: usize,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct CaravanExtendedPublicKey {
+    name: String,
+    #[serde(rename = "bip32Path")]
+    bip32_path: Option<DerivationPath>,
+    xpub: ExtendedPubKey,
+    xfp: Option<Fingerprint>,
+}
+
+impl ToString for CaravanExport {
     fn to_string(&self) -> String {
         serde_json::to_string(self).unwrap()
     }
 }
 
-impl FromStr for FullyNodedExport {
+impl FromStr for CaravanExport {
     type Err = serde_json::Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -100,271 +333,115 @@ impl FromStr for FullyNodedExport {
     }
 }
 
-fn remove_checksum(s: String) -> String {
-    s.split_once('#').map(|(a, _)| String::from(a)).unwrap()
-}
-
-impl FullyNodedExport {
-    /// Export a wallet
-    ///
-    /// This function returns an error if it determines that the `wallet`'s descriptor(s) are not
-    /// supported by Bitcoin Core or don't follow the standard derivation paths defined by BIP44
-    /// and others.
-    ///
-    /// If `include_blockheight` is `true`, this function will look into the `wallet`'s database
-    /// for the oldest transaction it knows and use that as the earliest block to rescan.
-    ///
-    /// If the database is empty or `include_blockheight` is false, the `blockheight` field
-    /// returned will be `0`.
-    pub fn export_wallet<D: BatchDatabase>(
-        wallet: &Wallet<D>,
-        label: &str,
-        include_blockheight: bool,
-    ) -> Result<Self, &'static str> {
-        let descriptor = wallet
-            .get_descriptor_for_keychain(KeychainKind::External)
-            .to_string_with_secret(
-                &wallet
-                    .get_signers(KeychainKind::External)
-                    .as_key_map(wallet.secp_ctx()),
-            );
-        let descriptor = remove_checksum(descriptor);
-        Self::is_compatible_with_core(&descriptor)?;
-
-        let blockheight = match wallet.database.borrow().iter_txs(false) {
-            _ if !include_blockheight => 0,
-            Err(_) => 0,
-            Ok(txs) => {
-                let mut heights = txs
-                    .into_iter()
-                    .map(|tx| tx.confirmation_time.map(|c| c.height).unwrap_or(0))
-                    .collect::<Vec<_>>();
-                heights.sort_unstable();
-
-                *heights.last().unwrap_or(&0)
-            }
-        };
-
-        let export = FullyNodedExport {
-            descriptor,
-            label: label.into(),
-            blockheight,
-        };
-
-        let change_descriptor = match wallet
-            .public_descriptor(KeychainKind::Internal)
-            .map_err(|_| "Invalid change descriptor")?
-            .is_some()
-        {
-            false => None,
-            true => {
-                let descriptor = wallet
-                    .get_descriptor_for_keychain(KeychainKind::Internal)
-                    .to_string_with_secret(
-                        &wallet
-                            .get_signers(KeychainKind::Internal)
-                            .as_key_map(wallet.secp_ctx()),
-                    );
-                Some(remove_checksum(descriptor))
-            }
-        };
-        if export.change_descriptor() != change_descriptor {
-            return Err("Incompatible change descriptor");
-        }
-
-        Ok(export)
-    }
-
-    fn is_compatible_with_core(descriptor: &str) -> Result<(), &'static str> {
-        fn check_ms<Ctx: ScriptContext>(
-            terminal: &Terminal<String, Ctx>,
-        ) -> Result<(), &'static str> {
-            if let Terminal::Multi(_, _) = terminal {
-                Ok(())
-            } else {
-                Err("The descriptor contains operators not supported by Bitcoin Core")
-            }
-        }
-
-        // pkh(), wpkh(), sh(wpkh()) are always fine, as well as multi() and sortedmulti()
-        match Descriptor::<String>::from_str(descriptor).map_err(|_| "Invalid descriptor")? {
-            Descriptor::Pkh(_) | Descriptor::Wpkh(_) => Ok(()),
-            Descriptor::Sh(sh) => match sh.as_inner() {
-                ShInner::Wpkh(_) => Ok(()),
-                ShInner::SortedMulti(_) => Ok(()),
-                ShInner::Wsh(wsh) => match wsh.as_inner() {
-                    WshInner::SortedMulti(_) => Ok(()),
-                    WshInner::Ms(ms) => check_ms(&ms.node),
-                },
-                ShInner::Ms(ms) => check_ms(&ms.node),
-            },
-            Descriptor::Wsh(wsh) => match wsh.as_inner() {
-                WshInner::SortedMulti(_) => Ok(()),
-                WshInner::Ms(ms) => check_ms(&ms.node),
-            },
-            _ => Err("The descriptor is not compatible with Bitcoin Core"),
-        }
-    }
-
-    /// Return the external descriptor
-    pub fn descriptor(&self) -> String {
-        self.descriptor.clone()
-    }
-
-    /// Return the internal descriptor, if present
-    pub fn change_descriptor(&self) -> Option<String> {
-        let replaced = self.descriptor.replace("/0/*", "/1/*");
-
-        if replaced != self.descriptor {
-            Some(replaced)
-        } else {
-            None
-        }
-    }
-}
-
 #[cfg(test)]
 mod test {
     use std::str::FromStr;
 
-    use bitcoin::{Network, Txid};
+    use crate::bitcoin::Address;
 
     use super::*;
-    use crate::database::{memory::MemoryDatabase, BatchOperations};
-    use crate::types::TransactionDetails;
-    use crate::wallet::Wallet;
-    use crate::BlockTime;
-
-    fn get_test_db() -> MemoryDatabase {
-        let mut db = MemoryDatabase::new();
-        db.set_tx(&TransactionDetails {
-            transaction: None,
-            txid: Txid::from_str(
-                "4ddff1fa33af17f377f62b72357b43107c19110a8009b36fb832af505efed98a",
-            )
-            .unwrap(),
-
-            received: 100_000,
-            sent: 0,
-            fee: Some(500),
-            confirmation_time: Some(BlockTime {
-                timestamp: 12345678,
-                height: 5000,
-            }),
-        })
-        .unwrap();
-
-        db
-    }
+    use crate::database::memory::MemoryDatabase;
+    use crate::wallet::{AddressIndex, Wallet};
+    use crate::KeychainKind;
 
     #[test]
-    fn test_export_bip44() {
-        let descriptor = "wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/44'/0'/0'/0/*)";
-        let change_descriptor = "wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/44'/0'/0'/1/*)";
+    fn test_import_from_json() {
+        let import_json = r#"{
+          "name": "P2WSH-T",
+          "addressType": "P2WSH",
+          "network": "testnet",
+          "client":  {
+            "type": "public"
+          },
+          "quorum": {
+            "requiredSigners": 2,
+            "totalSigners": 2
+          },
+          "extendedPublicKeys": [
+            {
+                "name": "osw",
+                "bip32Path": "m/48'/1'/100'/2'",
+                "xpub": "tpubDFc9Mm4tw6EkgR4YTC1GrU6CGEd9yw7KSBnSssL4LXAXh89D4uMZigRyv3csdXbeU3BhLQc4vWKTLewboA1Pt8Fu6fbHKu81MZ6VGdc32eM",
+                "xfp" : "f57ec65d"
+              },
+            {
+                "name": "d",
+                "bip32Path": "m/48'/1'/100'/2'",
+                "xpub": "tpubDErWN5qfdLwYE94mh12oWr4uURDDNKCjKVhCEcAgZ7jKnnAwq5tcTF2iEk3VuznkJuk2G8SCHft9gS6aKbBd18ptYWPqKLRSTRQY7e2rrDj",
+                "xfp" : "efa5d916"
+              }
+          ],
+          "startingAddressIndex": 0
+        }"#;
 
-        let wallet = Wallet::new(
-            descriptor,
-            Some(change_descriptor),
-            Network::Bitcoin,
-            get_test_db(),
-        )
-        .unwrap();
-        let export = FullyNodedExport::export_wallet(&wallet, "Test Label", true).unwrap();
+        let import = CaravanExport::from_str(import_json).expect("import");
+        let descriptor = import.descriptor().expect("descriptor");
 
-        assert_eq!(export.descriptor(), descriptor);
-        assert_eq!(export.change_descriptor(), Some(change_descriptor.into()));
-        assert_eq!(export.blockheight, 5000);
-        assert_eq!(export.label, "Test Label");
-    }
+        println!("descriptor: {}", descriptor);
 
-    #[test]
-    #[should_panic(expected = "Incompatible change descriptor")]
-    fn test_export_no_change() {
-        // This wallet explicitly doesn't have a change descriptor. It should be impossible to
-        // export, because exporting this kind of external descriptor normally implies the
-        // existence of an internal descriptor
-
-        let descriptor = "wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/44'/0'/0'/0/*)";
-
-        let wallet = Wallet::new(descriptor, None, Network::Bitcoin, get_test_db()).unwrap();
-        FullyNodedExport::export_wallet(&wallet, "Test Label", true).unwrap();
-    }
-
-    #[test]
-    #[should_panic(expected = "Incompatible change descriptor")]
-    fn test_export_incompatible_change() {
-        // This wallet has a change descriptor, but the derivation path is not in the "standard"
-        // bip44/49/etc format
-
-        let descriptor = "wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/44'/0'/0'/0/*)";
-        let change_descriptor = "wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/50'/0'/1/*)";
-
-        let wallet = Wallet::new(
-            descriptor,
-            Some(change_descriptor),
-            Network::Bitcoin,
-            get_test_db(),
-        )
-        .unwrap();
-        FullyNodedExport::export_wallet(&wallet, "Test Label", true).unwrap();
-    }
-
-    #[test]
-    fn test_export_multi() {
-        let descriptor = "wsh(multi(2,\
-                                [73756c7f/48'/0'/0'/2']tpubDCKxNyM3bLgbEX13Mcd8mYxbVg9ajDkWXMh29hMWBurKfVmBfWAM96QVP3zaUcN51HvkZ3ar4VwP82kC8JZhhux8vFQoJintSpVBwpFvyU3/0/*,\
-                                [f9f62194/48'/0'/0'/2']tpubDDp3ZSH1yCwusRppH7zgSxq2t1VEUyXSeEp8E5aFS8m43MknUjiF1bSLo3CGWAxbDyhF1XowA5ukPzyJZjznYk3kYi6oe7QxtX2euvKWsk4/0/*,\
-                                [c98b1535/48'/0'/0'/2']tpubDCDi5W4sP6zSnzJeowy8rQDVhBdRARaPhK1axABi8V1661wEPeanpEXj4ZLAUEoikVtoWcyK26TKKJSecSfeKxwHCcRrge9k1ybuiL71z4a/0/*\
-                          ))";
-        let change_descriptor = "wsh(multi(2,\
-                                       [73756c7f/48'/0'/0'/2']tpubDCKxNyM3bLgbEX13Mcd8mYxbVg9ajDkWXMh29hMWBurKfVmBfWAM96QVP3zaUcN51HvkZ3ar4VwP82kC8JZhhux8vFQoJintSpVBwpFvyU3/1/*,\
-                                       [f9f62194/48'/0'/0'/2']tpubDDp3ZSH1yCwusRppH7zgSxq2t1VEUyXSeEp8E5aFS8m43MknUjiF1bSLo3CGWAxbDyhF1XowA5ukPzyJZjznYk3kYi6oe7QxtX2euvKWsk4/1/*,\
-                                       [c98b1535/48'/0'/0'/2']tpubDCDi5W4sP6zSnzJeowy8rQDVhBdRARaPhK1axABi8V1661wEPeanpEXj4ZLAUEoikVtoWcyK26TKKJSecSfeKxwHCcRrge9k1ybuiL71z4a/1/*\
-                                 ))";
-
-        let wallet = Wallet::new(
-            descriptor,
-            Some(change_descriptor),
-            Network::Testnet,
-            get_test_db(),
-        )
-        .unwrap();
-        let export = FullyNodedExport::export_wallet(&wallet, "Test Label", true).unwrap();
-
-        assert_eq!(export.descriptor(), descriptor);
-        assert_eq!(export.change_descriptor(), Some(change_descriptor.into()));
-        assert_eq!(export.blockheight, 5000);
-        assert_eq!(export.label, "Test Label");
+        let wallet =
+            Wallet::new(descriptor, None, import.network(), MemoryDatabase::new()).expect("wallet");
+        let expected_address_0 =
+            Address::from_str("tb1qhgj3fnwn50pq966rjnj4pg8uz9ktsd8nge32qxd73ffvvg636p5q54g7m0")
+                .expect("address[0]");
+        assert_eq!(
+            wallet.get_address(AddressIndex::Peek(0)).unwrap().address,
+            expected_address_0
+        );
+        let expected_address_9 =
+            Address::from_str("tb1qxzw9q520f3ee6hjpc6wc7jrh7wxfgvundhfclqv8w7gtdd2srwns4krnc0")
+                .expect("address[9]");
+        assert_eq!(
+            wallet.get_address(AddressIndex::Peek(9)).unwrap().address,
+            expected_address_9
+        );
     }
 
     #[test]
     fn test_export_to_json() {
-        let descriptor = "wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/44'/0'/0'/0/*)";
-        let change_descriptor = "wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/44'/0'/0'/1/*)";
-
         let wallet = Wallet::new(
-            descriptor,
-            Some(change_descriptor),
-            Network::Bitcoin,
-            get_test_db(),
-        )
-        .unwrap();
-        let export = FullyNodedExport::export_wallet(&wallet, "Test Label", true).unwrap();
+            "wsh(sortedmulti(2,[f57ec65d/48'/1'/100'/2']tpubDFc9Mm4tw6EkgR4YTC1GrU6CGEd9yw7KSBnSssL4LXAXh89D4uMZigRyv3csdXbeU3BhLQc4vWKTLewboA1Pt8Fu6fbHKu81MZ6VGdc32eM/0/*,[efa5d916/48'/1'/100'/2']tpubDErWN5qfdLwYE94mh12oWr4uURDDNKCjKVhCEcAgZ7jKnnAwq5tcTF2iEk3VuznkJuk2G8SCHft9gS6aKbBd18ptYWPqKLRSTRQY7e2rrDj/0/*))#nv5k65uf",
+            None,
+            Network::Testnet,
+            MemoryDatabase::default()
+        ).expect("wallet");
 
-        assert_eq!(export.to_string(), "{\"descriptor\":\"wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/44\'/0\'/0\'/0/*)\",\"blockheight\":5000,\"label\":\"Test Label\"}");
-    }
+        let name = "P2WSH-T".to_string();
+        let client = "public".to_string();
+        let network = wallet.network();
+        let descriptor = wallet.get_descriptor_for_keychain(KeychainKind::External);
 
-    #[test]
-    fn test_export_from_json() {
-        let descriptor = "wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/44'/0'/0'/0/*)";
-        let change_descriptor = "wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/44'/0'/0'/1/*)";
+        let export = CaravanExport::export(name, client, network, &descriptor).expect("export");
 
-        let import_str = "{\"descriptor\":\"wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/44\'/0\'/0\'/0/*)\",\"blockheight\":5000,\"label\":\"Test Label\"}";
-        let export = FullyNodedExport::from_str(import_str).unwrap();
+        println!("Exported: {}", export.to_string());
 
-        assert_eq!(export.descriptor(), descriptor);
-        assert_eq!(export.change_descriptor(), Some(change_descriptor.into()));
-        assert_eq!(export.blockheight, 5000);
-        assert_eq!(export.label, "Test Label");
+        // NOTE: .extendedPublicKeys[].name fields are set to key hash and are not expected
+        let expected_export = json!({
+          "name": "P2WSH-T",
+          "addressType": "P2WSH",
+          "network": "testnet",
+          "client":  {
+            "type": "public"
+          },
+          "quorum": {
+            "requiredSigners": 2,
+            "totalSigners": 2
+          },
+          "extendedPublicKeys": [
+            {
+                "bip32Path": "m/48'/1'/100'/2'",
+                "xpub": "tpubDFc9Mm4tw6EkgR4YTC1GrU6CGEd9yw7KSBnSssL4LXAXh89D4uMZigRyv3csdXbeU3BhLQc4vWKTLewboA1Pt8Fu6fbHKu81MZ6VGdc32eM",
+                "xfp" : "f57ec65d"
+              },
+            {
+                "bip32Path": "m/48'/1'/100'/2'",
+                "xpub": "tpubDErWN5qfdLwYE94mh12oWr4uURDDNKCjKVhCEcAgZ7jKnnAwq5tcTF2iEk3VuznkJuk2G8SCHft9gS6aKbBd18ptYWPqKLRSTRQY7e2rrDj",
+                "xfp" : "efa5d916"
+              }
+          ],
+          "startingAddressIndex": 0
+        });
+        use assert_json_diff::assert_json_include;
+        assert_json_include!(actual: &export, expected: expected_export);
     }
 }

--- a/src/wallet/export/caravan.rs
+++ b/src/wallet/export/caravan.rs
@@ -1,0 +1,370 @@
+// Bitcoin Dev Kit
+// Written in 2020 by Alekos Filini <alekos.filini@gmail.com>
+//
+// Copyright (c) 2020-2021 Bitcoin Dev Kit Developers
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+//! Wallet export
+//!
+//! This modules implements the wallet export format used by [FullyNoded](https://github.com/Fonta1n3/FullyNoded/blob/10b7808c8b929b171cca537fb50522d015168ac9/Docs/Wallets/Wallet-Export-Spec.md).
+//!
+//! ## Examples
+//!
+//! ### Import from JSON
+//!
+//! ```
+//! # use std::str::FromStr;
+//! # use bitcoin::*;
+//! # use bdk::database::*;
+//! # use bdk::wallet::fully_noded::*;
+//! # use bdk::*;
+//! let import = r#"{
+//!     "descriptor": "wpkh([c258d2e4\/84h\/1h\/0h]tpubDD3ynpHgJQW8VvWRzQ5WFDCrs4jqVFGHB3vLC3r49XHJSqP8bHKdK4AriuUKLccK68zfzowx7YhmDN8SiSkgCDENUFx9qVw65YyqM78vyVe\/0\/*)",
+//!     "blockheight":1782088,
+//!     "label":"testnet"
+//! }"#;
+//!
+//! let import = FullyNodedExport::from_str(import)?;
+//! let wallet = Wallet::new(
+//!     &import.descriptor(),
+//!     import.change_descriptor().as_ref(),
+//!     Network::Testnet,
+//!     MemoryDatabase::default(),
+//! )?;
+//! # Ok::<_, bdk::Error>(())
+//! ```
+//!
+//! ### Export a `Wallet`
+//! ```
+//! # use bitcoin::*;
+//! # use bdk::database::*;
+//! # use bdk::wallet::fully_noded::*;
+//! # use bdk::*;
+//! let wallet = Wallet::new(
+//!     "wpkh([c258d2e4/84h/1h/0h]tpubDD3ynpHgJQW8VvWRzQ5WFDCrs4jqVFGHB3vLC3r49XHJSqP8bHKdK4AriuUKLccK68zfzowx7YhmDN8SiSkgCDENUFx9qVw65YyqM78vyVe/0/*)",
+//!     Some("wpkh([c258d2e4/84h/1h/0h]tpubDD3ynpHgJQW8VvWRzQ5WFDCrs4jqVFGHB3vLC3r49XHJSqP8bHKdK4AriuUKLccK68zfzowx7YhmDN8SiSkgCDENUFx9qVw65YyqM78vyVe/1/*)"),
+//!     Network::Testnet,
+//!     MemoryDatabase::default()
+//! )?;
+//! let export = FullyNodedExport::export_wallet(&wallet, "exported wallet", true)
+//!     .map_err(ToString::to_string)
+//!     .map_err(bdk::Error::Generic)?;
+//!
+//! println!("Exported: {}", export.to_string());
+//! # Ok::<_, bdk::Error>(())
+//! ```
+
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+use miniscript::descriptor::{ShInner, WshInner};
+use miniscript::{Descriptor, ScriptContext, Terminal};
+
+use crate::database::BatchDatabase;
+use crate::types::KeychainKind;
+use crate::wallet::Wallet;
+
+/// Alias for [`FullyNodedExport`]
+#[deprecated(since = "0.18.0", note = "Please use [`FullyNodedExport`] instead")]
+pub type WalletExport = FullyNodedExport;
+
+/// Structure that contains the export of a wallet
+///
+/// For a usage example see [this module](crate::wallet::export)'s documentation.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct FullyNodedExport {
+    descriptor: String,
+    /// Earliest block to rescan when looking for the wallet's transactions
+    pub blockheight: u32,
+    /// Arbitrary label for the wallet
+    pub label: String,
+}
+
+impl ToString for FullyNodedExport {
+    fn to_string(&self) -> String {
+        serde_json::to_string(self).unwrap()
+    }
+}
+
+impl FromStr for FullyNodedExport {
+    type Err = serde_json::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s)
+    }
+}
+
+fn remove_checksum(s: String) -> String {
+    s.split_once('#').map(|(a, _)| String::from(a)).unwrap()
+}
+
+impl FullyNodedExport {
+    /// Export a wallet
+    ///
+    /// This function returns an error if it determines that the `wallet`'s descriptor(s) are not
+    /// supported by Bitcoin Core or don't follow the standard derivation paths defined by BIP44
+    /// and others.
+    ///
+    /// If `include_blockheight` is `true`, this function will look into the `wallet`'s database
+    /// for the oldest transaction it knows and use that as the earliest block to rescan.
+    ///
+    /// If the database is empty or `include_blockheight` is false, the `blockheight` field
+    /// returned will be `0`.
+    pub fn export_wallet<D: BatchDatabase>(
+        wallet: &Wallet<D>,
+        label: &str,
+        include_blockheight: bool,
+    ) -> Result<Self, &'static str> {
+        let descriptor = wallet
+            .get_descriptor_for_keychain(KeychainKind::External)
+            .to_string_with_secret(
+                &wallet
+                    .get_signers(KeychainKind::External)
+                    .as_key_map(wallet.secp_ctx()),
+            );
+        let descriptor = remove_checksum(descriptor);
+        Self::is_compatible_with_core(&descriptor)?;
+
+        let blockheight = match wallet.database.borrow().iter_txs(false) {
+            _ if !include_blockheight => 0,
+            Err(_) => 0,
+            Ok(txs) => {
+                let mut heights = txs
+                    .into_iter()
+                    .map(|tx| tx.confirmation_time.map(|c| c.height).unwrap_or(0))
+                    .collect::<Vec<_>>();
+                heights.sort_unstable();
+
+                *heights.last().unwrap_or(&0)
+            }
+        };
+
+        let export = FullyNodedExport {
+            descriptor,
+            label: label.into(),
+            blockheight,
+        };
+
+        let change_descriptor = match wallet
+            .public_descriptor(KeychainKind::Internal)
+            .map_err(|_| "Invalid change descriptor")?
+            .is_some()
+        {
+            false => None,
+            true => {
+                let descriptor = wallet
+                    .get_descriptor_for_keychain(KeychainKind::Internal)
+                    .to_string_with_secret(
+                        &wallet
+                            .get_signers(KeychainKind::Internal)
+                            .as_key_map(wallet.secp_ctx()),
+                    );
+                Some(remove_checksum(descriptor))
+            }
+        };
+        if export.change_descriptor() != change_descriptor {
+            return Err("Incompatible change descriptor");
+        }
+
+        Ok(export)
+    }
+
+    fn is_compatible_with_core(descriptor: &str) -> Result<(), &'static str> {
+        fn check_ms<Ctx: ScriptContext>(
+            terminal: &Terminal<String, Ctx>,
+        ) -> Result<(), &'static str> {
+            if let Terminal::Multi(_, _) = terminal {
+                Ok(())
+            } else {
+                Err("The descriptor contains operators not supported by Bitcoin Core")
+            }
+        }
+
+        // pkh(), wpkh(), sh(wpkh()) are always fine, as well as multi() and sortedmulti()
+        match Descriptor::<String>::from_str(descriptor).map_err(|_| "Invalid descriptor")? {
+            Descriptor::Pkh(_) | Descriptor::Wpkh(_) => Ok(()),
+            Descriptor::Sh(sh) => match sh.as_inner() {
+                ShInner::Wpkh(_) => Ok(()),
+                ShInner::SortedMulti(_) => Ok(()),
+                ShInner::Wsh(wsh) => match wsh.as_inner() {
+                    WshInner::SortedMulti(_) => Ok(()),
+                    WshInner::Ms(ms) => check_ms(&ms.node),
+                },
+                ShInner::Ms(ms) => check_ms(&ms.node),
+            },
+            Descriptor::Wsh(wsh) => match wsh.as_inner() {
+                WshInner::SortedMulti(_) => Ok(()),
+                WshInner::Ms(ms) => check_ms(&ms.node),
+            },
+            _ => Err("The descriptor is not compatible with Bitcoin Core"),
+        }
+    }
+
+    /// Return the external descriptor
+    pub fn descriptor(&self) -> String {
+        self.descriptor.clone()
+    }
+
+    /// Return the internal descriptor, if present
+    pub fn change_descriptor(&self) -> Option<String> {
+        let replaced = self.descriptor.replace("/0/*", "/1/*");
+
+        if replaced != self.descriptor {
+            Some(replaced)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::str::FromStr;
+
+    use bitcoin::{Network, Txid};
+
+    use super::*;
+    use crate::database::{memory::MemoryDatabase, BatchOperations};
+    use crate::types::TransactionDetails;
+    use crate::wallet::Wallet;
+    use crate::BlockTime;
+
+    fn get_test_db() -> MemoryDatabase {
+        let mut db = MemoryDatabase::new();
+        db.set_tx(&TransactionDetails {
+            transaction: None,
+            txid: Txid::from_str(
+                "4ddff1fa33af17f377f62b72357b43107c19110a8009b36fb832af505efed98a",
+            )
+            .unwrap(),
+
+            received: 100_000,
+            sent: 0,
+            fee: Some(500),
+            confirmation_time: Some(BlockTime {
+                timestamp: 12345678,
+                height: 5000,
+            }),
+        })
+        .unwrap();
+
+        db
+    }
+
+    #[test]
+    fn test_export_bip44() {
+        let descriptor = "wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/44'/0'/0'/0/*)";
+        let change_descriptor = "wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/44'/0'/0'/1/*)";
+
+        let wallet = Wallet::new(
+            descriptor,
+            Some(change_descriptor),
+            Network::Bitcoin,
+            get_test_db(),
+        )
+        .unwrap();
+        let export = FullyNodedExport::export_wallet(&wallet, "Test Label", true).unwrap();
+
+        assert_eq!(export.descriptor(), descriptor);
+        assert_eq!(export.change_descriptor(), Some(change_descriptor.into()));
+        assert_eq!(export.blockheight, 5000);
+        assert_eq!(export.label, "Test Label");
+    }
+
+    #[test]
+    #[should_panic(expected = "Incompatible change descriptor")]
+    fn test_export_no_change() {
+        // This wallet explicitly doesn't have a change descriptor. It should be impossible to
+        // export, because exporting this kind of external descriptor normally implies the
+        // existence of an internal descriptor
+
+        let descriptor = "wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/44'/0'/0'/0/*)";
+
+        let wallet = Wallet::new(descriptor, None, Network::Bitcoin, get_test_db()).unwrap();
+        FullyNodedExport::export_wallet(&wallet, "Test Label", true).unwrap();
+    }
+
+    #[test]
+    #[should_panic(expected = "Incompatible change descriptor")]
+    fn test_export_incompatible_change() {
+        // This wallet has a change descriptor, but the derivation path is not in the "standard"
+        // bip44/49/etc format
+
+        let descriptor = "wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/44'/0'/0'/0/*)";
+        let change_descriptor = "wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/50'/0'/1/*)";
+
+        let wallet = Wallet::new(
+            descriptor,
+            Some(change_descriptor),
+            Network::Bitcoin,
+            get_test_db(),
+        )
+        .unwrap();
+        FullyNodedExport::export_wallet(&wallet, "Test Label", true).unwrap();
+    }
+
+    #[test]
+    fn test_export_multi() {
+        let descriptor = "wsh(multi(2,\
+                                [73756c7f/48'/0'/0'/2']tpubDCKxNyM3bLgbEX13Mcd8mYxbVg9ajDkWXMh29hMWBurKfVmBfWAM96QVP3zaUcN51HvkZ3ar4VwP82kC8JZhhux8vFQoJintSpVBwpFvyU3/0/*,\
+                                [f9f62194/48'/0'/0'/2']tpubDDp3ZSH1yCwusRppH7zgSxq2t1VEUyXSeEp8E5aFS8m43MknUjiF1bSLo3CGWAxbDyhF1XowA5ukPzyJZjznYk3kYi6oe7QxtX2euvKWsk4/0/*,\
+                                [c98b1535/48'/0'/0'/2']tpubDCDi5W4sP6zSnzJeowy8rQDVhBdRARaPhK1axABi8V1661wEPeanpEXj4ZLAUEoikVtoWcyK26TKKJSecSfeKxwHCcRrge9k1ybuiL71z4a/0/*\
+                          ))";
+        let change_descriptor = "wsh(multi(2,\
+                                       [73756c7f/48'/0'/0'/2']tpubDCKxNyM3bLgbEX13Mcd8mYxbVg9ajDkWXMh29hMWBurKfVmBfWAM96QVP3zaUcN51HvkZ3ar4VwP82kC8JZhhux8vFQoJintSpVBwpFvyU3/1/*,\
+                                       [f9f62194/48'/0'/0'/2']tpubDDp3ZSH1yCwusRppH7zgSxq2t1VEUyXSeEp8E5aFS8m43MknUjiF1bSLo3CGWAxbDyhF1XowA5ukPzyJZjznYk3kYi6oe7QxtX2euvKWsk4/1/*,\
+                                       [c98b1535/48'/0'/0'/2']tpubDCDi5W4sP6zSnzJeowy8rQDVhBdRARaPhK1axABi8V1661wEPeanpEXj4ZLAUEoikVtoWcyK26TKKJSecSfeKxwHCcRrge9k1ybuiL71z4a/1/*\
+                                 ))";
+
+        let wallet = Wallet::new(
+            descriptor,
+            Some(change_descriptor),
+            Network::Testnet,
+            get_test_db(),
+        )
+        .unwrap();
+        let export = FullyNodedExport::export_wallet(&wallet, "Test Label", true).unwrap();
+
+        assert_eq!(export.descriptor(), descriptor);
+        assert_eq!(export.change_descriptor(), Some(change_descriptor.into()));
+        assert_eq!(export.blockheight, 5000);
+        assert_eq!(export.label, "Test Label");
+    }
+
+    #[test]
+    fn test_export_to_json() {
+        let descriptor = "wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/44'/0'/0'/0/*)";
+        let change_descriptor = "wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/44'/0'/0'/1/*)";
+
+        let wallet = Wallet::new(
+            descriptor,
+            Some(change_descriptor),
+            Network::Bitcoin,
+            get_test_db(),
+        )
+        .unwrap();
+        let export = FullyNodedExport::export_wallet(&wallet, "Test Label", true).unwrap();
+
+        assert_eq!(export.to_string(), "{\"descriptor\":\"wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/44\'/0\'/0\'/0/*)\",\"blockheight\":5000,\"label\":\"Test Label\"}");
+    }
+
+    #[test]
+    fn test_export_from_json() {
+        let descriptor = "wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/44'/0'/0'/0/*)";
+        let change_descriptor = "wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/44'/0'/0'/1/*)";
+
+        let import_str = "{\"descriptor\":\"wpkh(xprv9s21ZrQH143K4CTb63EaMxja1YiTnSEWKMbn23uoEnAzxjdUJRQkazCAtzxGm4LSoTSVTptoV9RbchnKPW9HxKtZumdyxyikZFDLhogJ5Uj/44\'/0\'/0\'/0/*)\",\"blockheight\":5000,\"label\":\"Test Label\"}";
+        let export = FullyNodedExport::from_str(import_str).unwrap();
+
+        assert_eq!(export.descriptor(), descriptor);
+        assert_eq!(export.change_descriptor(), Some(change_descriptor.into()));
+        assert_eq!(export.blockheight, 5000);
+        assert_eq!(export.label, "Test Label");
+    }
+}

--- a/src/wallet/export/caravan.rs
+++ b/src/wallet/export/caravan.rs
@@ -109,26 +109,34 @@ pub type WalletExport = FullyNodedExport;
 /// For a usage example see [this module](crate::wallet::export::caravan)'s documentation.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CaravanExport {
+    /// Vault name
     pub name: String,
+    /// Caravan address type,
     #[serde(rename = "addressType")]
     pub address_type: CaravanAddressType,
+    /// Caravan network
     network: CaravanNetwork,
+    /// Caravan client
     pub client: CaravanClient,
+    /// Signing quorum
     pub quorum: Quorum,
+    /// Extended public keys
     #[serde(rename = "extendedPublicKeys")]
     pub extended_public_keys: Vec<CaravanExtendedPublicKey>,
+    /// Starting address index, always 0 when exporting
     #[serde(rename = "startingAddressIndex")]
     pub starting_address_index: u32,
 }
 
 impl CaravanExport {
+    /// Get the bitcoin network value
     pub fn network(&self) -> Network {
         match self.network {
             CaravanNetwork::Mainnet => Network::Bitcoin,
             CaravanNetwork::Testnet => Network::Testnet,
         }
     }
-
+    /// Get the descriptor value
     pub fn descriptor(&self) -> Result<Descriptor<DescriptorPublicKey>, Error> {
         let required = self.quorum.required_signers;
         let network: Network = self.network();
@@ -198,6 +206,7 @@ impl CaravanExport {
         (quorum, extended_public_keys)
     }
 
+    /// Export BDK wallet configuration as a Caravan configuration
     pub fn export(
         name: String,
         client_type: String,
@@ -278,16 +287,21 @@ impl CaravanExport {
     }
 }
 
+/// The address types supported by Caravan
 #[derive(Debug, Serialize, Deserialize)]
 pub enum CaravanAddressType {
+    /// P2SH
     #[serde(rename = "P2SH")]
     P2sh,
+    /// P2SH-P2WSH
     #[serde(rename = "P2SH-P2WSH")]
     P2shP2wsh,
+    /// P2WSH
     #[serde(rename = "P2WSH")]
     P2wsh,
 }
 
+/// The networks supported by Caravan
 #[derive(Debug, Serialize, Deserialize)]
 enum CaravanNetwork {
     #[serde(rename = "mainnet")]
@@ -296,12 +310,15 @@ enum CaravanNetwork {
     Testnet,
 }
 
+/// A caravan client
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CaravanClient {
+    /// The client type value
     #[serde(rename = "type")]
     value: String,
 }
 
+/// The quorum of signers required and total signers
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Quorum {
     #[serde(rename = "requiredSigners")]
@@ -310,6 +327,7 @@ pub struct Quorum {
     total_signers: usize,
 }
 
+/// The Caravan extended public key information
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CaravanExtendedPublicKey {
     name: String,

--- a/src/wallet/export/fully_noded.rs
+++ b/src/wallet/export/fully_noded.rs
@@ -1,7 +1,7 @@
 // Bitcoin Dev Kit
 // Written in 2020 by Alekos Filini <alekos.filini@gmail.com>
 //
-// Copyright (c) 2020-2021 Bitcoin Dev Kit Developers
+// Copyright (c) 2020-2022 Bitcoin Dev Kit Developers
 //
 // This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
 // or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -21,7 +21,7 @@
 //! # use std::str::FromStr;
 //! # use bitcoin::*;
 //! # use bdk::database::*;
-//! # use bdk::wallet::fully_noded::*;
+//! # use bdk::wallet::export::fully_noded::*;
 //! # use bdk::*;
 //! let import = r#"{
 //!     "descriptor": "wpkh([c258d2e4\/84h\/1h\/0h]tpubDD3ynpHgJQW8VvWRzQ5WFDCrs4jqVFGHB3vLC3r49XHJSqP8bHKdK4AriuUKLccK68zfzowx7YhmDN8SiSkgCDENUFx9qVw65YyqM78vyVe\/0\/*)",
@@ -43,7 +43,7 @@
 //! ```
 //! # use bitcoin::*;
 //! # use bdk::database::*;
-//! # use bdk::wallet::fully_noded::*;
+//! # use bdk::wallet::export::fully_noded::*;
 //! # use bdk::*;
 //! let wallet = Wallet::new(
 //!     "wpkh([c258d2e4/84h/1h/0h]tpubDD3ynpHgJQW8VvWRzQ5WFDCrs4jqVFGHB3vLC3r49XHJSqP8bHKdK4AriuUKLccK68zfzowx7YhmDN8SiSkgCDENUFx9qVw65YyqM78vyVe/0/*)",

--- a/src/wallet/export/fully_noded.rs
+++ b/src/wallet/export/fully_noded.rs
@@ -9,7 +9,7 @@
 // You may not use this file except in accordance with one or both of these
 // licenses.
 
-//! Wallet export
+//! Fully Noded Wallet export
 //!
 //! This modules implements the wallet export format used by [FullyNoded](https://github.com/Fonta1n3/FullyNoded/blob/10b7808c8b929b171cca537fb50522d015168ac9/Docs/Wallets/Wallet-Export-Spec.md).
 //!
@@ -21,7 +21,7 @@
 //! # use std::str::FromStr;
 //! # use bitcoin::*;
 //! # use bdk::database::*;
-//! # use bdk::wallet::export::*;
+//! # use bdk::wallet::fully_noded::*;
 //! # use bdk::*;
 //! let import = r#"{
 //!     "descriptor": "wpkh([c258d2e4\/84h\/1h\/0h]tpubDD3ynpHgJQW8VvWRzQ5WFDCrs4jqVFGHB3vLC3r49XHJSqP8bHKdK4AriuUKLccK68zfzowx7YhmDN8SiSkgCDENUFx9qVw65YyqM78vyVe\/0\/*)",
@@ -43,7 +43,7 @@
 //! ```
 //! # use bitcoin::*;
 //! # use bdk::database::*;
-//! # use bdk::wallet::export::*;
+//! # use bdk::wallet::fully_noded::*;
 //! # use bdk::*;
 //! let wallet = Wallet::new(
 //!     "wpkh([c258d2e4/84h/1h/0h]tpubDD3ynpHgJQW8VvWRzQ5WFDCrs4jqVFGHB3vLC3r49XHJSqP8bHKdK4AriuUKLccK68zfzowx7YhmDN8SiSkgCDENUFx9qVw65YyqM78vyVe/0/*)",
@@ -76,7 +76,7 @@ pub type WalletExport = FullyNodedExport;
 
 /// Structure that contains the export of a wallet
 ///
-/// For a usage example see [this module](crate::wallet::export)'s documentation.
+/// For a usage example see [this module](crate::wallet::export::fully_noded)'s documentation.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FullyNodedExport {
     descriptor: String,

--- a/src/wallet/export/mod.rs
+++ b/src/wallet/export/mod.rs
@@ -10,4 +10,5 @@
 
 //! This module contains submodules that implement various wallet export formats.
 
+pub mod caravan;
 pub mod fully_noded;

--- a/src/wallet/export/mod.rs
+++ b/src/wallet/export/mod.rs
@@ -1,0 +1,13 @@
+// Bitcoin Dev Kit
+//
+// Copyright (c) 2020-2022 Bitcoin Dev Kit Developers
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+//! This module contains submodules that implement various wallet export formats.
+
+pub mod fully_noded;


### PR DESCRIPTION
### Description

This is a new module for importing and exporting a wallet descriptor and network from and to a [Caravan] config JSON file. 

### Notes to the reviewers

I only have minimal happy path tests now. More negative test cases are needed.

Open issues:

  - [ ] What is the  `client.type` field? are there enum values?
  - [ ] Is it OK to put the descriptor key hash in the `.extendedPublicKeys[].name` fields when exporting?
  - [ ] I'm only supporting "sortedmulti" inner expressions, are any others expected?
  - [ ] Change descriptors aren't supported but could be, need to confirm derivation path
  - [x] Add tests for all example configs
  - [x] Do private key wallets/vaults need to be supported? No.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR

[Caravan]:https://github.com/unchained-capital/caravan
