### PR TITLE
Pin transitive dependency 'http' to version 0.2.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ electrum-client = { version = "0.8", optional = true }
 rusqlite = { version = "0.25.3", optional = true }
 ahash = { version = "=0.7.4", optional = true }
 reqwest = { version = "0.11", optional = true, default-features = false, features = ["json"] }
+# pinned http versions to work with MSRV 1.46
+http = { version = "=0.2.6", optional = true }
+
 ureq = { version = "~2.2.0", features = ["json"], optional = true }
 futures = { version = "0.3", optional = true }
 async-trait = { version = "0.1", optional = true }
@@ -78,7 +81,7 @@ rpc = ["bitcoincore-rpc"]
 async-interface = ["async-trait"]
 electrum = ["electrum-client"]
 # MUST ALSO USE `--no-default-features`.
-use-esplora-reqwest = ["esplora", "reqwest", "reqwest/socks", "futures"]
+use-esplora-reqwest = ["esplora", "reqwest", "http", "reqwest/socks", "futures"]
 use-esplora-ureq = ["esplora", "ureq", "ureq/socks"]
 # Typical configurations will not need to use `esplora` feature directly.
 esplora = []


### PR DESCRIPTION
### Description

This is required because `http` (a transitive dependency of `reqwest`) changed their MSRV to 1.49 and bdk MSRV is still 1.46.

### Notes to the reviewers

The `http` dependency MSRV [was change in `http` version 0.2.7](https://github.com/hyperium/http/pull/499/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542) released on [April 28, 2022](https://crates.io/crates/http/versions).

```shell
% cargo tree --all-features -i http                                       
http v0.2.7
├── bdk v0.19.0-dev (/home/steve/git/notmandatory/bdk)
├── h2 v0.3.13
│   ├── hyper v0.14.18
│   │   ├── hyper-tls v0.5.0
│   │   │   └── reqwest v0.11.10
│   │   │       └── bdk v0.19.0-dev (/home/steve/git/notmandatory/bdk)
│   │   └── reqwest v0.11.10 (*)
│   └── reqwest v0.11.10 (*)
├── http-body v0.4.4
│   ├── hyper v0.14.18 (*)
│   └── reqwest v0.11.10 (*)
├── hyper v0.14.18 (*)
└── reqwest v0.11.10 (*)
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
