### PR TITLE
Bump MSRV to 1.56

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -10,9 +10,9 @@ jobs:
     strategy:
       matrix:
         rust:
-          - version: 1.56.0 # STABLE
+          - version: 1.60.0 # STABLE
             clippy: true
-          - version: 1.46.0 # MSRV
+          - version: 1.56.0 # MSRV
         features:
           - default
           - minimal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - added `OldestFirstCoinSelection` impl to `CoinSelectionAlgorithm`
+- New MSRV set to `1.56`
 
 
 ## [v0.18.0] - [v0.17.0]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
     <a href="https://github.com/bitcoindevkit/bdk/actions?query=workflow%3ACI"><img alt="CI Status" src="https://github.com/bitcoindevkit/bdk/workflows/CI/badge.svg"></a>
     <a href="https://codecov.io/gh/bitcoindevkit/bdk"><img src="https://codecov.io/gh/bitcoindevkit/bdk/branch/master/graph/badge.svg"/></a>
     <a href="https://docs.rs/bdk"><img alt="API Docs" src="https://img.shields.io/badge/docs.rs-bdk-green"/></a>
-    <a href="https://blog.rust-lang.org/2020/08/27/Rust-1.46.0.html"><img alt="Rustc Version 1.46+" src="https://img.shields.io/badge/rustc-1.46%2B-lightgrey.svg"/></a>
+    <a href="https://blog.rust-lang.org/2020/08/27/Rust-1.56.0.html"><img alt="Rustc Version 1.56+" src="https://img.shields.io/badge/rustc-1.56%2B-lightgrey.svg"/></a>
     <a href="https://discord.gg/d7NkDKm"><img alt="Chat on Discord" src="https://img.shields.io/discord/753336465005608961?logo=discord"></a>
   </p>
 

--- a/examples/compiler.rs
+++ b/examples/compiler.rs
@@ -85,7 +85,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let network = matches
         .value_of("network")
-        .map(|n| Network::from_str(n))
+        .map(Network::from_str)
         .transpose()
         .unwrap()
         .unwrap_or(Network::Testnet);

--- a/src/blockchain/compact_filters/peer.rs
+++ b/src/blockchain/compact_filters/peer.rs
@@ -94,8 +94,7 @@ impl Mempool {
             TxIdentifier::Wtxid(wtxid) => self.0.read().unwrap().wtxids.get(&wtxid).cloned(),
         };
 
-        txid.map(|txid| self.0.read().unwrap().txs.get(&txid).cloned())
-            .flatten()
+        txid.and_then(|txid| self.0.read().unwrap().txs.get(&txid).cloned())
     }
 
     /// Return whether or not the mempool contains a transaction with a given txid
@@ -111,6 +110,7 @@ impl Mempool {
 
 /// A Bitcoin peer
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct Peer {
     writer: Arc<Mutex<TcpStream>>,
     responses: Arc<RwLock<ResponsesMap>>,

--- a/src/blockchain/rpc.rs
+++ b/src/blockchain/rpc.rs
@@ -54,8 +54,6 @@ use std::str::FromStr;
 pub struct RpcBlockchain {
     /// Rpc client to the node, includes the wallet name
     client: Client,
-    /// Network used
-    network: Network,
     /// Blockchain capabilities, cached here at startup
     capabilities: HashSet<Capability>,
     /// Skip this many blocks of the blockchain at the first rescan, if None the rescan is done from the genesis block
@@ -417,7 +415,6 @@ impl ConfigurableBlockchain for RpcBlockchain {
 
         Ok(RpcBlockchain {
             client,
-            network,
             capabilities,
             _storage_address: storage_address,
             skip_blocks: config.skip_blocks,

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -200,8 +200,7 @@ pub(crate) trait DatabaseUtils: Database {
         D: FnOnce() -> Result<Option<Transaction>, Error>,
     {
         self.get_tx(txid, true)?
-            .map(|t| t.transaction)
-            .flatten()
+            .and_then(|t| t.transaction)
             .map_or_else(default, |t| Ok(Some(t)))
     }
 

--- a/src/descriptor/policy.rs
+++ b/src/descriptor/policy.rs
@@ -357,7 +357,8 @@ impl Satisfaction {
                     // we map each of the combinations of elements into a tuple of ([chosen items], [conditions]). unfortunately, those items have potentially more than one
                     // condition (think about ORs), so we also use `mix` to expand those, i.e. [[0], [1, 2]] becomes [[0, 1], [0, 2]]. This is necessary to make sure that we
                     // consider every possible options and check whether or not they are compatible.
-                    .map(|i_vec| {
+                    // since this step can turn one item of the iterator into multiple ones, we use `flat_map()` to expand them out
+                    .flat_map(|i_vec| {
                         mix(i_vec
                             .iter()
                             .map(|i| {
@@ -371,9 +372,6 @@ impl Satisfaction {
                         .map(|x| (i_vec.clone(), x))
                         .collect::<Vec<(Vec<usize>, Vec<Condition>)>>()
                     })
-                    // .inspect(|x: &Vec<(Vec<usize>, Vec<Condition>)>| println!("fetch {:?}", x))
-                    // since the previous step can turn one item of the iterator into multiple ones, we call flatten to expand them out
-                    .flatten()
                     // .inspect(|x| println!("flat {:?}", x))
                     // try to fold all the conditions for this specific combination of indexes/options. if they are not compatible, try_fold will be Err
                     .map(|(key, val)| {

--- a/src/wallet/export.rs
+++ b/src/wallet/export.rs
@@ -101,7 +101,7 @@ impl FromStr for FullyNodedExport {
 }
 
 fn remove_checksum(s: String) -> String {
-    s.splitn(2, '#').next().map(String::from).unwrap()
+    s.split_once('#').map(|(a, _)| String::from(a)).unwrap()
 }
 
 impl FullyNodedExport {

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1603,9 +1603,9 @@ where
     pub fn descriptor_checksum(&self, keychain: KeychainKind) -> String {
         self.get_descriptor_for_keychain(keychain)
             .to_string()
-            .splitn(2, '#')
-            .next()
+            .split_once('#')
             .unwrap()
+            .0
             .to_string()
     }
 }

--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -479,6 +479,7 @@ pub struct SignOptions {
     pub allow_all_sighashes: bool,
 }
 
+#[allow(clippy::derivable_impls)]
 impl Default for SignOptions {
     fn default() -> Self {
         SignOptions {


### PR DESCRIPTION
### Description

Following the discussion in #331, bump the MSRV to `1.56`. We already have other PRs bumping it to at least `1.51` (#593), but I'm felling like we are always lagging behind and our CI breaks regularly. As @LLFourn suggested, this PR makes a relatively large bump, hoping this buys us enough time to finish splitting up BDK, which will allow us to have a lower MSRV for the "core" crate.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've updated `CHANGELOG.md`
