### PR TITLE
Change wallet::get_funded_wallet to return Wallet<AnyDatabase>

### DIFF
--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -57,7 +57,7 @@ use utils::{check_nlocktime, check_nsequence_rbf, After, Older, SecpCtx};
 
 use crate::blockchain::{GetHeight, NoopProgress, Progress, WalletSync};
 use crate::database::memory::MemoryDatabase;
-use crate::database::{BatchDatabase, BatchOperations, DatabaseUtils, SyncTime};
+use crate::database::{AnyDatabase, BatchDatabase, BatchOperations, DatabaseUtils, SyncTime};
 use crate::descriptor::derived::AsDerived;
 use crate::descriptor::policy::BuildSatisfaction;
 use crate::descriptor::{
@@ -1613,17 +1613,13 @@ where
 /// Return a fake wallet that appears to be funded for testing.
 pub fn get_funded_wallet(
     descriptor: &str,
-) -> (
-    Wallet<MemoryDatabase>,
-    (String, Option<String>),
-    bitcoin::Txid,
-) {
+) -> (Wallet<AnyDatabase>, (String, Option<String>), bitcoin::Txid) {
     let descriptors = testutils!(@descriptors (descriptor));
     let wallet = Wallet::new(
         &descriptors.0,
         None,
         Network::Regtest,
-        MemoryDatabase::new(),
+        AnyDatabase::Memory(MemoryDatabase::new()),
     )
     .unwrap();
 


### PR DESCRIPTION
### Description

Change testing function `wallet::get_funded_wallet` to return `Wallet<AnyDatabase>` instead of `Wallet<MemoryDatabase>`. This will allow us to use this function for testing `bdk-ffi` which only works with `Wallet<AnyDatabase>`. 

### Notes to the reviewers

This is required to complete https://github.com/bitcoindevkit/bdk-ffi/pull/148.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
