### PR TITLE
Fix sqlite database set_utxo to insert or update utxos

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -90,12 +90,16 @@ jobs:
       matrix:
         blockchain:
           - name: electrum
+            testprefix: blockchain::electrum::test
             features: test-electrum,verify
           - name: rpc
+            testprefix: blockchain::rpc::test
             features: test-rpc
           - name: esplora
+            testprefix: esplora
             features: test-esplora,use-esplora-reqwest,verify
           - name: esplora
+            testprefix: esplora
             features: test-esplora,use-esplora-ureq,verify
     steps:
       - name: Checkout
@@ -114,7 +118,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Test
-        run: cargo test --no-default-features --features ${{ matrix.blockchain.features }} ${{ matrix.blockchain.name }}::bdk_blockchain_tests
+        run: cargo test --no-default-features --features ${{ matrix.blockchain.features }} ${{ matrix.blockchain.testprefix }}::bdk_blockchain_tests
 
   check-wasm:
     name: Check WASM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New MSRV set to `1.56`
 - Unpinned tokio to `1`
 - Add traits to reuse `Blockchain`s across multiple wallets (`BlockchainFactory` and `StatelessBlockchain`).
-- Upgrade to rust-bitcoin `0.28` 
-
+- Upgrade to rust-bitcoin `0.28`
+- If using the `sqlite-db` feature all cached wallet data is deleted due to a possible UTXO inconsistency, a wallet.sync will recreate it  
 
 ## [v0.18.0] - [v0.17.0]
 

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -323,7 +323,8 @@ pub mod test {
         };
 
         tree.set_utxo(&utxo).unwrap();
-
+        tree.set_utxo(&utxo).unwrap();
+        assert_eq!(tree.iter_utxos().unwrap().len(), 1);
         assert_eq!(tree.get_utxo(&outpoint).unwrap(), Some(utxo));
     }
 


### PR DESCRIPTION
### Description

This PR fixes #591 by:
1. Add sqlite `MIGRATIONS` statements to remove duplicate utxos and add unique utxos index on txid and vout.
2. Do an upsert (if insert fails update) instead of an insert in `set_utxo()`.
3. Update database::test::test_utxo to also verify `set_utxo()` doesn't insert duplicate utxos.

### Notes to the reviewers

I verified the updated `test_utxo` fails as expected before my fix and passes after the fix. I tested the new migrations using the below `bdk-cli` command and a manually updated sqlite db with duplicate utxos.
```shell
cargo run --no-default-features --features cli,sqlite-db,esplora-ureq -- wallet -w test1 --descriptor "wpkh(tpubEBr4i6yk5nf5DAaJpsi9N2pPYBeJ7fZ5Z9rmN4977iYLCGco1VyjB9tvvuvYtfZzjD5A8igzgw3HeWeeKFmanHYqksqZXYXGsw5zjnj7KM9/*)" sync
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
