### PR TITLE
Add remove_partial_sigs and try_finalize to SignOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Signing Taproot PSBTs (key spend and script spend)
   - Support for `tr()` descriptors in the `descriptor!()` macro
 - Add support for Bitcoin Core 23.0 when using the `rpc` blockchain
-- Add `remove_partial_sigs` to `SignOptions`
+- Add `remove_partial_sigs` and `try_finalize` to `SignOptions`
 
 ## [v0.18.0] - [v0.17.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Signing Taproot PSBTs (key spend and script spend)
   - Support for `tr()` descriptors in the `descriptor!()` macro
 - Add support for Bitcoin Core 23.0 when using the `rpc` blockchain
+- Add `remove_partial_sigs` to `SignOptions`
 
 ## [v0.18.0] - [v0.17.0]
 

--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -667,6 +667,10 @@ pub struct SignOptions {
     ///
     /// Defaults to `false` which will only allow signing using `SIGHASH_ALL`.
     pub allow_all_sighashes: bool,
+    /// Whether to remove partial_sigs from psbt inputs while finalizing psbt.
+    ///
+    /// Defaults to `true` which will remove partial_sigs after finalizing.
+    pub remove_partial_sigs: bool,
 }
 
 #[allow(clippy::derivable_impls)]
@@ -676,6 +680,7 @@ impl Default for SignOptions {
             trust_witness_utxo: false,
             assume_height: None,
             allow_all_sighashes: false,
+            remove_partial_sigs: true,
         }
     }
 }

--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -671,6 +671,10 @@ pub struct SignOptions {
     ///
     /// Defaults to `true` which will remove partial_sigs after finalizing.
     pub remove_partial_sigs: bool,
+    /// Whether to try finalizing psbt input after the inputs are signed.
+    ///
+    /// Defaults to `true` which will try fianlizing psbt after inputs are signed.
+    pub try_finalize: bool,
 }
 
 #[allow(clippy::derivable_impls)]
@@ -681,6 +685,7 @@ impl Default for SignOptions {
             assume_height: None,
             allow_all_sighashes: false,
             remove_partial_sigs: true,
+            try_finalize: true,
         }
     }
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

This PR is to add 2 keys(`try_finalize` and `remove_partial_sigs`) in `SignOptions`. See this issue for detail https://github.com/bitcoindevkit/bdk/issues/612

### Notes to the reviewers

~I found the negative naming of these 2 new keys `do_not_finalize` and `do_not_remove_partial_sigs` are a bit confusing(like most negative named paremeter/variable). Should we actually change it back to positive naming(`do_finalize` and `do_remove_partial_sigs`)?~ 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
