### PR TITLE
rpc: use `importdescriptors` with Core >= 0.21

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -95,6 +95,9 @@ jobs:
           - name: rpc
             testprefix: blockchain::rpc::test
             features: test-rpc
+          - name: rpc-legacy
+            testprefix: blockchain::rpc::test
+            features: test-rpc-legacy
           - name: esplora
             testprefix: esplora
             features: test-esplora,use-esplora-reqwest,verify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Creation of Taproot PSBTs (BIP-371)
   - Signing Taproot PSBTs (key spend and script spend)
   - Support for `tr()` descriptors in the `descriptor!()` macro
+- Add support for Bitcoin Core 23.0 when using the `rpc` blockchain
 
 ## [v0.18.0] - [v0.17.0]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,16 +88,17 @@ reqwest-default-tls = ["reqwest/default-tls"]
 
 # Debug/Test features
 test-blockchains = ["bitcoincore-rpc", "electrum-client"]
-test-electrum = ["electrum", "electrsd/electrs_0_8_10", "test-blockchains"]
-test-rpc = ["rpc", "electrsd/electrs_0_8_10", "test-blockchains"]
-test-esplora = ["electrsd/legacy", "electrsd/esplora_a33e97e1", "test-blockchains"]
+test-electrum = ["electrum", "electrsd/electrs_0_8_10", "electrsd/bitcoind_22_0", "test-blockchains"]
+test-rpc = ["rpc", "electrsd/electrs_0_8_10", "electrsd/bitcoind_22_0", "test-blockchains"]
+test-rpc-legacy = ["rpc", "electrsd/electrs_0_8_10", "electrsd/bitcoind_0_20_0", "test-blockchains"]
+test-esplora = ["electrsd/legacy", "electrsd/esplora_a33e97e1", "electrsd/bitcoind_22_0", "test-blockchains"]
 test-md-docs = ["electrum"]
 
 [dev-dependencies]
 lazy_static = "1.4"
 env_logger = "0.7"
 clap = "2.33"
-electrsd = { version= "0.19.1", features = ["bitcoind_22_0"] }
+electrsd = "0.19.1"
 
 [[example]]
 name = "address_validator"

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Integration testing require testing features, for example:
 cargo test --features test-electrum
 ```
 
-The other options are `test-esplora` or `test-rpc`.
+The other options are `test-esplora`, `test-rpc` or `test-rpc-legacy` which runs against an older version of Bitcoin Core.
 Note that `electrs` and `bitcoind` binaries are automatically downloaded (on mac and linux), to specify you already have installed binaries you must use `--no-default-features` and provide `BITCOIND_EXE` and `ELECTRS_EXE` as environment variables.
 
 ## License

--- a/src/testutils/blockchain_tests.rs
+++ b/src/testutils/blockchain_tests.rs
@@ -387,6 +387,7 @@ macro_rules! bdk_blockchain_tests {
                 Wallet::new(&descriptors.0.to_string(), descriptors.1.as_ref(), Network::Regtest, MemoryDatabase::new()).unwrap()
             }
 
+            #[allow(dead_code)]
             enum WalletType {
                 WpkhSingleSig,
                 TaprootKeySpend,
@@ -421,7 +422,7 @@ macro_rules! bdk_blockchain_tests {
                 let wallet = get_wallet_from_descriptors(&descriptors);
 
                 // rpc need to call import_multi before receiving any tx, otherwise will not see tx in the mempool
-                #[cfg(feature = "test-rpc")]
+                #[cfg(any(feature = "test-rpc", feature = "test-rpc-legacy"))]
                 wallet.sync(&blockchain, SyncOptions::default()).unwrap();
 
                 (wallet, blockchain, descriptors, test_client)
@@ -446,7 +447,7 @@ macro_rules! bdk_blockchain_tests {
 
                 // the RPC blockchain needs to call `sync()` during initialization to import the
                 // addresses (see `init_single_sig()`), so we skip this assertion
-                #[cfg(not(feature = "test-rpc"))]
+                #[cfg(not(any(feature = "test-rpc", feature = "test-rpc-legacy")))]
                 assert!(wallet.database().deref().get_sync_time().unwrap().is_none(), "initial sync_time not none");
 
                 wallet.sync(&blockchain, SyncOptions::default()).unwrap();
@@ -933,7 +934,7 @@ macro_rules! bdk_blockchain_tests {
             #[test]
             fn test_sync_bump_fee_add_input_no_change() {
                 let (wallet, blockchain, descriptors, mut test_client) = init_single_sig();
-                                let node_addr = test_client.get_node_address(None);
+                let node_addr = test_client.get_node_address(None);
 
                 test_client.receive(testutils! {
                     @tx ( (@external descriptors, 0) => 50_000, (@external descriptors, 1) => 25_000 ) (@confirmations 1)
@@ -1021,6 +1022,7 @@ macro_rules! bdk_blockchain_tests {
             }
 
             #[test]
+            #[cfg(not(feature = "test-rpc-legacy"))]
             fn test_send_to_bech32m_addr() {
                 use std::str::FromStr;
                 use serde;
@@ -1207,7 +1209,7 @@ macro_rules! bdk_blockchain_tests {
                 let blockchain = get_blockchain(&test_client);
 
                 let wallet = get_wallet_from_descriptors(&descriptors);
-                #[cfg(feature = "test-rpc")]
+                #[cfg(any(feature = "test-rpc", feature = "test-rpc-legacy"))]
                 wallet.sync(&blockchain, SyncOptions::default()).unwrap();
 
                 let _ = test_client.receive(testutils! {
@@ -1231,6 +1233,7 @@ macro_rules! bdk_blockchain_tests {
             }
 
             #[test]
+            #[cfg(not(feature = "test-rpc-legacy"))]
             fn test_taproot_key_spend() {
                 let (wallet, blockchain, descriptors, mut test_client) = init_wallet(WalletType::TaprootKeySpend);
 
@@ -1251,6 +1254,7 @@ macro_rules! bdk_blockchain_tests {
             }
 
             #[test]
+            #[cfg(not(feature = "test-rpc-legacy"))]
             fn test_taproot_script_spend() {
                 let (wallet, blockchain, descriptors, mut test_client) = init_wallet(WalletType::TaprootScriptSpend);
 
@@ -1279,20 +1283,24 @@ macro_rules! bdk_blockchain_tests {
             }
 
             #[test]
+            #[cfg(not(feature = "test-rpc-legacy"))]
             fn test_sign_taproot_core_keyspend_psbt() {
                 test_sign_taproot_core_psbt(WalletType::TaprootKeySpend);
             }
 
             #[test]
+            #[cfg(not(feature = "test-rpc-legacy"))]
             fn test_sign_taproot_core_scriptspend2_psbt() {
                 test_sign_taproot_core_psbt(WalletType::TaprootScriptSpend2);
             }
 
             #[test]
+            #[cfg(not(feature = "test-rpc-legacy"))]
             fn test_sign_taproot_core_scriptspend3_psbt() {
                 test_sign_taproot_core_psbt(WalletType::TaprootScriptSpend3);
             }
 
+            #[cfg(not(feature = "test-rpc-legacy"))]
             fn test_sign_taproot_core_psbt(wallet_type: WalletType) {
                 use std::str::FromStr;
                 use serde_json;


### PR DESCRIPTION
### Description

Only use the old `importmulti` with Core versions that don't support descriptor-based (sqlite) wallets.

Add an extra feature to test against Core 0.20 called `test-rpc-legacy`.

This also makes us compatible with Core 23.0 and is thus a replacement for #613, which actually looking back at it was adding support for 23.0 but probably breaking older wallets by adding the extra argument to `createwallet`.

I believe #613 should now only focus on getting the tests to work against 23.0, which is still important but not such a high priority as being compatible with the latest version of Core.

Also fixes #598 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`
