### PR TITLE
test: BDK won't add unconf inputs when fee bumping 

### DIFF
--- a/src/database/memory.rs
+++ b/src/database/memory.rs
@@ -512,10 +512,13 @@ macro_rules! populate_test_db {
         };
 
         let txid = tx.txid();
-        let confirmation_time = tx_meta.min_confirmations.map(|conf| $crate::BlockTime {
-            height: current_height.unwrap().checked_sub(conf as u32).unwrap(),
-            timestamp: 0,
-        });
+        let confirmation_time = tx_meta
+            .min_confirmations
+            .and_then(|v| if v == 0 { None } else { Some(v) })
+            .map(|conf| $crate::BlockTime {
+                height: current_height.unwrap().checked_sub(conf as u32).unwrap() + 1,
+                timestamp: 0,
+            });
 
         let tx_details = $crate::TransactionDetails {
             transaction: Some(tx.clone()),

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -899,8 +899,6 @@ where
     /// # Ok::<(), bdk::Error>(())
     /// ```
     // TODO: support for merging multiple transactions while bumping the fees
-    // TODO: option to force addition of an extra output? seems bad for privacy to update the
-    // change
     pub fn build_fee_bump(
         &self,
         txid: Txid,

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -4723,7 +4723,7 @@ pub(crate) mod test {
 
         crate::populate_test_db!(
             wallet.database.borrow_mut(),
-            testutils! (@tx ( (@external descriptors, 0) => 25_000 ) (@confirmations 0)),
+            testutils! (@tx ( (@external descriptors, 0) => 25_000 ) (@confirmations 1)),
             Some(confirmation_time),
             (@coinbase true)
         );


### PR DESCRIPTION
### Description

Closes #144 

### Notes to reviewers

#144 is describing a bug that doesn't seem to happen in BDK master anymore (BDK not respecting BIP125 rule 2). This PR just adds a test to check that the bug is fixed.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
