### PR TITLE
Multi descriptor: Introduce `DatabaseFactory` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Introduce `DatabaseFactory` trait.
 
 ## [v0.20.0] - [v0.19.0]
 


### PR DESCRIPTION
### Description

This is part of bitcoindevkit/bdk_wallet#188 to add multi-descriptor wallet support to BDK.

As each `DescriptorTracker` should have it's own database, and a `MultiTracker` structure will handle an aggregate of `DescriptorTracker`s, we need a factory structure that the `MultiTracker` can use to create `Database`s for each `DescriptorTracker`.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`

