### PR TITLE
Fix: Run README.md examples on the CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ use bdk::blockchain::ElectrumBlockchain;
 use bdk::electrum_client::Client;
 use bdk::wallet::AddressIndex::New;
 
+use bitcoin::base64;
 use bitcoin::consensus::serialize;
 
 fn main() -> Result<(), bdk::Error> {
@@ -131,6 +132,7 @@ fn main() -> Result<(), bdk::Error> {
 ```rust,no_run
 use bdk::{Wallet, SignOptions, database::MemoryDatabase};
 
+use bitcoin::base64;
 use bitcoin::consensus::deserialize;
 
 fn main() -> Result<(), bdk::Error> {
@@ -154,7 +156,7 @@ fn main() -> Result<(), bdk::Error> {
 
 ### Unit testing
 
-```
+```bash
 cargo test
 ```
 
@@ -162,7 +164,7 @@ cargo test
 
 Integration testing require testing features, for example:
 
-```
+```bash
 cargo test --features test-electrum
 ```
 

--- a/src/doctest.rs
+++ b/src/doctest.rs
@@ -9,6 +9,6 @@
 // You may not use this file except in accordance with one or both of these
 // licenses.
 
-#[doc(include = "../README.md")]
+#[doc = include_str!("../README.md")]
 #[cfg(doctest)]
 pub struct ReadmeDoctests;


### PR DESCRIPTION
### Description
Seems like `doc(include = "../README.md")` doesn't include the readme file as doc for the dummy struct. This might be due to a difference in Rust edition used back then or something.

Fixes #637 
### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
