### PR TITLE
Various fixes to the `fee_amount` calculation in `create_tx`

### DIFF
--- a/src/wallet/coin_selection.rs
+++ b/src/wallet/coin_selection.rs
@@ -30,7 +30,7 @@
 //! # use bdk::database::Database;
 //! # use bdk::*;
 //! # use bdk::wallet::coin_selection::decide_change;
-//! # const TXIN_BASE_WEIGHT: usize = (32 + 4 + 4 + 1) * 4;
+//! # const TXIN_BASE_WEIGHT: usize = (32 + 4 + 4) * 4;
 //! #[derive(Debug)]
 //! struct AlwaysSpendEverything;
 //!
@@ -119,8 +119,8 @@ pub type DefaultCoinSelectionAlgorithm = BranchAndBoundCoinSelection;
 pub type DefaultCoinSelectionAlgorithm = LargestFirstCoinSelection; // make the tests more predictable
 
 // Base weight of a Txin, not counting the weight needed for satisfying it.
-// prev_txid (32 bytes) + prev_vout (4 bytes) + sequence (4 bytes) + script_len (1 bytes)
-pub(crate) const TXIN_BASE_WEIGHT: usize = (32 + 4 + 4 + 1) * 4;
+// prev_txid (32 bytes) + prev_vout (4 bytes) + sequence (4 bytes)
+pub(crate) const TXIN_BASE_WEIGHT: usize = (32 + 4 + 4) * 4;
 
 #[derive(Debug)]
 /// Remaining amount after performing coin selection
@@ -731,7 +731,7 @@ mod test {
     use rand::seq::SliceRandom;
     use rand::{Rng, SeedableRng};
 
-    const P2WPKH_WITNESS_SIZE: usize = 73 + 33 + 2;
+    const P2WPKH_SATISFACTION_SIZE: usize = 73 + 33 + 2 + 1;
 
     const FEE_AMOUNT: u64 = 50;
 
@@ -743,7 +743,7 @@ mod test {
         ))
         .unwrap();
         WeightedUtxo {
-            satisfaction_weight: P2WPKH_WITNESS_SIZE,
+            satisfaction_weight: P2WPKH_SATISFACTION_SIZE,
             utxo: Utxo::Local(LocalUtxo {
                 outpoint,
                 txout: TxOut {
@@ -823,7 +823,7 @@ mod test {
         let mut res = Vec::new();
         for _ in 0..utxos_number {
             res.push(WeightedUtxo {
-                satisfaction_weight: P2WPKH_WITNESS_SIZE,
+                satisfaction_weight: P2WPKH_SATISFACTION_SIZE,
                 utxo: Utxo::Local(LocalUtxo {
                     outpoint: OutPoint::from_str(
                         "ebd9813ecebc57ff8f30797de7c205e3c7498ca950ea4341ee51a685ff2fa30a:0",
@@ -843,7 +843,7 @@ mod test {
 
     fn generate_same_value_utxos(utxos_value: u64, utxos_number: usize) -> Vec<WeightedUtxo> {
         let utxo = WeightedUtxo {
-            satisfaction_weight: P2WPKH_WITNESS_SIZE,
+            satisfaction_weight: P2WPKH_SATISFACTION_SIZE,
             utxo: Utxo::Local(LocalUtxo {
                 outpoint: OutPoint::from_str(
                     "ebd9813ecebc57ff8f30797de7c205e3c7498ca950ea4341ee51a685ff2fa30a:0",
@@ -1313,7 +1313,7 @@ mod test {
 
         assert_eq!(result.selected.len(), 1);
         assert_eq!(result.selected_amount(), 100_000);
-        let input_size = (TXIN_BASE_WEIGHT + P2WPKH_WITNESS_SIZE).vbytes();
+        let input_size = (TXIN_BASE_WEIGHT + P2WPKH_SATISFACTION_SIZE).vbytes();
         let epsilon = 0.5;
         assert!((1.0 - (result.fee_amount as f32 / input_size as f32)).abs() < epsilon);
     }

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1871,6 +1871,14 @@ pub(crate) mod test {
     use crate::signer::{SignOptions, SignerError};
     use crate::wallet::AddressIndex::{LastUnused, New, Peek, Reset};
 
+    // The satisfaction size of a P2WPKH is 112 WU =
+    // 1 (elements in witness) + 1 (OP_PUSH) + 33 (pk) + 1 (OP_PUSH) + 72 (signature + sighash) + 1*4 (script len)
+    // On the witness itself, we have to push once for the pk (33WU) and once for signature + sighash (72WU), for
+    // a total of 105 WU.
+    // Here, we push just once for simplicity, so we have to add an extra byte for the missing
+    // OP_PUSH.
+    const P2WPKH_FAKE_WITNESS_SIZE: usize = 106;
+
     #[test]
     fn test_cache_addresses_fixed() {
         let db = MemoryDatabase::new();
@@ -2007,7 +2015,7 @@ pub(crate) mod test {
             $(
                 $( $add_signature )*
                 for txin in &mut tx.input {
-                    txin.witness.push([0x00; 108]); // fake signature
+                    txin.witness.push([0x00; P2WPKH_FAKE_WITNESS_SIZE]); // fake signature
                 }
             )*
 
@@ -3236,7 +3244,7 @@ pub(crate) mod test {
         let txid = tx.txid();
         // skip saving the new utxos, we know they can't be used anyways
         for txin in &mut tx.input {
-            txin.witness.push([0x00; 108]); // fake signature
+            txin.witness.push([0x00; P2WPKH_FAKE_WITNESS_SIZE]); // fake signature
             wallet
                 .database
                 .borrow_mut()
@@ -3296,7 +3304,7 @@ pub(crate) mod test {
         let txid = tx.txid();
         // skip saving the new utxos, we know they can't be used anyways
         for txin in &mut tx.input {
-            txin.witness.push([0x00; 108]); // fake signature
+            txin.witness.push([0x00; P2WPKH_FAKE_WITNESS_SIZE]); // fake signature
             wallet
                 .database
                 .borrow_mut()
@@ -3362,7 +3370,7 @@ pub(crate) mod test {
         let mut tx = psbt.extract_tx();
         let txid = tx.txid();
         for txin in &mut tx.input {
-            txin.witness.push([0x00; 108]); // fake signature
+            txin.witness.push([0x00; P2WPKH_FAKE_WITNESS_SIZE]); // fake signature
             wallet
                 .database
                 .borrow_mut()
@@ -3406,7 +3414,7 @@ pub(crate) mod test {
         let mut tx = psbt.extract_tx();
         let txid = tx.txid();
         for txin in &mut tx.input {
-            txin.witness.push([0x00; 108]); // fake signature
+            txin.witness.push([0x00; P2WPKH_FAKE_WITNESS_SIZE]); // fake signature
             wallet
                 .database
                 .borrow_mut()
@@ -3462,7 +3470,7 @@ pub(crate) mod test {
         let mut tx = psbt.extract_tx();
         let txid = tx.txid();
         for txin in &mut tx.input {
-            txin.witness.push([0x00; 108]); // fake signature
+            txin.witness.push([0x00; P2WPKH_FAKE_WITNESS_SIZE]); // fake signature
             wallet
                 .database
                 .borrow_mut()
@@ -3519,7 +3527,7 @@ pub(crate) mod test {
         let mut tx = psbt.extract_tx();
         let txid = tx.txid();
         for txin in &mut tx.input {
-            txin.witness.push([0x00; 108]); // fake signature
+            txin.witness.push([0x00; P2WPKH_FAKE_WITNESS_SIZE]); // fake signature
             wallet
                 .database
                 .borrow_mut()
@@ -3560,7 +3568,7 @@ pub(crate) mod test {
         let txid = tx.txid();
         // skip saving the new utxos, we know they can't be used anyways
         for txin in &mut tx.input {
-            txin.witness.push([0x00; 108]); // fake signature
+            txin.witness.push([0x00; P2WPKH_FAKE_WITNESS_SIZE]); // fake signature
             wallet
                 .database
                 .borrow_mut()
@@ -3623,7 +3631,7 @@ pub(crate) mod test {
         let txid = tx.txid();
         // skip saving the new utxos, we know they can't be used anyways
         for txin in &mut tx.input {
-            txin.witness.push([0x00; 108]); // fake signature
+            txin.witness.push([0x00; P2WPKH_FAKE_WITNESS_SIZE]); // fake signature
             wallet
                 .database
                 .borrow_mut()
@@ -3694,7 +3702,7 @@ pub(crate) mod test {
         let txid = tx.txid();
         // skip saving the new utxos, we know they can't be used anyways
         for txin in &mut tx.input {
-            txin.witness.push([0x00; 108]); // fake signature
+            txin.witness.push([0x00; P2WPKH_FAKE_WITNESS_SIZE]); // fake signature
             wallet
                 .database
                 .borrow_mut()
@@ -3765,7 +3773,7 @@ pub(crate) mod test {
         let txid = tx.txid();
         // skip saving the new utxos, we know they can't be used anyways
         for txin in &mut tx.input {
-            txin.witness.push([0x00; 108]); // fake signature
+            txin.witness.push([0x00; P2WPKH_FAKE_WITNESS_SIZE]); // fake signature
             wallet
                 .database
                 .borrow_mut()
@@ -3826,7 +3834,7 @@ pub(crate) mod test {
         let txid = tx.txid();
         // skip saving the new utxos, we know they can't be used anyways
         for txin in &mut tx.input {
-            txin.witness.push([0x00; 108]); // fake signature
+            txin.witness.push([0x00; P2WPKH_FAKE_WITNESS_SIZE]); // fake signature
             wallet
                 .database
                 .borrow_mut()
@@ -3897,7 +3905,7 @@ pub(crate) mod test {
         let txid = tx.txid();
         // skip saving the new utxos, we know they can't be used anyways
         for txin in &mut tx.input {
-            txin.witness.push([0x00; 108]); // fake signature
+            txin.witness.push([0x00; P2WPKH_FAKE_WITNESS_SIZE]); // fake signature
             wallet
                 .database
                 .borrow_mut()
@@ -3976,7 +3984,7 @@ pub(crate) mod test {
         let mut tx = psbt.extract_tx();
         let txid = tx.txid();
         for txin in &mut tx.input {
-            txin.witness.push([0x00; 108]); // fake signature
+            txin.witness.push([0x00; P2WPKH_FAKE_WITNESS_SIZE]); // fake signature
             wallet
                 .database
                 .borrow_mut()
@@ -4020,7 +4028,7 @@ pub(crate) mod test {
         let mut tx = psbt.extract_tx();
         let txid = tx.txid();
         for txin in &mut tx.input {
-            txin.witness.push([0x00; 108]); // fake signature
+            txin.witness.push([0x00; P2WPKH_FAKE_WITNESS_SIZE]); // fake signature
             wallet
                 .database
                 .borrow_mut()

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -736,8 +736,6 @@ where
         let mut outgoing: u64 = 0;
         let mut received: u64 = 0;
 
-        fee_amount += fee_rate.fee_wu(tx.weight());
-
         let recipients = params.recipients.iter().map(|(r, v)| (r, *v));
 
         for (index, (script_pubkey, value)) in recipients.enumerate() {
@@ -753,12 +751,13 @@ where
                 script_pubkey: script_pubkey.clone(),
                 value,
             };
-            fee_amount += fee_rate.fee_vb(serialize(&new_out).len());
 
             tx.output.push(new_out);
 
             outgoing += value;
         }
+
+        fee_amount += fee_rate.fee_wu(tx.weight());
 
         if params.change_policy != tx_builder::ChangeSpendPolicy::ChangeAllowed
             && self.change_descriptor.is_none()
@@ -851,6 +850,9 @@ where
                     script_pubkey: drain_script,
                 };
 
+                // TODO: We should pay attention when adding a new output: this might increase
+                // the lenght of the "number of vouts" parameter by 2 bytes, potentially making
+                // our feerate too low
                 tx.output.push(drain_output);
             }
         };

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -759,6 +759,17 @@ where
 
         fee_amount += fee_rate.fee_wu(tx.weight());
 
+        // Segwit transactions' header is 2WU larger than legacy txs' header,
+        // as they contain a witness marker (1WU) and a witness flag (1WU) (see BIP144).
+        // At this point we really don't know if the resulting transaction will be segwit
+        // or legacy, so we just add this 2WU to the fee_amount - overshooting the fee amount
+        // is better than undershooting it.
+        // If we pass a fee_amount that is slightly higher than the final fee_amount, we
+        // end up with a transaction with a slightly higher fee rate than the requested one.
+        // If, instead, we undershoot, we may end up with a feerate lower than the requested one
+        // - we might come up with non broadcastable txs!
+        fee_amount += fee_rate.fee_wu(2);
+
         if params.change_policy != tx_builder::ChangeSpendPolicy::ChangeAllowed
             && self.change_descriptor.is_none()
         {

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -2022,7 +2022,7 @@ pub(crate) mod test {
             let fee_rate = $fee_rate;
 
             if !dust_change {
-                assert!((tx_fee_rate - fee_rate).as_sat_vb().abs() < 0.5, "Expected fee rate of {:?}, the tx has {:?}", fee_rate, tx_fee_rate);
+                assert!(tx_fee_rate >= fee_rate && (tx_fee_rate - fee_rate).as_sat_vb().abs() < 0.5, "Expected fee rate of {:?}, the tx has {:?}", fee_rate, tx_fee_rate);
             } else {
                 assert!(tx_fee_rate >= fee_rate, "Expected fee rate of at least {:?}, the tx has {:?}", fee_rate, tx_fee_rate);
             }


### PR DESCRIPTION
### Description

This PR mainly fixes two bugs:
1. TXIN_BASE_WEIGHT wrongly included the `script_len` (Fixes #160)
2. We wouldn't take into account the segwit header in the fee calculation, which could have resulted in a transaction with a lower feerate than the requested one
3. In tests we used to push 108 bytes on the witness as a fake signature, but we should have pushed 106 instead

I also add a test to reproduce the conditions of #660, to check if it's solved. Turns out it's been solved already in #630, but if you're curious about what the bug was, here it is: https://github.com/bitcoindevkit/bdk/issues/660#issuecomment-1196436776
### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
