### PR TITLE
Rename `set_current_height` to `current_height`

### DIFF
--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -2067,7 +2067,7 @@ pub(crate) mod test {
             .set_sync_time(sync_time)
             .unwrap();
         let current_height = 25;
-        builder.set_current_height(current_height);
+        builder.current_height(current_height);
         let (psbt, _) = builder.finish().unwrap();
 
         // current_height will override the last sync height
@@ -2115,7 +2115,7 @@ pub(crate) mod test {
         let mut builder = wallet.build_tx();
         builder
             .add_recipient(addr.script_pubkey(), 25_000)
-            .set_current_height(630_001)
+            .current_height(630_001)
             .nlocktime(630_000);
         let (psbt, _) = builder.finish().unwrap();
 
@@ -4916,7 +4916,7 @@ pub(crate) mod test {
         let mut builder = wallet.build_tx();
         builder
             .add_recipient(addr.script_pubkey(), balance / 2)
-            .set_current_height(confirmation_time);
+            .current_height(confirmation_time);
         assert!(matches!(
             builder.finish().unwrap_err(),
             Error::InsufficientFunds {
@@ -4929,7 +4929,7 @@ pub(crate) mod test {
         let mut builder = wallet.build_tx();
         builder
             .add_recipient(addr.script_pubkey(), balance / 2)
-            .set_current_height(not_yet_mature_time);
+            .current_height(not_yet_mature_time);
         assert!(matches!(
             builder.finish().unwrap_err(),
             Error::InsufficientFunds {
@@ -4942,7 +4942,7 @@ pub(crate) mod test {
         let mut builder = wallet.build_tx();
         builder
             .add_recipient(addr.script_pubkey(), balance / 2)
-            .set_current_height(maturity_time);
+            .current_height(maturity_time);
         builder.finish().unwrap();
     }
 }

--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -556,7 +556,7 @@ impl<'a, D: BatchDatabase, Cs: CoinSelectionAlgorithm<D>, Ctx: TxBuilderContext>
     ///    add them using [`TxBuilder::add_utxos`].
     ///
     /// In both cases, if you don't provide a current height, we use the last sync height.
-    pub fn set_current_height(&mut self, height: u32) -> &mut Self {
+    pub fn current_height(&mut self, height: u32) -> &mut Self {
         self.params.current_height = Some(height);
         self
     }


### PR DESCRIPTION
### Description

Usually we don't have any prefix except for methods that can *add* to a list or replace the list entirely (e.g. `add_recipients` vs `set_recipients`)

I missed this during review of #611 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing