### PR TITLE
Add testing on Compact Block filters in CI

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -104,6 +104,9 @@ jobs:
           - name: esplora
             testprefix: esplora
             features: test-esplora,use-esplora-ureq,verify
+          - name: compact-filters
+            testprefix: blockchain::compact_filters::test
+            features: test-compact-filters
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,7 @@ test-electrum = ["electrum", "electrsd/electrs_0_8_10", "electrsd/bitcoind_22_0"
 test-rpc = ["rpc", "electrsd/electrs_0_8_10", "electrsd/bitcoind_22_0", "test-blockchains"]
 test-rpc-legacy = ["rpc", "electrsd/electrs_0_8_10", "electrsd/bitcoind_0_20_0", "test-blockchains"]
 test-esplora = ["electrsd/legacy", "electrsd/esplora_a33e97e1", "electrsd/bitcoind_22_0", "test-blockchains"]
+test-compact-filters = ["compact_filters", "electrsd/electrs_0_8_10", "electrsd/bitcoind_22_0", "test-blockchains"]
 test-md-docs = ["electrum"]
 
 [dev-dependencies]

--- a/src/blockchain/compact_filters/mod.rs
+++ b/src/blockchain/compact_filters/mod.rs
@@ -580,3 +580,22 @@ impl From<crate::error::Error> for CompactFiltersError {
         CompactFiltersError::Global(Box::new(err))
     }
 }
+
+#[cfg(test)]
+#[cfg(feature = "test-compact-filters")]
+mod test {
+
+    use super::*;
+
+    crate::bdk_blockchain_tests! {
+        fn test_instance(test_client: &TestClient) -> CompactFiltersBlockchain {
+            let bitcoind_port = test_client.bitcoind.params.rpc_socket.port();
+            let num_threads = 2;
+            let mempool = Arc::new(Mempool::default());
+            let peers = (0..num_threads)
+            .map(|_| Peer::connect(format!("localhost:{}", bitcoind_port), Arc::clone(&mempool), Network::Regtest))
+            .collect::<Result<_, _>>().unwrap();
+            CompactFiltersBlockchain::new(peers, "./wallet-filters", Some(0)).unwrap()
+        }
+    }
+}


### PR DESCRIPTION
Setup testing on Compact block filters blockchain
backend.

### Description

While working on #634, I realized we don't have a setup for carrying out test on Compact Block Filters blockchain in CI. This PR is a work in progress solution to get that setup. 

### Notes to the reviewers
For some reason the tests are taking too long to run. 

![compact-block-filter-ci](https://user-images.githubusercontent.com/11140070/178816960-ffa6f85a-8677-417f-b4c2-e9540de13738.png)




### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
