### PR TITLE
Add `get_block_headers` and check timestamps 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `Excess` enum to handle remaining amount after coin selection.
 - Move change creation from `Wallet::create_tx` to `CoinSelectionAlgorithm::coin_select`.
 - Change the interface of `SqliteDatabase::new` to accept any type that implement AsRef<Path>
+- Change trait `GetBlockHash` to `GetBlockInfo`. A new function is added to the new trait `get_block_header` which expects a block height and returns corresponding block header. This is implemented on every blockchain backend.
 
 ## [v0.20.0] - [v0.19.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move change creation from `Wallet::create_tx` to `CoinSelectionAlgorithm::coin_select`.
 - Change the interface of `SqliteDatabase::new` to accept any type that implement AsRef<Path>
 - Change trait `GetBlockHash` to `GetBlockInfo`. A new function is added to the new trait `get_block_header` which expects a block height and returns corresponding block header. This is implemented on every blockchain backend.
+- Amend the struct `After` and `Older` to accept and check against timestamps as well.
 
 ## [v0.20.0] - [v0.19.0]
 

--- a/src/blockchain/any.rs
+++ b/src/blockchain/any.rs
@@ -121,9 +121,12 @@ impl GetTx for AnyBlockchain {
 }
 
 #[maybe_async]
-impl GetBlockHash for AnyBlockchain {
+impl GetBlockInfo for AnyBlockchain {
     fn get_block_hash(&self, height: u64) -> Result<BlockHash, Error> {
         maybe_await!(impl_inner_method!(self, get_block_hash, height))
+    }
+    fn get_block_header(&self, height: u64) -> Result<BlockHeader, Error> {
+        maybe_await!(impl_inner_method!(self, get_block_header, height))
     }
 }
 

--- a/src/blockchain/compact_filters/mod.rs
+++ b/src/blockchain/compact_filters/mod.rs
@@ -260,13 +260,18 @@ impl GetTx for CompactFiltersBlockchain {
     }
 }
 
-impl GetBlockHash for CompactFiltersBlockchain {
+impl GetBlockInfo for CompactFiltersBlockchain {
     fn get_block_hash(&self, height: u64) -> Result<BlockHash, Error> {
         self.headers
             .get_block_hash(height as usize)?
             .ok_or(Error::CompactFilters(
                 CompactFiltersError::BlockHashNotFound,
             ))
+    }
+    fn get_block_header(&self, height: u64) -> Result<BlockHeader, Error> {
+        self.headers
+            .get_block_header(height as usize)?
+            .ok_or(Error::CompactFilters(CompactFiltersError::InvalidHeaders))
     }
 }
 

--- a/src/blockchain/compact_filters/store.rs
+++ b/src/blockchain/compact_filters/store.rs
@@ -436,6 +436,16 @@ impl ChainStore<Full> {
     }
 
     pub fn get_block_hash(&self, height: usize) -> Result<Option<BlockHash>, CompactFiltersError> {
+        match self.get_block_header(height)? {
+            Some(header) => Ok(Some(header.block_hash())),
+            None => Ok(None),
+        }
+    }
+
+    pub fn get_block_header(
+        &self,
+        height: usize,
+    ) -> Result<Option<BlockHeader>, CompactFiltersError> {
         let read_store = self.store.read().unwrap();
         let cf_handle = read_store.cf_handle(&self.cf_name).unwrap();
 
@@ -444,7 +454,7 @@ impl ChainStore<Full> {
         data.map(|data| {
             let (header, _): (BlockHeader, Uint256) =
                 deserialize(&data).map_err(|_| CompactFiltersError::DataCorruption)?;
-            Ok::<_, CompactFiltersError>(header.block_hash())
+            Ok::<_, CompactFiltersError>(header)
         })
         .transpose()
     }

--- a/src/blockchain/electrum.rs
+++ b/src/blockchain/electrum.rs
@@ -98,10 +98,14 @@ impl GetTx for ElectrumBlockchain {
     }
 }
 
-impl GetBlockHash for ElectrumBlockchain {
+impl GetBlockInfo for ElectrumBlockchain {
     fn get_block_hash(&self, height: u64) -> Result<BlockHash, Error> {
         let block_header = self.client.block_header(height as usize)?;
         Ok(block_header.block_hash())
+    }
+    fn get_block_header(&self, height: u64) -> Result<BlockHeader, Error> {
+        let block_header = self.client.block_header(height as usize)?;
+        Ok(block_header)
     }
 }
 

--- a/src/blockchain/esplora/reqwest.rs
+++ b/src/blockchain/esplora/reqwest.rs
@@ -118,10 +118,14 @@ impl GetTx for EsploraBlockchain {
 }
 
 #[maybe_async]
-impl GetBlockHash for EsploraBlockchain {
+impl GetBlockInfo for EsploraBlockchain {
     fn get_block_hash(&self, height: u64) -> Result<BlockHash, Error> {
         let block_header = await_or_block!(self.url_client._get_header(height as u32))?;
         Ok(block_header.block_hash())
+    }
+    fn get_block_header(&self, height: u64) -> Result<BlockHeader, Error> {
+        let block_header = await_or_block!(self.url_client._get_header(height as u32))?;
+        Ok(block_header)
     }
 }
 

--- a/src/blockchain/esplora/ureq.rs
+++ b/src/blockchain/esplora/ureq.rs
@@ -112,10 +112,14 @@ impl GetTx for EsploraBlockchain {
     }
 }
 
-impl GetBlockHash for EsploraBlockchain {
+impl GetBlockInfo for EsploraBlockchain {
     fn get_block_hash(&self, height: u64) -> Result<BlockHash, Error> {
         let block_header = self.url_client._get_header(height as u32)?;
         Ok(block_header.block_hash())
+    }
+    fn get_block_header(&self, height: u64) -> Result<BlockHeader, Error> {
+        let block_header = await_or_block!(self.url_client._get_header(height as u32))?;
+        Ok(block_header)
     }
 }
 

--- a/src/blockchain/rpc.rs
+++ b/src/blockchain/rpc.rs
@@ -169,9 +169,13 @@ impl GetHeight for RpcBlockchain {
     }
 }
 
-impl GetBlockHash for RpcBlockchain {
+impl GetBlockInfo for RpcBlockchain {
     fn get_block_hash(&self, height: u64) -> Result<BlockHash, Error> {
         Ok(self.client.get_block_hash(height)?)
+    }
+    fn get_block_header(&self, height: u64) -> Result<BlockHeader, Error> {
+        let block_hash = self.client.get_block_hash(height)?;
+        Ok(self.client.get_block_header(&block_hash)?)
     }
 }
 

--- a/src/descriptor/policy.rs
+++ b/src/descriptor/policy.rs
@@ -904,7 +904,7 @@ impl<Ctx: ScriptContext + 'static> ExtractPolicy for Miniscript<DescriptorPublic
                     ..
                 } = build_sat
                 {
-                    let after = After::new(Some(current_height), false);
+                    let after = After::new(Some(current_height), None, false);
                     let after_sat = Satisfier::<bitcoin::PublicKey>::check_after(&after, *value);
                     let inputs_sat = psbt_inputs_sat(psbt)
                         .all(|sat| Satisfier::<bitcoin::PublicKey>::check_after(&sat, *value));
@@ -929,7 +929,13 @@ impl<Ctx: ScriptContext + 'static> ExtractPolicy for Miniscript<DescriptorPublic
                     psbt,
                 } = build_sat
                 {
-                    let older = Older::new(Some(current_height), Some(input_max_height), false);
+                    let older = Older::new(
+                        Some(current_height),
+                        None,
+                        Some(input_max_height),
+                        None,
+                        false,
+                    );
                     let older_sat = Satisfier::<bitcoin::PublicKey>::check_older(&older, *value);
                     let inputs_sat = psbt_inputs_sat(psbt)
                         .all(|sat| Satisfier::<bitcoin::PublicKey>::check_older(&sat, *value));

--- a/src/testutils/blockchain_tests.rs
+++ b/src/testutils/blockchain_tests.rs
@@ -1419,7 +1419,7 @@ macro_rules! bdk_blockchain_tests {
             #[test]
             fn test_get_block_hash() {
                 use bitcoincore_rpc::{ RpcApi };
-                use crate::blockchain::GetBlockHash;
+                use crate::blockchain::GetBlockInfo;
 
                 // create wallet with init_wallet
                 let (_, blockchain, _descriptors, mut test_client) = init_single_sig();


### PR DESCRIPTION
### Description

This changes `GetBlockHash` to `GetBlockInfo`. A new function is added to the new trait (in addition to the old one `get_block_hash`) which is `get_block_headers`, which returns block headers for a given block height. It is implemented on all blockchain backends.

This also changes `After` and `Older` defined in `wallet/utils.rs` to accept and check against timestamps.

### Notes to the reviewers

This PR was meant to fix bitcoindevkit/bdk_wallet#183, but further testing revealed that (a) the checking functions in `wallet/utils.rs` aren't actually called, the implementations in `miniscript/satisfy.rs` are called, which already check timestamps; and (b) the checking functions in `wallet/utils.rs` have a slightly different purpose (checking if the transaction can be broadcasted) compared to miniscript implementations (checking if the transaction timelocks are satisfied). Hence I changed the `wallet/utils.rs` functions, without changing the current flow of code. 
Hence the issue is already fixed and this PR barely changes anything.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`
