### PR TITLE
Add DescriptorKey derive, extend, to_public and to_string functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `descriptor::checksum::get_checksum_bytes` method.
 - Add `Excess` enum to handle remaining amount after coin selection.
 - Move change creation from `Wallet::create_tx` to `CoinSelectionAlgorithm::coin_select`.
-- Add `DescriptorKey` `derive`, `extend`, `to_public` and `to_string` functions
-- Add `DescriptorKey` `generate_xprv`, `derive`, `extend`, `to_public` and `to_string` functions.
+- Add `DescriptorKey` functions `generate_xprv`, `restore_xprv`, `derive`, `extend`, `as_public` and `to_string'.
 
 ## [v0.20.0] - [v0.19.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `Excess` enum to handle remaining amount after coin selection.
 - Move change creation from `Wallet::create_tx` to `CoinSelectionAlgorithm::coin_select`.
 - Add `DescriptorKey` `derive`, `extend`, `to_public` and `to_string` functions
+- Add `DescriptorKey` `generate_xprv`, `derive`, `extend`, `to_public` and `to_string` functions.
 
 ## [v0.20.0] - [v0.19.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 - Add `descriptor::checksum::get_checksum_bytes` method.
 - Add `Excess` enum to handle remaining amount after coin selection.
 - Move change creation from `Wallet::create_tx` to `CoinSelectionAlgorithm::coin_select`.
+- Add `DescriptorKey` `derive`, `extend`, `to_public` and `to_string` functions
 
 ## [v0.20.0] - [v0.19.0]
 


### PR DESCRIPTION
### Description

Add DescriptorKey functions generate_xprv, restore_xprv, derive, extend, to_public and to_string. 

* `DescriptorKey::generate_xprv` generate an `ExtendedPrivKey` based `DescriptorKey` for a given network with the default generate options and random entropy. The key will be a master xkey with no origin or extended derivation path.

* `DescriptorKey::restore_xprv` Restore an `ExtendedPrivKey` based `DescriptorKey` for a given network from `Mnemonic` seed words and optional password (BIP-39). The key will be a master xkey with no origin or extended derivation path.

* `DescriptorKey::derive` derive a new `DescriptorKey` from the origin key at a given `DerivationPath` keeping the extended path part the same.

* `DescriptorKey::extend` extend the extended path of a `DescriptorKey` with a given `DerivationPath` keeping the origin part the same.

* `DescriptorKey::as_public` dreate a new public key version of the `DescriptorKey`, if already public return a copy of the same key.

### Notes to the reviewers

The changes in this PR are based on work and discussion around https://github.com/bitcoindevkit/bdk-ffi/pull/154.

The goal is to create simplified functions that can be used in the `bdk-ffi` and `bdk-cli` projects. 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`