### PR TITLE
Use T: AsRef<Path> as param to SqliteDatabase::new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `descriptor::checksum::get_checksum_bytes` method.
 - Add `Excess` enum to handle remaining amount after coin selection.
 - Move change creation from `Wallet::create_tx` to `CoinSelectionAlgorithm::coin_select`.
+- Change the interface of `SqliteDatabase::new` to accept any type that implement AsRef<Path>
 
 ## [v0.20.0] - [v0.19.0]
 

--- a/src/database/sqlite.rs
+++ b/src/database/sqlite.rs
@@ -8,6 +8,8 @@
 // <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
 // You may not use this file except in accordance with one or both of these
 // licenses.
+use std::path::Path;
+use std::path::PathBuf;
 
 use bitcoin::consensus::encode::{deserialize, serialize};
 use bitcoin::hash_types::Txid;
@@ -60,7 +62,7 @@ static MIGRATIONS: &[&str] = &[
 #[derive(Debug)]
 pub struct SqliteDatabase {
     /// Path on the local filesystem to store the sqlite file
-    pub path: String,
+    pub path: PathBuf,
     /// A rusqlite connection object to the sqlite database
     pub connection: Connection,
 }
@@ -68,9 +70,12 @@ pub struct SqliteDatabase {
 impl SqliteDatabase {
     /// Instantiate a new SqliteDatabase instance by creating a connection
     /// to the database stored at path
-    pub fn new(path: String) -> Self {
+    pub fn new<T: AsRef<Path>>(path: T) -> Self {
         let connection = get_connection(&path).unwrap();
-        SqliteDatabase { path, connection }
+        SqliteDatabase {
+            path: PathBuf::from(path.as_ref()),
+            connection,
+        }
     }
     fn insert_script_pubkey(
         &self,
@@ -908,7 +913,7 @@ impl BatchDatabase for SqliteDatabase {
     }
 }
 
-pub fn get_connection(path: &str) -> Result<Connection, Error> {
+pub fn get_connection<T: AsRef<Path>>(path: &T) -> Result<Connection, Error> {
     let connection = Connection::open(path)?;
     migrate(&connection)?;
     Ok(connection)


### PR DESCRIPTION
This PR fixes #674 

### Description

Currently SqliteDatabase::new takes a String as path,
with this change, it now accepts any type that implements
AsRef<Path>.

### Notes to the reviewers

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
