### PR TITLE
Add `electrsd/bitcoind_22_0` to `example\rpcwallet` target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,7 +114,7 @@ required-features = ["compiler"]
 [[example]]
 name = "rpcwallet"
 path = "examples/rpcwallet.rs"
-required-features = ["keys-bip39", "key-value-db", "rpc"]
+required-features = ["keys-bip39", "key-value-db", "rpc", "electrsd/bitcoind_22_0"]
 
 [workspace]
 members = ["macros"]


### PR DESCRIPTION
On master branch, `example\rpcwallet` fails.

```
$ cargo run --features="keys-bip39 key-value-db rpc" --example rpcwallet 
   Compiling bitcoin_hashes v0.9.7
   Compiling bip39 v1.0.1
   Compiling bdk v0.20.1-dev (/home/node01/Dev/wbdk)
    Finished dev [unoptimized + debuginfo] target(s) in 19.64s
     Running `target/debug/examples/rpcwallet`
>> Setting up bitcoind
thread 'main' panicked at 'We should always have downloaded path: Called a method requiring a feature to be set, but it's not', examples/rpcwallet.rs:56:51
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

This PR adds `electrsd/bitcoind_22_0` to `required-features`, making clear that this lib is needed to run this example..

```
$ cargo run --features="keys-bip39 key-value-db rpc electrsd/bitcoind_22_0" --example rpcwallet
    Blocking waiting for file lock on package cache
   Compiling electrsd v0.19.1
   Compiling bdk v0.20.1-dev (/home/node01/Dev/wbdk)
    Finished dev [unoptimized + debuginfo] target(s) in 10.27s
     Running `target/debug/examples/rpcwallet`
>> Setting up bitcoind
>> bitcoind setup complete
Available coins in Core wallet : 50.00000000 BTC

>> Setting up BDK wallet
>> BDK wallet setup complete.
Available initial coins in BDK wallet : 0 sats

>> Sending coins: Core --> BDK, 10 BTC
>> Received coins in BDK wallet
Available balance in BDK wallet: 1000000000 sats

>> Sending coins: BDK --> Core, 5 BTC
>> Coins sent to Core wallet
Remaining BDK wallet balance: 499999859 sats

Congrats!! you made your first test transaction with bdk and bitcoin core.
```