### PR TITLE
Fix derivable-descriptor detection during wallet sync

### DIFF
--- a/src/blockchain/script_sync.rs
+++ b/src/blockchain/script_sync.rs
@@ -131,8 +131,9 @@ impl<'a, D: BatchDatabase> ScriptReq<'a, D> {
         let current_gap = self.script_index - last;
 
         // this is a hack to check whether the scripts are coming from a derivable descriptor
-        // we assume for non-derivable descriptors, the initial script count is always 1
-        let is_derivable = self.initial_scripts_needed > 1;
+        // we assume for non-derivable descriptors, the initial script count is always 1 and
+        // as we are working with (at-most) 2 descriptors, we use 2 to determine derivability
+        let is_derivable = self.initial_scripts_needed > 2;
 
         debug!(
             "sync: last={}, remaining={}, diff={}, stop_gap={}",


### PR DESCRIPTION
### Description

This fix is for electrum-based blockchains.

Previously, it was assumed that containing > 1 spks in database means the descriptor is derivable, however each database tracks two descriptors so it should really check > 2.

### Notes to the reviewers

This is a touch-up on work done in https://github.com/bitcoindevkit/bdk/pull/672

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

~* [ ] This pull request breaks the existing API~
~* [ ] I've added tests to reproduce the issue which are now passing~
~* [ ] I'm linking the issue being fixed by this PR~
