### PR TITLE
Add a `GetTxStatus` trait in `blockchain`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rand = "^0.7"
 
 # Optional dependencies
 sled = { version = "0.34", optional = true }
-electrum-client = { version = "0.10", optional = true }
+electrum-client = { git = "https://github.com/tnull/rust-electrum-client", branch = "TheCharlatan-verboseTransactionGet-rebased", optional = true}
 rusqlite = { version = "0.27.0", optional = true }
 ahash = { version = "0.7.6", optional = true }
 reqwest = { version = "0.11", optional = true, default-features = false, features = ["json"] }

--- a/src/blockchain/any.rs
+++ b/src/blockchain/any.rs
@@ -122,7 +122,7 @@ impl GetTx for AnyBlockchain {
 
 #[maybe_async]
 impl GetTxStatus for AnyBlockchain {
-    fn get_tx_status(&self, txid: &Txid) -> Result<TransactionStatus, Error> {
+    fn get_tx_status(&self, txid: &Txid) -> Result<Option<TxStatus>, Error> {
         maybe_await!(impl_inner_method!(self, get_tx_status, txid))
     }
 }

--- a/src/blockchain/any.rs
+++ b/src/blockchain/any.rs
@@ -121,6 +121,13 @@ impl GetTx for AnyBlockchain {
 }
 
 #[maybe_async]
+impl GetTxStatus for AnyBlockchain {
+    fn get_tx_status(&self, txid: &Txid) -> Result<TransactionStatus, Error> {
+        maybe_await!(impl_inner_method!(self, get_tx_status, txid))
+    }
+}
+
+#[maybe_async]
 impl GetBlockHash for AnyBlockchain {
     fn get_block_hash(&self, height: u64) -> Result<BlockHash, Error> {
         maybe_await!(impl_inner_method!(self, get_block_hash, height))

--- a/src/blockchain/esplora/api.rs
+++ b/src/blockchain/esplora/api.rs
@@ -1,8 +1,10 @@
 //! structs from the esplora API
 //!
 //! see: <https://github.com/Blockstream/esplora/blob/master/API.md>
+use crate::blockchain::TransactionStatus;
 use crate::BlockTime;
-use bitcoin::{OutPoint, Script, Transaction, TxIn, TxOut, Txid, Witness};
+use bitcoin::{BlockHash, OutPoint, Script, Transaction, TxIn, TxOut, Txid, Witness};
+use std::convert::From;
 
 #[derive(serde::Deserialize, Clone, Debug)]
 pub struct PrevOut {
@@ -33,7 +35,18 @@ pub struct Vout {
 pub struct TxStatus {
     pub confirmed: bool,
     pub block_height: Option<u32>,
+    pub block_hash: Option<BlockHash>,
     pub block_time: Option<u64>,
+}
+
+impl From<TxStatus> for TransactionStatus {
+    fn from(esplora_tx_status: TxStatus) -> Self {
+        TransactionStatus {
+            confirmed: esplora_tx_status.confirmed,
+            block_height: esplora_tx_status.block_height,
+            block_hash: esplora_tx_status.block_hash,
+        }
+    }
 }
 
 #[derive(serde::Deserialize, Clone, Debug)]
@@ -84,6 +97,7 @@ impl Tx {
                 confirmed: true,
                 block_height: Some(height),
                 block_time: Some(timestamp),
+                ..
             } => Some(BlockTime { timestamp, height }),
             _ => None,
         }

--- a/src/blockchain/esplora/api.rs
+++ b/src/blockchain/esplora/api.rs
@@ -1,7 +1,7 @@
 //! structs from the esplora API
 //!
 //! see: <https://github.com/Blockstream/esplora/blob/master/API.md>
-use crate::blockchain::TransactionStatus;
+use crate::blockchain::TxStatus;
 use crate::BlockTime;
 use bitcoin::{BlockHash, OutPoint, Script, Transaction, TxIn, TxOut, Txid, Witness};
 use std::convert::From;
@@ -29,24 +29,6 @@ pub struct Vin {
 pub struct Vout {
     pub value: u64,
     pub scriptpubkey: Script,
-}
-
-#[derive(serde::Deserialize, Clone, Debug)]
-pub struct TxStatus {
-    pub confirmed: bool,
-    pub block_height: Option<u32>,
-    pub block_hash: Option<BlockHash>,
-    pub block_time: Option<u64>,
-}
-
-impl From<TxStatus> for TransactionStatus {
-    fn from(esplora_tx_status: TxStatus) -> Self {
-        TransactionStatus {
-            confirmed: esplora_tx_status.confirmed,
-            block_height: esplora_tx_status.block_height,
-            block_hash: esplora_tx_status.block_hash,
-        }
-    }
 }
 
 #[derive(serde::Deserialize, Clone, Debug)]

--- a/src/blockchain/esplora/reqwest.rs
+++ b/src/blockchain/esplora/reqwest.rs
@@ -24,7 +24,7 @@ use log::{debug, error, info, trace};
 use ::reqwest::{Client, StatusCode};
 use futures::stream::{FuturesOrdered, TryStreamExt};
 
-use super::api::Tx;
+use super::api::{Tx, TxStatus};
 use crate::blockchain::esplora::EsploraError;
 use crate::blockchain::*;
 use crate::database::BatchDatabase;
@@ -114,6 +114,13 @@ impl GetHeight for EsploraBlockchain {
 impl GetTx for EsploraBlockchain {
     fn get_tx(&self, txid: &Txid) -> Result<Option<Transaction>, Error> {
         Ok(await_or_block!(self.url_client._get_tx(txid))?)
+    }
+}
+
+#[maybe_async]
+impl GetTxStatus for EsploraBlockchain {
+    fn get_tx_status(&self, txid: &Txid) -> Result<TransactionStatus, Error> {
+        Ok(await_or_block!(self.url_client._get_tx_status(txid))?)
     }
 }
 
@@ -230,6 +237,18 @@ impl UrlClient {
         }
 
         Ok(Some(deserialize(&resp.error_for_status()?.bytes().await?)?))
+    }
+
+    async fn _get_tx_status(&self, txid: &Txid) -> Result<TransactionStatus, EsploraError> {
+        let resp = self
+            .client
+            .get(&format!("{}/tx/{}/status", self.url, txid))
+            .send()
+            .await?;
+
+        let tx_status: TxStatus = resp.error_for_status()?.json::<TxStatus>().await?;
+
+        Ok(tx_status.into())
     }
 
     async fn _get_tx_no_opt(&self, txid: &Txid) -> Result<Transaction, EsploraError> {

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -87,7 +87,7 @@ pub enum Capability {
 
 /// Trait that defines the actions that must be supported by a blockchain backend
 #[maybe_async]
-pub trait Blockchain: WalletSync + GetHeight + GetTx + GetBlockHash {
+pub trait Blockchain: WalletSync + GetHeight + GetTx + GetTxStatus + GetBlockHash {
     /// Return the set of [`Capability`] supported by this backend
     fn get_capabilities(&self) -> HashSet<Capability>;
     /// Broadcast a transaction
@@ -114,7 +114,7 @@ pub trait GetTx {
 /// Trait for getting the status of a transaction by txid
 pub trait GetTxStatus {
     /// Fetch the status of a transaction given its txid
-    fn get_tx_status(&self, txid: &Txid) -> Result<Option<TransactionStatus>, Error>;
+    fn get_tx_status(&self, txid: &Txid) -> Result<TransactionStatus, Error>;
 }
 
 /// The confirmation status of a transaction
@@ -376,7 +376,7 @@ impl<T: GetTx> GetTx for Arc<T> {
 
 #[maybe_async]
 impl<T: GetTxStatus> GetTxStatus for Arc<T> {
-    fn get_tx_status(&self, txid: &Txid) -> Result<Option<TransactionStatus>, Error> {
+    fn get_tx_status(&self, txid: &Txid) -> Result<TransactionStatus, Error> {
         maybe_await!(self.deref().get_tx_status(txid))
     }
 }

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -111,6 +111,21 @@ pub trait GetTx {
 }
 
 #[maybe_async]
+/// Trait for getting the status of a transaction by txid
+pub trait GetTxStatus {
+    /// Fetch the status of a transaction given its txid
+    fn get_tx_status(&self, txid: &Txid) -> Result<Option<TransactionStatus>, Error>;
+}
+
+/// The confirmation status of a transaction
+#[derive(Debug, Clone, PartialEq)]
+pub struct TransactionStatus {
+    confirmed: bool,
+    block_height: Option<u32>,
+    block_hash: Option<BlockHash>,
+}
+
+#[maybe_async]
 /// Trait for getting block hash by block height
 pub trait GetBlockHash {
     /// fetch block hash given its height
@@ -356,6 +371,13 @@ impl<T: Blockchain> Blockchain for Arc<T> {
 impl<T: GetTx> GetTx for Arc<T> {
     fn get_tx(&self, txid: &Txid) -> Result<Option<Transaction>, Error> {
         maybe_await!(self.deref().get_tx(txid))
+    }
+}
+
+#[maybe_async]
+impl<T: GetTxStatus> GetTxStatus for Arc<T> {
+    fn get_tx_status(&self, txid: &Txid) -> Result<Option<TransactionStatus>, Error> {
+        maybe_await!(self.deref().get_tx_status(txid))
     }
 }
 

--- a/src/blockchain/rpc.rs
+++ b/src/blockchain/rpc.rs
@@ -164,7 +164,7 @@ impl GetTx for RpcBlockchain {
 }
 
 impl GetTxStatus for RpcBlockchain {
-    fn get_tx_status(&self, txid: &Txid) -> Result<TransactionStatus, Error> {
+    fn get_tx_status(&self, txid: &Txid) -> Result<Option<TxStatus>, Error> {
         let tx_info = self.client.get_raw_transaction_info(txid, None)?;
         if let Some(confirmations) = tx_info.confirmations {
             if confirmations > 0 {
@@ -176,19 +176,20 @@ impl GetTxStatus for RpcBlockchain {
                 // the current tip.
                 let block_height = cur_height + 1 - confirmations;
 
-                return Ok(TransactionStatus {
+                return Ok(Some(TxStatus {
                     confirmed: true,
                     block_hash: tx_info.blockhash,
                     block_height: Some(block_height),
-                });
+                    block_time: tx_info.blocktime.map(|t| t as u64),
+                }));
             }
         }
-
-        Ok(TransactionStatus {
+        return Ok(Some(TxStatus {
             confirmed: false,
             block_height: None,
             block_hash: None,
-        })
+            block_time: None,
+        }));
     }
 }
 


### PR DESCRIPTION
### Description

This adds a `GetTxStatus` trait that, when implemented, allows to query for the confirmation status of a transaction. I now also added a preliminary implementation for `Esplora` and will also update `ElectrumClient` as [soon as it allows to query the necessary data](https://github.com/bitcoindevkit/rust-electrum-client/pull/58).

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`