### PR TITLE
Implement `Deref<Target=Client>` for `ElectrumBlockchain`

### DIFF
--- a/src/blockchain/electrum.rs
+++ b/src/blockchain/electrum.rs
@@ -25,6 +25,7 @@
 //! ```
 
 use std::collections::{HashMap, HashSet};
+use std::ops::Deref;
 
 #[allow(unused_imports)]
 use log::{debug, error, info, trace};
@@ -76,6 +77,14 @@ impl Blockchain for ElectrumBlockchain {
         Ok(FeeRate::from_btc_per_kvb(
             self.client.estimate_fee(target)? as f32
         ))
+    }
+}
+
+impl Deref for ElectrumBlockchain {
+    type Target = Client;
+
+    fn deref(&self) -> &Self::Target {
+        &self.client
     }
 }
 


### PR DESCRIPTION
### Description

As pointed out in https://github.com/bitcoindevkit/rust-electrum-client/pull/58#issuecomment-1207890096 there was no way to keep using the client once it was given to BDK.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing