### PR TITLE
Add datatype for is_spent sqlite column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.18.0] - [v0.17.0]
 
-- Add `sqlite-bundled` feature for deployments that need a bundled version of sqlite, ie. for mobile platforms.
+- Add `sqlite-bundled` feature for deployments that need a bundled version of sqlite, i.e. for mobile platforms.
 - Added `Wallet::get_signers()`, `Wallet::descriptor_checksum()` and `Wallet::get_address_validators()`, exposed the `AsDerived` trait.
 - Deprecate `database::Database::flush()`, the function is only needed for the sled database on mobile, instead for mobile use the sqlite database.
 - Add `keychain: KeychainKind` to `wallet::AddressInfo`.

--- a/DEVELOPMENT_CYCLE.md
+++ b/DEVELOPMENT_CYCLE.md
@@ -39,7 +39,7 @@ Pre-`v1.0.0` our "major" releases only affect the "minor" semver value. Accordin
 11. Publish **all** the updated crates to crates.io.
 12. Make a new commit to bump the version value to `x.y.(z+1)-dev`. The message should be "Bump version to x.y.(z+1)-dev".
 13. Merge the release branch back into `master`.
-14. If the `master` branch contains any unreleased changes to the `bdk-macros` crate, change the `bdk` Cargo.toml `[dependencies]` to point to the local path (ie. `bdk-macros = { path = "./macros"}`)
+14. If the `master` branch contains any unreleased changes to the `bdk-macros` crate, change the `bdk` Cargo.toml `[dependencies]` to point to the local path (i.e. `bdk-macros = { path = "./macros"}`)
 15. Create the release on GitHub: go to "tags", click on the dots on the right and select "Create Release". Then set the title to `vx.y.z` and write down some brief release notes.
 16. Make sure the new release shows up on crates.io and that the docs are built correctly on docs.rs.
 17. Announce the release on Twitter, Discord and Telegram.

--- a/src/database/sqlite.rs
+++ b/src/database/sqlite.rs
@@ -42,7 +42,7 @@ static MIGRATIONS: &[&str] = &[
     "CREATE TABLE transaction_details (txid BLOB, timestamp INTEGER, received INTEGER, sent INTEGER, fee INTEGER, height INTEGER);",
     "INSERT INTO transaction_details SELECT txid, timestamp, received, sent, fee, height FROM transaction_details_old;",
     "DROP TABLE transaction_details_old;",
-    "ALTER TABLE utxos ADD COLUMN is_spent;",
+    "ALTER TABLE utxos ADD COLUMN is_spent BOOLEAN CHECK (is_spent IN (0, 1));",
     // drop all data due to possible inconsistencies with duplicate utxos, re-sync required
     "DELETE FROM checksums;",
     "DELETE FROM last_derivation_indices;",

--- a/src/descriptor/dsl.rs
+++ b/src/descriptor/dsl.rs
@@ -839,7 +839,7 @@ mod test {
         }
     }
 
-    // - at least one of each "type" of operator; ie. one modifier, one leaf_opcode, one leaf_opcode_value, etc.
+    // - at least one of each "type" of operator; i.e. one modifier, one leaf_opcode, one leaf_opcode_value, etc.
     // - mixing up key types that implement IntoDescriptorKey in multi() or thresh()
 
     // expected script for pk and bare manually created

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -325,7 +325,7 @@ where
 
     /// Return a derived address using the external descriptor, see [`AddressIndex`] for
     /// available address index selection strategies. If none of the keys in the descriptor are derivable
-    /// (ie. does not end with /*) then the same address will always be returned for any [`AddressIndex`].
+    /// (i.e. does not end with /*) then the same address will always be returned for any [`AddressIndex`].
     pub fn get_address(&self, address_index: AddressIndex) -> Result<AddressInfo, Error> {
         self._get_address(address_index, KeychainKind::External)
     }
@@ -335,7 +335,7 @@ where
     /// If the wallet doesn't have an internal descriptor it will use the external descriptor.
     ///
     /// see [`AddressIndex`] for available address index selection strategies. If none of the keys
-    /// in the descriptor are derivable (ie. does not end with /*) then the same address will always
+    /// in the descriptor are derivable (i.e. does not end with /*) then the same address will always
     /// be returned for any [`AddressIndex`].
     pub fn get_internal_address(&self, address_index: AddressIndex) -> Result<AddressInfo, Error> {
         self._get_address(address_index, KeychainKind::Internal)
@@ -454,7 +454,7 @@ where
     /// });
     /// ```
     ///
-    /// Note that this methods only operate on the internal database, which first needs to be
+    /// Note that this method only operates on the internal database, which first needs to be
     /// [`Wallet::sync`] manually.
     pub fn list_transactions(&self, include_raw: bool) -> Result<Vec<TransactionDetails>, Error> {
         self.database.borrow().iter_txs(include_raw)
@@ -463,7 +463,7 @@ where
     /// Return the balance, separated into available, trusted-pending, untrusted-pending and immature
     /// values.
     ///
-    /// Note that this methods only operate on the internal database, which first needs to be
+    /// Note that this method only operates on the internal database, which first needs to be
     /// [`Wallet::sync`] manually.
     pub fn get_balance(&self) -> Result<Balance, Error> {
         let mut immature = 0;

--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -516,7 +516,7 @@ impl<'a, D: BatchDatabase, Cs: CoinSelectionAlgorithm<D>, Ctx: TxBuilderContext>
         }
     }
 
-    /// Finish the building the transaction.
+    /// Finish building the transaction.
     ///
     /// Returns the [`BIP174`] "PSBT" and summary details about the transaction.
     ///


### PR DESCRIPTION
### Description
During table creation, Sqlite does not throw an error when a column datatype is not defined. In addition, the datatype provided during table creation does not put a constraint on the type of data that can be put in that column. So you can easily put a string value in an integer column. Despite this, I think it is important for us to add the datatype for clarity.

### Notes to the reviewers
You can read more about how Sqlite dynamic typing [here](https://www.sqlite.org/faq.html)

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing


#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
