### PR TITLE
Add datatype for is_spent sqlite column

### DIFF
--- a/src/database/sqlite.rs
+++ b/src/database/sqlite.rs
@@ -52,7 +52,14 @@ static MIGRATIONS: &[&str] = &[
     "DELETE FROM transactions;",
     "DELETE FROM utxos;",
     "DROP INDEX idx_txid_vout;",
-    "CREATE UNIQUE INDEX idx_utxos_txid_vout ON utxos(txid, vout);"
+    "CREATE UNIQUE INDEX idx_utxos_txid_vout ON utxos(txid, vout);",
+    "BEGIN TRANSACTION;\
+    ALTER TABLE utxos RENAME TO utxos_old;\
+    CREATE TABLE utxos (value INTEGER, keychain TEXT, vout INTEGER, txid BLOB, script BLOB, is_spent BOOLEAN DEFAULT 0);\
+    INSERT INTO utxos SELECT value, keychain, vout, txid, script, is_spent FROM utxos_old;\
+    DROP TABLE utxos_old;\
+    CREATE UNIQUE INDEX idx_utxos_txid_vout ON utxos(txid, vout);\
+    COMMIT;"
 ];
 
 /// Sqlite database stored on filesystem

--- a/src/database/sqlite.rs
+++ b/src/database/sqlite.rs
@@ -53,13 +53,11 @@ static MIGRATIONS: &[&str] = &[
     "DELETE FROM utxos;",
     "DROP INDEX idx_txid_vout;",
     "CREATE UNIQUE INDEX idx_utxos_txid_vout ON utxos(txid, vout);",
-    "BEGIN TRANSACTION;\
-    ALTER TABLE utxos RENAME TO utxos_old;\
-    CREATE TABLE utxos (value INTEGER, keychain TEXT, vout INTEGER, txid BLOB, script BLOB, is_spent BOOLEAN DEFAULT 0);\
-    INSERT INTO utxos SELECT value, keychain, vout, txid, script, is_spent FROM utxos_old;\
-    DROP TABLE utxos_old;\
-    CREATE UNIQUE INDEX idx_utxos_txid_vout ON utxos(txid, vout);\
-    COMMIT;"
+    "ALTER TABLE utxos RENAME TO utxos_old;",
+    "CREATE TABLE utxos (value INTEGER, keychain TEXT, vout INTEGER, txid BLOB, script BLOB, is_spent BOOLEAN DEFAULT 0);",
+    "INSERT INTO utxos SELECT value, keychain, vout, txid, script, is_spent FROM utxos_old;",
+    "DROP TABLE utxos_old;",
+    "CREATE UNIQUE INDEX idx_utxos_txid_vout ON utxos(txid, vout);"
 ];
 
 /// Sqlite database stored on filesystem
@@ -921,8 +919,8 @@ impl BatchDatabase for SqliteDatabase {
 }
 
 pub fn get_connection<T: AsRef<Path>>(path: &T) -> Result<Connection, Error> {
-    let connection = Connection::open(path)?;
-    migrate(&connection)?;
+    let mut connection = Connection::open(path)?;
+    migrate(&mut connection)?;
     Ok(connection)
 }
 
@@ -957,28 +955,41 @@ pub fn set_schema_version(conn: &Connection, version: i32) -> rusqlite::Result<u
     )
 }
 
-pub fn migrate(conn: &Connection) -> rusqlite::Result<()> {
+pub fn migrate(conn: &mut Connection) -> Result<(), Error> {
     let version = get_schema_version(conn)?;
     let stmts = &MIGRATIONS[(version as usize)..];
-    let mut i: i32 = version;
 
-    if version == MIGRATIONS.len() as i32 {
+    // begin transaction, all migration statements and new schema version commit or rollback
+    let tx = conn.transaction()?;
+
+    // execute every statement and return `Some` new schema version
+    // if execution fails, return `Error::Rusqlite`
+    // if no statements executed returns `None`
+    let new_version = stmts
+        .iter()
+        .enumerate()
+        .map(|version_stmt| {
+            log::info!(
+                "executing db migration {}: `{}`",
+                version + version_stmt.0 as i32 + 1,
+                version_stmt.1
+            );
+            tx.execute(version_stmt.1, [])
+                // map result value to next migration version
+                .map(|_| version_stmt.0 as i32 + version + 1)
+        })
+        .last()
+        .transpose()?;
+
+    // if `Some` new statement version, set new schema version
+    if let Some(version) = new_version {
+        set_schema_version(&tx, version)?;
+    } else {
         log::info!("db up to date, no migration needed");
-        return Ok(());
     }
 
-    for stmt in stmts {
-        let res = conn.execute(stmt, []);
-        if res.is_err() {
-            println!("migration failed on:\n{}\n{:?}", stmt, res);
-            break;
-        }
-
-        i += 1;
-    }
-
-    set_schema_version(conn, i)?;
-
+    // commit transaction
+    tx.commit()?;
     Ok(())
 }
 


### PR DESCRIPTION
### Description

During table creation, Sqlite does not throw an error when a column datatype is not defined. In addition, the datatype provided during table creation does not put a constraint on the type of data that can be put in that column. So you can easily put a string value in an integer column. Despite this, I think it is important for us to add the datatype for clarity.

### Notes to the reviewers

You can read more about how Sqlite dynamic typing [here](https://www.sqlite.org/faq.html). I have amended our `migrate` code with a new commit. The idea is to run migrations in a transaction so that they either succeed or fail. This prevents us from having the database in an inconsistent state at any point in time.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing


#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
