### PR TITLE
[bug-fix] Set the sync time in populate test db.

### DIFF
--- a/src/database/memory.rs
+++ b/src/database/memory.rs
@@ -520,6 +520,13 @@ macro_rules! populate_test_db {
                 timestamp: 0,
             });
 
+        let sync_time = BlockTime {
+            height: current_height.unwrap(),
+            timestamp: 0
+        };
+
+        db.set_sync_time(SyncTime{block_time: sync_time}).unwrap();
+
         let tx_details = $crate::TransactionDetails {
             transaction: Some(tx.clone()),
             txid,

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -2114,6 +2114,12 @@ pub(crate) mod test {
     }
 
     #[test]
+    fn test_get_funded_wallet_balance() {
+        let (wallet, _, _) = get_funded_wallet(get_test_wpkh());
+        assert_eq!(wallet.get_balance().unwrap().confirmed, 50000);
+    }
+
+    #[test]
     #[should_panic(expected = "NoRecipients")]
     fn test_create_tx_empty_recipients() {
         let (wallet, _, _) = get_funded_wallet(get_test_wpkh());


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

After recent changes in balance calculation, the `get_funded_wallet` test function will not show any balance because we are not setting the `sync_time` in the `populate_test_db` macro.. 

Our existing tests are not failing, because even if the balance is shown zero, it will still be able to produce transactions. But its causing test failure in downstream `bdk-reserves` crate where the balances are required to assert scenarios. 

### Notes to the reviewers

This will be replayed in #624 too, as this function is being refactored there.. For now opening it as separate PR for quick merge.  

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [x] I've added tests to reproduce the issue which are now passing
