### PR TITLE
Implement Deref<Target=UrlClient> for EsploraBlockchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.18.0] - [v0.17.0]
 
-- Add `sqlite-bundled` feature for deployments that need a bundled version of sqlite, ie. for mobile platforms.
+- Add `sqlite-bundled` feature for deployments that need a bundled version of sqlite, i.e. for mobile platforms.
 - Added `Wallet::get_signers()`, `Wallet::descriptor_checksum()` and `Wallet::get_address_validators()`, exposed the `AsDerived` trait.
 - Deprecate `database::Database::flush()`, the function is only needed for the sled database on mobile, instead for mobile use the sqlite database.
 - Add `keychain: KeychainKind` to `wallet::AddressInfo`.

--- a/DEVELOPMENT_CYCLE.md
+++ b/DEVELOPMENT_CYCLE.md
@@ -39,7 +39,7 @@ Pre-`v1.0.0` our "major" releases only affect the "minor" semver value. Accordin
 11. Publish **all** the updated crates to crates.io.
 12. Make a new commit to bump the version value to `x.y.(z+1)-dev`. The message should be "Bump version to x.y.(z+1)-dev".
 13. Merge the release branch back into `master`.
-14. If the `master` branch contains any unreleased changes to the `bdk-macros` crate, change the `bdk` Cargo.toml `[dependencies]` to point to the local path (ie. `bdk-macros = { path = "./macros"}`)
+14. If the `master` branch contains any unreleased changes to the `bdk-macros` crate, change the `bdk` Cargo.toml `[dependencies]` to point to the local path (i.e. `bdk-macros = { path = "./macros"}`)
 15. Create the release on GitHub: go to "tags", click on the dots on the right and select "Create Release". Then set the title to `vx.y.z` and write down some brief release notes.
 16. Make sure the new release shows up on crates.io and that the docs are built correctly on docs.rs.
 17. Announce the release on Twitter, Discord and Telegram.

--- a/src/blockchain/esplora/reqwest.rs
+++ b/src/blockchain/esplora/reqwest.rs
@@ -31,8 +31,9 @@ use crate::database::BatchDatabase;
 use crate::error::Error;
 use crate::FeeRate;
 
+/// Structure that encapsulates Esplora client
 #[derive(Debug)]
-struct UrlClient {
+pub struct UrlClient {
     url: String,
     // We use the async client instead of the blocking one because it automatically uses `fetch`
     // when the target platform is wasm32.
@@ -98,6 +99,14 @@ impl Blockchain for EsploraBlockchain {
     fn estimate_fee(&self, target: usize) -> Result<FeeRate, Error> {
         let estimates = await_or_block!(self.url_client._get_fee_estimates())?;
         super::into_fee_rate(target, estimates)
+    }
+}
+
+impl Deref for EsploraBlockchain {
+    type Target = UrlClient;
+
+    fn deref(&self) -> &Self::Target {
+        &self.url_client
     }
 }
 

--- a/src/blockchain/esplora/ureq.rs
+++ b/src/blockchain/esplora/ureq.rs
@@ -33,8 +33,9 @@ use crate::database::BatchDatabase;
 use crate::error::Error;
 use crate::FeeRate;
 
+/// Structure that encapsulates Esplora client
 #[derive(Debug, Clone)]
-struct UrlClient {
+pub struct UrlClient {
     url: String,
     agent: Agent,
 }
@@ -95,6 +96,14 @@ impl Blockchain for EsploraBlockchain {
     fn estimate_fee(&self, target: usize) -> Result<FeeRate, Error> {
         let estimates = self.url_client._get_fee_estimates()?;
         super::into_fee_rate(target, estimates)
+    }
+}
+
+impl Deref for EsploraBlockchain {
+    type Target = UrlClient;
+
+    fn deref(&self) -> &Self::Target {
+        &self.url_client
     }
 }
 

--- a/src/descriptor/dsl.rs
+++ b/src/descriptor/dsl.rs
@@ -839,7 +839,7 @@ mod test {
         }
     }
 
-    // - at least one of each "type" of operator; ie. one modifier, one leaf_opcode, one leaf_opcode_value, etc.
+    // - at least one of each "type" of operator; i.e. one modifier, one leaf_opcode, one leaf_opcode_value, etc.
     // - mixing up key types that implement IntoDescriptorKey in multi() or thresh()
 
     // expected script for pk and bare manually created

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -325,7 +325,7 @@ where
 
     /// Return a derived address using the external descriptor, see [`AddressIndex`] for
     /// available address index selection strategies. If none of the keys in the descriptor are derivable
-    /// (ie. does not end with /*) then the same address will always be returned for any [`AddressIndex`].
+    /// (i.e. does not end with /*) then the same address will always be returned for any [`AddressIndex`].
     pub fn get_address(&self, address_index: AddressIndex) -> Result<AddressInfo, Error> {
         self._get_address(address_index, KeychainKind::External)
     }
@@ -335,7 +335,7 @@ where
     /// If the wallet doesn't have an internal descriptor it will use the external descriptor.
     ///
     /// see [`AddressIndex`] for available address index selection strategies. If none of the keys
-    /// in the descriptor are derivable (ie. does not end with /*) then the same address will always
+    /// in the descriptor are derivable (i.e. does not end with /*) then the same address will always
     /// be returned for any [`AddressIndex`].
     pub fn get_internal_address(&self, address_index: AddressIndex) -> Result<AddressInfo, Error> {
         self._get_address(address_index, KeychainKind::Internal)
@@ -454,7 +454,7 @@ where
     /// });
     /// ```
     ///
-    /// Note that this methods only operate on the internal database, which first needs to be
+    /// Note that this method only operates on the internal database, which first needs to be
     /// [`Wallet::sync`] manually.
     pub fn list_transactions(&self, include_raw: bool) -> Result<Vec<TransactionDetails>, Error> {
         self.database.borrow().iter_txs(include_raw)
@@ -463,7 +463,7 @@ where
     /// Return the balance, separated into available, trusted-pending, untrusted-pending and immature
     /// values.
     ///
-    /// Note that this methods only operate on the internal database, which first needs to be
+    /// Note that this method only operates on the internal database, which first needs to be
     /// [`Wallet::sync`] manually.
     pub fn get_balance(&self) -> Result<Balance, Error> {
         let mut immature = 0;

--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -516,7 +516,7 @@ impl<'a, D: BatchDatabase, Cs: CoinSelectionAlgorithm<D>, Ctx: TxBuilderContext>
         }
     }
 
-    /// Finish the building the transaction.
+    /// Finish building the transaction.
     ///
     /// Returns the [`BIP174`] "PSBT" and summary details about the transaction.
     ///


### PR DESCRIPTION

### Description

There is currently no way to access the client from the EsploraBlockchain. This makes it difficult for users to extend it's functionality. This PR exposes both the reqwest and ureq clients. This PR is related to PR #705.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

