### PR TITLE
Fix P2WPKH_SATISFACTION_SIZE in CS tests

### DIFF
--- a/src/wallet/coin_selection.rs
+++ b/src/wallet/coin_selection.rs
@@ -734,7 +734,9 @@ mod test {
     use rand::seq::SliceRandom;
     use rand::{Rng, SeedableRng};
 
-    const P2WPKH_SATISFACTION_SIZE: usize = 73 + 33 + 2 + 1;
+    // n. of items on witness (1WU) + signature len (1WU) + signature and sighash (72WU)
+    // + pubkey len (1WU) + pubkey (33WU) + script sig len (1 byte, 4WU)
+    const P2WPKH_SATISFACTION_SIZE: usize = 1 + 1 + 72 + 1 + 33 + 4;
 
     const FEE_AMOUNT: u64 = 50;
 


### PR DESCRIPTION
Our costant for the P2WPKH satisfaction size was wrong: in
7ac87b8f99fc0897753ce57d48ea24adf495a633 we added 1 WU for the script
sig len - but actually, that's 4WU! This resulted in
P2WPKH_SATISFACTION_SIZE being equal to 109 instead of 112.
This also adds a comment for better readability.

### Description

### Notes to the reviewers

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
