### PR TITLE
Add API to delete spent UTXOs from database

### DIFF
--- a/src/database/keyvalue.rs
+++ b/src/database/keyvalue.rs
@@ -532,4 +532,9 @@ mod test {
     fn test_check_descriptor_checksum() {
         crate::database::test::test_check_descriptor_checksum(get_tree());
     }
+
+    #[test]
+    fn test_del_spent_utxos() {
+        crate::database::test::test_del_spent_utxos(get_tree());
+    }
 }

--- a/src/database/memory.rs
+++ b/src/database/memory.rs
@@ -687,4 +687,9 @@ mod test {
     fn test_check_descriptor_checksum() {
         crate::database::test::test_check_descriptor_checksum(get_tree());
     }
+
+    #[test]
+    fn test_del_spent_utxos() {
+        crate::database::test::test_del_spent_utxos(get_tree());
+    }
 }

--- a/src/database/sqlite.rs
+++ b/src/database/sqlite.rs
@@ -1096,4 +1096,9 @@ pub mod test {
     fn test_check_descriptor_checksum() {
         crate::database::test::test_check_descriptor_checksum(get_database());
     }
+
+    #[test]
+    fn test_del_spent_utxos() {
+        crate::database::test::test_del_spent_utxos(get_database());
+    }
 }


### PR DESCRIPTION
### Description

We currently store spent UTXOs in the database with an `is_spent` field and we don't provide users with a way to delete these UTXOs. The issue here is that these could easily bloat the database or memory. This PR provides methods that can allow users to delete spent UTXOs from the database following certain criteria like size of spent utxos and number of confirmations.
This PR fixes issue #573

### Notes to the reviewers

I haven't added this change to the change log and written test for it. I'm thinking we can use this PR as a starting point to discuss how best we can solve this issue. I think having an API that users can call manually is a great start towards solving this issue but it  might also be necessary to implement an automatic version of this. 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature
* [ ] I've updated `CHANGELOG.md`
