### PR TITLE
Add `process_and_select_coins` function

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -13,7 +13,7 @@ use std::convert::AsRef;
 use std::ops::Sub;
 
 use bitcoin::blockdata::transaction::{OutPoint, Transaction, TxOut};
-use bitcoin::{hash_types::Txid, util::psbt};
+use bitcoin::{hash_types::Txid, util::psbt, Script};
 
 use serde::{Deserialize, Serialize};
 
@@ -175,6 +175,18 @@ pub struct WeightedUtxo {
     pub satisfaction_weight: usize,
     /// The UTXO
     pub utxo: Utxo,
+}
+
+/// A wallet owned script_pubkey with the weight of the `witness` + `scriptSig` in [weight units]
+/// to spend from it.
+/// Useful to optimize reducing the waste metric in coin selection algorithms.
+/// [weight units]: <https://en.bitcoin.it/wiki/Weight_units>
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WeightedScriptPubkey {
+    /// The weight of the witness data and `scriptSig` expressed in [weight units].
+    pub satisfaction_weight: usize,
+    /// The script_pubkey
+    pub script_pubkey: Script,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -56,7 +56,7 @@ pub use utils::IsDust;
 
 #[allow(deprecated)]
 use address_validator::AddressValidator;
-use coin_selection::DefaultCoinSelectionAlgorithm;
+use coin_selection::{process_and_select_coins, DefaultCoinSelectionAlgorithm, Excess};
 use signer::{SignOptions, SignerOrdering, SignersContainer, TransactionSigner};
 use tx_builder::{BumpFee, CreateTx, FeePolicy, TxBuilder, TxParams};
 use utils::{check_nlocktime, check_nsequence_rbf, After, Older, SecpCtx};
@@ -76,7 +76,6 @@ use crate::psbt::PsbtUtils;
 use crate::signer::SignerError;
 use crate::testutils;
 use crate::types::*;
-use crate::wallet::coin_selection::Excess::{Change, NoChange};
 
 const CACHE_ADDR_BATCH_SIZE: u32 = 100;
 const COINBASE_MATURITY: u32 = 100;
@@ -843,25 +842,41 @@ where
             current_height,
         )?;
 
-        // get drain script
-        let drain_script = match params.drain_to {
-            Some(ref drain_recipient) => drain_recipient.clone(),
-            None => self
-                .get_internal_address(AddressIndex::New)?
-                .address
-                .script_pubkey(),
+        // prepare the drain script
+        let weighted_drain_script = {
+            let script_pubkey = match params.drain_to {
+                Some(ref drain_recipient) => drain_recipient.clone(),
+                None => self
+                    .get_internal_address(AddressIndex::New)?
+                    .address
+                    .script_pubkey(),
+            };
+
+            let satisfaction_weight = if params.drain_to.is_none() {
+                self.get_descriptor_for_keychain(KeychainKind::Internal)
+                    .max_satisfaction_weight()
+                    .unwrap()
+            } else {
+                0
+            };
+
+            WeightedScriptPubkey {
+                satisfaction_weight,
+                script_pubkey,
+            }
         };
 
-        let coin_selection = coin_selection.coin_select(
+        let coin_selection = process_and_select_coins(
+            coin_selection,
             self.database.borrow().deref(),
             required_utxos,
             optional_utxos,
             fee_rate,
             outgoing + fee_amount,
-            &drain_script,
+            &weighted_drain_script,
         )?;
+
         fee_amount += coin_selection.fee_amount;
-        let excess = &coin_selection.excess;
 
         tx.input = coin_selection
             .selected
@@ -883,11 +898,11 @@ where
             // Otherwise, we don't know who we should send the funds to, and how much
             // we should send!
             if params.drain_to.is_some() && (params.drain_wallet || !params.utxos.is_empty()) {
-                if let NoChange {
+                if let Excess::NoChange {
                     dust_threshold,
                     remaining_amount,
                     change_fee,
-                } = excess
+                } = &coin_selection.excess
                 {
                     return Err(Error::InsufficientFunds {
                         needed: *dust_threshold,
@@ -899,11 +914,12 @@ where
             }
         }
 
-        match excess {
-            NoChange {
+        match &coin_selection.excess {
+            Excess::NoChange {
                 remaining_amount, ..
             } => fee_amount += remaining_amount,
-            Change { amount, fee } => {
+            Excess::Change { amount, fee } => {
+                let drain_script = weighted_drain_script.script_pubkey;
                 if self.is_mine(&drain_script)? {
                     received += amount;
                 }


### PR DESCRIPTION
### Description

There were some common tasks identified in the construction of a coin selection
result that the different algorithms performed separately. Those tasks were
blended inside the algorithms or separated into functions, but the underlying
actions were the same:
- Do some preprocessing to the inputs.
- Select utxos based in the algorithm criterium.
- Decide change.
- Build the coin selection result.

This commit intends to create a single function that consumes different
algorithms and perform all the mentioned tasks as a pipeline taking utxos as
input and producing coin selection results at the end.

The new function reduces the work needed to implement other coin selection
algorithms, modularizes the code not related directly to the selection process
and reduces the number of lines to review and understand its logic.

~As a side effect of the implementation, the `SingleRandomDraw` algorithm was
extracted from its host algorithm, `BranchAndBound`, and introduced as a
`FallBack` algorithm. But I consider this a feature.~

### Notes to the reviewers

I'm not totally satisfied with some parts of the code.

For example, I don't like to have "ad-hoc" parameters in the current signature
of `coin_select` just for the sake of `BranchAndBound` compatibility. I thought
of some solutions to this, like the addition of a `cost_of_change` field into the
struct or the recomputation of the available value inside
`BranchAndBound::coin_select` (duplicating the amount of work), but I would
like to hear other opinions.

Another thing that bothers me is the conversion of `target_amount` from u64 to
i64 and the other way back. I must be obfuscated with it because I can't see
another way to do it.

This PR will set up the structure needed to integrate the Waste metric (#558)
with the coin selection module.

**BREAKING CHANGES**: This PR modifies the API of `coin_select` and introduce a new
function, `get_selection`, that supersedes its functionality.

### Changelog notice

- Added `process_and_select_coins()` function.
- Added `OutputGroup`s as a public structure that holds the `WeightedUtxo`, its
  effective value, and its fees.
- Changed `CoinSelectionAlgorithm::coin_select()` signature. The scope of the
  selection was reduced to select utxos only from `optional_utxos`. It only
  returns the selected `OutputGroups` from now on.
- Added `WeightedScriptPubkey` struct.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've ~added~ updated the tests for the new feature
* [x] I've added docs for the new feature
* [x] I've updated `CHANGELOG.md`
