### PR TITLE
Make `RpcBlockchain` import more efficient

### DIFF
--- a/src/blockchain/any.rs
+++ b/src/blockchain/any.rs
@@ -194,7 +194,7 @@ impl_from!(boxed rpc::RpcBlockchain, AnyBlockchain, Rpc, #[cfg(feature = "rpc")]
 /// );
 /// # }
 /// ```
-#[derive(Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AnyBlockchainConfig {
     #[cfg(feature = "electrum")]

--- a/src/blockchain/compact_filters/mod.rs
+++ b/src/blockchain/compact_filters/mod.rs
@@ -479,7 +479,7 @@ impl WalletSync for CompactFiltersBlockchain {
 }
 
 /// Data to connect to a Bitcoin P2P peer
-#[derive(Debug, serde::Deserialize, serde::Serialize, Clone, PartialEq)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone, PartialEq, Eq)]
 pub struct BitcoinPeerConfig {
     /// Peer address such as 127.0.0.1:18333
     pub address: String,
@@ -490,7 +490,7 @@ pub struct BitcoinPeerConfig {
 }
 
 /// Configuration for a [`CompactFiltersBlockchain`]
-#[derive(Debug, serde::Deserialize, serde::Serialize, Clone, PartialEq)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone, PartialEq, Eq)]
 pub struct CompactFiltersBlockchainConfig {
     /// List of peers to try to connect to for asking headers and filters
     pub peers: Vec<BitcoinPeerConfig>,

--- a/src/blockchain/electrum.rs
+++ b/src/blockchain/electrum.rs
@@ -296,7 +296,7 @@ impl<'a, 'b, D: Database> TxCache<'a, 'b, D> {
 }
 
 /// Configuration for an [`ElectrumBlockchain`]
-#[derive(Debug, serde::Deserialize, serde::Serialize, Clone, PartialEq)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone, PartialEq, Eq)]
 pub struct ElectrumBlockchainConfig {
     /// URL of the Electrum server (such as ElectrumX, Esplora, BWT) may start with `ssl://` or `tcp://` and include a port
     ///

--- a/src/blockchain/esplora/mod.rs
+++ b/src/blockchain/esplora/mod.rs
@@ -97,7 +97,7 @@ impl fmt::Display for EsploraError {
 }
 
 /// Configuration for an [`EsploraBlockchain`]
-#[derive(Debug, serde::Deserialize, serde::Serialize, Clone, PartialEq)]
+#[derive(Debug, serde::Deserialize, serde::Serialize, Clone, PartialEq, Eq)]
 pub struct EsploraBlockchainConfig {
     /// Base URL of the esplora service
     ///

--- a/src/blockchain/rpc.rs
+++ b/src/blockchain/rpc.rs
@@ -77,7 +77,7 @@ impl Deref for RpcBlockchain {
 }
 
 /// RpcBlockchain configuration options
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct RpcConfig {
     /// The bitcoin node url
     pub url: String,
@@ -96,7 +96,7 @@ pub struct RpcConfig {
 /// In general, BDK tries to sync `scriptPubKey`s cached in [`crate::database::Database`] with
 /// `scriptPubKey`s imported in the Bitcoin Core Wallet. These parameters are used for determining
 /// how the `importdescriptors` RPC calls are to be made.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct RpcSyncParams {
     /// The minimum number of scripts to scan for on initial sync.
     pub start_script_count: usize,
@@ -373,7 +373,7 @@ impl<'a, D: BatchDatabase> DbState<'a, D> {
 
     /// Sync states of [BatchDatabase] and Core wallet.
     /// First we import all `scriptPubKey`s from database into core wallet
-    fn sync_with_core(&mut self, client: &Client, is_descriptor: bool) -> Result<&mut Self, Error> {
+    fn sync_with_core(&mut self, client: &Client, use_desc: bool) -> Result<&mut Self, Error> {
         // this tells Core wallet where to sync from for imported scripts
         let start_epoch = if self.params.force_start_time {
             self.params.start_time
@@ -385,7 +385,7 @@ impl<'a, D: BatchDatabase> DbState<'a, D> {
 
         // sync scriptPubKeys from Database to Core wallet
         let scripts_iter = self.ext_spks.iter().chain(&self.int_spks);
-        if is_descriptor {
+        if use_desc {
             import_descriptors(client, start_epoch, scripts_iter)?;
         } else {
             import_multi(client, start_epoch, scripts_iter)?;

--- a/src/blockchain/rpc.rs
+++ b/src/blockchain/rpc.rs
@@ -98,11 +98,12 @@ pub struct RpcConfig {
 /// how the `importdescriptors` RPC calls are to be made.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct RpcSyncParams {
-    /// The minimum number of scripts to scan for on initial sync.
+    /// The minimum number of scripts to scan for on the first sync.
     pub start_script_count: usize,
     /// Time in unix seconds in which initial sync will start scanning from (0 to start from genesis).
     pub start_time: u64,
-    /// Forces every sync to use `start_time` as import timestamp.
+    /// Forces every sync to use [`crate::database::SyncTime`] as import timestamp. The default
+    /// behavior is to use the last `sync_time` as the import timestamp.
     pub force_start_time: bool,
     /// RPC poll rate (in seconds) to get state updates.
     pub poll_rate_sec: u64,

--- a/src/testutils/blockchain_tests.rs
+++ b/src/testutils/blockchain_tests.rs
@@ -755,6 +755,12 @@ macro_rules! bdk_blockchain_tests {
 
                 blockchain.broadcast(&tx1).expect("broadcasting first");
                 blockchain.broadcast(&tx2).expect("broadcasting replacement");
+
+                // TODO @evanlinjin: Core's `listtransactions` RPC call does not return conflicting
+                // unconfirmed transactions (unless we re-import associated scriptPubKey/descriptor)
+                #[cfg(feature = "rpc")]
+                blockchain.replace_import_parameters(Default::default());
+
                 receiver_wallet.sync(&blockchain, SyncOptions::default()).expect("syncing receiver");
                 assert_eq!(receiver_wallet.get_balance().expect("balance").untrusted_pending, 49_000, "should have received coins once and only once");
             }

--- a/src/types.rs
+++ b/src/types.rs
@@ -166,7 +166,7 @@ pub struct LocalUtxo {
 }
 
 /// A [`Utxo`] with its `satisfaction_weight`.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WeightedUtxo {
     /// The weight of the witness data and `scriptSig` expressed in [weight units]. This is used to
     /// properly maintain the feerate when adding this input to a transaction during coin selection.
@@ -177,7 +177,7 @@ pub struct WeightedUtxo {
     pub utxo: Utxo,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 /// An unspent transaction output (UTXO).
 pub enum Utxo {
     /// A UTXO owned by the local wallet.

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -143,7 +143,7 @@ pub enum AddressIndex {
 
 /// A derived address and the index it was found at
 /// For convenience this automatically derefs to `Address`
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct AddressInfo {
     /// Child index of this address
     pub index: u32,

--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -720,7 +720,7 @@ pub struct SignOptions {
 }
 
 /// Customize which taproot script-path leaves the signer should sign.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TapLeavesOptions {
     /// The signer will sign all the leaves it has a key for.
     All,


### PR DESCRIPTION
Fixes #715

### Description

Introduces `RpcImportParams` that keeps track of next derivation index to start import from for next sync. This avoids re-importing scripts/descriptors into Bitcoin Core for every sync cycle. However, the user will be responsible for persisting the `RpcImportParams` structure; the `RpcBlockchain::get_import_parameters` and `RpcBlockchain::replace_import_parameters` functions can be used for this purpose.

Also add pagination for importing scripts/descriptors.

Also had to make `clippy` happy by deriving `Eq` for various structures.

### Notes to the reviewers

Refer to: https://github.com/bitcoindevkit/bdk/issues/715#issuecomment-1233656187

### Changelog notice

* Introduce `RpcImportParams` to make sync more efficient
* Introduce `RpcSyncParams::page_size` to restrict request/response array size of RPC calls

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

~* [ ] This pull request breaks the existing API~
~* [ ] I've added tests to reproduce the issue which are now passing~ (This is a performance bug fix)
* [x] I'm linking the issue being fixed by this PR
