### PR TITLE
Enable signing taproot transactions with only `non_witness_utxos`

### DIFF
--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -103,6 +103,7 @@ use miniscript::{Legacy, MiniscriptKey, Segwitv0, Tap};
 
 use super::utils::SecpCtx;
 use crate::descriptor::{DescriptorMeta, XKeyUtils};
+use crate::psbt::PsbtUtils;
 
 /// Identifier of a signer in the `SignersContainers`. Used as a key to find the right signer among
 /// multiple of them
@@ -921,11 +922,8 @@ impl ComputeSighash for Tap {
             .unwrap_or_else(|| SchnorrSighashType::Default.into())
             .schnorr_hash_ty()
             .map_err(|_| SignerError::InvalidSighash)?;
-        let witness_utxos = psbt
-            .inputs
-            .iter()
-            .cloned()
-            .map(|i| i.witness_utxo)
+        let witness_utxos = (0..psbt.inputs.len())
+            .map(|i| psbt.get_utxo_for(i))
             .collect::<Vec<_>>();
         let mut all_witness_utxos = vec![];
 


### PR DESCRIPTION
### Description

Some wallets may only specify the `non_witness_utxo` for a PSBT input. If that's the case, BDK should still be able to sign.

This was pointed out in the discussion of #734

### Changelog notice

- Enable signing taproot transactions that only specify the `non_witness_utxo`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
