### PR TITLE
Remove redundant duplicated keys check

### DIFF
--- a/src/descriptor/error.rs
+++ b/src/descriptor/error.rs
@@ -20,8 +20,6 @@ pub enum Error {
     InvalidDescriptorChecksum,
     /// The descriptor contains hardened derivation steps on public extended keys
     HardenedDerivationXpub,
-    /// The descriptor contains multiple keys with the same BIP32 fingerprint
-    DuplicatedKeys,
 
     /// Error thrown while working with [`keys`](crate::keys)
     Key(crate::keys::KeyError),

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -2077,6 +2077,10 @@ pub(crate) mod test {
         "tr(cNJmN3fH9DDbDt131fQNkVakkpzawJBSeybCUNmP1BovpmGQ45xG,{pk(tprv8ZgxMBicQKsPdDArR4xSAECuVxeX1jwwSXR4ApKbkYgZiziDc4LdBy2WvJeGDfUSE4UT4hHhbgEwbdq8ajjUHiKDegkwrNU6V55CxcxonVN/*),pk(8aee2b8120a5f157f1223f72b5e62b825831a27a9fdf427db7cc697494d4a642)})"
     }
 
+    pub(crate) fn get_test_tr_dup_keys() -> &'static str {
+        "tr(cNJmN3fH9DDbDt131fQNkVakkpzawJBSeybCUNmP1BovpmGQ45xG,{pk(8aee2b8120a5f157f1223f72b5e62b825831a27a9fdf427db7cc697494d4a642),pk(8aee2b8120a5f157f1223f72b5e62b825831a27a9fdf427db7cc697494d4a642)})"
+    }
+
     macro_rules! assert_fee_rate {
         ($psbt:expr, $fees:expr, $fee_rate:expr $( ,@dust_change $( $dust_change:expr )* )* $( ,@add_signature $( $add_signature:expr )* )* ) => ({
             let psbt = $psbt.clone();
@@ -5553,5 +5557,20 @@ pub(crate) mod test {
 
         let finalized = wallet.sign(&mut psbt, Default::default()).unwrap();
         assert!(finalized);
+    }
+
+    #[test]
+    fn test_taproot_load_descriptor_duplicated_keys() {
+        // Added after issue https://github.com/bitcoindevkit/bdk/issues/760
+        //
+        // Having the same key in multiple taproot leaves is safe and should be accepted by BDK
+
+        let (wallet, _, _) = get_funded_wallet(get_test_tr_dup_keys());
+        let addr = wallet.get_address(New).unwrap();
+
+        assert_eq!(
+            addr.to_string(),
+            "bcrt1pvysh4nmh85ysrkpwtrr8q8gdadhgdejpy6f9v424a8v9htjxjhyqw9c5s5"
+        );
     }
 }


### PR DESCRIPTION
### Description

This check is redundant since it's already performed by miniscript (see https://docs.rs/miniscript/7.0.0/miniscript/miniscript/analyzable/enum.AnalysisError.html#variant.RepeatedPubkeys) and it was incorrectly failing on tr descriptors that contain duplicated keys across different taproot leaves

Fixes #760

### Changelog notice


### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [x] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
