### PR TITLE
Fix `Wallet::descriptor_checksum` to actually return the checksum

### DIFF
--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1842,7 +1842,7 @@ where
             .to_string()
             .split_once('#')
             .unwrap()
-            .0
+            .1
             .to_string()
     }
 }
@@ -1937,6 +1937,22 @@ pub(crate) mod test {
     // Here, we push just once for simplicity, so we have to add an extra byte for the missing
     // OP_PUSH.
     const P2WPKH_FAKE_WITNESS_SIZE: usize = 106;
+
+    #[test]
+    fn test_descriptor_checksum() {
+        let (wallet, _, _) = get_funded_wallet(get_test_wpkh());
+        let checksum = wallet.descriptor_checksum(KeychainKind::External);
+        assert_eq!(checksum.len(), 8);
+
+        let raw_descriptor = wallet
+            .descriptor
+            .to_string()
+            .split_once('#')
+            .unwrap()
+            .0
+            .to_string();
+        assert_eq!(get_checksum(&raw_descriptor).unwrap(), checksum);
+    }
 
     #[test]
     fn test_get_funded_wallet_balance() {


### PR DESCRIPTION
### Description

`Wallet::descriptor_checksum` should return the checksum, not the descriptor without the checksum.

### Notes to the reviewers

Please merge.

### Changelog notice

Fix `Wallet::descriptor_checksum` to actually return the descriptor checksum.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

~* [ ] This pull request breaks the existing API~
* [x] I've added tests to reproduce the issue which are now passing
~* [ ] I'm linking the issue being fixed by this PR~
