### PR TITLE
Remove generic `D: Database` from `CoinSelectionAlgorithm`

### DIFF
--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -605,7 +605,7 @@ where
         }
     }
 
-    pub(crate) fn create_tx<Cs: coin_selection::CoinSelectionAlgorithm<D>>(
+    pub(crate) fn create_tx<Cs: coin_selection::CoinSelectionAlgorithm>(
         &self,
         coin_selection: Cs,
         params: TxParams,
@@ -853,7 +853,6 @@ where
         };
 
         let coin_selection = coin_selection.coin_select(
-            self.database.borrow().deref(),
             required_utxos,
             optional_utxos,
             fee_rate,

--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -181,7 +181,7 @@ impl<'a, Cs: Clone, Ctx, D> Clone for TxBuilder<'a, D, Cs, Ctx> {
 }
 
 // methods supported by both contexts, for any CoinSelectionAlgorithm
-impl<'a, D: BatchDatabase, Cs: CoinSelectionAlgorithm<D>, Ctx: TxBuilderContext>
+impl<'a, D: BatchDatabase, Cs: CoinSelectionAlgorithm, Ctx: TxBuilderContext>
     TxBuilder<'a, D, Cs, Ctx>
 {
     /// Set a custom fee rate
@@ -505,7 +505,7 @@ impl<'a, D: BatchDatabase, Cs: CoinSelectionAlgorithm<D>, Ctx: TxBuilderContext>
     /// Overrides the [`DefaultCoinSelectionAlgorithm`](super::coin_selection::DefaultCoinSelectionAlgorithm).
     ///
     /// Note that this function consumes the builder and returns it so it is usually best to put this as the first call on the builder.
-    pub fn coin_selection<P: CoinSelectionAlgorithm<D>>(
+    pub fn coin_selection<P: CoinSelectionAlgorithm>(
         self,
         coin_selection: P,
     ) -> TxBuilder<'a, D, P, Ctx> {
@@ -571,7 +571,7 @@ impl<'a, D: BatchDatabase, Cs: CoinSelectionAlgorithm<D>, Ctx: TxBuilderContext>
     }
 }
 
-impl<'a, D: BatchDatabase, Cs: CoinSelectionAlgorithm<D>> TxBuilder<'a, D, Cs, CreateTx> {
+impl<'a, D: BatchDatabase, Cs: CoinSelectionAlgorithm> TxBuilder<'a, D, Cs, CreateTx> {
     /// Replace the recipients already added with a new list
     pub fn set_recipients(&mut self, recipients: Vec<(Script, u64)>) -> &mut Self {
         self.params.recipients = recipients;


### PR DESCRIPTION
Fixes #281 

### Description

Since `CoinSelectionAlgorithm` is a trait, if the database is really needed, one can create a struct that contains a database field which implements the `CoinSelectionAlgorithm` trait.

Most `CoinSelectionAlgorithm` implementations do not require a database.

### Changelog notice

The `CoinSelectionAlgorithm` trait no longer depends on a database.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

~* [ ] I've added tests for the new feature~
* [x] I've added docs for the new feature
* [x] This pull request breaks the existing API (it removes a single input from a trait's method)
