### PR TITLE
`FeeRate` calculation fixes

### DIFF
--- a/src/testutils/blockchain_tests.rs
+++ b/src/testutils/blockchain_tests.rs
@@ -1021,7 +1021,7 @@ macro_rules! bdk_blockchain_tests {
                 assert_eq!(details.received, 1_000 - details.fee.unwrap_or(0), "incorrect received after send");
 
                 let mut builder = wallet.build_fee_bump(details.txid).unwrap();
-                builder.fee_rate(FeeRate::from_sat_per_vb(123.0));
+                builder.fee_rate(FeeRate::from_sat_per_vb(124.0));
                 let (mut new_psbt, new_details) = builder.finish().unwrap();
                 println!("{:#?}", new_details);
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -141,13 +141,13 @@ impl Sub for FeeRate {
 }
 
 /// Trait implemented by types that can be used to measure weight units.
-pub trait Vbytes {
+pub trait WeightUnits {
     /// Convert weight units to virtual bytes.
-    fn vbytes(self) -> f32;
+    fn to_vbytes(self) -> f32;
 }
 
-impl Vbytes for usize {
-    fn vbytes(self) -> f32 {
+impl WeightUnits for usize {
+    fn to_vbytes(self) -> f32 {
         // ref: https://github.com/bitcoin/bips/blob/master/bip-0141.mediawiki#transaction-size-calculations
         self as f32 / 4.0
     }

--- a/src/wallet/coin_selection.rs
+++ b/src/wallet/coin_selection.rs
@@ -727,7 +727,7 @@ mod test {
     use super::*;
     use crate::database::{BatchOperations, MemoryDatabase};
     use crate::types::*;
-    use crate::wallet::Vbytes;
+    use crate::wallet::WeightUnits;
 
     use rand::rngs::StdRng;
     use rand::seq::SliceRandom;
@@ -1318,7 +1318,7 @@ mod test {
 
         assert_eq!(result.selected.len(), 1);
         assert_eq!(result.selected_amount(), 100_000);
-        let input_size = (TXIN_BASE_WEIGHT + P2WPKH_SATISFACTION_SIZE).vbytes();
+        let input_size = (TXIN_BASE_WEIGHT + P2WPKH_SATISFACTION_SIZE).to_vbytes();
         // the final fee rate should be exactly the same as the fee rate given
         assert!((1.0 - (result.fee_amount as f32 / input_size as f32)).abs() < f32::EPSILON);
     }

--- a/src/wallet/coin_selection.rs
+++ b/src/wallet/coin_selection.rs
@@ -304,9 +304,8 @@ impl<D: Database> CoinSelectionAlgorithm<D> for OldestFirstCoinSelection {
 /// - `fee_rate`: required fee rate for the current selection
 /// - `drain_script`: script to consider change creation
 pub fn decide_change(remaining_amount: u64, fee_rate: FeeRate, drain_script: &Script) -> Excess {
-    // drain_output_len = size(len(script_pubkey)) + len(script_pubkey) + size(output_value)
-    let drain_output_len = serialize(drain_script).len() + 8usize;
-    let change_fee = fee_rate.fee_vb(drain_output_len);
+    let drain_output_len = serialize(drain_script).len() + 8_usize;
+    let change_fee = fee_rate.fee_vb(drain_output_len as f32);
     let drain_val = remaining_amount.saturating_sub(change_fee);
 
     if drain_val.is_dust(drain_script) {

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -2649,7 +2649,7 @@ pub(crate) mod test {
         builder
             .drain_to(addr.script_pubkey())
             .drain_wallet()
-            .fee_rate(FeeRate::from_sat_per_vb(453.0));
+            .fee_rate(FeeRate::from_sat_per_vb(455.0));
         builder.finish().unwrap();
     }
 


### PR DESCRIPTION
### Description

Weight units should always be whole units. However, virtual bytes will need decimal places and the conversion from weight unit to vbytes should not be rounded.

This commit has the following changes:
* vbytes should always be represented in `f32`
* conversion between vbytes and weight units should never be rounded
* simple calculations (such as those for feerates) should be explicitly defined (instead of using multiple small functions)

### Notes to the reviewers

Some "feerate" values for tests needed to be increased. This is because we were calling `.ceil()` on weight unit to vbytes conversion before (which is wrong, and results in more "vbytes" than what is real).

### Changelog notice

Improve accuracy of fee/feerate calculations and conversions. Also renamed the `Vbytes` trait to `WeightUnits`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [x] This pull request breaks the existing API
~* [ ] I've added tests to reproduce the issue which are now passing~
~* [ ] I'm linking the issue being fixed by this PR~
