### PR TITLE
Make psbt mod public and add required docs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,7 +263,7 @@ pub mod descriptor;
 #[cfg(feature = "test-md-docs")]
 mod doctest;
 pub mod keys;
-pub(crate) mod psbt;
+pub mod psbt;
 pub(crate) mod types;
 pub mod wallet;
 

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -9,11 +9,17 @@
 // You may not use this file except in accordance with one or both of these
 // licenses.
 
+//! Additional functions on the `rust-bitcoin` `PartiallySignedTransaction` structure.
+
 use crate::FeeRate;
 use bitcoin::util::psbt::PartiallySignedTransaction as Psbt;
 use bitcoin::TxOut;
 
+// TODO upstream the functions here to `rust-bitcoin`?
+
+/// Trait to add functions to extract utxos and calculate fees.
 pub trait PsbtUtils {
+    /// Get the `TxOut` for the specified input index, if it doesn't exist in the PSBT `None` is returned.
     fn get_utxo_for(&self, input_index: usize) -> Option<TxOut>;
 
     /// The total transaction fee amount, sum of input amounts minus sum of output amounts, in Sats.


### PR DESCRIPTION
### Description

Make psbt mod public and add required docs. The module needs to be public so `bdk-ffi` can expose the new PSBT `fee_amount()` and `fee_rate()` functions.

### Notes to the reviewers

I should have done this as part of #728. 

### Changelog notice

Make psbt module public to expose PsbtUtils trait to downstream projects.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature
