### PR TITLE
Use Esplora's `get_block_hash()` method

### DIFF
--- a/src/blockchain/esplora/async.rs
+++ b/src/blockchain/esplora/async.rs
@@ -125,8 +125,9 @@ impl GetTx for EsploraBlockchain {
 #[maybe_async]
 impl GetBlockHash for EsploraBlockchain {
     fn get_block_hash(&self, height: u64) -> Result<BlockHash, Error> {
-        let block_header = await_or_block!(self.url_client.get_header(height as u32))?;
-        Ok(block_header.block_hash())
+        Ok(await_or_block!(self
+            .url_client
+            .get_block_hash(height as u32))?)
     }
 }
 

--- a/src/blockchain/esplora/blocking.rs
+++ b/src/blockchain/esplora/blocking.rs
@@ -110,8 +110,7 @@ impl GetTx for EsploraBlockchain {
 
 impl GetBlockHash for EsploraBlockchain {
     fn get_block_hash(&self, height: u64) -> Result<BlockHash, Error> {
-        let block_header = self.url_client.get_header(height as u32)?;
-        Ok(block_header.block_hash())
+        Ok(self.url_client.get_block_hash(height as u32)?)
     }
 }
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description
This PR makes use of the recently added `get_block_hash()` API method of the Esplora client. 

Previously, we retrieved the entire header to extract the `BlockHash`. Funnily enough, the header was internally retrieved through a combination of getting hash by height and then getting the header by hash.
<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

This is currently blocked on the next release of `rust-esplora-client`.
<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
