### PR TITLE
Update CI rust stable to 1.65.0

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - version: 1.60.0 # STABLE
+          - version: 1.65.0 # STABLE
             clippy: true
           - version: 1.56.1 # MSRV
         features:

--- a/src/descriptor/policy.rs
+++ b/src/descriptor/policy.rs
@@ -1197,7 +1197,7 @@ mod test {
 
         assert!(matches!(&policy.item, EcdsaSignature(PkOrF::Fingerprint(f)) if f == &fingerprint));
         assert!(
-            matches!(&policy.contribution, Satisfaction::Complete {condition} if condition.csv == None && condition.timelock == None)
+            matches!(&policy.contribution, Satisfaction::Complete {condition} if condition.csv.is_none() && condition.timelock.is_none())
         );
     }
 
@@ -1360,7 +1360,7 @@ mod test {
 
         assert!(matches!(policy.item, EcdsaSignature(PkOrF::Fingerprint(f)) if f == fingerprint));
         assert!(
-            matches!(policy.contribution, Satisfaction::Complete {condition} if condition.csv == None && condition.timelock == None)
+            matches!(policy.contribution, Satisfaction::Complete {condition} if condition.csv.is_none() && condition.timelock.is_none())
         );
     }
 


### PR DESCRIPTION
### Description

Updates CI's rust stable from 1.60.0 (7 April, 2022)  to 1.65.0 (3 November, 2022).

### Notes to the reviewers

I originally created this PR to update the esplora-client version so that I could bump the rust stable version, but that ended up getting done for the 0.24.0 release so all I had to do here was update the CI.

### Changelog notice

None.

### Checklists

#### All Submissions:

* [X] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
