### PR TITLE
electrum: add validate_domain to ElectrumBlockchainConfig

### DIFF
--- a/src/blockchain/any.rs
+++ b/src/blockchain/any.rs
@@ -178,7 +178,8 @@ impl_from!(boxed rpc::RpcBlockchain, AnyBlockchain, Rpc, #[cfg(feature = "rpc")]
 ///    "type" : "electrum",
 ///    "url" : "ssl://electrum.blockstream.info:50002",
 ///    "retry": 2,
-///    "stop_gap": 20
+///    "stop_gap": 20,
+///    "validate_domain": true
 /// }"#,
 /// )
 /// .unwrap();
@@ -190,6 +191,7 @@ impl_from!(boxed rpc::RpcBlockchain, AnyBlockchain, Rpc, #[cfg(feature = "rpc")]
 ///         socks5: None,
 ///         timeout: None,
 ///         stop_gap: 20,
+///         validate_domain: true,
 ///     })
 /// );
 /// # }

--- a/src/blockchain/electrum.rs
+++ b/src/blockchain/electrum.rs
@@ -312,6 +312,8 @@ pub struct ElectrumBlockchainConfig {
     pub timeout: Option<u8>,
     /// Stop searching addresses for transactions after finding an unused gap of this length
     pub stop_gap: usize,
+    /// Validate the domain when using SSL
+    pub validate_domain: bool,
 }
 
 impl ConfigurableBlockchain for ElectrumBlockchain {
@@ -323,6 +325,7 @@ impl ConfigurableBlockchain for ElectrumBlockchain {
             .retry(config.retry)
             .timeout(config.timeout)?
             .socks5(socks5)?
+            .validate_domain(config.validate_domain)
             .build();
 
         Ok(ElectrumBlockchain {
@@ -417,6 +420,7 @@ mod test {
                     retry: 0,
                     timeout: None,
                     stop_gap: stop_gap,
+                    validate_domain: true,
                 })
             }
         }


### PR DESCRIPTION
### Description

The purpose of the PR is to be able to configure both `stop_gap` **and** `validate_domain`. Perhaps there are nicer ways.

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [x] This pull request breaks the existing API
* [x] I'm linking the issue being fixed by this PR

Issue in https://github.com/bitcoindevkit/bdk/issues/804