### PR TITLE
Ensure there are no duplicated script_pubkeys in sqlite

### DIFF
--- a/src/database/sqlite.rs
+++ b/src/database/sqlite.rs
@@ -59,8 +59,15 @@ static MIGRATIONS: &[&str] = &[
     "DROP TABLE utxos_old;",
     "CREATE UNIQUE INDEX idx_utxos_txid_vout ON utxos(txid, vout);",
     // Fix issue https://github.com/bitcoindevkit/bdk/issues/801: drop duplicated script_pubkeys
-    // TODO "",
+    "ALTER TABLE script_pubkeys RENAME TO script_pubkeys_old;",
+    "DROP INDEX idx_keychain_child;",
+    "DROP INDEX idx_script;",
+    "CREATE TABLE script_pubkeys (keychain TEXT, child INTEGER, script BLOB);",
+    "CREATE INDEX idx_keychain_child ON script_pubkeys(keychain, child);",
+    "CREATE INDEX idx_script ON script_pubkeys(script);",
     "CREATE UNIQUE INDEX idx_script_pks_unique ON script_pubkeys(keychain, child);",
+    "INSERT OR REPLACE INTO script_pubkeys SELECT keychain, child, script FROM script_pubkeys_old;",
+    "DROP TABLE script_pubkeys_old;"
 ];
 
 /// Sqlite database stored on filesystem


### PR DESCRIPTION
### Description

Add a `UNIQUE` constraint on the script_pubkeys table so that it doesn't grow constantly when caching new addresses.

Fixes #801

### Notes to the reviewers

Adding it to the 0.25 milestone since it's just a bugfix.

Still in draft because I need to add extra migration queries to clean up existing dbs.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
