### PR TITLE
WIP: Integrated TOR proxy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ env_logger = "0.7"
 electrsd = "0.21"
 # Move back to importing from rust-bitcoin once https://github.com/rust-bitcoin/rust-bitcoin/pull/1342 is released
 base64 = "^0.13"
+libtor = "47.8.0+0.4.7.x"
 
 [[example]]
 name = "compact_filters_balance"

--- a/examples/compact_filters_balance.rs
+++ b/examples/compact_filters_balance.rs
@@ -36,14 +36,22 @@ fn main() -> Result<(), CompactFiltersError> {
     let num_threads = 4;
     let mempool = Arc::new(Mempool::default());
     let peers = (0..num_threads)
-        .map(|_| {if use_tor() {
-            let addr = &tor_addrs.as_ref().unwrap().hidden_service.as_ref().unwrap();
-            let proxy = &tor_addrs.as_ref().unwrap().socks;
-            info!("conecting to {} via {}", &addr, &proxy);
-            Peer::connect_proxy(addr.as_str(), &proxy, None,  Arc::clone(&mempool), Network::Testnet)
-        } else {
-            Peer::connect("localhost:18333", Arc::clone(&mempool), Network::Testnet)
-        }})
+        .map(|_| {
+            if use_tor() {
+                let addr = &tor_addrs.as_ref().unwrap().hidden_service.as_ref().unwrap();
+                let proxy = &tor_addrs.as_ref().unwrap().socks;
+                info!("conecting to {} via {}", &addr, &proxy);
+                Peer::connect_proxy(
+                    addr.as_str(),
+                    &proxy,
+                    None,
+                    Arc::clone(&mempool),
+                    Network::Testnet,
+                )
+            } else {
+                Peer::connect("localhost:18333", Arc::clone(&mempool), Network::Testnet)
+            }
+        })
         .collect::<Result<_, _>>()?;
     let blockchain = CompactFiltersBlockchain::new(peers, "./wallet-filters", Some(500_000))?;
     info!("done {:?}", blockchain);

--- a/examples/electrum_backend.rs
+++ b/examples/electrum_backend.rs
@@ -14,8 +14,8 @@ use bitcoin::util::bip32;
 
 pub mod utils;
 
-use crate::utils::tx::build_signed_tx;
 use crate::utils::tor::{start_tor, use_tor};
+use crate::utils::tx::build_signed_tx;
 
 /// This will create a wallet from an xpriv and get the balance by connecting to an Electrum server.
 /// If enough amount is available, this will send a transaction to an address.
@@ -52,7 +52,8 @@ fn run(network: &Network, electrum_url: &str, xpriv: &str) {
             .socks5(Some(Socks5Config {
                 addr: tor_addrs.socks,
                 credentials: None,
-            })).unwrap()
+            }))
+            .unwrap()
             .build();
         Client::from_config(electrum_url, config).unwrap()
     } else {

--- a/examples/esplora_backend_asynchronous.rs
+++ b/examples/esplora_backend_asynchronous.rs
@@ -1,19 +1,19 @@
 use std::str::FromStr;
 
 use bitcoin::{
-    Network,
     util::bip32::{self, ExtendedPrivKey},
+    Network,
 };
 use esplora_client::Builder;
 
+use bdk::blockchain::Blockchain;
 use bdk::{
     blockchain::esplora::EsploraBlockchain,
     database::MemoryDatabase,
-    KeychainKind,
-    SyncOptions,
-    template::Bip84, wallet::{AddressIndex, export::FullyNodedExport}, Wallet,
+    template::Bip84,
+    wallet::{export::FullyNodedExport, AddressIndex},
+    KeychainKind, SyncOptions, Wallet,
 };
-use bdk::blockchain::Blockchain;
 
 use crate::utils::tor::{start_tor, use_tor};
 use crate::utils::tx::build_signed_tx;

--- a/examples/esplora_backend_synchronous.rs
+++ b/examples/esplora_backend_synchronous.rs
@@ -1,6 +1,8 @@
 use std::str::FromStr;
 
+use crate::utils::tor::{start_tor, use_tor};
 use bdk::blockchain::Blockchain;
+use bdk::esplora_client::Builder;
 use bdk::{
     blockchain::esplora::EsploraBlockchain,
     database::MemoryDatabase,
@@ -12,8 +14,6 @@ use bitcoin::{
     util::bip32::{self, ExtendedPrivKey},
     Network,
 };
-use bdk::esplora_client::Builder;
-use crate::utils::tor::{start_tor, use_tor};
 
 pub mod utils;
 

--- a/examples/utils/mod.rs
+++ b/examples/utils/mod.rs
@@ -28,3 +28,109 @@ pub(crate) mod tx {
         psbt.extract_tx()
     }
 }
+
+pub(crate) mod tor {
+    use std::fs::File;
+    use std::io::prelude::*;
+    use std::thread;
+    use std::time::Duration;
+
+    use libtor::{HiddenServiceVersion, Tor, TorAddress, TorFlag};
+    use libtor::LogDestination;
+    use libtor::LogLevel;
+
+    use std::env;
+
+    pub struct TorAddresses {
+        pub socks: String,
+        pub hidden_service: Option<String>,
+    }
+
+    pub fn use_tor() -> bool {
+        match env::var("TOR") {
+            Ok(val) => val == "1" || val == "true",
+            _ => false
+        }
+    }
+
+    pub fn start_tor(hidden_service_port: Option<u16>) -> TorAddresses {
+        let socks_port = 19050;
+
+        let data_dir = format!("{}/{}", env::temp_dir().display(), "bdk-tor-example");
+        let log_file_name = format!("{}/{}", &data_dir, "log");
+        let hidden_service_dir = hidden_service_port.map(|port| format!("{}/{}-{}", &data_dir, "hs-dir", port));
+
+        println!("Staring Tor in {}", &data_dir);
+
+        truncate_log(&log_file_name);
+
+        if let Some(hs_port) = hidden_service_port {
+            Tor::new()
+                .flag(TorFlag::DataDirectory(data_dir.into()))
+                .flag(TorFlag::LogTo(LogLevel::Notice, LogDestination::File(log_file_name.as_str().into())))
+                .flag(TorFlag::SocksPort(socks_port))
+                .flag(TorFlag::Custom("ExitPolicy reject *:*".into()))
+                .flag(TorFlag::Custom("BridgeRelay 0".into()))
+                .flag(TorFlag::HiddenServiceDir(hidden_service_dir.as_ref().unwrap().into()))
+                .flag(TorFlag::HiddenServiceVersion(HiddenServiceVersion::V3))
+                .flag(TorFlag::HiddenServicePort(TorAddress::Port(hs_port), None.into()))
+                .start_background()
+        } else {
+            Tor::new()
+                .flag(TorFlag::DataDirectory(data_dir.into()))
+                .flag(TorFlag::LogTo(LogLevel::Notice, LogDestination::File(log_file_name.as_str().into())))
+                .flag(TorFlag::SocksPort(socks_port))
+                .flag(TorFlag::Custom("ExitPolicy reject *:*".into()))
+                .flag(TorFlag::Custom("BridgeRelay 0".into()))
+                .start_background()
+        };
+
+        let mut started = false;
+        let mut tries = 0;
+        while !started {
+            tries += 1;
+            if tries > 120 {
+                panic!("It took too long to start Tor. See {} for details", &log_file_name);
+            }
+
+            thread::sleep(Duration::from_millis(1000));
+            started = find_string_in_log(&log_file_name, &"Bootstrapped 100%".into());
+        }
+
+        println!("Tor started");
+
+        TorAddresses {
+            socks: format!("127.0.0.1:{}", socks_port),
+            hidden_service: hidden_service_port.map(|port| format!("{}:{}", get_onion_address(&hidden_service_dir.unwrap()), port)),
+        }
+    }
+
+    fn truncate_log(filename: &String) {
+        let path = std::path::Path::new(filename);
+        if path.exists() {
+            let file = File::options().write(true).open(path).expect("no such file");
+            file.set_len(0).expect("cannot set size to 0");
+        }
+    }
+
+    fn find_string_in_log(filename: &String, str: &String) -> bool {
+        let path = std::path::Path::new(filename);
+        if path.exists() {
+            let mut file = File::open(path).expect("cannot open log file");
+            let mut buf = String::new();
+            file.read_to_string(&mut buf).expect("cannot read log file");
+            buf.contains(str)
+        } else {
+            false
+        }
+    }
+
+    fn get_onion_address(hidden_service_dir: &String) -> String {
+        let filename = format!("{}/{}", hidden_service_dir, "hostname");
+        let path = std::path::Path::new(&filename);
+        let mut file = File::open(path).expect("cannot open hostname file");
+        let mut buf = String::new();
+        file.read_to_string(&mut buf).expect("cannot read log file");
+        buf.replace("\n", "")
+    }
+}

--- a/examples/utils/mod.rs
+++ b/examples/utils/mod.rs
@@ -35,9 +35,9 @@ pub(crate) mod tor {
     use std::thread;
     use std::time::Duration;
 
-    use libtor::{HiddenServiceVersion, Tor, TorAddress, TorFlag};
     use libtor::LogDestination;
     use libtor::LogLevel;
+    use libtor::{HiddenServiceVersion, Tor, TorAddress, TorFlag};
 
     use std::env;
 
@@ -49,7 +49,7 @@ pub(crate) mod tor {
     pub fn use_tor() -> bool {
         match env::var("TOR") {
             Ok(val) => val == "1" || val == "true",
-            _ => false
+            _ => false,
         }
     }
 
@@ -58,7 +58,8 @@ pub(crate) mod tor {
 
         let data_dir = format!("{}/{}", env::temp_dir().display(), "bdk-tor-example");
         let log_file_name = format!("{}/{}", &data_dir, "log");
-        let hidden_service_dir = hidden_service_port.map(|port| format!("{}/{}-{}", &data_dir, "hs-dir", port));
+        let hidden_service_dir =
+            hidden_service_port.map(|port| format!("{}/{}-{}", &data_dir, "hs-dir", port));
 
         println!("Staring Tor in {}", &data_dir);
 
@@ -67,18 +68,29 @@ pub(crate) mod tor {
         if let Some(hs_port) = hidden_service_port {
             Tor::new()
                 .flag(TorFlag::DataDirectory(data_dir.into()))
-                .flag(TorFlag::LogTo(LogLevel::Notice, LogDestination::File(log_file_name.as_str().into())))
+                .flag(TorFlag::LogTo(
+                    LogLevel::Notice,
+                    LogDestination::File(log_file_name.as_str().into()),
+                ))
                 .flag(TorFlag::SocksPort(socks_port))
                 .flag(TorFlag::Custom("ExitPolicy reject *:*".into()))
                 .flag(TorFlag::Custom("BridgeRelay 0".into()))
-                .flag(TorFlag::HiddenServiceDir(hidden_service_dir.as_ref().unwrap().into()))
+                .flag(TorFlag::HiddenServiceDir(
+                    hidden_service_dir.as_ref().unwrap().into(),
+                ))
                 .flag(TorFlag::HiddenServiceVersion(HiddenServiceVersion::V3))
-                .flag(TorFlag::HiddenServicePort(TorAddress::Port(hs_port), None.into()))
+                .flag(TorFlag::HiddenServicePort(
+                    TorAddress::Port(hs_port),
+                    None.into(),
+                ))
                 .start_background()
         } else {
             Tor::new()
                 .flag(TorFlag::DataDirectory(data_dir.into()))
-                .flag(TorFlag::LogTo(LogLevel::Notice, LogDestination::File(log_file_name.as_str().into())))
+                .flag(TorFlag::LogTo(
+                    LogLevel::Notice,
+                    LogDestination::File(log_file_name.as_str().into()),
+                ))
                 .flag(TorFlag::SocksPort(socks_port))
                 .flag(TorFlag::Custom("ExitPolicy reject *:*".into()))
                 .flag(TorFlag::Custom("BridgeRelay 0".into()))
@@ -90,7 +102,10 @@ pub(crate) mod tor {
         while !started {
             tries += 1;
             if tries > 120 {
-                panic!("It took too long to start Tor. See {} for details", &log_file_name);
+                panic!(
+                    "It took too long to start Tor. See {} for details",
+                    &log_file_name
+                );
             }
 
             thread::sleep(Duration::from_millis(1000));
@@ -101,14 +116,23 @@ pub(crate) mod tor {
 
         TorAddresses {
             socks: format!("127.0.0.1:{}", socks_port),
-            hidden_service: hidden_service_port.map(|port| format!("{}:{}", get_onion_address(&hidden_service_dir.unwrap()), port)),
+            hidden_service: hidden_service_port.map(|port| {
+                format!(
+                    "{}:{}",
+                    get_onion_address(&hidden_service_dir.unwrap()),
+                    port
+                )
+            }),
         }
     }
 
     fn truncate_log(filename: &String) {
         let path = std::path::Path::new(filename);
         if path.exists() {
-            let file = File::options().write(true).open(path).expect("no such file");
+            let file = File::options()
+                .write(true)
+                .open(path)
+                .expect("no such file");
             file.set_len(0).expect("cannot set size to 0");
         }
     }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

This PR adds the example code for how to use the integrated Rust Tor client to sync a BDK wallet.

It simply extends the existing blockchain examples: `compact_filters_balance`, `electrum_backend`, `esplora_backend_asynchronous`, and `esplora_backend_synchronous`.

To run an example with Tor you need to set `TOR` environment variable to `1` or `true` like:

```bash
$ TOR=1 cargo run --example=compact_filters_balance --features="compact_filters"
``` 

In this case the example code will start a Tor daemon, and configure the network client to use Tor as a SOCKS5 proxy.
`compact_filters_balance` also creates a hidden service for a locally running `bitcoind`.

Fixes https://github.com/bitcoindevkit/bdk_wallet/issues/196

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
