### PR TITLE
Downgrade ubuntu to 20.04 for test_hardware_wallet CI job

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -173,8 +173,8 @@ jobs:
       - name: Check fmt
         run: cargo fmt --all -- --config format_code_in_doc_comments=true --check
 
-  test_harware_wallet:
-    runs-on: ubuntu-latest
+  test_hardware_wallet:
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         rust:


### PR DESCRIPTION
### Description

As suggested by bitcoindevkit/rust-hwi#61, downgrade ubuntu version to 20.04 (instead of using latest), to fix `test_hardware_wallet` CI job.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
