### PR TITLE
Bump CI Rust stable version to 1.65.0 

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - version: 1.60.0 # STABLE
+          - version: 1.65.0 # STABLE
             clippy: true
           - version: 1.56.1 # MSRV
         features:

--- a/src/blockchain/any.rs
+++ b/src/blockchain/any.rs
@@ -131,7 +131,7 @@ impl GetBlockHash for AnyBlockchain {
 impl WalletSync for AnyBlockchain {
     fn wallet_sync<D: BatchDatabase>(
         &self,
-        database: &mut D,
+        database: &RefCell<D>,
         progress_update: Box<dyn Progress>,
     ) -> Result<(), Error> {
         maybe_await!(impl_inner_method!(
@@ -144,7 +144,7 @@ impl WalletSync for AnyBlockchain {
 
     fn wallet_setup<D: BatchDatabase>(
         &self,
-        database: &mut D,
+        database: &RefCell<D>,
         progress_update: Box<dyn Progress>,
     ) -> Result<(), Error> {
         maybe_await!(impl_inner_method!(

--- a/src/blockchain/compact_filters/store.rs
+++ b/src/blockchain/compact_filters/store.rs
@@ -233,7 +233,7 @@ impl ChainStore<Full> {
             batch.put_cf(
                 cf_handle,
                 StoreEntry::BlockHeaderIndex(Some(genesis.block_hash())).get_key(),
-                &0usize.to_be_bytes(),
+                0usize.to_be_bytes(),
             );
             store.write(batch)?;
         }
@@ -302,7 +302,7 @@ impl ChainStore<Full> {
         batch.put_cf(
             new_cf_handle,
             StoreEntry::BlockHeaderIndex(Some(header.block_hash())).get_key(),
-            &from.to_be_bytes(),
+            from.to_be_bytes(),
         );
         batch.put_cf(
             new_cf_handle,
@@ -584,7 +584,7 @@ impl<T: StoreType> ChainStore<T> {
             batch.put_cf(
                 cf_handle,
                 StoreEntry::BlockHeaderIndex(Some(header.block_hash())).get_key(),
-                &(height).to_be_bytes(),
+                (height).to_be_bytes(),
             );
             batch.put_cf(
                 cf_handle,

--- a/src/blockchain/electrum.rs
+++ b/src/blockchain/electrum.rs
@@ -25,7 +25,7 @@
 //! ```
 
 use std::collections::{HashMap, HashSet};
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 #[allow(unused_imports)]
 use log::{debug, error, info, trace};
@@ -117,9 +117,11 @@ impl GetBlockHash for ElectrumBlockchain {
 impl WalletSync for ElectrumBlockchain {
     fn wallet_setup<D: BatchDatabase>(
         &self,
-        database: &mut D,
+        database: &RefCell<D>,
         _progress_update: Box<dyn Progress>,
     ) -> Result<(), Error> {
+        let mut database = database.borrow_mut();
+        let database = database.deref_mut();
         let mut request = script_sync::start(database, self.stop_gap)?;
         let mut block_times = HashMap::<u32, u32>::new();
         let mut txid_to_height = HashMap::<Txid, u32>::new();

--- a/src/blockchain/esplora/async.rs
+++ b/src/blockchain/esplora/async.rs
@@ -12,7 +12,7 @@
 //! Esplora by way of `reqwest` HTTP client.
 
 use std::collections::{HashMap, HashSet};
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 use bitcoin::{Transaction, Txid};
 
@@ -135,10 +135,12 @@ impl GetBlockHash for EsploraBlockchain {
 impl WalletSync for EsploraBlockchain {
     fn wallet_setup<D: BatchDatabase>(
         &self,
-        database: &mut D,
+        database: &RefCell<D>,
         _progress_update: Box<dyn Progress>,
     ) -> Result<(), Error> {
         use crate::blockchain::script_sync::Request;
+        let mut database = database.borrow_mut();
+        let database = database.deref_mut();
         let mut request = script_sync::start(database, self.stop_gap)?;
         let mut tx_index: HashMap<Txid, Tx> = HashMap::new();
 

--- a/src/blockchain/esplora/blocking.rs
+++ b/src/blockchain/esplora/blocking.rs
@@ -12,6 +12,7 @@
 //! Esplora by way of `ureq` HTTP client.
 
 use std::collections::{HashMap, HashSet};
+use std::ops::DerefMut;
 
 #[allow(unused_imports)]
 use log::{debug, error, info, trace};
@@ -117,10 +118,12 @@ impl GetBlockHash for EsploraBlockchain {
 impl WalletSync for EsploraBlockchain {
     fn wallet_setup<D: BatchDatabase>(
         &self,
-        database: &mut D,
+        database: &RefCell<D>,
         _progress_update: Box<dyn Progress>,
     ) -> Result<(), Error> {
         use crate::blockchain::script_sync::Request;
+        let mut database = database.borrow_mut();
+        let database = database.deref_mut();
         let mut request = script_sync::start(database, self.stop_gap)?;
         let mut tx_index: HashMap<Txid, Tx> = HashMap::new();
         let batch_update = loop {

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -16,6 +16,7 @@
 //! [Compact Filters/Neutrino](crate::blockchain::compact_filters), along with a generalized trait
 //! [`Blockchain`] that can be implemented to build customized backends.
 
+use std::cell::RefCell;
 use std::collections::HashSet;
 use std::ops::Deref;
 use std::sync::mpsc::{channel, Receiver, Sender};
@@ -133,7 +134,7 @@ pub trait WalletSync {
     /// Populate the internal database with transactions and UTXOs
     fn wallet_setup<D: BatchDatabase>(
         &self,
-        database: &mut D,
+        database: &RefCell<D>,
         progress_update: Box<dyn Progress>,
     ) -> Result<(), Error>;
 
@@ -156,7 +157,7 @@ pub trait WalletSync {
     /// [`BatchOperations::del_utxo`]: crate::database::BatchOperations::del_utxo
     fn wallet_sync<D: BatchDatabase>(
         &self,
-        database: &mut D,
+        database: &RefCell<D>,
         progress_update: Box<dyn Progress>,
     ) -> Result<(), Error> {
         maybe_await!(self.wallet_setup(database, progress_update))
@@ -377,7 +378,7 @@ impl<T: GetBlockHash> GetBlockHash for Arc<T> {
 impl<T: WalletSync> WalletSync for Arc<T> {
     fn wallet_setup<D: BatchDatabase>(
         &self,
-        database: &mut D,
+        database: &RefCell<D>,
         progress_update: Box<dyn Progress>,
     ) -> Result<(), Error> {
         maybe_await!(self.deref().wallet_setup(database, progress_update))
@@ -385,7 +386,7 @@ impl<T: WalletSync> WalletSync for Arc<T> {
 
     fn wallet_sync<D: BatchDatabase>(
         &self,
-        database: &mut D,
+        database: &RefCell<D>,
         progress_update: Box<dyn Progress>,
     ) -> Result<(), Error> {
         maybe_await!(self.deref().wallet_sync(database, progress_update))

--- a/src/blockchain/rpc.rs
+++ b/src/blockchain/rpc.rs
@@ -49,8 +49,9 @@ use bitcoincore_rpc::Auth as RpcAuth;
 use bitcoincore_rpc::{Client, RpcApi};
 use log::{debug, info};
 use serde::{Deserialize, Serialize};
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 use std::path::PathBuf;
 use std::thread;
 use std::time::Duration;
@@ -192,10 +193,12 @@ impl GetBlockHash for RpcBlockchain {
 }
 
 impl WalletSync for RpcBlockchain {
-    fn wallet_setup<D>(&self, db: &mut D, prog: Box<dyn Progress>) -> Result<(), Error>
+    fn wallet_setup<D>(&self, db: &RefCell<D>, prog: Box<dyn Progress>) -> Result<(), Error>
     where
         D: BatchDatabase,
     {
+        let mut db = db.borrow_mut();
+        let db = db.deref_mut();
         let batch = DbState::new(db, &self.sync_params, &*prog)?
             .sync_with_core(&self.client, self.is_descriptors)?
             .as_db_batch()?;

--- a/src/descriptor/policy.rs
+++ b/src/descriptor/policy.rs
@@ -1197,7 +1197,7 @@ mod test {
             .unwrap();
 
         assert_matches!(&policy.item, EcdsaSignature(PkOrF::Fingerprint(f)) if f == &fingerprint);
-        assert_matches!(&policy.contribution, Satisfaction::Complete {condition} if condition.csv == None && condition.timelock == None);
+        assert_matches!(&policy.contribution, Satisfaction::Complete {condition} if condition.csv.is_none() && condition.timelock.is_none());
     }
 
     // 2 pub keys descriptor, required 2 prv keys
@@ -1346,7 +1346,7 @@ mod test {
             .unwrap();
 
         assert_matches!(policy.item, EcdsaSignature(PkOrF::Fingerprint(f)) if f == fingerprint);
-        assert_matches!(policy.contribution, Satisfaction::Complete {condition} if condition.csv == None && condition.timelock == None);
+        assert_matches!(policy.contribution, Satisfaction::Complete {condition} if condition.csv.is_none() && condition.timelock.is_none());
     }
 
     // single key, 1 prv and 1 pub key descriptor, required 1 prv keys

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -17,7 +17,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::collections::{BTreeMap, HashSet};
 use std::fmt;
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -1719,14 +1719,11 @@ where
         let max_rounds = if has_wildcard { 100 } else { 1 };
 
         for _ in 0..max_rounds {
-            let sync_res =
-                if run_setup {
-                    maybe_await!(blockchain
-                        .wallet_setup(self.database.borrow_mut().deref_mut(), new_progress()))
-                } else {
-                    maybe_await!(blockchain
-                        .wallet_sync(self.database.borrow_mut().deref_mut(), new_progress()))
-                };
+            let sync_res = if run_setup {
+                maybe_await!(blockchain.wallet_setup(&self.database, new_progress()))
+            } else {
+                maybe_await!(blockchain.wallet_sync(&self.database, new_progress()))
+            };
 
             // If the error is the special `MissingCachedScripts` error, we return the number of
             // scripts we should ensure cached.


### PR DESCRIPTION
### Description

* Fix clippy for Rust 1.65.0  
* Bump CI Rust stable version to 1.65.0

### Checklists

#### All Submissions:

* [X] I've signed all my commits
* [X] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [X] I ran `cargo fmt` and `cargo clippy` before committing
