### PR TITLE
Update ci nightly-docs workflow to use nightly-2022-12-14

### DIFF
--- a/.github/workflows/nightly_docs.yml
+++ b/.github/workflows/nightly_docs.yml
@@ -18,7 +18,7 @@ jobs:
             target
           key: nightly-docs-${{ hashFiles('**/Cargo.toml','**/Cargo.lock') }}
       - name: Set default toolchain
-        run: rustup default nightly-2022-01-25
+        run: rustup default nightly-2022-12-14
       - name: Set profile
         run: rustup set profile minimal
       - name: Update toolchain


### PR DESCRIPTION
### Description

The current nightly version we were using for the nightly-docs workflow is failing so I updated it to tonight's (2022-12-14)
version.

### Notes to the reviewers

I decided to select another hard-coded date nightly version so we don't run the risk of some random nightly release breaking this workflow. 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
