### PR TITLE
Don't default to use `async`/`await` on `wasm32`

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Update toolchain
         run: rustup update
       - name: Check
-        run: cargo check --target wasm32-unknown-unknown --features use-esplora-async,dev-getrandom-wasm --no-default-features
+        run: cargo check --target wasm32-unknown-unknown --features async-interface,use-esplora-async,dev-getrandom-wasm --no-default-features
 
   fmt:
     name: Rust fmt

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -249,11 +249,8 @@ pub trait BlockchainFactory {
     /// operations to build a blockchain for a given wallet, so if a wallet needs to be synced
     /// often it's recommended to use [`BlockchainFactory::build_for_wallet`] to reuse the same
     /// blockchain multiple times.
-    #[cfg(not(any(target_arch = "wasm32", feature = "async-interface")))]
-    #[cfg_attr(
-        docsrs,
-        doc(cfg(not(any(target_arch = "wasm32", feature = "async-interface"))))
-    )]
+    #[cfg(not(feature = "async-interface"))]
+    #[cfg_attr(docsrs, doc(cfg(not(feature = "async-interface"))))]
     fn sync_wallet<D: BatchDatabase>(
         &self,
         wallet: &Wallet<D>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,7 @@ compile_error!(
 #[cfg(feature = "keys-bip39")]
 extern crate bip39;
 
-#[cfg(any(target_arch = "wasm32", feature = "async-interface"))]
+#[cfg(feature = "async-interface")]
 #[macro_use]
 extern crate async_trait;
 #[macro_use]


### PR DESCRIPTION
### Description

We don't automatically want to make the interface `async` based on the used architecture, but now require the user to explicitly set the `async-interface` feature.

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing