### PR TITLE
Document return type of `sign` method.

### DIFF
--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1084,7 +1084,7 @@ where
     }
 
     /// Sign a transaction with all the wallet's signers, in the order specified by every signer's
-    /// [`SignerOrdering`]
+    /// [`SignerOrdering`]. This function returns the `Result` type with an encapsulated `bool` that has the value true if the PSBT was finalized, or false otherwise.
     ///
     /// The [`SignOptions`] can be used to tweak the behavior of the software signers, and the way
     /// the transaction is finalized at the end. Note that it can't be guaranteed that *every*


### PR DESCRIPTION
Small thing but I had to look up the code to see what the returned boolean was about, thought it might be good to have in the docs.

### Description

Documents the meaning of the returned value on the wallet `sign` method.

I've just edited from github so skipped all the checks if that's not ok maybe someone else can update it properly.