### PR TITLE
Derive `PartialEq`, `Eq` on `SyncTime`

### DIFF
--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -49,7 +49,7 @@ pub use memory::MemoryDatabase;
 /// Blockchain state at the time of syncing
 ///
 /// Contains only the block time and height at the moment
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SyncTime {
     /// Block timestamp and height at the time of sync
     pub block_time: BlockTime,


### PR DESCRIPTION
### Description

This enables e.g. `assert_eq!` comparisons of `SyncTime` in tests (we use this)

### Changelog notice

Derived `PartialEq`, `Eq` on `SyncTime`

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing