### PR TITLE
Add small clarification to docs

### DIFF
--- a/examples/compiler.rs
+++ b/examples/compiler.rs
@@ -29,7 +29,7 @@ use bdk::wallet::AddressIndex::New;
 use bdk::{KeychainKind, Wallet};
 
 /// Miniscript policy is a high level abstraction of spending conditions. Defined in the
-/// rust-miscript library here  https://docs.rs/miniscript/7.0.0/miniscript/policy/index.html
+/// rust-miniscript library here  https://docs.rs/miniscript/7.0.0/miniscript/policy/index.html
 /// rust-miniscript provides a `compile()` function that can be used to compile any miniscript policy
 /// into a descriptor. This descriptor then in turn can be used in bdk a fully functioning wallet
 /// can be derived from the policy.

--- a/src/descriptor/template.rs
+++ b/src/descriptor/template.rs
@@ -287,7 +287,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip49<K> {
 
 /// BIP49 public template. Expands to `sh(wpkh(key/{0,1}/*))`
 ///
-/// This assumes that the key used has already been derived with `m/49'/0'/0'`.
+/// This assumes that the key used has already been derived with `m/49'/0'/0'` for Mainnet or `m/49'/1'/0'` for Testnet.
 ///
 /// This template requires the parent fingerprint to populate correctly the metadata of PSBTs.
 ///
@@ -366,7 +366,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip84<K> {
 
 /// BIP84 public template. Expands to `wpkh(key/{0,1}/*)`
 ///
-/// This assumes that the key used has already been derived with `m/84'/0'/0'`.
+/// This assumes that the key used has already been derived with `m/84'/0'/0'` for Mainnet or `m/84'/1'/0'` for Testnet.
 ///
 /// This template requires the parent fingerprint to populate correctly the metadata of PSBTs.
 ///

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -40,7 +40,7 @@ pub mod bip39;
 /// Set of valid networks for a key
 pub type ValidNetworks = HashSet<Network>;
 
-/// Create a set containing mainnet, testnet and regtest
+/// Create a set containing mainnet, testnet, signet, and regtest
 pub fn any_network() -> ValidNetworks {
     vec![
         Network::Bitcoin,
@@ -95,7 +95,7 @@ impl<Ctx: ScriptContext> DescriptorKey<Ctx> {
     }
 
     // This method is used internally by `bdk::fragment!` and `bdk::descriptor!`. It has to be
-    // public because it is effectively called by external crates, once the macros are expanded,
+    // public because it is effectively called by external crates once the macros are expanded,
     // but since it is not meant to be part of the public api we hide it from the docs.
     #[doc(hidden)]
     pub fn extract(
@@ -375,7 +375,7 @@ impl<Ctx: ScriptContext> From<bip32::ExtendedPrivKey> for ExtendedKey<Ctx> {
 /// `(DerivableKey, KeySource, DerivationPath)` tuples.
 ///
 /// For key types that don't encode any indication about the path to use (like bip39), it's
-/// generally recommended to implemented this trait instead of [`IntoDescriptorKey`]. The same
+/// generally recommended to implement this trait instead of [`IntoDescriptorKey`]. The same
 /// rules regarding script context and valid networks apply.
 ///
 /// ## Examples

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -22,7 +22,7 @@ pub trait PsbtUtils {
     /// Get the `TxOut` for the specified input index, if it doesn't exist in the PSBT `None` is returned.
     fn get_utxo_for(&self, input_index: usize) -> Option<TxOut>;
 
-    /// The total transaction fee amount, sum of input amounts minus sum of output amounts, in Sats.
+    /// The total transaction fee amount, sum of input amounts minus sum of output amounts, in sats.
     /// If the PSBT is missing a TxOut for an input returns None.
     fn fee_amount(&self) -> Option<u64>;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -230,7 +230,6 @@ pub struct TransactionDetails {
     pub transaction: Option<Transaction>,
     /// Transaction id
     pub txid: Txid,
-
     /// Received value (sats)
     /// Sum of owned outputs of this transaction.
     pub received: u64,
@@ -242,7 +241,7 @@ pub struct TransactionDetails {
     /// Server backend, but it could be `None` with a Bitcoin RPC node without txindex that receive
     /// funds while offline.
     pub fee: Option<u64>,
-    /// If the transaction is confirmed, contains height and timestamp of the block containing the
+    /// If the transaction is confirmed, contains height and Unix timestamp of the block containing the
     /// transaction, unconfirmed transaction contains `None`.
     pub confirmation_time: Option<BlockTime>,
 }

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -132,7 +132,7 @@ pub enum AddressIndex {
     Reset(u32),
 }
 
-/// A derived address and the index it was found at
+/// A derived address and the index it was found at.
 /// For convenience this automatically derefs to `Address`
 #[derive(Debug, PartialEq, Eq)]
 pub struct AddressInfo {


### PR DESCRIPTION
### Description
Very small fixes to documentation:
1. I got a DM last week from a user who thought we had a bug with our timestamps. It turns out he was using the milliseconds version of the Unix timestamp in his project and didn't realize we were giving out a standard Unix timestamp. The docs now mention this explicitly.
2. I noticed some small inconsistencies in the documentation on the public templates while porting them over to Kotlin. This PR also fixes that so that all templates use a common documentation wording.

### Checklists
#### All Submissions:
* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
