### PR TITLE
Features/txbuilder expose params

### DIFF
--- a/.github/ISSUE_TEMPLATE/minor_release.md
+++ b/.github/ISSUE_TEMPLATE/minor_release.md
@@ -34,6 +34,7 @@ Change the `master` branch to the next MINOR+1 version:
 - [ ] Create a new PR branch called `bump_dev_MAJOR_MINOR+1`, eg. `bump_dev_0_22`.
 - [ ] Bump the `bump_dev_MAJOR_MINOR+1` branch to the next development MINOR+1 version.
   - Change the `Cargo.toml` version value to `MAJOR.MINOR+1.0`.
+  - Update the `CHANGELOG.md` file.
   - The commit message should be "Bump version to MAJOR.MINOR+1.0".
 - [ ] Create PR and merge the `bump_dev_MAJOR_MINOR+1` branch to `master`.
   - Title PR "Bump version to MAJOR.MINOR+1.0".

--- a/.github/ISSUE_TEMPLATE/patch_release.md
+++ b/.github/ISSUE_TEMPLATE/patch_release.md
@@ -34,6 +34,7 @@ Change the `master` branch to the new PATCH+1 version:
 - [ ] Create a new PR branch called `bump_dev_MAJOR_MINOR_PATCH+1`, eg. `bump_dev_0_22_1`.
 - [ ] Bump the `bump_dev_MAJOR_MINOR` branch to the next development PATCH+1 version.
   - Change the `Cargo.toml` version value to `MAJOR.MINOR.PATCH+1`.
+  - Update the `CHANGELOG.md` file.
   - The commit message should be "Bump version to MAJOR.MINOR.PATCH+1".
 - [ ] Create PR and merge the `bump_dev_MAJOR_MINOR_PATCH+1` branch to `master`.
   - Title PR "Bump version to MAJOR.MINOR.PATCH+1".

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Update toolchain
         run: rustup update
       - name: Check
-        run: cargo check --target wasm32-unknown-unknown --features use-esplora-async,dev-getrandom-wasm --no-default-features
+        run: cargo check --target wasm32-unknown-unknown --features async-interface,use-esplora-async,dev-getrandom-wasm --no-default-features
 
   fmt:
     name: Rust fmt

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - version: 1.60.0 # STABLE
+          - version: 1.65.0 # STABLE
             clippy: true
           - version: 1.56.1 # MSRV
         features:

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -12,7 +12,7 @@ jobs:
         rust:
           - version: 1.65.0 # STABLE
             clippy: true
-          - version: 1.56.1 # MSRV
+          - version: 1.57.0 # MSRV
         features:
           - default
           - minimal
@@ -146,7 +146,7 @@ jobs:
       - run: sudo apt-get update || exit 1
       - run: sudo apt-get install -y libclang-common-10-dev clang-10 libc6-dev-i386 || exit 1
       - name: Set default toolchain
-        run: rustup default 1.56.1 # STABLE
+        run: rustup default 1.65.0 # STABLE
       - name: Set profile
         run: rustup set profile minimal
       - name: Add target wasm32
@@ -178,8 +178,8 @@ jobs:
     strategy:
       matrix:
         rust:
-          - version: 1.60.0 # STABLE
-          - version: 1.56.1 # MSRV
+          - version: 1.65.0 # STABLE
+          - version: 1.57.0 # MSRV
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ page. See [DEVELOPMENT_CYCLE.md](DEVELOPMENT_CYCLE.md) for more details.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Add `wallet::tx_builder::get_params` method
+
 ## [v0.21.0] - [v0.20.0]
 
 - Add `descriptor::checksum::get_checksum_bytes` method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ A maintenance release with a bump in project MSRV to 1.57.0, updated dependence 
 - Don't default to use async/await on wasm32 #831
 - Project MSRV changed from 1.56.1 to 1.57.0 #842
 - Update rust-miniscript dependency to latest bug fix release 9.0 #844
+- New `tx_builder` `get_params` method #839
 
 ### Added
 
@@ -711,11 +712,5 @@ final transaction is created by calling `finish` on the builder.
 [v0.24.0]: https://github.com/bitcoindevkit/bdk/compare/v0.23.0...v0.24.0
 [v0.25.0]: https://github.com/bitcoindevkit/bdk/compare/v0.24.0...v0.25.0
 [v0.26.0]: https://github.com/bitcoindevkit/bdk/compare/v0.25.0...v0.26.0
-
-<<<<<<< HEAD
-[unreleased]: https://github.com/bitcoindevkit/bdk/compare/v0.26.0...HEAD
-=======
 [v0.27.0]: https://github.com/bitcoindevkit/bdk/compare/v0.26.0...v0.27.0
-[Unreleased]: https://github.com/bitcoindevkit/bdk/compare/v0.27.0...HEAD
-
-> > > > > > > e83bb7c (Bump version to 0.27.0)
+[unreleased]: https://github.com/bitcoindevkit/bdk/compare/v0.27.0...HEAD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Add `wallet::tx_builder::get_params` method
+- # Add `wallet::tx_builder::get_params` method
+
+## [v0.27.0]
+
+### Summary
+
+A maintenance release with a bump in project MSRV to 1.57.0, updated dependence and a few developer oriented improvements. Improvements include better error formatting, don't default to async/await for wasm32 and adding derived PartialEq and Eq on SyncTime.
+
+### Changed
+
+- Improve display error formatting #814
+- Don't default to use async/await on wasm32 #831
+- Project MSRV changed from 1.56.1 to 1.57.0 #842
+- Update rust-miniscript dependency to latest bug fix release 9.0 #844
+
+### Added
+
+- Derive PartialEq, Eq on SyncTime #837
+- New `tx_builder` `get_params` method #839
 
 ## [v0.26.0]
 
@@ -693,4 +711,11 @@ final transaction is created by calling `finish` on the builder.
 [v0.24.0]: https://github.com/bitcoindevkit/bdk/compare/v0.23.0...v0.24.0
 [v0.25.0]: https://github.com/bitcoindevkit/bdk/compare/v0.24.0...v0.25.0
 [v0.26.0]: https://github.com/bitcoindevkit/bdk/compare/v0.25.0...v0.26.0
+
+<<<<<<< HEAD
 [unreleased]: https://github.com/bitcoindevkit/bdk/compare/v0.26.0...HEAD
+=======
+[v0.27.0]: https://github.com/bitcoindevkit/bdk/compare/v0.26.0...v0.27.0
+[Unreleased]: https://github.com/bitcoindevkit/bdk/compare/v0.27.0...HEAD
+
+> > > > > > > e83bb7c (Bump version to 0.27.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,128 @@
 # Changelog
-All notable changes to this project prior to release **0.22.0** are documented in this file. Future
-changelog information can be found in each release's git tag and can be viewed with `git tag -ln100 "v*"`.
-Changelog info is also documented on the [GitHub releases](https://github.com/bitcoindevkit/bdk/releases)
-page. See [DEVELOPMENT_CYCLE.md](DEVELOPMENT_CYCLE.md) for more details.
+
+All notable changes to this project can be found here and in each release's git tag and can be viewed with `git tag -ln100 "v*"`. See also [DEVELOPMENT_CYCLE.md](DEVELOPMENT_CYCLE.md) for more details.
+
+Contributors do not need to change this file but do need to add changelog details in their PR descriptions. The person making the next release will collect changelog details from included PRs and edit this file prior to each release.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 - Add `wallet::tx_builder::get_params` method
 
-## [v0.21.0] - [v0.20.0]
+## [v0.26.0]
+
+### Summary
+
+This release improves Fulcrum electrum server compatibility and fixes public descriptor template key origin paths. We also snuck in small enhancements to configure the electrum client to validate the domain using SSL and sort TransactionDetails by block height and timestamp.
+
+### Fixed
+
+- Make electrum blockchain client `save_tx` function order independent to work with Fulcrum servers. #808
+- Fix wrong testnet key origin path in public descriptor templates. #818
+- Make README.md code examples compile without errors. #820
+
+### Changed
+
+- Bump `hwi` dependency to `0.4.0`. #825
+- Bump `esplora-client` dependency to `0.3` #830
+
+### Added
+
+- For electrum blockchain client, allow user to configure whether to validate the domain using SSL. #805
+- Implement ordering for `TransactionDetails`. #812
+
+## [v0.25.0]
+
+### Summary
+
+This release fixes slow sync time and big script_pubkeys table with SQLite, the wallet rescan height for the FullyNodedExport and setting the network for keys in the KeyMap when using descriptor templates. Also added are new blockchain and mnemonic examples.
+
+### Fixed
+
+- Slow sync time and big script_pubkeys table with SQLite.
+- Wallet rescan height for the FullyNodedExport.
+- Setting the network for keys in the KeyMap when using descriptor templates.
+
+### Added
+
+- Examples for connecting to Esplora, Electrum Server, Neutrino and Bitcoin Core.
+- Example for using a mnemonic in a descriptors.
+
+## [v0.24.0]
+
+### Summary
+
+This release contains important dependency updates for `rust-bitcoin` to `0.29` and `rust-miniscript` to `8.0`, plus related crates that also depend on the latest version of `rust-bitcoin`. The release also includes a breaking change to the BDK signer which now produces low-R signatures by default, saving one byte. A bug was found in the `get_checksum` and `get_checksum_bytes` functions, which are now deprecated in favor of fixed versions called `calc_checksum` and `calc_checksum_bytes`. And finally a new `hardware-signer` features was added that re-exports the `hwi` crate, along with a new `hardware_signers.rs` example file.
+
+### Changed
+
+- Updated dependency versions for `rust-bitcoin` to `0.29` and `rust-miniscript` to `8.0`, plus all related crates. @afilini #770
+- BDK Signer now produces low-R signatures by default, saving one byte. If you want to preserve the original behavior, set allow_grinding in the SignOptions to false. @vladimirfomene #779
+- Deprecated `get_checksum`and `get_checksum_bytes` due to bug where they calculates the checksum of a descriptor that already has a checksum. Use `calc_checksum` and `calc_checksum_bytes` instead. @evanlinjin #765
+- Remove deprecated "address validators". @afilini #770
+
+### Added
+
+- New `calc_checksum` and `calc_checksum_bytes`, replace deprecated `get_checksum` and `get_checksum_bytes`. @evanlinjin #765
+- Re-export the hwi crate when the feature hardware-signer is on. @danielabrozzoni #758
+- New examples/hardware_signer.rs. @danielabrozzoni #758
+- Make psbt module public to expose PsbtUtils trait to downstream projects. @notmandatory #782
+
+## [v0.23.0]
+
+### Summary
+
+This release brings new utilities functions on PSBTs like `fee_amount()` and `fee_rate()` and migrates BDK to use our new external esplora client library.
+As always many bug fixes, docs and tests improvement are also included.
+
+### Changed
+
+- Update electrum-client to 0.11.0 by @afilini in https://github.com/bitcoindevkit/bdk/pull/737
+- Change configs for source-base code coverage by @wszdexdrf in https://github.com/bitcoindevkit/bdk/pull/708
+- Improve docs regarding PSBT finalization by @tnull in https://github.com/bitcoindevkit/bdk/pull/753
+- Update compiler example to a Policy example by @rajarshimaitra in https://github.com/bitcoindevkit/bdk/pull/730
+- Fix the release process by @afilini in https://github.com/bitcoindevkit/bdk/pull/754
+- Remove redundant duplicated keys check by @afilini in https://github.com/bitcoindevkit/bdk/pull/761
+- Remove genesis_block lazy initialization by @shobitb in https://github.com/bitcoindevkit/bdk/pull/756
+- Fix `Wallet::descriptor_checksum` to actually return the checksum by @evanlinjin in https://github.com/bitcoindevkit/bdk/pull/763
+- Use the esplora client crate by @afilini in https://github.com/bitcoindevkit/bdk/pull/764
+
+### Added
+
+- Run code coverage on every PR by @danielabrozzoni in https://github.com/bitcoindevkit/bdk/pull/747
+- Add psbt_signer.rs example by @notmandatory in https://github.com/bitcoindevkit/bdk/pull/744
+- Add fee_amount() and fee_rate() functions to PsbtUtils trait by @notmandatory in https://github.com/bitcoindevkit/bdk/pull/728
+- Add tests to improve coverage by @vladimirfomene in https://github.com/bitcoindevkit/bdk/pull/745
+- Enable signing taproot transactions with only `non_witness_utxos` by @afilini in https://github.com/bitcoindevkit/bdk/pull/757
+- Add datatype for is_spent sqlite column by @vladimirfomene in https://github.com/bitcoindevkit/bdk/pull/713
+- Add vscode filter to gitignore by @evanlinjin in https://github.com/bitcoindevkit/bdk/pull/762
+
+## [v0.22.0]
+
+### Summary
+
+This release brings support for hardware signers on desktop through the HWI library.
+It also includes fixes and improvements which are part of our ongoing effort of integrating
+BDK and LDK together.
+
+### Changed
+
+- FeeRate function name as_sat_vb to as_sat_per_vb. #678
+- Verify signatures after signing. #718
+- Dependency electrum-client to 0.11.0. #737
+
+### Added
+
+- Functions to create FeeRate from sats/kvbytes and sats/kwu. #678
+- Custom hardware wallet signer HwiSigner in wallet::hardwaresigner module. #682
+- Function allow_dust on TxBuilder. #689
+- Implementation of Deref<Target=UrlClient> for EsploraBlockchain. #722
+- Implementation of Deref<Target=Client> for ElectrumBlockchain #705
+- Implementation of Deref<Target=Client> for RpcBlockchain. #731
+
+## [v0.21.0]
 
 - Add `descriptor::checksum::get_checksum_bytes` method.
 - Add `Excess` enum to handle remaining amount after coin selection.
@@ -23,7 +135,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New `RpcBlockchain` implementation with various fixes.
 - Return balance in separate categories, namely `confirmed`, `trusted_pending`, `untrusted_pending` & `immature`.
 
-## [v0.20.0] - [v0.19.0]
+## [v0.20.0]
 
 - New MSRV set to `1.56.1`
 - Fee sniping discouraging through nLockTime - if the user specifies a `current_height`, we use that as a nlocktime, otherwise we use the last sync height (or 0 if we never synced)
@@ -34,7 +146,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deprecate `AddressValidator`
 - Fix Electrum wallet sync potentially causing address index decrement - compare proposed index and current index before applying batch operations during sync.
 
-## [v0.19.0] - [v0.18.0]
+## [v0.19.0]
 
 - added `OldestFirstCoinSelection` impl to `CoinSelectionAlgorithm`
 - New MSRV set to `1.56`
@@ -50,7 +162,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Support for `tr()` descriptors in the `descriptor!()` macro
 - Add support for Bitcoin Core 23.0 when using the `rpc` blockchain
 
-## [v0.18.0] - [v0.17.0]
+## [v0.18.0]
 
 - Add `sqlite-bundled` feature for deployments that need a bundled version of sqlite, i.e. for mobile platforms.
 - Added `Wallet::get_signers()`, `Wallet::descriptor_checksum()` and `Wallet::get_address_validators()`, exposed the `AsDerived` trait.
@@ -60,7 +172,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Rename `WalletExport` to `FullyNodedExport`, deprecate the former.
 - Bump `miniscript` dependency version to `^6.1`.
 
-## [v0.17.0] - [v0.16.1]
+## [v0.17.0]
 
 - Removed default verification from `wallet::sync`. sync-time verification is added in `script_sync` and is activated by `verify` feature flag.
 - `verify` flag removed from `TransactionDetails`.
@@ -81,45 +193,45 @@ To decouple the `Wallet` from the `Blockchain` we've made major changes:
 - Removed `max_addresses` sync parameter which determined how many addresses to cache before syncing since this can just be done with `ensure_addresses_cached`.
 - remove `flush` method from the `Database` trait.
 
-## [v0.16.1] - [v0.16.0]
+## [v0.16.1]
 
 - Pin tokio dependency version to ~1.14 to prevent errors due to their new MSRV 1.49.0
 
-## [v0.16.0] - [v0.15.0]
+## [v0.16.0]
 
 - Disable `reqwest` default features.
 - Added `reqwest-default-tls` feature: Use this to restore the TLS defaults of reqwest if you don't want to add a dependency to it in your own manifest.
 - Use dust_value from rust-bitcoin
 - Fixed generating WIF in the correct network format.
 
-## [v0.15.0] - [v0.14.0]
+## [v0.15.0]
 
 - Overhauled sync logic for electrum and esplora.
 - Unify ureq and reqwest esplora backends to have the same configuration parameters. This means reqwest now has a timeout parameter and ureq has a concurrency parameter.
 - Fixed esplora fee estimation.
 
-## [v0.14.0] - [v0.13.0]
+## [v0.14.0]
 
 - BIP39 implementation dependency, in `keys::bip39` changed from tiny-bip39 to rust-bip39.
 - Add new method on the `TxBuilder` to embed data in the transaction via `OP_RETURN`. To allow that a fix to check the dust only on spendable output has been introduced.
 - Update the `Database` trait to store the last sync timestamp and block height
 - Rename `ConfirmationTime` to `BlockTime`
 
-## [v0.13.0] - [v0.12.0]
+## [v0.13.0]
 
 - Exposed `get_tx()` method from `Database` to `Wallet`.
 
-## [v0.12.0] - [v0.11.0]
+## [v0.12.0]
 
 - Activate `miniscript/use-serde` feature to allow consumers of the library to access it via the re-exported `miniscript` crate.
 - Add support for proxies in `EsploraBlockchain`
 - Added `SqliteDatabase` that implements `Database` backed by a sqlite database using `rusqlite` crate.
 
-## [v0.11.0] - [v0.10.0]
+## [v0.11.0]
 
 - Added `flush` method to the `Database` trait to explicitly flush to disk latest changes on the db.
 
-## [v0.10.0] - [v0.9.0]
+## [v0.10.0]
 
 - Added `RpcBlockchain` in the `AnyBlockchain` struct to allow using Rpc backend where `AnyBlockchain` is used (eg `bdk-cli`)
 - Removed hard dependency on `tokio`.
@@ -133,27 +245,33 @@ To decouple the `Wallet` from the `Blockchain` we've made major changes:
 - Removed `stop_gap` from `Blockchain` trait and added it to only `ElectrumBlockchain` and `EsploraBlockchain` structs.
 - Added a `ureq` backend for use when not using feature `async-interface` or target WASM. `ureq` is a blocking HTTP client.
 
-## [v0.9.0] - [v0.8.0]
+## [v0.9.0]
 
 ### Wallet
 
 - Added Bitcoin core RPC added as blockchain backend
 - Added a `verify` feature that can be enable to verify the unconfirmed txs we download against the consensus rules
 
-## [v0.8.0] - [v0.7.0]
+## [v0.8.0]
 
 ### Wallet
+
 - Added an option that must be explicitly enabled to allow signing using non-`SIGHASH_ALL` sighashes (#350)
+
 #### Changed
+
 `get_address` now returns an `AddressInfo` struct that includes the index and derefs to `Address`.
 
-## [v0.7.0] - [v0.6.0]
+## [v0.7.0]
 
 ### Policy
+
 #### Changed
+
 Removed `fill_satisfaction` method in favor of enum parameter in `extract_policy` method
 
 #### Added
+
 Timelocks are considered (optionally) in building the `satisfaction` field
 
 ### Wallet
@@ -162,86 +280,118 @@ Timelocks are considered (optionally) in building the `satisfaction` field
 - Require and validate `non_witness_utxo` for SegWit signatures by default, can be adjusted with `SignOptions`
 - Replace the opt-in builder option `force_non_witness_utxo` with the opposite `only_witness_utxo`. From now on we will provide the `non_witness_utxo`, unless explicitly asked not to.
 
-## [v0.6.0] - [v0.5.1]
+## [v0.6.0]
 
 ### Misc
+
 #### Changed
+
 - New minimum supported rust version is 1.46.0
 - Changed `AnyBlockchainConfig` to use serde tagged representation.
 
 ### Descriptor
+
 #### Added
+
 - Added ability to analyze a `PSBT` to check which and how many signatures are already available
 
 ### Wallet
+
 #### Changed
+
 - `get_new_address()` refactored to `get_address(AddressIndex::New)` to support different `get_address()` index selection strategies
 
 #### Added
+
 - Added `get_address(AddressIndex::LastUnused)` which returns the last derived address if it has not been used or if used in a received transaction returns a new address
 - Added `get_address(AddressIndex::Peek(u32))` which returns a derived address for a specified descriptor index but does not change the current index
 - Added `get_address(AddressIndex::Reset(u32))` which returns a derived address for a specified descriptor index and resets current index to the given value
 - Added `get_psbt_input` to create the corresponding psbt input for a local utxo.
 
 #### Fixed
+
 - Fixed `coin_select` calculation for UTXOs where `value < fee` that caused over-/underflow errors.
 
-## [v0.5.1] - [v0.5.0]
+## [v0.5.1]
 
 ### Misc
+
 #### Changed
+
 - Pin `hyper` to `=0.14.4` to make it compile on Rust 1.45
 
-## [v0.5.0] - [v0.4.0]
+## [v0.5.0]
 
 ### Misc
+
 #### Changed
+
 - Updated `electrum-client` to version `0.7`
 
 ### Wallet
+
 #### Changed
+
 - `FeeRate` constructors `from_sat_per_vb` and `default_min_relay_fee` are now `const` functions
 
-## [v0.4.0] - [v0.3.0]
+## [v0.4.0]
 
 ### Keys
+
 #### Changed
+
 - Renamed `DerivableKey::add_metadata()` to `DerivableKey::into_descriptor_key()`
 - Renamed `ToDescriptorKey::to_descriptor_key()` to `IntoDescriptorKey::into_descriptor_key()`
+
 #### Added
+
 - Added an `ExtendedKey` type that is an enum of `bip32::ExtendedPubKey` and `bip32::ExtendedPrivKey`
 - Added `DerivableKey::into_extended_key()` as the only method that needs to be implemented
 
 ### Misc
+
 #### Removed
+
 - Removed the `parse_descriptor` example, since it wasn't demonstrating any bdk-specific API anymore.
+
 #### Changed
+
 - Updated `bitcoin` to `0.26`, `miniscript` to `5.1` and `electrum-client` to `0.6`
+
 #### Added
+
 - Added support for the `signet` network (issue #62)
 - Added a function to get the version of BDK at runtime
 
 ### Wallet
+
 #### Changed
+
 - Removed the explicit `id` argument from `Wallet::add_signer()` since that's now part of `Signer` itself
 - Renamed `ToWalletDescriptor::to_wallet_descriptor()` to `IntoWalletDescriptor::into_wallet_descriptor()`
 
 ### Policy
+
 #### Changed
+
 - Removed unneeded `Result<(), PolicyError>` return type for `Satisfaction::finalize()`
 - Removed the `TooManyItemsSelected` policy error (see commit message for more details)
 
-## [v0.3.0] - [v0.2.0]
+## [v0.3.0]
 
 ### Descriptor
+
 #### Changed
+
 - Added an alias `DescriptorError` for `descriptor::error::Error`
 - Changed the error returned by `descriptor!()` and `fragment!()` to `DescriptorError`
 - Changed the error type in `ToWalletDescriptor` to `DescriptorError`
 - Improved checks on descriptors built using the macros
 
 ### Blockchain
+
 #### Changed
+
 - Remove `BlockchainMarker`, `OfflineClient` and `OfflineWallet` in favor of just using the unit
   type to mark for a missing client.
 - Upgrade `tokio` to `1.0`.
@@ -265,13 +415,17 @@ final transaction is created by calling `finish` on the builder.
 - Added `TxBuilder::add_foreign_utxo` which allows adding a utxo external to the wallet.
 
 ### CLI
+
 #### Changed
+
 - Remove `cli.rs` module, `cli-utils` feature and `repl.rs` example; moved to new [`bdk-cli`](https://github.com/bitcoindevkit/bdk-cli) repository
 
-## [v0.2.0] - [0.1.0-beta.1]
+## [v0.2.0]
 
 ### Project
+
 #### Added
+
 - Add CONTRIBUTING.md
 - Add a Discord badge to the README
 - Add code coverage github actions workflow
@@ -279,6 +433,7 @@ final transaction is created by calling `finish` on the builder.
 - Add CHANGELOG.md
 
 #### Changed
+
 - Rename the library to `bdk`
 - Rename `ScriptType` to `KeychainKind`
 - Prettify README examples on github
@@ -290,11 +445,14 @@ final transaction is created by calling `finish` on the builder.
 - Fix to at least bitcoin ^0.25.2
 
 #### Fixed
+
 - Fix or ignore clippy warnings for all optional features except compact_filters
 - Pin cc version because last breaks rocksdb build
 
 ### Blockchain
+
 #### Added
+
 - Add a trait to create `Blockchain`s from a configuration
 - Add an `AnyBlockchain` enum to allow switching at runtime
 - Document `AnyBlockchain` and `ConfigurableBlockchain`
@@ -303,29 +461,38 @@ final transaction is created by calling `finish` on the builder.
 - Allow to set concurrency in Esplora config and optionally pass it in repl
 
 #### Fixed
+
 - Fix receiving a coinbase using Electrum/Esplora
 - Use proper type for EsploraHeader, make conversion to BlockHeader infallible
 - Eagerly unwrap height option, save one collect
 
 #### Changed
+
 - Simplify the architecture of blockchain traits
 - Improve sync
 - Remove unused varaint HeaderParseFail
 
 ### CLI
+
 #### Added
+
 - Conditionally remove cli args according to enabled feature
 
 #### Changed
+
 - Add max_addresses param in sync
 - Split the internal and external policy paths
 
 ### Database
+
 #### Added
+
 - Add `AnyDatabase` and `ConfigurableDatabase` traits
 
 ### Descriptor
+
 #### Added
+
 - Add a macro to write descriptors from code
 - Add descriptor templates, add `DerivableKey`
 - Add ToWalletDescriptor trait tests
@@ -335,13 +502,17 @@ final transaction is created by calling `finish` on the builder.
 - Add descriptor macro tests
 
 #### Changes
+
 - Improve the descriptor macro, add traits for key and descriptor types
 
 #### Fixes
+
 - Fix the recovery of a descriptor given a PSBT
 
 ### Keys
+
 #### Added
+
 - Add BIP39 support
 - Take `ScriptContext` into account when converting keys
 - Add a way to restrict the networks in which keys are valid
@@ -354,10 +525,13 @@ final transaction is created by calling `finish` on the builder.
 - Add a shortcut to generate keys with the default options
 
 #### Fixed
+
 - Fix all-keys and cli-utils tests
 
 ### Wallet
+
 #### Added
+
 - Allow to define static fees for transactions Fixes #137
 - Merging two match expressions for fee calculation
 - Incorporate RBF rules into utxo selection function
@@ -371,6 +545,7 @@ final transaction is created by calling `finish` on the builder.
 - Eagerly finalize inputs
 
 #### Changed
+
 - Use collect to avoid iter unwrapping Options
 - Make coin_select take may/must use utxo lists
 - Improve `CoinSelectionAlgorithm`
@@ -398,25 +573,32 @@ final transaction is created by calling `finish` on the builder.
 - More consistent references with 'signers' variables
 
 #### Fixed
+
 - Fix signing for `ShWpkh` inputs
 - Fix the recovery of a descriptor given a PSBT
 
 ### Examples
+
 #### Added
+
 - Support esplora blockchain source in repl
 
 #### Changed
+
 - Revert back the REPL example to use Electrum
 - Remove the `magic` alias for `repl`
 - Require esplora feature for repl example
 
 #### Security
+
 - Use dirs-next instead of dirs since the latter is unmantained
 
 ## [0.1.0-beta.1] - 2020-09-08
 
 ### Blockchain
+
 #### Added
+
 - Lightweight Electrum client with SSL/SOCKS5 support
 - Add a generalized "Blockchain" interface
 - Add Error::OfflineClient
@@ -427,23 +609,31 @@ final transaction is created by calling `finish` on the builder.
 - Impl OnlineBlockchain for types wrapped in Arc
 
 ### Database
+
 #### Added
+
 - Add a generalized database trait and a Sled-based implementation
 - Add an in-memory database
 
 ### Descriptor
+
 #### Added
+
 - Wrap Miniscript descriptors to support xpubs
 - Policy and contribution
 - Transform a descriptor into its "public" version
 - Use `miniscript::DescriptorPublicKey`
 
 ### Macros
+
 #### Added
+
 - Add a feature to enable the async interface on non-wasm32 platforms
 
 ### Wallet
+
 #### Added
+
 - Wallet logic
 - Add `assume_height_reached` in PSBTSatisfier
 - Add an option to change the assumed current height
@@ -466,7 +656,9 @@ final transaction is created by calling `finish` on the builder.
 - Create a PSBT signer from an ExtendedDescriptor
 
 ### Examples
+
 #### Added
+
 - Add REPL broadcast command
 - Add a miniscript compiler CLI
 - Expose list_transactions() in the REPL
@@ -496,3 +688,9 @@ final transaction is created by calling `finish` on the builder.
 [v0.19.0]: https://github.com/bitcoindevkit/bdk/compare/v0.18.0...v0.19.0
 [v0.20.0]: https://github.com/bitcoindevkit/bdk/compare/v0.19.0...v0.20.0
 [v0.21.0]: https://github.com/bitcoindevkit/bdk/compare/v0.20.0...v0.21.0
+[v0.22.0]: https://github.com/bitcoindevkit/bdk/compare/v0.21.0...v0.22.0
+[v0.23.0]: https://github.com/bitcoindevkit/bdk/compare/v0.22.0...v0.23.0
+[v0.24.0]: https://github.com/bitcoindevkit/bdk/compare/v0.23.0...v0.24.0
+[v0.25.0]: https://github.com/bitcoindevkit/bdk/compare/v0.24.0...v0.25.0
+[v0.26.0]: https://github.com/bitcoindevkit/bdk/compare/v0.25.0...v0.26.0
+[unreleased]: https://github.com/bitcoindevkit/bdk/compare/v0.26.0...HEAD

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2018"
 authors = ["Alekos Filini <alekos.filini@gmail.com>", "Riccardo Casatta <riccardo@casatta.it>"]
 homepage = "https://bitcoindevkit.org"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 bdk-macros = "^0.6"
 log = "^0.4"
-miniscript = { version = "8.0", features = ["serde"] }
+miniscript = { version = "9.0", features = ["serde"] }
 bitcoin = { version = "0.29.1", features = ["serde", "base64", "rand"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
@@ -31,7 +31,7 @@ async-trait = { version = "0.1", optional = true }
 rocksdb = { version = "0.14", default-features = false, features = ["snappy"], optional = true }
 cc = { version = ">=1.0.64", optional = true }
 socks = { version = "0.3", optional = true }
-hwi = { version = "0.4.0", optional = true, features = [ "use-miniscript"] }
+hwi = { version = "0.5", optional = true, features = [ "use-miniscript"] }
 
 bip39 = { version = "1.0.1", optional = true }
 bitcoinconsensus = { version = "0.19.0-3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ dev-getrandom-wasm = ["getrandom/js"]
 [dev-dependencies]
 lazy_static = "1.4"
 env_logger = "0.7"
-electrsd = "0.21"
+electrsd = "0.22"
 # Move back to importing from rust-bitcoin once https://github.com/rust-bitcoin/rust-bitcoin/pull/1342 is released
 base64 = "^0.13"
 assert_matches = "1.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,8 @@ electrsd = "0.22"
 # Move back to importing from rust-bitcoin once https://github.com/rust-bitcoin/rust-bitcoin/pull/1342 is released
 base64 = "^0.13"
 assert_matches = "1.5.0"
+# zip versions after 0.6.3 don't work with our MSRV 1.57.0
+zip = "=0.6.3"
 
 [[example]]
 name = "compact_filters_balance"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
     <a href="https://github.com/bitcoindevkit/bdk/actions?query=workflow%3ACI"><img alt="CI Status" src="https://github.com/bitcoindevkit/bdk/workflows/CI/badge.svg"></a>
     <a href="https://coveralls.io/github/bitcoindevkit/bdk?branch=master"><img src="https://coveralls.io/repos/github/bitcoindevkit/bdk/badge.svg?branch=master"/></a>
     <a href="https://docs.rs/bdk"><img alt="API Docs" src="https://img.shields.io/badge/docs.rs-bdk-green"/></a>
-    <a href="https://blog.rust-lang.org/2021/11/01/Rust-1.56.1.html"><img alt="Rustc Version 1.56.1+" src="https://img.shields.io/badge/rustc-1.56.1%2B-lightgrey.svg"/></a>
+    <a href="https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html"><img alt="Rustc Version 1.57.0+" src="https://img.shields.io/badge/rustc-1.57.0%2B-lightgrey.svg"/></a>
     <a href="https://discord.gg/d7NkDKm"><img alt="Chat on Discord" src="https://img.shields.io/discord/753336465005608961?logo=discord"></a>
   </p>
 

--- a/ci/Dockerfile.ledger
+++ b/ci/Dockerfile.ledger
@@ -6,4 +6,4 @@ RUN apt-get install wget -y
 RUN wget "https://github.com/LedgerHQ/speculos/blob/master/apps/nanos%23btc%232.1%231c8db8da.elf?raw=true" -O /speculos/btc.elf
 ADD automation.json /speculos/automation.json
 
-ENTRYPOINT ["python", "./speculos.py", "--automation", "file:automation.json", "--display", "headless", "--vnc-port", "41000", "btc.elf"]
+ENTRYPOINT ["python", "./speculos.py", "--automation", "file:automation.json", "--model", "nanos", "--display", "headless", "--vnc-port", "41000", "btc.elf"]

--- a/examples/compiler.rs
+++ b/examples/compiler.rs
@@ -29,7 +29,7 @@ use bdk::wallet::AddressIndex::New;
 use bdk::{KeychainKind, Wallet};
 
 /// Miniscript policy is a high level abstraction of spending conditions. Defined in the
-/// rust-miscript library here  https://docs.rs/miniscript/7.0.0/miniscript/policy/index.html
+/// rust-miniscript library here  https://docs.rs/miniscript/7.0.0/miniscript/policy/index.html
 /// rust-miniscript provides a `compile()` function that can be used to compile any miniscript policy
 /// into a descriptor. This descriptor then in turn can be used in bdk a fully functioning wallet
 /// can be derived from the policy.

--- a/src/blockchain/any.rs
+++ b/src/blockchain/any.rs
@@ -131,7 +131,7 @@ impl GetBlockHash for AnyBlockchain {
 impl WalletSync for AnyBlockchain {
     fn wallet_sync<D: BatchDatabase>(
         &self,
-        database: &mut D,
+        database: &RefCell<D>,
         progress_update: Box<dyn Progress>,
     ) -> Result<(), Error> {
         maybe_await!(impl_inner_method!(
@@ -144,7 +144,7 @@ impl WalletSync for AnyBlockchain {
 
     fn wallet_setup<D: BatchDatabase>(
         &self,
-        database: &mut D,
+        database: &RefCell<D>,
         progress_update: Box<dyn Progress>,
     ) -> Result<(), Error> {
         maybe_await!(impl_inner_method!(

--- a/src/blockchain/compact_filters/mod.rs
+++ b/src/blockchain/compact_filters/mod.rs
@@ -580,7 +580,27 @@ pub enum CompactFiltersError {
 
 impl fmt::Display for CompactFiltersError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        match self {
+            Self::InvalidResponse => write!(f, "A peer sent an invalid or unexpected response"),
+            Self::InvalidHeaders => write!(f, "Invalid headers"),
+            Self::InvalidFilterHeader => write!(f, "Invalid filter header"),
+            Self::InvalidFilter => write!(f, "Invalid filters"),
+            Self::MissingBlock => write!(f, "The peer is missing a block in the valid chain"),
+            Self::BlockHashNotFound => write!(f, "Block hash not found"),
+            Self::DataCorruption => write!(
+                f,
+                "The data stored in the block filters storage are corrupted"
+            ),
+            Self::NotConnected => write!(f, "A peer is not connected"),
+            Self::Timeout => write!(f, "A peer took too long to reply to one of our messages"),
+            Self::PeerBloomDisabled => write!(f, "Peer doesn't advertise the BLOOM service flag"),
+            Self::NoPeers => write!(f, "No peers have been specified"),
+            Self::Db(err) => write!(f, "Internal database error: {}", err),
+            Self::Io(err) => write!(f, "Internal I/O error: {}", err),
+            Self::Bip158(err) => write!(f, "Invalid BIP158 filter: {}", err),
+            Self::Time(err) => write!(f, "Invalid system time: {}", err),
+            Self::Global(err) => write!(f, "Generic error: {}", err),
+        }
     }
 }
 

--- a/src/blockchain/compact_filters/store.rs
+++ b/src/blockchain/compact_filters/store.rs
@@ -233,7 +233,7 @@ impl ChainStore<Full> {
             batch.put_cf(
                 cf_handle,
                 StoreEntry::BlockHeaderIndex(Some(genesis.block_hash())).get_key(),
-                &0usize.to_be_bytes(),
+                0usize.to_be_bytes(),
             );
             store.write(batch)?;
         }
@@ -302,7 +302,7 @@ impl ChainStore<Full> {
         batch.put_cf(
             new_cf_handle,
             StoreEntry::BlockHeaderIndex(Some(header.block_hash())).get_key(),
-            &from.to_be_bytes(),
+            from.to_be_bytes(),
         );
         batch.put_cf(
             new_cf_handle,
@@ -584,7 +584,7 @@ impl<T: StoreType> ChainStore<T> {
             batch.put_cf(
                 cf_handle,
                 StoreEntry::BlockHeaderIndex(Some(header.block_hash())).get_key(),
-                &(height).to_be_bytes(),
+                (height).to_be_bytes(),
             );
             batch.put_cf(
                 cf_handle,

--- a/src/blockchain/electrum.rs
+++ b/src/blockchain/electrum.rs
@@ -25,7 +25,7 @@
 //! ```
 
 use std::collections::{HashMap, HashSet};
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 #[allow(unused_imports)]
 use log::{debug, error, info, trace};
@@ -117,9 +117,11 @@ impl GetBlockHash for ElectrumBlockchain {
 impl WalletSync for ElectrumBlockchain {
     fn wallet_setup<D: BatchDatabase>(
         &self,
-        database: &mut D,
+        database: &RefCell<D>,
         _progress_update: Box<dyn Progress>,
     ) -> Result<(), Error> {
+        let mut database = database.borrow_mut();
+        let database = database.deref_mut();
         let mut request = script_sync::start(database, self.stop_gap)?;
         let mut block_times = HashMap::<u32, u32>::new();
         let mut txid_to_height = HashMap::<Txid, u32>::new();

--- a/src/blockchain/esplora/async.rs
+++ b/src/blockchain/esplora/async.rs
@@ -12,7 +12,7 @@
 //! Esplora by way of `reqwest` HTTP client.
 
 use std::collections::{HashMap, HashSet};
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 
 use bitcoin::{Transaction, Txid};
 
@@ -135,10 +135,12 @@ impl GetBlockHash for EsploraBlockchain {
 impl WalletSync for EsploraBlockchain {
     fn wallet_setup<D: BatchDatabase>(
         &self,
-        database: &mut D,
+        database: &RefCell<D>,
         _progress_update: Box<dyn Progress>,
     ) -> Result<(), Error> {
         use crate::blockchain::script_sync::Request;
+        let mut database = database.borrow_mut();
+        let database = database.deref_mut();
         let mut request = script_sync::start(database, self.stop_gap)?;
         let mut tx_index: HashMap<Txid, Tx> = HashMap::new();
 

--- a/src/blockchain/esplora/blocking.rs
+++ b/src/blockchain/esplora/blocking.rs
@@ -12,6 +12,7 @@
 //! Esplora by way of `ureq` HTTP client.
 
 use std::collections::{HashMap, HashSet};
+use std::ops::DerefMut;
 
 #[allow(unused_imports)]
 use log::{debug, error, info, trace};
@@ -117,10 +118,12 @@ impl GetBlockHash for EsploraBlockchain {
 impl WalletSync for EsploraBlockchain {
     fn wallet_setup<D: BatchDatabase>(
         &self,
-        database: &mut D,
+        database: &RefCell<D>,
         _progress_update: Box<dyn Progress>,
     ) -> Result<(), Error> {
         use crate::blockchain::script_sync::Request;
+        let mut database = database.borrow_mut();
+        let database = database.deref_mut();
         let mut request = script_sync::start(database, self.stop_gap)?;
         let mut tx_index: HashMap<Txid, Tx> = HashMap::new();
         let batch_update = loop {

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -16,6 +16,7 @@
 //! [Compact Filters/Neutrino](crate::blockchain::compact_filters), along with a generalized trait
 //! [`Blockchain`] that can be implemented to build customized backends.
 
+use std::cell::RefCell;
 use std::collections::HashSet;
 use std::ops::Deref;
 use std::sync::mpsc::{channel, Receiver, Sender};
@@ -133,7 +134,7 @@ pub trait WalletSync {
     /// Populate the internal database with transactions and UTXOs
     fn wallet_setup<D: BatchDatabase>(
         &self,
-        database: &mut D,
+        database: &RefCell<D>,
         progress_update: Box<dyn Progress>,
     ) -> Result<(), Error>;
 
@@ -156,7 +157,7 @@ pub trait WalletSync {
     /// [`BatchOperations::del_utxo`]: crate::database::BatchOperations::del_utxo
     fn wallet_sync<D: BatchDatabase>(
         &self,
-        database: &mut D,
+        database: &RefCell<D>,
         progress_update: Box<dyn Progress>,
     ) -> Result<(), Error> {
         maybe_await!(self.wallet_setup(database, progress_update))
@@ -377,7 +378,7 @@ impl<T: GetBlockHash> GetBlockHash for Arc<T> {
 impl<T: WalletSync> WalletSync for Arc<T> {
     fn wallet_setup<D: BatchDatabase>(
         &self,
-        database: &mut D,
+        database: &RefCell<D>,
         progress_update: Box<dyn Progress>,
     ) -> Result<(), Error> {
         maybe_await!(self.deref().wallet_setup(database, progress_update))
@@ -385,7 +386,7 @@ impl<T: WalletSync> WalletSync for Arc<T> {
 
     fn wallet_sync<D: BatchDatabase>(
         &self,
-        database: &mut D,
+        database: &RefCell<D>,
         progress_update: Box<dyn Progress>,
     ) -> Result<(), Error> {
         maybe_await!(self.deref().wallet_sync(database, progress_update))

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -249,11 +249,8 @@ pub trait BlockchainFactory {
     /// operations to build a blockchain for a given wallet, so if a wallet needs to be synced
     /// often it's recommended to use [`BlockchainFactory::build_for_wallet`] to reuse the same
     /// blockchain multiple times.
-    #[cfg(not(any(target_arch = "wasm32", feature = "async-interface")))]
-    #[cfg_attr(
-        docsrs,
-        doc(cfg(not(any(target_arch = "wasm32", feature = "async-interface"))))
-    )]
+    #[cfg(not(feature = "async-interface"))]
+    #[cfg_attr(docsrs, doc(cfg(not(feature = "async-interface"))))]
     fn sync_wallet<D: BatchDatabase>(
         &self,
         wallet: &Wallet<D>,

--- a/src/blockchain/rpc.rs
+++ b/src/blockchain/rpc.rs
@@ -49,8 +49,9 @@ use bitcoincore_rpc::Auth as RpcAuth;
 use bitcoincore_rpc::{Client, RpcApi};
 use log::{debug, info};
 use serde::{Deserialize, Serialize};
+use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
-use std::ops::Deref;
+use std::ops::{Deref, DerefMut};
 use std::path::PathBuf;
 use std::thread;
 use std::time::Duration;
@@ -192,10 +193,12 @@ impl GetBlockHash for RpcBlockchain {
 }
 
 impl WalletSync for RpcBlockchain {
-    fn wallet_setup<D>(&self, db: &mut D, prog: Box<dyn Progress>) -> Result<(), Error>
+    fn wallet_setup<D>(&self, db: &RefCell<D>, prog: Box<dyn Progress>) -> Result<(), Error>
     where
         D: BatchDatabase,
     {
+        let mut db = db.borrow_mut();
+        let db = db.deref_mut();
         let batch = DbState::new(db, &self.sync_params, &*prog)?
             .sync_with_core(&self.client, self.is_descriptors)?
             .as_db_batch()?;

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -49,7 +49,7 @@ pub use memory::MemoryDatabase;
 /// Blockchain state at the time of syncing
 ///
 /// Contains only the block time and height at the moment
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SyncTime {
     /// Block timestamp and height at the time of sync
     pub block_time: BlockTime,

--- a/src/descriptor/error.rs
+++ b/src/descriptor/error.rs
@@ -53,7 +53,26 @@ impl From<crate::keys::KeyError> for Error {
 
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        match self {
+            Self::InvalidHdKeyPath => write!(f, "Invalid HD key path"),
+            Self::InvalidDescriptorChecksum => {
+                write!(f, "The provided descriptor doesn't match its checksum")
+            }
+            Self::HardenedDerivationXpub => write!(
+                f,
+                "The descriptor contains hardened derivation steps on public extended keys"
+            ),
+            Self::Key(err) => write!(f, "Key error: {}", err),
+            Self::Policy(err) => write!(f, "Policy error: {}", err),
+            Self::InvalidDescriptorCharacter(char) => {
+                write!(f, "Invalid descriptor character: {}", char)
+            }
+            Self::Bip32(err) => write!(f, "BIP32 error: {}", err),
+            Self::Base58(err) => write!(f, "Base58 error: {}", err),
+            Self::Pk(err) => write!(f, "Key-related error: {}", err),
+            Self::Miniscript(err) => write!(f, "Miniscript error: {}", err),
+            Self::Hex(err) => write!(f, "Hex decoding error: {}", err),
+        }
     }
 }
 

--- a/src/descriptor/policy.rs
+++ b/src/descriptor/policy.rs
@@ -512,7 +512,14 @@ pub enum PolicyError {
 
 impl fmt::Display for PolicyError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        match self {
+            Self::NotEnoughItemsSelected(err) => write!(f, "Not enought items selected: {}", err),
+            Self::IndexOutOfRange(index) => write!(f, "Index out of range: {}", index),
+            Self::AddOnLeaf => write!(f, "Add on leaf"),
+            Self::AddOnPartialComplete => write!(f, "Add on partial complete"),
+            Self::MixedTimelockUnits => write!(f, "Mixed timelock units"),
+            Self::IncompatibleConditions => write!(f, "Incompatible conditions"),
+        }
     }
 }
 

--- a/src/descriptor/policy.rs
+++ b/src/descriptor/policy.rs
@@ -1197,7 +1197,7 @@ mod test {
             .unwrap();
 
         assert_matches!(&policy.item, EcdsaSignature(PkOrF::Fingerprint(f)) if f == &fingerprint);
-        assert_matches!(&policy.contribution, Satisfaction::Complete {condition} if condition.csv == None && condition.timelock == None);
+        assert_matches!(&policy.contribution, Satisfaction::Complete {condition} if condition.csv.is_none() && condition.timelock.is_none());
     }
 
     // 2 pub keys descriptor, required 2 prv keys
@@ -1346,7 +1346,7 @@ mod test {
             .unwrap();
 
         assert_matches!(policy.item, EcdsaSignature(PkOrF::Fingerprint(f)) if f == fingerprint);
-        assert_matches!(policy.contribution, Satisfaction::Complete {condition} if condition.csv == None && condition.timelock == None);
+        assert_matches!(policy.contribution, Satisfaction::Complete {condition} if condition.csv.is_none() && condition.timelock.is_none());
     }
 
     // single key, 1 prv and 1 pub key descriptor, required 1 prv keys

--- a/src/descriptor/template.rs
+++ b/src/descriptor/template.rs
@@ -287,7 +287,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip49<K> {
 
 /// BIP49 public template. Expands to `sh(wpkh(key/{0,1}/*))`
 ///
-/// This assumes that the key used has already been derived with `m/49'/0'/0'`.
+/// This assumes that the key used has already been derived with `m/49'/0'/0'` for Mainnet or `m/49'/1'/0'` for Testnet.
 ///
 /// This template requires the parent fingerprint to populate correctly the metadata of PSBTs.
 ///
@@ -366,7 +366,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip84<K> {
 
 /// BIP84 public template. Expands to `wpkh(key/{0,1}/*)`
 ///
-/// This assumes that the key used has already been derived with `m/84'/0'/0'`.
+/// This assumes that the key used has already been derived with `m/84'/0'/0'` for Mainnet or `m/84'/1'/0'` for Testnet.
 ///
 /// This template requires the parent fingerprint to populate correctly the metadata of PSBTs.
 ///

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -40,7 +40,7 @@ pub mod bip39;
 /// Set of valid networks for a key
 pub type ValidNetworks = HashSet<Network>;
 
-/// Create a set containing mainnet, testnet and regtest
+/// Create a set containing mainnet, testnet, signet, and regtest
 pub fn any_network() -> ValidNetworks {
     vec![
         Network::Bitcoin,
@@ -95,7 +95,7 @@ impl<Ctx: ScriptContext> DescriptorKey<Ctx> {
     }
 
     // This method is used internally by `bdk::fragment!` and `bdk::descriptor!`. It has to be
-    // public because it is effectively called by external crates, once the macros are expanded,
+    // public because it is effectively called by external crates once the macros are expanded,
     // but since it is not meant to be part of the public api we hide it from the docs.
     #[doc(hidden)]
     pub fn extract(
@@ -375,7 +375,7 @@ impl<Ctx: ScriptContext> From<bip32::ExtendedPrivKey> for ExtendedKey<Ctx> {
 /// `(DerivableKey, KeySource, DerivationPath)` tuples.
 ///
 /// For key types that don't encode any indication about the path to use (like bip39), it's
-/// generally recommended to implemented this trait instead of [`IntoDescriptorKey`]. The same
+/// generally recommended to implement this trait instead of [`IntoDescriptorKey`]. The same
 /// rules regarding script context and valid networks apply.
 ///
 /// ## Examples

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -935,7 +935,14 @@ impl_error!(bitcoin::util::bip32::Error, Bip32, KeyError);
 
 impl std::fmt::Display for KeyError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        match self {
+            Self::InvalidScriptContext => write!(f, "Invalid script context"),
+            Self::InvalidNetwork => write!(f, "Invalid network"),
+            Self::InvalidChecksum => write!(f, "Invalid checksum"),
+            Self::Message(err) => write!(f, "{}", err),
+            Self::Bip32(err) => write!(f, "BIP32 error: {}", err),
+            Self::Miniscript(err) => write!(f, "Miniscript error: {}", err),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,7 @@ compile_error!(
 #[cfg(feature = "keys-bip39")]
 extern crate bip39;
 
-#[cfg(any(target_arch = "wasm32", feature = "async-interface"))]
+#[cfg(feature = "async-interface")]
 #[macro_use]
 extern crate async_trait;
 #[macro_use]

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -22,7 +22,7 @@ pub trait PsbtUtils {
     /// Get the `TxOut` for the specified input index, if it doesn't exist in the PSBT `None` is returned.
     fn get_utxo_for(&self, input_index: usize) -> Option<TxOut>;
 
-    /// The total transaction fee amount, sum of input amounts minus sum of output amounts, in Sats.
+    /// The total transaction fee amount, sum of input amounts minus sum of output amounts, in sats.
     /// If the PSBT is missing a TxOut for an input returns None.
     fn fee_amount(&self) -> Option<u64>;
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -230,7 +230,6 @@ pub struct TransactionDetails {
     pub transaction: Option<Transaction>,
     /// Transaction id
     pub txid: Txid,
-
     /// Received value (sats)
     /// Sum of owned outputs of this transaction.
     pub received: u64,
@@ -242,7 +241,7 @@ pub struct TransactionDetails {
     /// Server backend, but it could be `None` with a Bitcoin RPC node without txindex that receive
     /// funds while offline.
     pub fee: Option<u64>,
-    /// If the transaction is confirmed, contains height and timestamp of the block containing the
+    /// If the transaction is confirmed, contains height and Unix timestamp of the block containing the
     /// transaction, unconfirmed transaction contains `None`.
     pub confirmation_time: Option<BlockTime>,
 }

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -17,7 +17,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::collections::{BTreeMap, HashSet};
 use std::fmt;
-use std::ops::{Deref, DerefMut};
+use std::ops::Deref;
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -1719,14 +1719,11 @@ where
         let max_rounds = if has_wildcard { 100 } else { 1 };
 
         for _ in 0..max_rounds {
-            let sync_res =
-                if run_setup {
-                    maybe_await!(blockchain
-                        .wallet_setup(self.database.borrow_mut().deref_mut(), new_progress()))
-                } else {
-                    maybe_await!(blockchain
-                        .wallet_sync(self.database.borrow_mut().deref_mut(), new_progress()))
-                };
+            let sync_res = if run_setup {
+                maybe_await!(blockchain.wallet_setup(&self.database, new_progress()))
+            } else {
+                maybe_await!(blockchain.wallet_sync(&self.database, new_progress()))
+            };
 
             // If the error is the special `MissingCachedScripts` error, we return the number of
             // scripts we should ensure cached.

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -132,7 +132,7 @@ pub enum AddressIndex {
     Reset(u32),
 }
 
-/// A derived address and the index it was found at
+/// A derived address and the index it was found at.
 /// For convenience this automatically derefs to `Address`
 #[derive(Debug, PartialEq, Eq)]
 pub struct AddressInfo {

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1084,7 +1084,7 @@ where
     }
 
     /// Sign a transaction with all the wallet's signers, in the order specified by every signer's
-    /// [`SignerOrdering`]
+    /// [`SignerOrdering`]. This function returns the `Result` type with an encapsulated `bool` that has the value true if the PSBT was finalized, or false otherwise.
     ///
     /// The [`SignOptions`] can be used to tweak the behavior of the software signers, and the way
     /// the transaction is finalized at the end. Note that it can't be guaranteed that *every*

--- a/src/wallet/signer.rs
+++ b/src/wallet/signer.rs
@@ -180,7 +180,22 @@ impl From<sighash::Error> for SignerError {
 
 impl fmt::Display for SignerError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        match self {
+            Self::MissingKey => write!(f, "Missing private key"),
+            Self::InvalidKey => write!(f, "The private key in use has the right fingerprint but derives differently than expected"),
+            Self::UserCanceled => write!(f, "The user canceled the operation"),
+            Self::InputIndexOutOfRange => write!(f, "Input index out of range"),
+            Self::MissingNonWitnessUtxo => write!(f, "Missing non-witness UTXO"),
+            Self::InvalidNonWitnessUtxo => write!(f, "Invalid non-witness UTXO"),
+            Self::MissingWitnessUtxo => write!(f, "Missing witness UTXO"),
+            Self::MissingWitnessScript => write!(f, "Missing witness script"),
+            Self::MissingHdKeypath => write!(f, "Missing fingerprint and derivation path"),
+            Self::NonStandardSighash => write!(f, "The psbt contains a non standard sighash"),
+            Self::InvalidSighash => write!(f, "Invalid SIGHASH for the signing context in use"),
+            Self::SighashError(err) => write!(f, "Error while computing the hash to sign: {}", err),
+            #[cfg(feature = "hardware-signer")]
+            Self::HWIError(err) => write!(f, "Error while signing using hardware wallets: {}", err),
+        }
     }
 }
 

--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -123,7 +123,7 @@ pub struct TxBuilder<'a, D, Cs, Ctx> {
 }
 
 /// The parameters for transaction creation sans coin selection algorithm.
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq)]
 pub struct TxParams {
     pub(crate) recipients: Vec<(Script, u64)>,
     pub(crate) drain_wallet: bool,
@@ -148,13 +148,13 @@ pub struct TxParams {
     pub(crate) allow_dust: bool,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) struct PreviousFee {
     pub absolute: u64,
     pub rate: f32,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) enum FeePolicy {
     FeeRate(FeeRate),
     FeeAmount(u64),

--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -123,9 +123,8 @@ pub struct TxBuilder<'a, D, Cs, Ctx> {
 }
 
 /// The parameters for transaction creation sans coin selection algorithm.
-//TODO: TxParams should eventually be exposed publicly.
 #[derive(Default, Debug, Clone)]
-pub(crate) struct TxParams {
+pub struct TxParams {
     pub(crate) recipients: Vec<(Script, u64)>,
     pub(crate) drain_wallet: bool,
     pub(crate) drain_to: Option<Script>,
@@ -566,6 +565,11 @@ impl<'a, D: BatchDatabase, Cs: CoinSelectionAlgorithm<D>, Ctx: TxBuilderContext>
     pub fn allow_dust(&mut self, allow_dust: bool) -> &mut Self {
         self.params.allow_dust = allow_dust;
         self
+    }
+
+    /// Retrieve the loaded transaction parameters.
+    pub fn get_params(&self) -> TxParams {
+        self.params.clone()
     }
 }
 

--- a/src/wallet/verify.rs
+++ b/src/wallet/verify.rs
@@ -91,7 +91,12 @@ pub enum VerifyError {
 
 impl fmt::Display for VerifyError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        match self {
+            Self::MissingInputTx(txid) => write!(f, "The transaction being spent is not available in the database or the blockchain client: {}", txid),
+            Self::InvalidInput(outpoint) => write!(f, "The transaction being spent doesn't have the requested output: {}", outpoint),
+            Self::Consensus(err) => write!(f, "Consensus error: {:?}", err),
+            Self::Global(err) => write!(f, "Generic error: {}", err),
+        }
     }
 }
 


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

Currently, `tx_builder` TxParams are not exposed publicly, although [it has been noted in the code](https://github.com/bitcoindevkit/bdk/blob/eac739d3954937e49705a7336b4a017652802996/src/wallet/tx_builder.rs#L126) the intention for the struct to be exposed publicly. Exposing TxParams enables the current state of TxBuilder (i.e. loaded transaction parameters) to be accessed prior to calling `tx_builder::finish()` to construct a PSBT. 

This would be useful for a number of reasons, including enabling BDK users to view and validate the configuration of a TxBuilder instance at a specific point in the code without needing to finalise TxBuilder to obtain a PSBT (and subsequently initialise a brand new TxBuilder from scratch if e.g. something intended is missing) which is necessary at present since TxBuilder's contents are private.

This PR introduces a `tx_builder::get_params()` method which can be called on a TxBuilder instance at any time to retrieve the current state of the TxBuilder/TxParams, and adds a basic corresponding `get_params()` test.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

The `tx_builder_test` TxBuilder instance used in the `get_params()` test was kept barebones, with only two tx config options added via their respective methods, in an attempt to keep the test data size to a minimum and avoid clutter.

If it's deemed beneficial for a more complex/realistic TxBuilder instance to be used in the `get_params()` test, I can add additional TxBuilder methods (e.g. recipients, fee rate) and amend the expected test data respectively.

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->
- Add `wallet::tx_builder::get_params` method

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature