### PR TITLE
Bump project MSRV to 1.57.0

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -12,7 +12,7 @@ jobs:
         rust:
           - version: 1.65.0 # STABLE
             clippy: true
-          - version: 1.56.1 # MSRV
+          - version: 1.57.0 # MSRV
         features:
           - default
           - minimal
@@ -146,7 +146,7 @@ jobs:
       - run: sudo apt-get update || exit 1
       - run: sudo apt-get install -y libclang-common-10-dev clang-10 libc6-dev-i386 || exit 1
       - name: Set default toolchain
-        run: rustup default 1.56.1 # STABLE
+        run: rustup default 1.65.0 # STABLE
       - name: Set profile
         run: rustup set profile minimal
       - name: Add target wasm32
@@ -178,8 +178,8 @@ jobs:
     strategy:
       matrix:
         rust:
-          - version: 1.60.0 # STABLE
-          - version: 1.56.1 # MSRV
+          - version: 1.65.0 # STABLE
+          - version: 1.57.0 # MSRV
     steps:
     - name: Checkout
       uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
     <a href="https://github.com/bitcoindevkit/bdk/actions?query=workflow%3ACI"><img alt="CI Status" src="https://github.com/bitcoindevkit/bdk/workflows/CI/badge.svg"></a>
     <a href="https://coveralls.io/github/bitcoindevkit/bdk?branch=master"><img src="https://coveralls.io/repos/github/bitcoindevkit/bdk/badge.svg?branch=master"/></a>
     <a href="https://docs.rs/bdk"><img alt="API Docs" src="https://img.shields.io/badge/docs.rs-bdk-green"/></a>
-    <a href="https://blog.rust-lang.org/2021/11/01/Rust-1.56.1.html"><img alt="Rustc Version 1.56.1+" src="https://img.shields.io/badge/rustc-1.56.1%2B-lightgrey.svg"/></a>
+    <a href="https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html"><img alt="Rustc Version 1.57.0+" src="https://img.shields.io/badge/rustc-1.57.0%2B-lightgrey.svg"/></a>
     <a href="https://discord.gg/d7NkDKm"><img alt="Chat on Discord" src="https://img.shields.io/discord/753336465005608961?logo=discord"></a>
   </p>
 


### PR DESCRIPTION
### Description

Bump project MSRV from 1.56.1 to 1.57.0.

Also bumped the `check-wasm` and `test_hardware_wallet` jobs rust STABLE version to 1.65.0 to match other jobs.

### Notes to the reviewers

The `rustls` crate changed their MSRV to 1.57 on 2023-01-12 with a patch release from 0.20.7 to 0.20.8, rustls/rustls#1152. This breaks our CI builds that use `esplora-client` 0.3 because it depends on a version of `ureq` that uses the latest `rustls`. 

```
rustls v0.20.8
└── ureq v2.6.2
    └── esplora-client v0.3.0
        └── bdk v0.26.0 (/Users/steve/git/notmandatory/bdk)
    [build-dependencies]
    └── electrsd v0.21.1
        [dev-dependencies]
        └── bdk v0.26.0 (/Users/steve/git/notmandatory/bdk)
```

https://github.com/rustls/rustls/blob/main/README.md

### Changelog notice

Project MSRV changed from 1.56.1 to 1.57.0.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing