### PR TITLE
Update electrsd to version 0.22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ dev-getrandom-wasm = ["getrandom/js"]
 [dev-dependencies]
 lazy_static = "1.4"
 env_logger = "0.7"
-electrsd = "0.21"
+electrsd = "0.22"
 # Move back to importing from rust-bitcoin once https://github.com/rust-bitcoin/rust-bitcoin/pull/1342 is released
 base64 = "^0.13"
 assert_matches = "1.5.0"


### PR DESCRIPTION
### Description

Update `electrsd` dev-dependency to version `0.22`. 

### Notes to the reviewers

We're able to do this now that esplora was updated in #830 and our MSRV was bumped to `1.57.0` in #842.

### Changelog

None.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)