### PR TITLE
Allow database begin_batch functions to fail

### DIFF
--- a/src/blockchain/compact_filters/mod.rs
+++ b/src/blockchain/compact_filters/mod.rs
@@ -151,7 +151,7 @@ impl CompactFiltersBlockchain {
         internal_max_deriv: &mut Option<u32>,
         external_max_deriv: &mut Option<u32>,
     ) -> Result<(), Error> {
-        let mut updates = database.begin_batch();
+        let mut updates = database.begin_batch()?;
 
         let mut incoming: u64 = 0;
         let mut outgoing: u64 = 0;
@@ -410,7 +410,7 @@ impl WalletSync for CompactFiltersBlockchain {
             "Dropping transactions newer than `last_synced_block` = {}",
             last_synced_block
         );
-        let mut updates = database.begin_batch();
+        let mut updates = database.begin_batch()?;
         for details in database.iter_txs(false)? {
             match details.confirmation_time {
                 Some(c) if (c.height as usize) < last_synced_block => continue,

--- a/src/blockchain/rpc.rs
+++ b/src/blockchain/rpc.rs
@@ -621,7 +621,7 @@ impl<'a, D: BatchDatabase> DbState<'a, D> {
 
     /// Prepare db batch operations.
     fn as_db_batch(&self) -> Result<D::Batch, Error> {
-        let mut batch = self.db.begin_batch();
+        let mut batch = self.db.begin_batch()?;
         let mut del_txs = 0_u32;
 
         // delete stale (not retained) txs from db

--- a/src/blockchain/script_sync.rs
+++ b/src/blockchain/script_sync.rs
@@ -364,7 +364,7 @@ impl<'a, D: BatchDatabase> State<'a, D> {
             })
             .collect::<Result<Vec<(KeychainKind, u32)>, _>>()?;
 
-        let mut batch = self.db.begin_batch();
+        let mut batch = self.db.begin_batch()?;
 
         // Delete old txs that no longer exist
         for txid in txids_to_delete {

--- a/src/database/any.rs
+++ b/src/database/any.rs
@@ -319,13 +319,13 @@ impl BatchOperations for AnyBatch {
 impl BatchDatabase for AnyDatabase {
     type Batch = AnyBatch;
 
-    fn begin_batch(&self) -> Self::Batch {
+    fn begin_batch(&self) -> Result<Self::Batch, Error> {
         match self {
-            AnyDatabase::Memory(inner) => inner.begin_batch().into(),
+            AnyDatabase::Memory(inner) => inner.begin_batch().map(Into::into),
             #[cfg(feature = "key-value-db")]
-            AnyDatabase::Sled(inner) => inner.begin_batch().into(),
+            AnyDatabase::Sled(inner) => inner.begin_batch().map(Into::into),
             #[cfg(feature = "sqlite")]
-            AnyDatabase::Sqlite(inner) => inner.begin_batch().into(),
+            AnyDatabase::Sqlite(inner) => inner.begin_batch().map(Into::into),
         }
     }
     fn commit_batch(&mut self, batch: Self::Batch) -> Result<(), Error> {

--- a/src/database/keyvalue.rs
+++ b/src/database/keyvalue.rs
@@ -393,8 +393,8 @@ fn ivec_to_u32(b: sled::IVec) -> Result<u32, Error> {
 impl BatchDatabase for Tree {
     type Batch = sled::Batch;
 
-    fn begin_batch(&self) -> Self::Batch {
-        sled::Batch::default()
+    fn begin_batch(&self) -> Result<Self::Batch, Error> {
+        Ok(sled::Batch::default())
     }
 
     fn commit_batch(&mut self, batch: Self::Batch) -> Result<(), Error> {

--- a/src/database/memory.rs
+++ b/src/database/memory.rs
@@ -454,8 +454,8 @@ impl Database for MemoryDatabase {
 impl BatchDatabase for MemoryDatabase {
     type Batch = Self;
 
-    fn begin_batch(&self) -> Self::Batch {
-        MemoryDatabase::new()
+    fn begin_batch(&self) -> Result<Self::Batch, Error> {
+        Ok(MemoryDatabase::new())
     }
 
     fn commit_batch(&mut self, mut batch: Self::Batch) -> Result<(), Error> {

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -168,7 +168,7 @@ pub trait BatchDatabase: Database {
     type Batch: BatchOperations;
 
     /// Create a new batch container
-    fn begin_batch(&self) -> Self::Batch;
+    fn begin_batch(&self) -> Result<Self::Batch, Error>;
     /// Consume and apply a batch of operations
     fn commit_batch(&mut self, batch: Self::Batch) -> Result<(), Error>;
 }
@@ -243,7 +243,7 @@ pub mod test {
     }
 
     pub fn test_batch_script_pubkey<D: BatchDatabase>(mut db: D) {
-        let mut batch = db.begin_batch();
+        let mut batch = db.begin_batch().unwrap();
 
         let script = Script::from(
             Vec::<u8>::from_hex("76a91402306a7c23f3e8010de41e9e591348bb83f11daa88ac").unwrap(),

--- a/src/database/sqlite.rs
+++ b/src/database/sqlite.rs
@@ -918,10 +918,10 @@ impl Database for SqliteDatabase {
 impl BatchDatabase for SqliteDatabase {
     type Batch = SqliteDatabase;
 
-    fn begin_batch(&self) -> Self::Batch {
+    fn begin_batch(&self) -> Result<Self::Batch, Error> {
         let db = SqliteDatabase::new(self.path.clone());
-        db.connection.execute("BEGIN TRANSACTION", []).unwrap();
-        db
+        db.connection.execute("BEGIN TRANSACTION", [])?;
+        Ok(db)
     }
 
     fn commit_batch(&mut self, batch: Self::Batch) -> Result<(), Error> {

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -1379,7 +1379,7 @@ where
             count = 1;
         }
 
-        let mut address_batch = self.database.borrow().begin_batch();
+        let mut address_batch = self.database.borrow().begin_batch()?;
 
         let start_time = time::Instant::new();
         for i in from..(from + count) {


### PR DESCRIPTION
When dealing with local or remote databases than beginning a transaction can fail. Not allowing implementations to return a result and resorting to unwrap() is a non-starter for reliable production code as this will skip Rust's own drop handler in many places and crashes the application.

I have not updated documentation / changelog yet, but would appreciate feedback on the change. I have not run yet any tests.

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits (with ssh)
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [x] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
