### PR TITLE
export: Add `tr()` descriptor as compatible with Bitcoin Core

### DIFF
--- a/src/wallet/export.rs
+++ b/src/wallet/export.rs
@@ -182,9 +182,9 @@ impl FullyNodedExport {
             }
         }
 
-        // pkh(), wpkh(), sh(wpkh()) are always fine, as well as multi() and sortedmulti()
+        // pkh(), wpkh(), tr() and sh(wpkh()) are always fine, as well as multi() and sortedmulti()
         match Descriptor::<String>::from_str(descriptor).map_err(|_| "Invalid descriptor")? {
-            Descriptor::Pkh(_) | Descriptor::Wpkh(_) => Ok(()),
+            Descriptor::Pkh(_) | Descriptor::Wpkh(_) | Descriptor::Tr(_) => Ok(()),
             Descriptor::Sh(sh) => match sh.as_inner() {
                 ShInner::Wpkh(_) => Ok(()),
                 ShInner::SortedMulti(_) => Ok(()),


### PR DESCRIPTION
I tried to export a Taproot wallet and got the error `The descriptor is not compatible with Bitcoin Core`.

It looks like this part of the code has not yet been updated for `tr()` descriptor. This PR fixes that.