### PR TITLE
cargo.toml: Update `tokio` library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ bitcoincore-rpc = { version = "0.16", optional = true }
 
 # Platform-specific dependencies
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tokio = { version = "1", features = ["rt", "macros"] }
+tokio = { version = "1.25.0", features = ["rt", "macros"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = "0.2"


### PR DESCRIPTION
This PR updates `cargo.toml` to use the latest version of `tokio` lib.