### PR TITLE
Fix ci Dockerfile.ledger

### DIFF
--- a/ci/Dockerfile.ledger
+++ b/ci/Dockerfile.ledger
@@ -6,4 +6,4 @@ RUN apt-get install wget -y
 RUN wget "https://github.com/LedgerHQ/speculos/blob/master/apps/nanos%23btc%232.1%231c8db8da.elf?raw=true" -O /speculos/btc.elf
 ADD automation.json /speculos/automation.json
 
-ENTRYPOINT ["python", "./speculos.py", "--automation", "file:automation.json", "--display", "headless", "--vnc-port", "41000", "btc.elf"]
+ENTRYPOINT ["python", "./speculos.py", "--automation", "file:automation.json", "--model", "nanos", "--display", "headless", "--vnc-port", "41000", "btc.elf"]


### PR DESCRIPTION
### Description

Ledger emulator used to default to `-model nanos` but in latest release we need to add it to the command line. This change fixes `test_hardware_wallet` CI tests.

### Notes to the reviewers

I originally made this fix in the `release/0.27` branch, this PR cherry-picks the change back to the `master` branch. I should have done a `master` branch PR first but it's only a CI change and I wanted to get the `0.27.0` release out. 

### Changelog notice

None.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
