### PR TITLE
Update rusqlite from 0.27.0 to 0.28.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rand = "^0.8"
 sled = { version = "0.34", optional = true }
 electrum-client = { version = "0.12", optional = true }
 esplora-client = { version = "0.3", default-features = false, optional = true }
-rusqlite = { version = "0.27.0", optional = true }
+rusqlite = { version = "0.28.0", optional = true }
 ahash = { version = "0.7.6", optional = true }
 futures = { version = "0.3", optional = true }
 async-trait = { version = "0.1", optional = true }


### PR DESCRIPTION
### Description

Fix #866 by updating `rusqlite` dependency version from `0.27.0` to `0.28.0` to fix [RUSTSEC-2022-0090](https://rustsec.org/advisories/RUSTSEC-2022-0090).

### Notes to the reviewers

This will also need to be cherry-picked to the `release/0.27` branch to create a new `0.27.1` release.

### Changelog notice

Changed

* Update rusqlite version from 0.27.0 to 0.28.0 to fix [RUSTSEC-2022-0090](https://rustsec.org/advisories/RUSTSEC-2022-0090).

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
