### PR TITLE
Fix TxOrdering::Shuffle to also shuffle the inputs

### DIFF
--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -703,6 +703,7 @@ impl TxOrdering {
                 #[cfg(test)]
                 let mut rng = rand::rngs::StdRng::seed_from_u64(12345);
 
+                tx.input.shuffle(&mut rng);
                 tx.output.shuffle(&mut rng);
             }
             TxOrdering::Bip69Lexicographic => {
@@ -815,7 +816,7 @@ mod test {
 
         TxOrdering::Shuffle.sort_tx(&mut tx);
 
-        assert_eq!(original_tx.input, tx.input);
+        assert_ne!(original_tx.input, tx.input);
         assert_ne!(original_tx.output, tx.output);
     }
 


### PR DESCRIPTION
### Description

Fixes #865 

This is a small change to make it so that `TxOrdering:Shuffle` also shuffles the inputs. 

### Notes to the reviewers

It looks like input shuffling was meant to be excluded in #38 when the `TxOrdering::Shuffle` option was added since the corresponding test check that inputs are not shuffled. 

### Changelog notice

Fixed

- The `TxOrdering::Shuffle` option in the `TxBuilder` now also shuffles the inputs. 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
