### PR TITLE
Set dev-dependency base64ct version to <1.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,8 @@ base64 = "^0.13"
 assert_matches = "1.5.0"
 # zip versions after 0.6.3 don't work with our MSRV 1.57.0
 zip = "=0.6.3"
+# base64ct versions at 1.6.0 and higher have MSRV 1.60.0
+base64ct = "<1.6.0"
 
 [[example]]
 name = "compact_filters_balance"


### PR DESCRIPTION
### Description

This PR fixes CI for MSRV 1.57.0. 

In the past we fixed our dev-dependency for `zip` (used by `electrsd`) to version 1.6.3 which has an MSRV of 1.57, but `zip` depends on `base64ct` which with it's 1.6.0 version changed it's MSRV to 1.60.0. This PR pins the dev-dependency `base64ct` to less than version 1.6.0 so that we can keep our project MSRV at 1.57.

### Notes to the reviewers

The MSRV issues caused by the `electrsd` crate are getting a bit out of hand but should get better when we have electrum and other blockchain clients in different crates that can have higher MSRVs than the core `bdk_chain` crate.

### Changelog notice

None.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
