### PR TITLE
Set `default-features = false` for rust-bitcoin and rust-miniscript

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 bdk-macros = "^0.6"
 log = "^0.4"
-miniscript = { version = "9.0", features = ["serde"] }
-bitcoin = { version = "0.29.1", features = ["serde", "base64", "rand"] }
+miniscript = { version = "9.0", default-features = false, features = ["serde"] }
+bitcoin = { version = "0.29.2", default-features = false, features = ["serde", "base64", "rand"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 rand = "^0.8"
@@ -31,7 +31,7 @@ async-trait = { version = "0.1", optional = true }
 rocksdb = { version = "0.14", default-features = false, features = ["snappy"], optional = true }
 cc = { version = ">=1.0.64", optional = true }
 socks = { version = "0.3", optional = true }
-hwi = { version = "0.5", optional = true, features = [ "use-miniscript"] }
+hwi = { version = "0.5", optional = true, features = ["use-miniscript"] }
 
 bip39 = { version = "1.0.1", optional = true }
 bitcoinconsensus = { version = "0.19.0-3", optional = true }
@@ -104,6 +104,8 @@ test-hardware-signer = ["hardware-signer"]
 dev-getrandom-wasm = ["getrandom/js"]
 
 [dev-dependencies]
+miniscript = { version = "9.0", features = ["std"] }
+bitcoin = { version = "0.29.2", features = ["std"] }
 lazy_static = "1.4"
 env_logger = "0.7"
 electrsd = "0.22"


### PR DESCRIPTION
Same as https://github.com/bitcoindevkit/rust-esplora-client/pull/39

Should let bdk be unbiased for things like no-std