### PR TITLE
Update esplora client dependency to version 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rand = "^0.8"
 # Optional dependencies
 sled = { version = "0.34", optional = true }
 electrum-client = { version = "0.12", optional = true }
-esplora-client = { version = "0.3", default-features = false, optional = true }
+esplora-client = { version = "0.4", default-features = false, optional = true }
 rusqlite = { version = "0.28.0", optional = true }
 ahash = { version = "0.7.6", optional = true }
 futures = { version = "0.3", optional = true }


### PR DESCRIPTION
### Description

Update the `esplora-client` to the new `0.4` release.

### Notes to the reviewers

The `esplora-client` was updated in bitcoindevkit/rust-esplora-client#39 to not include default `rust-bitcoin` dependencies.

### Changelog notice

- Update the `esplora-client` optional dependency to version `0.4`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing