### PR TITLE
Add docs for `EsploraAsyncExt` and make doctests runnable

### DIFF
--- a/crates/bdk/README.md
+++ b/crates/bdk/README.md
@@ -64,7 +64,7 @@ To persist the `Wallet` on disk, `Wallet` needs to be constructed with a
 
 **Example**
 
-```rust,no_run
+```rust
 use bdk::{bitcoin::Network, wallet::{AddressIndex, Wallet}};
 
 fn main() {

--- a/crates/esplora/README.md
+++ b/crates/esplora/README.md
@@ -22,15 +22,12 @@ For async-only (with https):
 bdk_esplora = { version = "0.1", features = ["async-https"] }
 ```
 
-To use the extension trait:
-
-```rust,no_run
+To use the extension traits:
+```rust
 // for blocking
 use bdk_esplora::EsploraExt;
 // for async
 use bdk_esplora::EsploraAsyncExt;
 ```
 
-<!-- BDK Esplora client library for updating the `bdk_chain` structures. -->
-
-<!-- [`esplora_client`]: https://docs.rs/esplora-client/latest -->
+For full examples, refer to [`example-crates/wallet_esplora`](https://github.com/bitcoindevkit/bdk/tree/master/example-crates/wallet_esplora) (blocking) and [`example-crates/wallet_esplora_async`](https://github.com/bitcoindevkit/bdk/tree/master/example-crates/wallet_esplora_async).

--- a/crates/esplora/src/async_ext.rs
+++ b/crates/esplora/src/async_ext.rs
@@ -12,6 +12,13 @@ use futures::stream::{FuturesOrdered, TryStreamExt};
 
 use crate::map_confirmation_time;
 
+/// Trait to extend [`esplora_client::AsyncClient`] functionality.
+///
+/// This is the async version of [`EsploraExt`]. Refer to
+/// [crate-level documentation] for more.
+///
+/// [`EsploraExt`]: crate::EsploraExt
+/// [crate-level documentation]: crate
 #[cfg(feature = "async")]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]


### PR DESCRIPTION
### Description

Add docs for `EsploraAsyncExt` and make various doctests runnable.