### PR TITLE
Set bitcoin, miniscript default-features = false, bump esplora-client version to 0.4

### DIFF
--- a/crates/bdk/Cargo.toml
+++ b/crates/bdk/Cargo.toml
@@ -15,8 +15,8 @@ rust-version = "1.57"
 [dependencies]
 log = "^0.4"
 rand = "^0.8"
-miniscript = { version = "9", features = ["serde"] }
-bitcoin = { version = "0.29", features = ["serde", "base64", "rand"] }
+miniscript = { version = "9", features = ["serde"], default-features = false }
+bitcoin = { version = "0.29", features = ["serde", "base64", "rand"], default-features = false }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 bdk_chain = { path = "../chain", version = "0.3.1", features = ["miniscript", "serde"] }

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -13,13 +13,13 @@ readme = "../README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitcoin = { version = "0.29" }
+bitcoin = { version = "0.29", default-features = false }
 serde_crate = { package = "serde", version = "1", optional = true, features = ["derive"] }
 
 # Use hashbrown as a feature flag to have HashSet and HashMap from it.
 # note version 0.13 breaks outs MSRV.
 hashbrown = { version = "0.12", optional = true,  features = ["serde"] }
-miniscript = { version = "9.0.0", optional = true  }
+miniscript = { version = "9.0.0", optional = true, default-features = false }
 
 [dev-dependencies]
 rand = "0.8"

--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 bdk_chain = { path = "../chain", version = "0.3.1", features = ["serde", "miniscript"] }
-esplora-client = { version = "0.3", default-features = false }
+esplora-client = { version = "0.4", default-features = false }
 async-trait = { version = "0.1.66", optional = true }
 futures = { version = "0.3.26", optional = true }
 


### PR DESCRIPTION
### Description

Carrying over relevant maintenance changes from release 0.27.2 to bdk `master`. Setting bitcoin and miniscript `default-features = false`. Bumped esplora-client to 0.4.

### Notes to the reviewers

The `default-features = false` is to let bdk be unbiased for things like no-std.

### Changelog notice

- Set default-features = false for rust-bitcoin and rust-miniscript #882
- Update esplora client dependency to version 0.4 #884

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
