### PR TITLE
Better no-std support

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -32,6 +32,34 @@ jobs:
       - name: Test
         run: cargo test ${{ matrix.features }}
 
+  check-no-std:
+    name: Check no_std
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+          # target: "thumbv6m-none-eabi"
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2.2.1
+      - name: Check bdk_chain
+        working-directory: ./crates/chain
+        # TODO "--target thumbv6m-none-eabi" should work but currently does not
+        run: cargo check --no-default-features --features bitcoin/no-std,miniscript/no-std,hashbrown
+      - name: Check bdk
+        working-directory: ./crates/bdk
+        # TODO "--target thumbv6m-none-eabi" should work but currently does not
+        run: cargo check --no-default-features --features bitcoin/no-std,miniscript/no-std,bdk_chain/hashbrown
+      - name: Check esplora
+        working-directory: ./crates/esplora
+        # TODO "--target thumbv6m-none-eabi" should work but currently does not
+        run: cargo check --no-default-features --features bitcoin/no-std,miniscript/no-std,bdk_chain/hashbrown
+
   check-wasm:
     name: Check WASM
     runs-on: ubuntu-20.04
@@ -57,10 +85,10 @@ jobs:
         uses: Swatinem/rust-cache@v2.2.1
       - name: Check bdk
         working-directory: ./crates/bdk
-        run: cargo check --target wasm32-unknown-unknown --features dev-getrandom-wasm
+        run: cargo check --target wasm32-unknown-unknown --no-default-features --features bitcoin/no-std,miniscript/no-std,bdk_chain/hashbrown,dev-getrandom-wasm
       - name: Check esplora
         working-directory: ./crates/esplora
-        run: cargo check --target wasm32-unknown-unknown --features async --no-default-features
+        run: cargo check --target wasm32-unknown-unknown --no-default-features --features bitcoin/no-std,miniscript/no-std,bdk_chain/hashbrown,async
 
   fmt:
     name: Rust fmt

--- a/crates/bdk/Cargo.toml
+++ b/crates/bdk/Cargo.toml
@@ -15,11 +15,11 @@ rust-version = "1.57"
 [dependencies]
 log = "=0.4.18"
 rand = "^0.8"
-miniscript = { version = "9", features = ["serde"] }
-bitcoin = { version = "0.29", features = ["serde", "base64", "rand"] }
+miniscript = { version = "9", features = ["serde"], default-features = false }
+bitcoin = { version = "0.29", features = ["serde", "base64", "rand"], default-features = false }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
-bdk_chain = { path = "../chain", version = "0.4.0", features = ["miniscript", "serde"] }
+bdk_chain = { path = "../chain", version = "0.4.0", features = ["miniscript", "serde"], default-features = false }
 
 # Optional dependencies
 hwi = { version = "0.5", optional = true, features = [ "use-miniscript"] }
@@ -29,16 +29,14 @@ bip39 = { version = "1.0.1", optional = true }
 getrandom = "0.2"
 js-sys = "0.3"
 
-
 [features]
 default = ["std"]
-std = []
+std = ["bitcoin/std", "miniscript/std", "bdk_chain/std"]
 compiler = ["miniscript/compiler"]
 all-keys = ["keys-bip39"]
 keys-bip39 = ["bip39"]
 hardware-signer = ["hwi"]
 test-hardware-signer = ["hardware-signer"]
-
 
 # This feature is used to run `cargo check` in our CI targeting wasm. It's not recommended
 # for libraries to explicitly include the "getrandom/js" feature, so we only do it when
@@ -52,11 +50,9 @@ env_logger = "0.7"
 base64 = "^0.13"
 assert_matches = "1.5.0"
 
-
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
-
 
 [[example]]
 name = "mnemonic_to_descriptors"

--- a/crates/bdk/src/descriptor/error.rs
+++ b/crates/bdk/src/descriptor/error.rs
@@ -11,6 +11,8 @@
 
 //! Descriptor errors
 
+use core::fmt;
+
 /// Errors related to the parsing and usage of descriptors
 #[derive(Debug)]
 pub enum Error {
@@ -51,8 +53,8 @@ impl From<crate::keys::KeyError> for Error {
     }
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::InvalidHdKeyPath => write!(f, "Invalid HD key path"),
             Self::InvalidDescriptorChecksum => {

--- a/crates/bdk/src/error.rs
+++ b/crates/bdk/src/error.rs
@@ -107,8 +107,10 @@ impl fmt::Display for MiniscriptPsbtError {
     }
 }
 
+#[cfg(feature = "std")]
 impl std::error::Error for MiniscriptPsbtError {}
 
+#[cfg(feature = "std")]
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/crates/bdk/src/keys/mod.rs
+++ b/crates/bdk/src/keys/mod.rs
@@ -15,6 +15,7 @@ use crate::collections::HashSet;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::any::TypeId;
+use core::fmt;
 use core::marker::PhantomData;
 use core::ops::Deref;
 use core::str::FromStr;
@@ -934,8 +935,8 @@ pub enum KeyError {
 impl_error!(miniscript::Error, Miniscript, KeyError);
 impl_error!(bitcoin::util::bip32::Error, Bip32, KeyError);
 
-impl std::fmt::Display for KeyError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for KeyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::InvalidScriptContext => write!(f, "Invalid script context"),
             Self::InvalidNetwork => write!(f, "Invalid network"),

--- a/crates/bdk/src/wallet/mod.rs
+++ b/crates/bdk/src/wallet/mod.rs
@@ -170,9 +170,9 @@ pub enum NewError<P> {
     Persist(P),
 }
 
-impl<P> core::fmt::Display for NewError<P>
+impl<P> fmt::Display for NewError<P>
 where
-    P: core::fmt::Display,
+    P: fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -13,18 +13,18 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitcoin = { version = "0.29" }
+bitcoin = { version = "0.29", default-features = false }
 serde_crate = { package = "serde", version = "1", optional = true, features = ["derive"] }
 
 # Use hashbrown as a feature flag to have HashSet and HashMap from it.
 # note version 0.13 breaks outs MSRV.
-hashbrown = { version = "0.12", optional = true,  features = ["serde"] }
-miniscript = { version = "9.0.0", optional = true  }
+hashbrown = { version = "0.12", optional = true, features = ["serde"] }
+miniscript = { version = "9.0.0", optional = true, default-features = false }
 
 [dev-dependencies]
 rand = "0.8"
 
 [features]
-default = ["std", "miniscript"]
-std = []
+default = ["std"]
+std = ["bitcoin/std"]
 serde = ["serde_crate", "bitcoin/serde" ]

--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -12,13 +12,18 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bdk_chain = { path = "../chain", version = "0.4.0", features = ["serde", "miniscript"] }
+bdk_chain = { path = "../chain", version = "0.4.0", default-features = false, features = ["serde", "miniscript"] }
 esplora-client = { version = "0.5", default-features = false }
 async-trait = { version = "0.1.66", optional = true }
 futures = { version = "0.3.26", optional = true }
 
+# use these dependencies if you need to enable their /no-std features
+bitcoin = { version = "0.29", optional = true, default-features = false }
+miniscript = { version = "9.0.0", optional = true, default-features = false }
+
 [features]
-default = ["blocking"]
+default = ["std", "async-https", "blocking"]
+std = ["bdk_chain/std"]
 async = ["async-trait", "futures", "esplora-client/async"]
 async-https = ["async", "esplora-client/async-https"]
 blocking = ["esplora-client/blocking"]


### PR DESCRIPTION
This replaces #893

### Description

Carrying over relevant maintenance changes from release 0.27.2 to bdk `master`.

- Use `default-features = false` for `miniscript` and `bitcoin`
- Introduce `std`  features for `bdk`, `bdk_chain` and `bdk_esplora`

### Notes to the reviewers

The `default-features = false`for `bitcoin` and `miniscript` is to let `bdk` be unbiased for things like no-std.

### Changelog notice

- Set default-features = false for rust-bitcoin and rust-miniscript #894
- Introduce `std`  features for `bdk`, `bdk_chain` and `bdk_esplora`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
