### PR TITLE
Revert: Set default-features = false for rust-bitcoin and rust-miniscript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.27.2]
 
-### Summary
-
-Disable default-features for rust-bitcoin and rust-miniscript dependencies, and for rust-esplora-client optional dependency.
-
-### Changed
-
--  Set default-features = false for rust-bitcoin and rust-miniscript #882
--  Update esplora client dependency to version 0.4 #884
+**Yanked**
 
 ## [v0.27.1]
 
@@ -654,4 +647,4 @@ final transaction is created by calling `finish` on the builder.
 [v0.27.0]: https://github.com/bitcoindevkit/bdk/compare/v0.26.0...v0.27.0
 [v0.27.1]: https://github.com/bitcoindevkit/bdk/compare/v0.27.0...v0.27.1
 [v0.27.2]: https://github.com/bitcoindevkit/bdk/compare/v0.27.1...v0.27.2
-[Unreleased]: https://github.com/bitcoindevkit/bdk/compare/v0.27.2...HEAD
+[Unreleased]: https://github.com/bitcoindevkit/bdk/compare/v0.27.1...release/0.27

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 bdk-macros = "^0.6"
 log = "^0.4"
-miniscript = { version = "9.0", default-features = false, features = ["serde"] }
-bitcoin = { version = "0.29.2", default-features = false, features = ["serde", "base64", "rand"] }
+miniscript = { version = "9.0", features = ["serde"] }
+bitcoin = { version = "0.29.1", features = ["serde", "base64", "rand"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 rand = "^0.8"
@@ -31,7 +31,7 @@ async-trait = { version = "0.1", optional = true }
 rocksdb = { version = "0.14", default-features = false, features = ["snappy"], optional = true }
 cc = { version = ">=1.0.64", optional = true }
 socks = { version = "0.3", optional = true }
-hwi = { version = "0.5", optional = true, features = ["use-miniscript"] }
+hwi = { version = "0.5", optional = true, features = [ "use-miniscript"] }
 
 bip39 = { version = "1.0.1", optional = true }
 bitcoinconsensus = { version = "0.19.0-3", optional = true }
@@ -104,8 +104,6 @@ test-hardware-signer = ["hardware-signer"]
 dev-getrandom-wasm = ["getrandom/js"]
 
 [dev-dependencies]
-miniscript = { version = "9.0", features = ["std"] }
-bitcoin = { version = "0.29.2", features = ["std"] }
 lazy_static = "1.4"
 env_logger = "0.7"
 electrsd = "0.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ async-trait = { version = "0.1", optional = true }
 rocksdb = { version = "0.14", default-features = false, features = ["snappy"], optional = true }
 cc = { version = ">=1.0.64", optional = true }
 socks = { version = "0.3", optional = true }
-hwi = { version = "0.5", optional = true, features = [ "use-miniscript"] }
+hwi = { version = "0.5", optional = true, features = ["use-miniscript"] }
 
 bip39 = { version = "1.0.1", optional = true }
 bitcoinconsensus = { version = "0.19.0-3", optional = true }


### PR DESCRIPTION
### Description

Since the `bitcoin` and `miniscript` dependencies require enabling either `std` or `no-std` the only way we can make this change is to add a corresponding `std` and `no-std` features and requiring our downstream users to enable one. But BDK doesn't really support `no-std` yet and we don't want to break downstream projects on a patch release. So unfortunately I need to revert #882. 

See also: rust-bitcoin/rust-miniscript#533

### Notes to the reviewers

I've also yanked release `0.27.2` on crates.io and will be sure to test future releases with downstream bdk-cli and bdk-ffi projects to catch any issues like this.

### Changelog notice

None

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
