### PR TITLE
Bump versions to prep for 1.0.0-alpha.0 release

### DIFF
--- a/crates/bdk/Cargo.toml
+++ b/crates/bdk/Cargo.toml
@@ -19,7 +19,7 @@ miniscript = { version = "9", features = ["serde"] }
 bitcoin = { version = "0.29", features = ["serde", "base64", "rand"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
-bdk_chain = { path = "../chain", version = "0.3.1", features = ["miniscript", "serde"] }
+bdk_chain = { path = "../chain", version = "0.4.0", features = ["miniscript", "serde"] }
 
 # Optional dependencies
 hwi = { version = "0.5", optional = true, features = [ "use-miniscript"] }

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_chain"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.57"
 homepage = "https://bitcoindevkit.org"

--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_electrum"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -12,5 +12,5 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bdk_chain = { path = "../chain", version = "0.3.1", features = ["serde", "miniscript"] }
+bdk_chain = { path = "../chain", version = "0.4.0", features = ["serde", "miniscript"] }
 electrum-client = { version = "0.12" }

--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_esplora"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -12,7 +12,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bdk_chain = { path = "../chain", version = "0.3.1", features = ["serde", "miniscript"] }
+bdk_chain = { path = "../chain", version = "0.4.0", features = ["serde", "miniscript"] }
 esplora-client = { version = "0.3", default-features = false }
 async-trait = { version = "0.1.66", optional = true }
 futures = { version = "0.3.26", optional = true }

--- a/crates/file_store/Cargo.toml
+++ b/crates/file_store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_file_store"
-version = "0.0.1"
+version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -10,7 +10,7 @@ authors = ["Bitcoin Dev Kit Developers"]
 readme = "README.md"
 
 [dependencies]
-bdk_chain = { path = "../chain", version = "0.3.1", features = [ "serde", "miniscript" ] }
+bdk_chain = { path = "../chain", version = "0.4.0", features = [ "serde", "miniscript" ] }
 bincode = { version = "1" }
 serde = { version = "1", features = ["derive"] }
 

--- a/example-crates/keychain_tracker_electrum/Cargo.toml
+++ b/example-crates/keychain_tracker_electrum/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bdk_chain = { path = "../../crates/chain", version = "0.3.1", features = ["serde"] }
+bdk_chain = { path = "../../crates/chain", features = ["serde"] }
 bdk_electrum = { path = "../../crates/electrum" }
 keychain_tracker_example_cli = { path = "../keychain_tracker_example_cli"}

--- a/example-crates/keychain_tracker_esplora/Cargo.toml
+++ b/example-crates/keychain_tracker_esplora/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bdk_chain = { path = "../../crates/chain", version = "0.3.1", features = ["serde", "miniscript"] }
+bdk_chain = { path = "../../crates/chain", features = ["serde", "miniscript"] }
 bdk_esplora = { path = "../../crates/esplora" }
 keychain_tracker_example_cli = { path = "../keychain_tracker_example_cli" }

--- a/example-crates/keychain_tracker_example_cli/Cargo.toml
+++ b/example-crates/keychain_tracker_example_cli/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-bdk_chain = { path = "../../crates/chain", version = "0.3.1", features = ["serde", "miniscript"]}
+bdk_chain = { path = "../../crates/chain", features = ["serde", "miniscript"]}
 bdk_file_store = { path = "../../crates/file_store" }
 bdk_tmp_plan = { path = "../../nursery/tmp_plan" }
 bdk_coin_select = { path = "../../nursery/coin_select" }

--- a/nursery/coin_select/Cargo.toml
+++ b/nursery/coin_select/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.1"
 authors = [ "LLFourn <lloyd.fourn@gmail.com>" ]
 
 [dependencies]
-bdk_chain = { path = "../../crates/chain", version = "0.3.1" }
+bdk_chain = { path = "../../crates/chain" }
 
 [features]
 default = ["std"]

--- a/nursery/tmp_plan/Cargo.toml
+++ b/nursery/tmp_plan/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bdk_chain = {  path = "../../crates/chain", version = "0.3.1", features = ["miniscript"] }
+bdk_chain = {  path = "../../crates/chain", features = ["miniscript"] }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
### Description

See #910 for release process.

- [For examples and nursery remove workspace dependency versions](https://github.com/bitcoindevkit/bdk/commit/3b68a7bcc042e0ca29a97a4f8aeb5436d4138420)
- [Bump bdk version to 1.0.0-alpha.0](https://github.com/bitcoindevkit/bdk/commit/82f9caddabecc3a52ba38ecc2e345e365d3b7d42)

chain to 0.4.0
electrum to 0.2.0
esplora to 0.2.0
file_store to 0.1.0

### Notes to the reviewers

After this is merged to `master` my plan is to make a `release/1.0.0-alpha` branch for all our alpha releases.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing