### PR TITLE
Implement utxo reservation

### DIFF
--- a/example-crates/keychain_tracker_electrum/src/main.rs
+++ b/example-crates/keychain_tracker_electrum/src/main.rs
@@ -173,7 +173,7 @@ fn main() -> anyhow::Result<()> {
 
             if utxos {
                 let utxos = tracker
-                    .full_utxos()
+                    .full_utxos(false)
                     .map(|(_, utxo)| utxo)
                     .collect::<Vec<_>>();
                 outpoints = Box::new(

--- a/example-crates/keychain_tracker_esplora/src/main.rs
+++ b/example-crates/keychain_tracker_esplora/src/main.rs
@@ -181,7 +181,7 @@ fn main() -> anyhow::Result<()> {
 
             if utxos {
                 let utxos = tracker
-                    .full_utxos()
+                    .full_utxos(false)
                     .map(|(_, utxo)| utxo)
                     .collect::<Vec<_>>();
                 outpoints = Box::new(

--- a/example-crates/wallet_electrum/src/main.rs
+++ b/example-crates/wallet_electrum/src/main.rs
@@ -32,7 +32,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let address = wallet.get_address(bdk::wallet::AddressIndex::New);
     println!("Generated Address: {}", address);
 
-    let balance = wallet.get_balance();
+    let balance = wallet.get_balance(false);
     println!("Wallet balance before syncing: {} sats", balance.total());
 
     print!("Syncing...");
@@ -74,7 +74,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     wallet.apply_update(update)?;
     wallet.commit()?;
 
-    let balance = wallet.get_balance();
+    let balance = wallet.get_balance(false);
     println!("Wallet balance after syncing: {} sats", balance.total());
 
     if balance.total() < SEND_AMOUNT {

--- a/example-crates/wallet_esplora/src/main.rs
+++ b/example-crates/wallet_esplora/src/main.rs
@@ -28,7 +28,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let address = wallet.get_address(AddressIndex::New);
     println!("Generated Address: {}", address);
 
-    let balance = wallet.get_balance();
+    let balance = wallet.get_balance(false);
     println!("Wallet balance before syncing: {} sats", balance.total());
 
     print!("Syncing...");
@@ -66,7 +66,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     wallet.apply_update(update)?;
     wallet.commit()?;
 
-    let balance = wallet.get_balance();
+    let balance = wallet.get_balance(false);
     println!("Wallet balance after syncing: {} sats", balance.total());
 
     if balance.total() < SEND_AMOUNT {

--- a/example-crates/wallet_esplora_async/src/main.rs
+++ b/example-crates/wallet_esplora_async/src/main.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let address = wallet.get_address(AddressIndex::New);
     println!("Generated Address: {}", address);
 
-    let balance = wallet.get_balance();
+    let balance = wallet.get_balance(false);
     println!("Wallet balance before syncing: {} sats", balance.total());
 
     print!("Syncing...");
@@ -69,7 +69,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     wallet.apply_update(update)?;
     wallet.commit()?;
 
-    let balance = wallet.get_balance();
+    let balance = wallet.get_balance(false);
     println!("Wallet balance after syncing: {} sats", balance.total());
 
     if balance.total() < SEND_AMOUNT {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

This PR solves issue bitcoindevkit/bdk_wallet#166. The current design keeps a set of UTXOs that have been reserved by transactions. UTXOs are released when a transaction is canceled. I'm currently thinking it might also make sense to release UTXOs once a transaction gets broadcasted (this idea is not implemented in this PR). 



<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

With the new `ChainOracle` design, it no longer makes sense to have this as part of the keychain tracker. It might make sense to have this inside the bdk wallet. 

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
