### PR TITLE
Add fixes for publishing to crates.io

### DIFF
--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/bitcoindevkit/bdk"
 documentation = "https://docs.rs/bdk_chain"
 description = "Collection of core structures for Bitcoin Dev Kit."
 license = "MIT OR Apache-2.0"
-readme = "../README.md"
+readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/chain/README.md
+++ b/crates/chain/README.md
@@ -1,0 +1,3 @@
+# BDK Chain
+
+BDK keychain tracker, tools for storing and indexing chain data.

--- a/crates/file_store/Cargo.toml
+++ b/crates/file_store/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bitcoindevkit/bdk"
 documentation = "https://docs.rs/bdk_file_store"
+description = "A simple append-only flat file implementation of Persist for Bitcoin Dev Kit."
 keywords = ["bitcoin", "persist", "persistence", "bdk", "file"]
 authors = ["Bitcoin Dev Kit Developers"]
 readme = "README.md"

--- a/crates/file_store/Cargo.toml
+++ b/crates/file_store/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bitcoindevkit/bdk"
 documentation = "https://docs.rs/bdk_file_store"
-keywords = ["bitcoin", "persist", "persistence", "bdk", "file", "store"]
+keywords = ["bitcoin", "persist", "persistence", "bdk", "file"]
 authors = ["Bitcoin Dev Kit Developers"]
 readme = "README.md"
 


### PR DESCRIPTION
### Description

To publish the `bdk_chain` crate I had to either fix the relative reference or create a local README. I decided to add a local README where we can put more detailed docs about `bdk_chain`.  I also had to remove a keyword (max allowed is 5) and add a description to the cargo meta data for `bdk_file_store`.

### Notes to the reviewers

For now the README is just a stub to be filled in later. I already merged this change into the `release/1.0.0-alpha` branch so I could get the alpha.0 release out today but I'm open to other solutions for the next alpha.1 release.

### Changelog notice

None

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
