### PR TITLE
Add default `std` feature, prep for 0.28.0 release

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -2,6 +2,9 @@ name: Audit
 
 on:
   push:
+    branches:
+      - 'master'
+      - 'release/*'
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -1,4 +1,12 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release/*'
+  pull_request:
+    branches:
+      - 'master'
+      - 'release/*'
 
 name: Code Coverage
 

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -1,4 +1,12 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release/*'
+  pull_request:
+    branches:
+      - 'master'
+      - 'release/*'
 
 name: CI
 

--- a/.github/workflows/nightly_docs.yml
+++ b/.github/workflows/nightly_docs.yml
@@ -1,6 +1,14 @@
 name: Publish Nightly Docs
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release/*'
+  pull_request:
+    branches:
+      - 'master'
+      - 'release/*'
 
 jobs:
   build_docs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [v0.27.2]
+## [v0.28.0]
 
 ### Summary
 
-Disable default-features for rust-bitcoin and rust-miniscript dependencies, and for rust-esplora-client optional dependency.
+Disable default-features for rust-bitcoin and rust-miniscript dependencies, and for rust-esplora-client optional dependency. New default `std` feature must be enabled unless building for wasm.
 
 ### Changed
 
--  Set default-features = false for rust-bitcoin and rust-miniscript #882
--  Update esplora client dependency to version 0.4 #884
+- Bump bip39 crate to v2.0.0 #875
+- Set default-features = false for rust-bitcoin and rust-miniscript #882
+- Update esplora client dependency to version 0.4 #884
+- Added new `std` feature as part of default features #930
 
 ## [v0.27.1]
 
@@ -653,5 +655,5 @@ final transaction is created by calling `finish` on the builder.
 [v0.26.0]: https://github.com/bitcoindevkit/bdk/compare/v0.25.0...v0.26.0
 [v0.27.0]: https://github.com/bitcoindevkit/bdk/compare/v0.26.0...v0.27.0
 [v0.27.1]: https://github.com/bitcoindevkit/bdk/compare/v0.27.0...v0.27.1
-[v0.27.2]: https://github.com/bitcoindevkit/bdk/compare/v0.27.1...v0.27.2
-[Unreleased]: https://github.com/bitcoindevkit/bdk/compare/v0.27.2...HEAD
+[v0.28.0]: https://github.com/bitcoindevkit/bdk/compare/v0.27.1...v0.28.0
+[Unreleased]: https://github.com/bitcoindevkit/bdk/compare/v0.28.0...HEAD

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,10 @@ js-sys = "0.3"
 minimal = []
 compiler = ["miniscript/compiler"]
 verify = ["bitcoinconsensus"]
-default = ["key-value-db", "electrum"]
+default = ["std", "key-value-db", "electrum"]
+# std feature is always required unless building for wasm32-unknown-unknown target
+# if building for wasm user must add dependencies bitcoin/no-std,miniscript/no-std
+std = ["bitcoin/std", "miniscript/std"]
 sqlite = ["rusqlite", "ahash"]
 sqlite-bundled = ["sqlite", "rusqlite/bundled"]
 compact_filters = ["rocksdb", "socks", "cc"]


### PR DESCRIPTION
### Description

Add new `std` feature which enables `bitcoin/std` and `miniscript/std`, and enable `std` feature in `default` feature set.

### Notes to the reviewers

When using `bdk` in a wasm environment then `default` features should be disabled and `bitcoin/no-std` and `miniscript/no-std` must be enabled.  This is a breaking change for anyone using `bdk` with `--no-default-features`.

I also updated the workflows to also run for `release/*` branches in addition to `master`.

### Changelog notice

Changed

- Added new `std` feature as part of `default` features, `std` must be enabled unless building for wasm.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature
