### PR TITLE
Reenable code coverage upload to Coveralls

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -38,15 +38,15 @@ jobs:
       - name: Install python dependencies
         run: pip install hwi==2.1.1 protobuf==3.20.1
       - name: Test
-        run: cargo test --all-features
+        run: (cd crates; cargo test --all-features)
       - name: Run grcov
         run: mkdir coverage; grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore '/*' -o ./coverage/lcov.info
       - name: Generate HTML coverage report
         run: genhtml -o coverage-report.html ./coverage/lcov.info
-          #      - name: Coveralls upload
-          #        uses: coverallsapp/github-action@master
-          #        with:
-          #          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Coveralls upload
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -9,7 +9,7 @@ jobs:
     env:
       RUSTFLAGS: "-Cinstrument-coverage"
       RUSTDOCFLAGS: "-Cinstrument-coverage"
-      LLVM_PROFILE_FILE: "report-%p-%m.profraw"
+      LLVM_PROFILE_FILE: "./target/coverage/%p-%m.profraw"
 
     steps:
       - name: Checkout
@@ -38,11 +38,13 @@ jobs:
       - name: Install python dependencies
         run: pip install hwi==2.1.1 protobuf==3.20.1
       - name: Test
-        run: (cd crates; cargo test --all-features)
+        run: cargo test --all-features
+      - name: Make coverage directory
+        run: mkdir coverage
       - name: Run grcov
-        run: mkdir coverage; grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --ignore '/*' -o ./coverage/lcov.info
+        run: grcov . --binary-path ./target/debug/ -s . -t lcov --branch --ignore-not-existing --keep-only '**/crates/**' --ignore '**/tests/**' --ignore '**/examples/**' -o ./coverage/lcov.info
       - name: Generate HTML coverage report
-        run: genhtml -o coverage-report.html ./coverage/lcov.info
+        run: genhtml -o coverage-report.html --ignore-errors source ./coverage/lcov.info
       - name: Coveralls upload
         uses: coverallsapp/github-action@master
         with:


### PR DESCRIPTION
### Description

Re-enable code coverage upload to Coveralls now that code is stabilizing and test coverage added. 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
