### PR TITLE
Improve `txout` listing and balance APIs for redesigned structures

### DIFF
--- a/crates/chain/src/keychain/txout_index.rs
+++ b/crates/chain/src/keychain/txout_index.rs
@@ -1,6 +1,6 @@
 use crate::{
     collections::*,
-    indexed_tx_graph::{Indexer, OwnedIndexer},
+    indexed_tx_graph::Indexer,
     miniscript::{Descriptor, DescriptorPublicKey},
     spk_iter::BIP32_MAX_INDEX,
     ForEachTxOut, SpkIterator, SpkTxOutIndex,
@@ -109,12 +109,6 @@ impl<K: Clone + Ord + Debug> Indexer for KeychainTxOutIndex<K> {
     }
 }
 
-impl<K: Clone + Ord + Debug> OwnedIndexer for KeychainTxOutIndex<K> {
-    fn is_spk_owned(&self, spk: &Script) -> bool {
-        self.index_of_spk(spk).is_some()
-    }
-}
-
 impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
     /// Scans an object for relevant outpoints, which are stored and indexed internally.
     ///
@@ -151,6 +145,11 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
     /// Return a reference to the internal [`SpkTxOutIndex`].
     pub fn inner(&self) -> &SpkTxOutIndex<(K, u32)> {
         &self.inner
+    }
+
+    /// Get a reference to the set of indexed outpoints.
+    pub fn outpoints(&self) -> &BTreeSet<((K, u32), OutPoint)> {
+        self.inner.outpoints()
     }
 
     /// Return a reference to the internal map of the keychain to descriptors.

--- a/crates/chain/src/persist.rs
+++ b/crates/chain/src/persist.rs
@@ -41,11 +41,19 @@ where
 
     /// Commit the staged changes to the underlying persistance backend.
     ///
+    /// Changes that are committed (if any) are returned.
+    ///
+    /// # Error
+    ///
     /// Returns a backend-defined error if this fails.
-    pub fn commit(&mut self) -> Result<(), B::WriteError> {
-        let mut temp = C::default();
-        core::mem::swap(&mut temp, &mut self.stage);
-        self.backend.write_changes(&temp)
+    pub fn commit(&mut self) -> Result<Option<C>, B::WriteError> {
+        if self.stage.is_empty() {
+            return Ok(None);
+        }
+        self.backend
+            .write_changes(&self.stage)
+            // if written successfully, take and return `self.stage`
+            .map(|_| Some(core::mem::take(&mut self.stage)))
     }
 }
 

--- a/crates/chain/src/spk_txout_index.rs
+++ b/crates/chain/src/spk_txout_index.rs
@@ -2,7 +2,7 @@ use core::ops::RangeBounds;
 
 use crate::{
     collections::{hash_map::Entry, BTreeMap, BTreeSet, HashMap},
-    indexed_tx_graph::{Indexer, OwnedIndexer},
+    indexed_tx_graph::Indexer,
     ForEachTxOut,
 };
 use bitcoin::{self, OutPoint, Script, Transaction, TxOut, Txid};
@@ -75,12 +75,6 @@ impl<I: Clone + Ord> Indexer for SpkTxOutIndex<I> {
     }
 }
 
-impl<I: Clone + Ord + 'static> OwnedIndexer for SpkTxOutIndex<I> {
-    fn is_spk_owned(&self, spk: &Script) -> bool {
-        self.spk_indices.get(spk).is_some()
-    }
-}
-
 /// This macro is used instead of a member function of `SpkTxOutIndex`, which would result in a
 /// compiler error[E0521]: "borrowed data escapes out of closure" when we attempt to take a
 /// reference out of the `ForEachTxOut` closure during scanning.
@@ -124,6 +118,11 @@ impl<I: Clone + Ord> SpkTxOutIndex<I> {
     /// script pubkey (if any).
     pub fn scan_txout(&mut self, op: OutPoint, txout: &TxOut) -> Option<&I> {
         scan_txout!(self, op, txout)
+    }
+
+    /// Get a reference to the set of indexed outpoints.
+    pub fn outpoints(&self) -> &BTreeSet<(I, OutPoint)> {
+        &self.spk_txouts
     }
 
     /// Iterate over all known txouts that spend to tracked script pubkeys.

--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -865,7 +865,12 @@ impl<A: Anchor> TxGraph<A> {
         outpoints: impl IntoIterator<Item = (S, OutPoint)> + 'a,
     ) -> impl Iterator<Item = Result<(S, FullTxOut<ObservedAs<A>>), C::Error>> + 'a {
         self.try_filter_chain_txouts(chain, chain_tip, outpoints)
-            .filter(|r| !matches!(r, Ok((_, full_txo)) if full_txo.spent_by.is_some()))
+            .filter(|r| match r {
+                // keep unspents, drop spents
+                Ok((_, full_txo)) => full_txo.spent_by.is_none(),
+                // keep errors
+                Err(_) => true,
+            })
     }
 
     /// Get a filtered list of unspent outputs (UTXOs) from the given `outpoints` that are in


### PR DESCRIPTION
### Description

As noted in https://github.com/bitcoindevkit/bdk/issues/971#issuecomment-1542408941.

Instead of relying on a `OwnedIndexer` trait to filter for relevant txouts, we move the listing and balance methods from `IndexedTxGraph` to `TxGraph` and add an additional input (list of relevant outpoints) to these methods.

This provides a simpler implementation and a more flexible API.

#### Other Fixes

The `Persist::commit` method is fixed in 96b10751325dc1bced09f9e864438216400e4ba3.

Previously, regardless of whether writing to persistence backend is successful or not, the logic always cleared `self.staged`. This is changed to only clear `self.staged` after successful write.

Additionally, the written changeset (if any) is returned, and `PersistBackend::write_changes` will not be called if `self.staged` is empty.

### Notes to the reviewers

Yes, slightly more boilerplate to do the same things, but less code to maintain and a much more flexible API. Very worth it IMO.

### Changelog notice

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
