### PR TITLE
Fix caching

### DIFF
--- a/src/blockchain/compact_filters/peer.rs
+++ b/src/blockchain/compact_filters/peer.rs
@@ -74,7 +74,7 @@ impl Mempool {
 
     /// Look-up a transaction in the mempool given an [`Inventory`] request
     pub fn get_tx(&self, inventory: &Inventory) -> Option<Transaction> {
-        let identifer = match inventory {
+        let identifier = match inventory {
             Inventory::Error
             | Inventory::Block(_)
             | Inventory::WitnessBlock(_)
@@ -92,7 +92,7 @@ impl Mempool {
             }
         };
 
-        let txid = match identifer {
+        let txid = match identifier {
             TxIdentifier::Txid(txid) => Some(txid),
             TxIdentifier::Wtxid(wtxid) => self.0.read().unwrap().wtxids.get(&wtxid).cloned(),
         };

--- a/src/blockchain/electrum.rs
+++ b/src/blockchain/electrum.rs
@@ -132,7 +132,7 @@ impl WalletSync for ElectrumBlockchain {
 
         // The electrum server has been inconsistent somehow in its responses during sync. For
         // example, we do a batch request of transactions and the response contains less
-        // tranascations than in the request. This should never happen but we don't want to panic.
+        // transactions than in the request. This should never happen but we don't want to panic.
         let electrum_goof = || Error::Generic("electrum server misbehaving".to_string());
 
         let batch_update = loop {

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -175,7 +175,7 @@ pub trait ConfigurableBlockchain: Blockchain + Sized {
 
 /// Trait for blockchains that don't contain any state
 ///
-/// Statless blockchains can be used to sync multiple wallets with different descriptors.
+/// Stateless blockchains can be used to sync multiple wallets with different descriptors.
 ///
 /// [`BlockchainFactory`] is automatically implemented for `Arc<T>` where `T` is a stateless
 /// blockchain.

--- a/src/blockchain/script_sync.rs
+++ b/src/blockchain/script_sync.rs
@@ -67,7 +67,7 @@ impl<'a, D: BatchDatabase> ScriptReq<'a, D> {
 
     pub fn satisfy(
         mut self,
-        // we want to know the txids assoiciated with the script and their height
+        // we want to know the txids associated with the script and their height
         txids: Vec<Vec<(Txid, Option<u32>)>>,
     ) -> Result<Request<'a, D>, Error> {
         for (txid_list, script) in txids.iter().zip(self.scripts_needed.iter()) {
@@ -397,7 +397,7 @@ impl<'a, D: BatchDatabase> State<'a, D> {
 
         // set every utxo we observed, unless it's already spent
         // we don't do this in the loop above as we want to know all the spent outputs before
-        // adding the non-spent to the batch in case there are new tranasactions
+        // adding the non-spent to the batch in case there are new transactions
         // that spend form each other.
         for finished_tx in &finished_txs {
             let tx = finished_tx

--- a/src/testutils/blockchain_tests.rs
+++ b/src/testutils/blockchain_tests.rs
@@ -493,6 +493,27 @@ macro_rules! bdk_blockchain_tests {
             }
 
             #[test]
+            fn test_sync_multiple_batches() {
+                let (wallet, blockchain, descriptors, mut test_client) = init_single_sig();
+
+                for index in 1..=310 {
+                    if index % 10 == 0 {
+                        test_client.receive(testutils! {
+                            @tx ( (@external descriptors, index) => 1_000 )
+                        });
+                    }
+                    if index % 50 == 0 {
+                        test_client.generate(1, None);
+                    }
+                }
+                wallet.sync(&blockchain, SyncOptions::default()).unwrap();
+
+                assert_eq!(wallet.get_balance().unwrap().confirmed, 30_000, "incorrect confirmed balance");
+                assert_eq!(wallet.get_balance().unwrap().untrusted_pending, 1_000, "incorrect untrusted balance");
+                assert_eq!(wallet.list_transactions(false).unwrap().len(), 31, "incorrect number of txs");
+            }
+
+            #[test]
             fn test_sync_before_and_after_receive() {
                 let (wallet, blockchain, descriptors, mut test_client) = init_single_sig();
 


### PR DESCRIPTION
### Description

The `Wallet.ensure_addresses_cached()` function was always regenerating and saving new scripts pubkeys starting from index 0.  This is inefficient and for very large wallets and can cause sync to fail. 

### Notes to the reviewers

This issue was discovered by @bodymindarts while testing on a 200K+ transaction wallet.

Since this is more of a performance issue than functional/scaling problem I only added a test to verify that with multiple cached batches created during sync, the transaction to addresses in each cached batch are found. An integration test syncing 200K+ tx would take too long to complete. 

### Changelog notice

* Fix script pubkey caching during sync to only cache starting from the current highest script index instead of 0.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
