### PR TITLE
Fix release/0.28 branch 1.57 MSRV errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ rocksdb = { version = "0.14", default-features = false, features = ["snappy"], o
 cc = { version = ">=1.0.64", optional = true }
 socks = { version = "0.3", optional = true }
 hwi = { version = "0.5", optional = true, features = ["use-miniscript"] }
+# required for sqlite feature, hashlink versions after 0.8.1 depend on Hashbrown 0.13 with MSRV 1.61.0
+hashlink = { version = "=0.8.1", optional = true }
 
 bip39 = { version = "2.0.0", optional = true }
 bitcoinconsensus = { version = "0.19.0-3", optional = true }
@@ -56,7 +58,7 @@ default = ["std", "key-value-db", "electrum"]
 # std feature is always required unless building for wasm32-unknown-unknown target
 # if building for wasm user must add dependencies bitcoin/no-std,miniscript/no-std
 std = ["bitcoin/std", "miniscript/std"]
-sqlite = ["rusqlite", "ahash"]
+sqlite = ["rusqlite", "ahash", "hashlink"]
 sqlite-bundled = ["sqlite", "rusqlite/bundled"]
 compact_filters = ["rocksdb", "socks", "cc"]
 key-value-db = ["sled"]
@@ -110,9 +112,9 @@ dev-getrandom-wasm = ["getrandom/js"]
 miniscript = { version = "9.0", features = ["std"] }
 bitcoin = { version = "0.29.2", features = ["std"] }
 lazy_static = "1.4"
-env_logger = "0.7"
+env_logger = { version = "0.7", default-features = false }
 electrsd = "0.22"
-# Move back to importing from rust-bitcoin once https://github.com/rust-bitcoin/rust-bitcoin/pull/1342 is released
+# Remove after upgrade to rust-bitcoin ^0.30 where base64 is re-exported
 base64 = "^0.13"
 assert_matches = "1.5.0"
 # zip versions after 0.6.3 don't work with our MSRV 1.57.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ socks = { version = "0.3", optional = true }
 hwi = { version = "0.5", optional = true, features = ["use-miniscript"] }
 # required for sqlite feature, hashlink versions after 0.8.1 depend on Hashbrown 0.13 with MSRV 1.61.0
 hashlink = { version = "=0.8.1", optional = true }
+# required for compact_filters feature, regex versions after 1.7.3 have MSRV 1.60.0
+regex = { version = "=1.7.3", optional = true }
 
 bip39 = { version = "2.0.0", optional = true }
 bitcoinconsensus = { version = "0.19.0-3", optional = true }
@@ -60,7 +62,7 @@ default = ["std", "key-value-db", "electrum"]
 std = ["bitcoin/std", "miniscript/std"]
 sqlite = ["rusqlite", "ahash", "hashlink"]
 sqlite-bundled = ["sqlite", "rusqlite/bundled"]
-compact_filters = ["rocksdb", "socks", "cc"]
+compact_filters = ["rocksdb", "socks", "cc", "regex"]
 key-value-db = ["sled"]
 all-keys = ["keys-bip39"]
 keys-bip39 = ["bip39"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 bdk-macros = "^0.6"
-log = "^0.4"
+# required because log versions starting with 0.4.19 have MSRV 1.60.0
+log = "=0.4.18"
 miniscript = { version = "9.0", default-features = false, features = ["serde"] }
 bitcoin = { version = "0.29.2", default-features = false, features = ["serde", "base64", "rand"] }
 serde = { version = "^1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rand = "^0.8"
 # Optional dependencies
 sled = { version = "0.34", optional = true }
 electrum-client = { version = "0.12", optional = true }
-esplora-client = { version = "0.4", default-features = false, optional = true }
+esplora-client = { version = "0.5", default-features = false, optional = true }
 rusqlite = { version = "0.28.0", optional = true }
 ahash = { version = "0.7.6", optional = true }
 futures = { version = "0.3", optional = true }


### PR DESCRIPTION
### Description

This PR fixes #986 for the release/0.28 branch. I ran into other build issues for 1.57 that I also needed to fix.

### Notes to the reviewers

The base64 issue happened a few days ago, I'm not sure when all the others broke but need to be fixed anyway. 

~~EDIT: I also restored the bitcoin/base64 dev-dependency that was waiting for a rust-bitcoin fix released in 0.29.0.
EDIT: I bumped base64 to 0.21.2 since the team there removed the MSRV change in that version~~
EDIT: base64 team made a patch release to restore support for MSRV 1.5.7.0

### Changelog notice

* Update dependencies to keep MSRV to 1.57.0
  * Disable env_logger default-features
  * Update esplora-client version to 0.5
  * Pin hashlink version to 0.8.1 for sqlite feature
  * Pin regex version to 1.7.3 for compact_filters feature
  * Pin log to version 0.4.18

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [x] I'm linking the issue being fixed by this PR
