### PR TITLE
Add big wallet example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,8 @@ hwi = { version = "0.5", optional = true, features = ["use-miniscript"] }
 base64 = { version = "=0.21.0", optional = true }
 # required for sqlite feature, hashlink versions after 0.8.1 depend on Hashbrown 0.13 with MSRV 1.61.0
 hashlink = { version = "=0.8.1", optional = true }
+# required for compact_filters feature, regex versions after 1.7.3 have MSRV 1.60.0
+regex = { version = "=1.7.3", optional = true }
 
 bip39 = { version = "2.0.0", optional = true }
 bitcoinconsensus = { version = "0.19.0-3", optional = true }
@@ -62,7 +64,7 @@ default = ["std", "key-value-db", "electrum"]
 std = ["bitcoin/std", "miniscript/std"]
 sqlite = ["rusqlite", "ahash", "hashlink"]
 sqlite-bundled = ["sqlite", "rusqlite/bundled"]
-compact_filters = ["rocksdb", "socks", "cc"]
+compact_filters = ["rocksdb", "socks", "cc", "regex"]
 key-value-db = ["sled"]
 all-keys = ["keys-bip39"]
 keys-bip39 = ["bip39"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,6 +174,11 @@ name = "mnemonic_to_descriptors"
 path = "examples/mnemonic_to_descriptors.rs"
 required-features = ["all-keys"]
 
+[[example]]
+name = "big_wallet_esplora"
+path = "examples/big_wallet_esplora.rs"
+required-features = ["all-keys", "sqlite", "use-esplora-async"]
+
 [workspace]
 members = ["macros"]
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,10 @@ rocksdb = { version = "0.14", default-features = false, features = ["snappy"], o
 cc = { version = ">=1.0.64", optional = true }
 socks = { version = "0.3", optional = true }
 hwi = { version = "0.5", optional = true, features = ["use-miniscript"] }
+# required for esplora feature, base64 versions after 0.21.0 have MSRV 1.60.0
+base64 = { version = "=0.21.0", optional = true }
+# required for sqlite feature, hashlink versions after 0.8.1 depend on Hashbrown 0.13 with MSRV 1.61.0
+hashlink = { version = "=0.8.1", optional = true }
 
 bip39 = { version = "2.0.0", optional = true }
 bitcoinconsensus = { version = "0.19.0-3", optional = true }
@@ -56,7 +60,7 @@ default = ["std", "key-value-db", "electrum"]
 # std feature is always required unless building for wasm32-unknown-unknown target
 # if building for wasm user must add dependencies bitcoin/no-std,miniscript/no-std
 std = ["bitcoin/std", "miniscript/std"]
-sqlite = ["rusqlite", "ahash"]
+sqlite = ["rusqlite", "ahash", "hashlink"]
 sqlite-bundled = ["sqlite", "rusqlite/bundled"]
 compact_filters = ["rocksdb", "socks", "cc"]
 key-value-db = ["sled"]
@@ -87,7 +91,7 @@ use-esplora-blocking = ["esplora", "esplora-client/blocking"]
 use-esplora-reqwest = ["use-esplora-async"]
 use-esplora-ureq = ["use-esplora-blocking"]
 # Typical configurations will not need to use `esplora` feature directly.
-esplora = []
+esplora = ["base64"]
 
 # Use below feature with `use-esplora-async` to enable reqwest default TLS support
 reqwest-default-tls = ["esplora-client/async-https"]
@@ -110,7 +114,7 @@ dev-getrandom-wasm = ["getrandom/js"]
 miniscript = { version = "9.0", features = ["std"] }
 bitcoin = { version = "0.29.2", features = ["std"] }
 lazy_static = "1.4"
-env_logger = "0.7"
+env_logger = { version = "0.7", default-features = false }
 electrsd = "0.22"
 # Move back to importing from rust-bitcoin once https://github.com/rust-bitcoin/rust-bitcoin/pull/1342 is released
 base64 = "^0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,17 +114,17 @@ dev-getrandom-wasm = ["getrandom/js"]
 
 [dev-dependencies]
 miniscript = { version = "9.0", features = ["std"] }
-bitcoin = { version = "0.29.2", features = ["std"] }
+bitcoin = { version = "0.29.2", features = ["std", "base64"] }
 lazy_static = "1.4"
 env_logger = { version = "0.7", default-features = false }
 electrsd = "0.22"
-# Move back to importing from rust-bitcoin once https://github.com/rust-bitcoin/rust-bitcoin/pull/1342 is released
-base64 = "^0.13"
 assert_matches = "1.5.0"
 # zip versions after 0.6.3 don't work with our MSRV 1.57.0
 zip = "=0.6.3"
 # base64ct versions at 1.6.0 and higher have MSRV 1.60.0
 base64ct = "<1.6.0"
+# required for README code, base64 versions after 0.21.0 have MSRV 1.60.0
+base64 = { version = "=0.21.0" }
 
 [[example]]
 name = "compact_filters_balance"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ rocksdb = { version = "0.14", default-features = false, features = ["snappy"], o
 cc = { version = ">=1.0.64", optional = true }
 socks = { version = "0.3", optional = true }
 hwi = { version = "0.5", optional = true, features = ["use-miniscript"] }
-# required for esplora feature, base64 versions after 0.21.0 have MSRV 1.60.0
-base64 = { version = "=0.21.0", optional = true }
+# required for esplora feature, don't use base64 versions 0.21.1, it requires MSRV 1.60.0
+base64 = { version = "0.21.2", optional = true }
 # required for sqlite feature, hashlink versions after 0.8.1 depend on Hashbrown 0.13 with MSRV 1.61.0
 hashlink = { version = "=0.8.1", optional = true }
 # required for compact_filters feature, regex versions after 1.7.3 have MSRV 1.60.0
@@ -123,8 +123,8 @@ assert_matches = "1.5.0"
 zip = "=0.6.3"
 # base64ct versions at 1.6.0 and higher have MSRV 1.60.0
 base64ct = "<1.6.0"
-# required for README code, base64 versions after 0.21.0 have MSRV 1.60.0
-base64 = { version = "=0.21.0" }
+# required for README.md example code, don't use base64 versions 0.21.1, it requires MSRV 1.60.0
+base64 = { version = "0.21.2" }
 
 [[example]]
 name = "compact_filters_balance"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rand = "^0.8"
 # Optional dependencies
 sled = { version = "0.34", optional = true }
 electrum-client = { version = "0.12", optional = true }
-esplora-client = { version = "0.4", default-features = false, optional = true }
+esplora-client = { version = "0.5", default-features = false, optional = true }
 rusqlite = { version = "0.28.0", optional = true }
 ahash = { version = "0.7.6", optional = true }
 futures = { version = "0.3", optional = true }

--- a/examples/big_wallet_esplora.rs
+++ b/examples/big_wallet_esplora.rs
@@ -1,0 +1,156 @@
+use bitcoin::{Amount, OutPoint};
+use std::borrow::BorrowMut;
+use std::ops::{Div, Rem};
+use std::str::FromStr;
+use std::time::SystemTime;
+use std::{thread, time};
+
+use bdk::bitcoin::util::bip32::ExtendedPrivKey;
+use bdk::bitcoin::Network;
+use bdk::blockchain::{
+    Blockchain, ConfigurableBlockchain, EsploraBlockchain, GetHeight, WalletSync,
+};
+use bdk::database::{AnyDatabase, AnyDatabaseConfig, ConfigurableDatabase, Database};
+use bdk::template::Bip84;
+use bdk::{KeychainKind, SignOptions, SyncOptions, Wallet};
+
+use bdk::blockchain::esplora::EsploraBlockchainConfig;
+use bdk::database::any::SqliteDbConfiguration;
+use bdk::wallet::tx_builder::ChangeSpendPolicy;
+use bdk::wallet::AddressIndex;
+use bdk::KeychainKind::External;
+use electrsd::bitcoind;
+use electrsd::bitcoind::bitcoincore_rpc::RpcApi;
+use electrsd::bitcoind::BitcoinD;
+use futures::StreamExt;
+use miniscript::psbt::PsbtExt;
+
+/// This example will create a wallet from an xpriv and get the balance by starting and connecting
+/// to local regtest bitcoind and electrs servers. It will tell bitcoind to send transactions to
+/// addresses it controls up to index 200,000 and then sync and confirm the wallet balance.
+///
+/// This example is run from the root folder with:
+/// ```
+/// cargo run --example big_wallet_esplora --features="all-keys sqlite use-esplora-async reqwest-default-tls"
+/// ```
+fn main() {
+    env_logger::init();
+
+    let network = Network::Signet;
+    //let xpriv = ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPcx5nBGsR63Pe8KnRUqmbJNENAfGftF3yuXoMMoVJJcYeUw5eVkm9WBPjWYt6HMWYJNesB5HaNVBaFc1M6dRjWSYnmewUMYy").unwrap();
+    //let xpriv = ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPf3jyLFqfFunqDeTz6JEV5YngSVgWnvDeSzh1iCGi5gdWbgRtntGQL2HevsY51XJtZQeFeGeGg4TrZVrZHmLStLvjntJ8QaM").unwrap();
+    let xpriv = ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPd16S7pZnjWam27aJq6eJLGms7nKKF5z5xLycwy1T7Ft1Bb1oXSXLfT43X2426seSxiT6g9eEv4sst457RP3yF3gQsejKYfu").unwrap();
+    let descriptor = Bip84(xpriv.clone(), KeychainKind::External);
+    let change_descriptor = Some(Bip84(xpriv, KeychainKind::Internal));
+
+    let database_config = AnyDatabaseConfig::Sqlite(SqliteDbConfiguration {
+        path: "./big_wallet_esplora.db".to_string(),
+    });
+    let database = AnyDatabase::from_config(&database_config).unwrap();
+
+    let esplora_config = EsploraBlockchainConfig {
+        base_url: "https://mutinynet.com/api".to_string(),
+        proxy: None,
+        concurrency: Some(250),
+        stop_gap: 150,
+        timeout: None,
+    };
+    let esplora_client = EsploraBlockchain::from_config(&esplora_config).unwrap();
+    let wallet = Wallet::new(descriptor, change_descriptor, network, database).unwrap();
+
+    println!("Initial BDK wallet syncing...");
+    sync_wallet(&wallet, &esplora_client);
+
+    let last_index = wallet
+        .database()
+        .get_last_index(External)
+        .unwrap()
+        .unwrap_or(0);
+    println!("BDK wallet last external keychain index is: {}", last_index);
+
+    let confirmed_balance = wallet.get_balance().unwrap().confirmed;
+    let required_balance = 1_000_000;
+    if required_balance > confirmed_balance {
+        let address = wallet.get_address(AddressIndex::New).unwrap();
+        println!(
+            "Your confirmed balance is {} but {} SATs are required.",
+            confirmed_balance, required_balance
+        );
+        println!(
+            "Deposit {} SATs to: {}",
+            required_balance - confirmed_balance,
+            address
+        );
+        println!("Mutinynet faucet: https://faucet.mutinynet.com/");
+        return;
+    }
+
+    let mut tx_builder = wallet.build_tx();
+
+    for index in last_index..=200_000 {
+        // every 100 addresses create add a new output to current transaction builder
+        if index > 0 && index % 100 == 0 {
+            let address = wallet
+                .get_address(AddressIndex::Reset(index))
+                .unwrap()
+                .address;
+            tx_builder.add_recipient(address.script_pubkey(), 1_000);
+        }
+        // every 200 addresses broadcast the transaction and create a new transaction builder
+        if index > 0 && index % 20_000 == 0 {
+            let (mut psbt, details) = tx_builder.finish().unwrap();
+            wallet.sign(&mut psbt, SignOptions::default()).unwrap();
+            println!(
+                "Created tx paying address indexes {} to {}, every 100 indexes: https://mutinynet.com/tx/{}",
+                index-20_000,
+                index,
+                details.txid
+            );
+
+            let tx = &psbt.clone().extract_tx();
+            println!("Broadcasting tx.");
+            let result = esplora_client.broadcast(tx);
+
+            if result.is_err() {
+                use bitcoin::consensus::serialize;
+                use bitcoin::hashes::hex::ToHex;
+
+                println!("Broadcast failed!");
+                dbg!(&tx);
+                println!("tx: {}", serialize(tx).to_hex());
+                panic!();
+            };
+
+            print!("Waiting for next block");
+            let current_height = esplora_client.get_height().unwrap();
+            let mut new_height = current_height;
+            while new_height <= current_height {
+                let ten_second = time::Duration::from_secs(10);
+                thread::sleep(ten_second);
+                print!(".");
+                new_height = esplora_client.get_height().unwrap();
+            }
+            println!("Wallet syncing...");
+            sync_wallet(&wallet, &esplora_client);
+            tx_builder = wallet.build_tx();
+        }
+    }
+    let balance = wallet.get_balance().unwrap();
+    println!("balance = {}", &balance);
+}
+
+fn sync_wallet<B: WalletSync + GetHeight>(wallet: &Wallet<AnyDatabase>, esplora_client: &B) {
+    let start = SystemTime::now();
+    let result = wallet.sync(esplora_client, SyncOptions::default());
+    if result.is_err() {
+        dbg!(result);
+        panic!();
+    }
+    let end = SystemTime::now();
+    let duration = end.duration_since(start).unwrap();
+    println!(
+        "Wallet sync took {} minutes and {} seconds",
+        duration.as_secs().div(60),
+        duration.as_secs().rem(60)
+    );
+}

--- a/src/blockchain/compact_filters/peer.rs
+++ b/src/blockchain/compact_filters/peer.rs
@@ -74,7 +74,7 @@ impl Mempool {
 
     /// Look-up a transaction in the mempool given an [`Inventory`] request
     pub fn get_tx(&self, inventory: &Inventory) -> Option<Transaction> {
-        let identifer = match inventory {
+        let identifier = match inventory {
             Inventory::Error
             | Inventory::Block(_)
             | Inventory::WitnessBlock(_)
@@ -92,7 +92,7 @@ impl Mempool {
             }
         };
 
-        let txid = match identifer {
+        let txid = match identifier {
             TxIdentifier::Txid(txid) => Some(txid),
             TxIdentifier::Wtxid(wtxid) => self.0.read().unwrap().wtxids.get(&wtxid).cloned(),
         };

--- a/src/blockchain/electrum.rs
+++ b/src/blockchain/electrum.rs
@@ -132,7 +132,7 @@ impl WalletSync for ElectrumBlockchain {
 
         // The electrum server has been inconsistent somehow in its responses during sync. For
         // example, we do a batch request of transactions and the response contains less
-        // tranascations than in the request. This should never happen but we don't want to panic.
+        // transactions than in the request. This should never happen but we don't want to panic.
         let electrum_goof = || Error::Generic("electrum server misbehaving".to_string());
 
         let batch_update = loop {

--- a/src/blockchain/esplora/async.rs
+++ b/src/blockchain/esplora/async.rs
@@ -35,7 +35,7 @@ use crate::FeeRate;
 pub struct EsploraBlockchain {
     url_client: AsyncClient,
     stop_gap: usize,
-    concurrency: u8,
+    concurrency: usize,
 }
 
 impl std::convert::From<AsyncClient> for EsploraBlockchain {
@@ -68,7 +68,7 @@ impl EsploraBlockchain {
     }
 
     /// Set the concurrency to use when doing batch queries against the Esplora instance.
-    pub fn with_concurrency(mut self, concurrency: u8) -> Self {
+    pub fn with_concurrency(mut self, concurrency: usize) -> Self {
         self.concurrency = concurrency;
         self
     }
@@ -149,7 +149,7 @@ impl WalletSync for EsploraBlockchain {
                 Request::Script(script_req) => {
                     let futures: FuturesOrdered<_> = script_req
                         .request()
-                        .take(self.concurrency as usize)
+                        .take(self.concurrency)
                         .map(|script| async move {
                             let mut related_txs: Vec<Tx> =
                                 self.url_client.scripthash_txs(script, None).await?;

--- a/src/blockchain/esplora/blocking.rs
+++ b/src/blockchain/esplora/blocking.rs
@@ -34,7 +34,7 @@ use crate::FeeRate;
 pub struct EsploraBlockchain {
     url_client: BlockingClient,
     stop_gap: usize,
-    concurrency: u8,
+    concurrency: usize,
 }
 
 impl EsploraBlockchain {
@@ -57,7 +57,7 @@ impl EsploraBlockchain {
     }
 
     /// Set the number of parallel requests the client can make.
-    pub fn with_concurrency(mut self, concurrency: u8) -> Self {
+    pub fn with_concurrency(mut self, concurrency: usize) -> Self {
         self.concurrency = concurrency;
         self
     }
@@ -129,10 +129,7 @@ impl WalletSync for EsploraBlockchain {
         let batch_update = loop {
             request = match request {
                 Request::Script(script_req) => {
-                    let scripts = script_req
-                        .request()
-                        .take(self.concurrency as usize)
-                        .cloned();
+                    let scripts = script_req.request().take(self.concurrency).cloned();
 
                     let mut handles = vec![];
                     for script in scripts {

--- a/src/blockchain/esplora/mod.rs
+++ b/src/blockchain/esplora/mod.rs
@@ -53,7 +53,7 @@ pub struct EsploraBlockchainConfig {
     pub proxy: Option<String>,
     /// Number of parallel requests sent to the esplora service (default: 4)
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub concurrency: Option<u8>,
+    pub concurrency: Option<usize>,
     /// Stop searching addresses for transactions after finding an unused gap of this length.
     pub stop_gap: usize,
     /// Socket timeout.
@@ -88,7 +88,7 @@ crate::bdk_blockchain_tests! {
     }
 }
 
-const DEFAULT_CONCURRENT_REQUESTS: u8 = 4;
+const DEFAULT_CONCURRENT_REQUESTS: usize = 4;
 
 #[cfg(test)]
 mod test {

--- a/src/blockchain/mod.rs
+++ b/src/blockchain/mod.rs
@@ -175,7 +175,7 @@ pub trait ConfigurableBlockchain: Blockchain + Sized {
 
 /// Trait for blockchains that don't contain any state
 ///
-/// Statless blockchains can be used to sync multiple wallets with different descriptors.
+/// Stateless blockchains can be used to sync multiple wallets with different descriptors.
 ///
 /// [`BlockchainFactory`] is automatically implemented for `Arc<T>` where `T` is a stateless
 /// blockchain.

--- a/src/blockchain/script_sync.rs
+++ b/src/blockchain/script_sync.rs
@@ -67,7 +67,7 @@ impl<'a, D: BatchDatabase> ScriptReq<'a, D> {
 
     pub fn satisfy(
         mut self,
-        // we want to know the txids assoiciated with the script and their height
+        // we want to know the txids associated with the script and their height
         txids: Vec<Vec<(Txid, Option<u32>)>>,
     ) -> Result<Request<'a, D>, Error> {
         for (txid_list, script) in txids.iter().zip(self.scripts_needed.iter()) {

--- a/src/blockchain/script_sync.rs
+++ b/src/blockchain/script_sync.rs
@@ -397,7 +397,7 @@ impl<'a, D: BatchDatabase> State<'a, D> {
 
         // set every utxo we observed, unless it's already spent
         // we don't do this in the loop above as we want to know all the spent outputs before
-        // adding the non-spent to the batch in case there are new tranasactions
+        // adding the non-spent to the batch in case there are new transactions
         // that spend form each other.
         for finished_tx in &finished_txs {
             let tx = finished_tx

--- a/src/testutils/blockchain_tests.rs
+++ b/src/testutils/blockchain_tests.rs
@@ -493,6 +493,27 @@ macro_rules! bdk_blockchain_tests {
             }
 
             #[test]
+            fn test_sync_multiple_batches() {
+                let (wallet, blockchain, descriptors, mut test_client) = init_single_sig();
+
+                for index in 1..=310 {
+                    if index % 10 == 0 {
+                        test_client.receive(testutils! {
+                            @tx ( (@external descriptors, index) => 1_000 )
+                        });
+                    }
+                    if index % 50 == 0 {
+                        test_client.generate(1, None);
+                    }
+                }
+                wallet.sync(&blockchain, SyncOptions::default()).unwrap();
+
+                assert_eq!(wallet.get_balance().unwrap().confirmed, 30_000, "incorrect confirmed balance");
+                assert_eq!(wallet.get_balance().unwrap().untrusted_pending, 1_000, "incorrect untrusted balance");
+                assert_eq!(wallet.list_transactions(false).unwrap().len(), 31, "incorrect number of txs");
+            }
+
+            #[test]
             fn test_sync_before_and_after_receive() {
                 let (wallet, blockchain, descriptors, mut test_client) = init_single_sig();
 


### PR DESCRIPTION
### Description

Adding an example that creates a wallet that uses up to address index 200K and times how long it takes to sync. I also changed the esplora concurrency value to be a usize since there shouldn't be any reason it can't use more then 256 connections. 

### Notes to the reviewers



### Changelog notice

- Change EsploraConfig concurrency value from a u8 to a usize
- Add new big_wallet_esplora example to test a wallet that monitor up to 200K addresses

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
