### PR TITLE
Ignore rocksdb audit error RUSTSEC-2022-0046

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,2 @@
+[advisories]
+ignore = ["RUSTSEC-2022-0046"]


### PR DESCRIPTION
### Description

Fixes #1006.

### Notes to the reviewers

The `compact_filters` feature is marked as **experimental** and we don't use the rocksdb "multiple column families with TTL" feature mentioned in this advisory. Also this feature will be completely reworked for the bdk 1.0 release.

### Changelog notice

None

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
