### PR TITLE
Pin log dependency to 0.4.18 to keep the MSRV to 1.57.0

### DIFF
--- a/crates/bdk/Cargo.toml
+++ b/crates/bdk/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-log = "^0.4"
+log = "=0.4.18"
 rand = "^0.8"
 miniscript = { version = "9", features = ["serde"] }
 bitcoin = { version = "0.29", features = ["serde", "base64", "rand"] }


### PR DESCRIPTION
### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing