### PR TITLE
[ci] fix docsrs error for bdk crate

### DIFF
--- a/crates/bdk/src/lib.rs
+++ b/crates/bdk/src/lib.rs
@@ -1,4 +1,10 @@
 #![doc = include_str!("../README.md")]
+// only enables the `doc_cfg` feature when the `docsrs` configuration attribute is defined
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(
+    docsrs,
+    doc(html_logo_url = "https://github.com/bitcoindevkit/bdk/raw/master/static/bdk.png")
+)]
 #![no_std]
 #![warn(missing_docs)]
 


### PR DESCRIPTION
### Description

Fixes #955

### Notes to the reviewers

- Fixed by adding `#![cfg_attr(docsrs, feature(doc_cfg))]` to `bdk` crate lib.rs.
- ~~Update nightly_docs workflow to use similar build command that docs.rs uses (and fails if above not done).~~
- ~~For example docs artifact produced see: https://github.com/bitcoindevkit/bdk/actions/runs/5326442890~~

### Changelog notice

none

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

