### PR TITLE
Fix cargo features

### DIFF
--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -13,12 +13,13 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+# For no-std, remember to enable the bitcoin/no-std feature
 bitcoin = { version = "0.29", default-features = false }
 serde_crate = { package = "serde", version = "1", optional = true, features = ["derive"] }
 
 # Use hashbrown as a feature flag to have HashSet and HashMap from it.
 # note version 0.13 breaks outs MSRV.
-hashbrown = { version = "0.12", optional = true, features = ["serde"] }
+hashbrown = { version = "0.11", optional = true, features = ["serde"] }
 miniscript = { version = "9.0.0", optional = true, default-features = false }
 
 [dev-dependencies]
@@ -26,5 +27,5 @@ rand = "0.8"
 
 [features]
 default = ["std"]
-std = ["bitcoin/std"]
-serde = ["serde_crate", "bitcoin/serde" ]
+std = ["bitcoin/std", "miniscript/std"]
+serde = ["serde_crate", "bitcoin/serde"]


### PR DESCRIPTION
### Description

The following commands failed on `master`:
```
$ cargo build -p bdk_esplora
$ cargo build -p bdk_electrum
```

This PR introduces the following fixes:
* `bdk_chain/std` should also enable `miniscript/std`
* use the version of `hashbrown` that `bitcoin` and `miniscript` uses

### Notes to the reviewers

### Changelog notice

* Change the version of `hashbrown` to `0.11` (the version that `bitcoin` and `miniscript` uses).
* Fix the `std` feature flags for `bdk_chain`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

~* [ ] This pull request breaks the existing API~
~* [ ] I've added tests to reproduce the issue which are now passing~
~* [ ] I'm linking the issue being fixed by this PR~
