### PR TITLE
Bump version to 1.0.0-alpha.1

### DIFF
--- a/crates/bdk/Cargo.toml
+++ b/crates/bdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bdk"
 homepage = "https://bitcoindevkit.org"
-version = "1.0.0-alpha.0"
+version = "1.0.0-alpha.1"
 repository = "https://github.com/bitcoindevkit/bdk"
 documentation = "https://docs.rs/bdk"
 description = "A modern, lightweight, descriptor-based wallet library"
@@ -19,7 +19,7 @@ miniscript = { version = "9", features = ["serde"], default-features = false }
 bitcoin = { version = "0.29", features = ["serde", "base64", "rand"], default-features = false }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
-bdk_chain = { path = "../chain", version = "0.4.0", features = ["miniscript", "serde"], default-features = false }
+bdk_chain = { path = "../chain", version = "0.5.0", features = ["miniscript", "serde"], default-features = false }
 
 # Optional dependencies
 hwi = { version = "0.5", optional = true, features = [ "use-miniscript"] }

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_chain"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 rust-version = "1.57"
 homepage = "https://bitcoindevkit.org"

--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_electrum"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -12,5 +12,5 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bdk_chain = { path = "../chain", version = "0.4.0", features = ["serde", "miniscript"] }
+bdk_chain = { path = "../chain", version = "0.5.0", features = ["serde", "miniscript"] }
 electrum-client = { version = "0.12" }

--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_esplora"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -12,7 +12,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bdk_chain = { path = "../chain", version = "0.4.0", default-features = false, features = ["serde", "miniscript"] }
+bdk_chain = { path = "../chain", version = "0.5.0", default-features = false, features = ["serde", "miniscript"] }
 esplora-client = { version = "0.5", default-features = false }
 async-trait = { version = "0.1.66", optional = true }
 futures = { version = "0.3.26", optional = true }

--- a/crates/esplora/README.md
+++ b/crates/esplora/README.md
@@ -9,17 +9,17 @@ There are two versions of the extension trait (blocking and async).
 
 For blocking-only:
 ```toml
-bdk_esplora = { version = "0.1", features = ["blocking"] }
+bdk_esplora = { version = "0.3", features = ["blocking"] }
 ```
 
 For async-only:
 ```toml
-bdk_esplora = { version = "0.1", features = ["async"] }
+bdk_esplora = { version = "0.3", features = ["async"] }
 ```
 
 For async-only (with https):
 ```toml
-bdk_esplora = { version = "0.1", features = ["async-https"] }
+bdk_esplora = { version = "0.3", features = ["async-https"] }
 ```
 
 To use the extension traits:

--- a/crates/file_store/Cargo.toml
+++ b/crates/file_store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_file_store"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -11,7 +11,7 @@ authors = ["Bitcoin Dev Kit Developers"]
 readme = "README.md"
 
 [dependencies]
-bdk_chain = { path = "../chain", version = "0.4.0", features = [ "serde", "miniscript" ] }
+bdk_chain = { path = "../chain", version = "0.5.0", features = [ "serde", "miniscript" ] }
 bincode = { version = "1" }
 serde = { version = "1", features = ["derive"] }
 

--- a/example-crates/example_cli/Cargo.toml
+++ b/example-crates/example_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example_cli"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/example-crates/example_electrum/Cargo.toml
+++ b/example-crates/example_electrum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example_electrum"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/example-crates/wallet_electrum/Cargo.toml
+++ b/example-crates/wallet_electrum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wallet_electrum_example"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/example-crates/wallet_esplora/Cargo.toml
+++ b/example-crates/wallet_esplora/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wallet_esplora"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 publish = false
 

--- a/example-crates/wallet_esplora_async/Cargo.toml
+++ b/example-crates/wallet_esplora_async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wallet_esplora_async"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
### Description

Fixes #1025 

### Notes to the reviewers

Bump the crates versions and README files:
- bdk to 1.0.0-alpha.1.
- bdk_chain to 0.5.0
- bdk_electrum to 0.3.0
- bdk_esplora to 0.3.0
- bdk_file_store to 0.2.0

Bump example-crates versions and README files
- example_cli to 0.2.0
- example_electrum to 0.2.0
- wallet_electrum_example to 0.2.0
- wallet_esplora to 0.2.0
- wallet_esplora_async to 0.2.0

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
