### PR TITLE
remove duplicate `is_empty`

### DIFF
--- a/crates/chain/src/keychain.rs
+++ b/crates/chain/src/keychain.rs
@@ -46,11 +46,6 @@ pub use txout_index::*;
 pub struct DerivationAdditions<K>(pub BTreeMap<K, u32>);
 
 impl<K> DerivationAdditions<K> {
-    /// Returns whether the additions are empty.
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-
     /// Get the inner map of the keychain to its new derivation index.
     pub fn as_inner(&self) -> &BTreeMap<K, u32> {
         &self.0
@@ -72,6 +67,7 @@ impl<K: Ord> Append for DerivationAdditions<K> {
         self.0.append(&mut other.0);
     }
 
+    /// Returns whether the additions are empty.
     fn is_empty(&self) -> bool {
         self.0.is_empty()
     }

--- a/crates/chain/tests/test_keychain_txout_index.rs
+++ b/crates/chain/tests/test_keychain_txout_index.rs
@@ -5,6 +5,7 @@ mod common;
 use bdk_chain::{
     collections::BTreeMap,
     keychain::{DerivationAdditions, KeychainTxOutIndex},
+    Append,
 };
 
 use bitcoin::{secp256k1::Secp256k1, OutPoint, Script, Transaction, TxOut};


### PR DESCRIPTION
Duplicate `is_empty` method

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing


