### PR TITLE
ci: pin dependencies with Cargo update instead of in Cargo.toml

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -59,6 +59,16 @@ jobs:
         run: rustup component add clippy
       - name: Update toolchain
         run: rustup update
+      - name: Pin dependencies for MSRV
+        if: matrix.rust.version == '1.57.0'
+        run: |
+          cargo update -p log --precise "0.4.18"
+          cargo update -p tempfile --precise "3.6.0"
+          cargo update -p hashlink --precise "0.8.1"
+          cargo update -p regex --precise "1.7.3"
+          cargo update -p zip --precise "0.6.3"
+          cargo update -p base64ct --precise "1.5.3"
+          cargo update -p rustix --precise "0.37.23"
       - name: Build
         run: cargo build --features ${{ matrix.features }} --no-default-features
       - name: Clippy
@@ -207,5 +217,15 @@ jobs:
       run: rustup set profile minimal
     - name: Update toolchain
       run: rustup update
+    - name: Pin dependencies for MSRV
+      if: matrix.rust.version == '1.57.0'
+      run: |
+        cargo update -p log --precise "0.4.18"
+        cargo update -p tempfile --precise "3.6.0"
+        cargo update -p hashlink --precise "0.8.1"
+        cargo update -p regex --precise "1.7.3"
+        cargo update -p zip --precise "0.6.3"
+        cargo update -p base64ct --precise "1.5.3"
+        cargo update -p rustix --precise "0.37.23"
     - name: Test
       run: cargo test --features test-hardware-signer

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 bdk-macros = "^0.6"
-# required because log versions starting with 0.4.19 have MSRV 1.60.0
-log = "=0.4.18"
+log = "0.4"
 miniscript = { version = "9.0", default-features = false, features = ["serde"] }
 bitcoin = { version = "0.29.2", default-features = false, features = ["serde", "base64", "rand"] }
 serde = { version = "^1.0", features = ["derive"] }
@@ -33,10 +32,6 @@ rocksdb = { version = "0.14", default-features = false, features = ["snappy"], o
 cc = { version = ">=1.0.64", optional = true }
 socks = { version = "0.3", optional = true }
 hwi = { version = "0.5", optional = true, features = ["use-miniscript"] }
-# required for sqlite feature, hashlink versions after 0.8.1 depend on Hashbrown 0.13 with MSRV 1.61.0
-hashlink = { version = "=0.8.1", optional = true }
-# required for compact_filters feature, regex versions after 1.7.3 have MSRV 1.60.0
-regex = { version = "=1.7.3", optional = true }
 
 bip39 = { version = "2.0.0", optional = true }
 bitcoinconsensus = { version = "0.19.0-3", optional = true }
@@ -61,9 +56,9 @@ default = ["std", "key-value-db", "electrum"]
 # std feature is always required unless building for wasm32-unknown-unknown target
 # if building for wasm user must add dependencies bitcoin/no-std,miniscript/no-std
 std = ["bitcoin/std", "miniscript/std"]
-sqlite = ["rusqlite", "ahash", "hashlink"]
+sqlite = ["rusqlite", "ahash"]
 sqlite-bundled = ["sqlite", "rusqlite/bundled"]
-compact_filters = ["rocksdb", "socks", "cc", "regex"]
+compact_filters = ["rocksdb", "socks", "cc"]
 key-value-db = ["sled"]
 all-keys = ["keys-bip39"]
 keys-bip39 = ["bip39"]
@@ -120,10 +115,6 @@ electrsd = "0.22"
 # Remove after upgrade to rust-bitcoin ^0.30 where base64 is re-exported
 base64 = "^0.13"
 assert_matches = "1.5.0"
-# zip versions after 0.6.3 don't work with our MSRV 1.57.0
-zip = "=0.6.3"
-# base64ct versions at 1.6.0 and higher have MSRV 1.60.0
-base64ct = "<1.6.0"
 
 [[example]]
 name = "compact_filters_balance"

--- a/README.md
+++ b/README.md
@@ -201,3 +201,26 @@ at your option.
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
+
+## Minimum Supported Rust Version (MSRV)
+
+This library should compile with any combination of features with Rust 1.57.0.
+
+To build with the MSRV you will need to pin dependencies as follows:
+
+```shell
+# log 0.4.19 has MSRV 1.60.0
+cargo update -p log --precise "0.4.18"
+# tempfile 3.7.0 has MSRV 1.63.0
+cargo update -p tempfile --precise "3.6.0"
+# required for sqlite feature, hashlink 0.8.2 has MSRV 1.61.0
+cargo update -p hashlink --precise "0.8.1"
+# required for compact_filters feature, regex after 1.7.3 has MSRV 1.60.0
+cargo update -p regex --precise "1.7.3"
+# zip 0.6.3 has MSRV 1.59.0 but still works
+cargo update -p zip --precise "0.6.3"
+# base64ct 1.6.0 has MSRV 1.60.0
+cargo update -p base64ct --precise "1.5.3"
+# rustix 0.38.0 has MSRV 1.65.0
+cargo update -p rustix --precise "0.37.23"
+```


### PR DESCRIPTION
### Description

Remove 1.57.0 MSRV dependency pinning from Cargo.toml and use `cargo update --precise` method instead. This is how bdk 1.0.0 and other rust projects are doing it now. 

### Notes to the reviewers

This is needed to get the release/0.28 branch to build again. After it's merged I'll be able to start making the `0.28.1` release.

### Changelog notice

none.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing