### PR TITLE
Add Compact Block Filters Syncing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "example-crates/wallet_electrum",
     "example-crates/wallet_esplora",
     "example-crates/wallet_esplora_async",
+    "example-crates/example_cbf",
     "nursery/tmp_plan",
     "nursery/coin_select"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/file_store",
     "crates/electrum",
     "crates/esplora",
+    "crates/bdk_cbf",
     "example-crates/example_cli",
     "example-crates/example_electrum",
     "example-crates/wallet_electrum",

--- a/crates/bdk_cbf/Cargo.toml
+++ b/crates/bdk_cbf/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 
 [dependencies]
 nakamoto = "0.4.0"
-bdk_chain = { path = "../chain", version = "0.4.0"}
+bdk_chain = { path = "../chain", version = "0.5.0"}

--- a/crates/bdk_cbf/Cargo.toml
+++ b/crates/bdk_cbf/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "bdk_cbf"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+nakamoto = "0.4.0"
+bdk_chain = { path = "../chain", version = "0.4.0"}

--- a/crates/bdk_cbf/src/lib.rs
+++ b/crates/bdk_cbf/src/lib.rs
@@ -1,18 +1,25 @@
 use std::{net, thread};
 
+use bdk_chain::keychain::DerivationAdditions;
 use nakamoto::client::network::Services;
-use nakamoto::client::traits::Handle as HandleTrait;
 use nakamoto::client::Handle;
+use nakamoto::client::traits::Handle as HandleTrait;
 use nakamoto::client::{chan, Client, Config, Error, Event};
 use nakamoto::common::block::Height;
 use nakamoto::net::poll;
 
+pub use nakamoto::client::network::Network;
+
 use bdk_chain::{
     bitcoin::{Script, Transaction},
-    BlockId, ChainOracle, TxGraph,
+    collections::BTreeMap,
+    indexed_tx_graph::{IndexedAdditions, IndexedTxGraph, Indexer},
+    keychain::KeychainTxOutIndex,
+    BlockId, ChainOracle, ConfirmationHeightAnchor, TxGraph,
 };
 
-/// The network reactor we're going to use.
+use core::fmt::Debug;
+
 type Reactor = poll::Reactor<net::TcpStream>;
 
 impl ChainOracle for CBFClient {
@@ -79,10 +86,9 @@ impl Iterator for CBFUpdateIterator {
     fn next(&mut self) -> Option<Self::Item> {
         match self.client.watch_events() {
             Ok(update) => {
-                if let CBFUpdate::Synced { .. } = update {
-                    None
-                } else {
-                    Some(Ok(update))
+                match update {
+                    CBFUpdate::Synced { height, tip } if height == tip => None,
+                    _ => Some(Ok(update))
                 }
             }
             Err(e) => Some(Err(e)),
@@ -101,6 +107,8 @@ impl CBFClient {
         // Wait for the client to be connected to a peer.
         handle.wait_for_peers(peer_count, Services::default())?;
 
+        println!("Connected to {} peers", peer_count);
+
         Ok(Self { handle })
     }
 
@@ -111,6 +119,7 @@ impl CBFClient {
         watch: impl Iterator<Item = Script>,
     ) -> Result<(), Error> {
         self.handle.rescan(start_height.., watch)?;
+        println!("About to start scanning from height {}", start_height);
         Ok(())
     }
 
@@ -118,6 +127,7 @@ impl CBFClient {
     pub fn watch_events(&self) -> Result<CBFUpdate, Error> {
         let events_chan = self.handle.events();
         loop {
+            print!("looping...");
             chan::select! {
                 recv(events_chan) -> event => {
                     let event = event?;
@@ -131,12 +141,14 @@ impl CBFClient {
                             transactions,
                             ..
                         } => {
+                            println!("Block matched: {} {}", height, hash);
                             return Ok(CBFUpdate::BlockMatched {
                                 transactions,
                                 block: BlockId { height: height as u32, hash }
                             });
                         }
                         Event::Synced { height, tip } => {
+                            println!("Synced: {} {}", height, tip);
                             return Ok(CBFUpdate::Synced { height, tip });
                         }
                         _ => {}
@@ -147,21 +159,18 @@ impl CBFClient {
     }
 
     // Turns a CBFUpdate into a TxGraph update
-    pub fn into_tx_graph_update<F>(
+    pub fn into_tx_graph_update(
         &self,
-        txs: Vec<Transaction>,
-        block: BlockId,
-        is_relevant: F,
-    ) -> TxGraph<BlockId>
-    where
-        F: Fn(&Transaction) -> bool,
-    {
+        block_txs: Vec<(BlockId, Vec<Transaction>)>,
+    ) -> TxGraph<ConfirmationHeightAnchor> {
         let mut tx_graph = TxGraph::default();
-        let filtered_txs = txs.into_iter().filter(|tx| is_relevant(tx));
-        for tx in filtered_txs {
-            let txid = tx.txid();
-            let _ = tx_graph.insert_anchor(txid, block);
-            let _ = tx_graph.insert_tx(tx);
+
+        for (blockid, txs) in block_txs.into_iter() {
+            for tx in txs {
+                let txid = tx.txid();
+                let _ = tx_graph.insert_anchor(txid, to_confirmation_height_anchor(blockid));
+                let _ = tx_graph.insert_tx(tx);
+            }
         }
         tx_graph
     }
@@ -170,5 +179,132 @@ impl CBFClient {
         CBFUpdateIterator {
             client: self.clone(),
         }
+    }
+
+    pub fn scan<K>(
+        &self,
+        mut watch_per_keychain: u32,
+        start_height: Height,
+        indexed_tx_graph: &mut IndexedTxGraph<ConfirmationHeightAnchor, KeychainTxOutIndex<K>>,
+        stop_gap: u32,
+    ) -> Result<IndexedAdditions<ConfirmationHeightAnchor, DerivationAdditions<K>>, Error>
+    where
+        K: Ord + Clone + Debug,
+    {
+        let mut keychain_spks = indexed_tx_graph.index.spks_of_all_keychains();
+        let mut empty_scripts_counter = BTreeMap::<K, u32>::new();
+        keychain_spks.keys().for_each(|k| {
+            empty_scripts_counter.insert(k.clone(), 0);
+        });
+
+        let mut updates = Vec::new();
+
+        while let Some(keychains) = Self::check_stop_gap(stop_gap, &empty_scripts_counter) {
+            keychains.iter().for_each(|k| {
+                /*let (_, _) =*/ indexed_tx_graph.index.set_lookahead(k, watch_per_keychain);
+            });
+
+            let mut spk_watchlist = BTreeMap::<K, Vec<Script>>::new();
+            for (k, script_iter) in keychain_spks.iter_mut() {
+                (0..watch_per_keychain).for_each(|_| {
+                    if let Some((_, script)) = script_iter.next() {
+                        let spks = spk_watchlist.entry(k.clone()).or_insert(vec![]);
+                        spks.push(script);
+                    }
+                });
+            }
+
+            let scripts = spk_watchlist.values().flatten().cloned().collect::<Vec<_>>();
+            self.start_scanning(start_height, scripts.into_iter())?;
+
+            for update in self.iter() {
+                match update {
+                    Ok(CBFUpdate::BlockMatched {
+                        transactions,
+                        block,
+                    }) => {
+                        let relevant_txs = transactions
+                            .into_iter()
+                            .filter(|tx| indexed_tx_graph.index.is_tx_relevant(tx))
+                            .collect::<Vec<_>>();
+                        updates.push((block, relevant_txs));
+                    }
+                    Ok(CBFUpdate::BlockDisconnected { .. }) => {
+                        //TODO: Don't know how to handle re-orgs yet
+                        //I will love to get your comments on this.
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        return Err(e);
+                    }
+                }
+            }
+
+            // Determine which scripts are part of the update.
+            for (k, scripts) in spk_watchlist.iter() {
+                for script in scripts {
+                    let counter = empty_scripts_counter.get_mut(k).unwrap();
+                    if Self::is_script_in_udpate(script.clone(), &updates) {
+                        *counter = 0;
+                    } else {
+                        *counter += 1;
+                    }
+                }
+            }
+
+            watch_per_keychain += watch_per_keychain;
+        }
+
+        //apply the updates to IndexedGraph
+        let graph_update = self.into_tx_graph_update(updates);
+        let additions = indexed_tx_graph.apply_update(graph_update);
+
+        Ok(additions)
+    }
+
+    fn is_script_in_udpate(script: Script, updates: &Vec<(BlockId, Vec<Transaction>)>) -> bool {
+        for update in updates {
+            for tx in update.1.iter() {
+                for output in tx.output.iter() {
+                    if output.script_pubkey == script {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    fn check_stop_gap<K>(stop_gap: u32, empty_scripts_counter: &BTreeMap<K, u32>) -> Option<Vec<K>>
+    where
+        K: Ord + Clone + Debug,
+    {
+        let keychains = empty_scripts_counter
+            .iter()
+            .filter(|(_, counter)| **counter < stop_gap)
+            .map(|(k, _)| k.clone())
+            .collect::<Vec<_>>();
+        if keychains.is_empty() {
+            None
+        } else {
+            Some(keychains)
+        }
+    }
+
+    pub fn submit_transaction(&self, tx: Transaction) -> Result<(), Error> {
+        self.handle.submit_transaction(tx)?;
+        Ok(())
+    }
+
+    pub fn shutdown(self) -> Result<(), Error>{
+        self.handle.shutdown()?;
+        Ok(())
+    }
+}
+
+fn to_confirmation_height_anchor(blockid: BlockId) -> ConfirmationHeightAnchor {
+    ConfirmationHeightAnchor {
+        anchor_block: blockid,
+        confirmation_height: blockid.height,
     }
 }

--- a/crates/bdk_cbf/src/lib.rs
+++ b/crates/bdk_cbf/src/lib.rs
@@ -1,0 +1,125 @@
+use std::{net, thread};
+
+use nakamoto::client::network::Services;
+use nakamoto::client::traits::Handle as HandleTrait;
+use nakamoto::client::Handle;
+use nakamoto::client::{Client, Config, Error, chan, Event};
+use nakamoto::common::block::Height;
+use nakamoto::net::poll;
+
+use bdk_chain::{bitcoin::{ Script, Transaction }, BlockId, ChainOracle};
+
+/// The network reactor we're going to use.
+type Reactor = poll::Reactor<net::TcpStream>;
+
+impl ChainOracle for CBFClient {
+    type Error = nakamoto::client::Error;
+
+    fn is_block_in_chain(
+        &self,
+        block: BlockId,
+        chain_tip: BlockId,
+    ) -> Result<Option<bool>, Self::Error> {
+        if block.height > chain_tip.height {
+            return Ok(None);
+        }
+
+        Ok(
+            match (
+                self.handle.get_block_by_height(block.height as _)?,
+                self.handle.get_block_by_height(chain_tip.height as _)?,
+            ) {
+                (Some(b), Some(c)) => {
+                    Some(b.block_hash() == block.hash && c.block_hash() == chain_tip.hash)
+                }
+                _ => None,
+            },
+        )
+    }
+
+    fn get_chain_tip(&self) -> Result<Option<BlockId>, Self::Error> {
+        let (height, header) = self.handle.get_tip()?;
+        Ok(Some(BlockId {
+            height: height as u32,
+            hash: header.block_hash(),
+        }))
+    }
+}
+
+pub struct CBFClient {
+    handle: Handle<poll::reactor::Waker>,
+}
+
+pub enum CBFUpdate {
+    Synced { height: Height, tip: Height },
+    BlockMatched {
+        transactions: Vec<Transaction>,
+        block: BlockId
+    },
+    BlockDisconnected { block: BlockId },
+}
+
+impl CBFClient {
+    pub fn start_client(cfg: Config, peer_count: usize) -> Result<Self, Error> {
+        let client = Client::<Reactor>::new()?;
+        let handle = client.handle();
+
+        // Run the client on a different thread, to not block the main thread.
+        thread::spawn(|| client.run(cfg).unwrap());
+
+        // Wait for the client to be connected to a peer.
+        handle.wait_for_peers(peer_count, Services::default())?;
+
+        Ok(Self { handle })
+    }
+
+    //create a function to watch
+    pub fn start_scanning(
+        &self,
+        start_height: Height,
+        watch: impl Iterator<Item = Script>,
+    ) -> Result<(), Error> {
+        self.handle.rescan(start_height.., watch)?;
+        Ok(())
+    }
+
+    pub fn watch_events(&self) -> Result<CBFUpdate, Error> {
+        let events_chan = self.handle.events();
+        loop {
+            chan::select! {
+                recv(events_chan) -> event => {
+                    let event = event?;
+                    match event {
+                        Event::Ready { .. } => {
+                            todo!("Handle ready event");
+                        }
+                        Event::FilterProcessed { .. } => {
+                            todo!("Handle filter processed event");
+                        }
+                        Event::BlockDisconnected { hash, height, .. } => {
+                            return Ok(CBFUpdate::BlockDisconnected { block: BlockId { height: height as u32, hash } });
+                        }
+                        Event::BlockMatched {
+                            hash,
+                            height,
+                            transactions,
+                            ..
+                        } => {
+                            return Ok(CBFUpdate::BlockMatched {
+                                transactions,
+                                block: BlockId { height: height as u32, hash }
+                            });
+                        }
+                        Event::Synced { height, tip } => {
+                            return Ok(CBFUpdate::Synced { height, tip });
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+
+    // Create a method that takes in a CBFUpdate and turns it into a 
+    // Indexed Graph update.
+}

--- a/example-crates/example_cbf/Cargo.toml
+++ b/example-crates/example_cbf/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 [dependencies]
 bdk_cbf = { path = "../../crates/bdk_cbf"}
 bdk_chain = { path = "../../crates/chain"}
-bdk_cli = { path = "../example_cli" }
+example_cli = { path = "../example_cli" }

--- a/example-crates/example_cbf/Cargo.toml
+++ b/example-crates/example_cbf/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "example_cbf"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bdk_cbf = { path = "../../crates/bdk_cbf"}
+bdk_chain = { path = "../../crates/chain"}
+bdk_cli = { path = "../example_cli" }

--- a/example-crates/example_cbf/src/main.rs
+++ b/example-crates/example_cbf/src/main.rs
@@ -1,0 +1,99 @@
+use std::sync::Mutex;
+
+use bdk_cbf::{CBFClient, Network};
+use bdk_chain::{keychain::LocalChangeSet, ConfirmationHeightAnchor, IndexedTxGraph};
+use example_cli::{
+    anyhow,
+    clap::{self, Args, Subcommand},
+    Keychain,
+};
+
+const DB_MAGIC: &[u8] = b"bdk_example_cbf";
+const DB_PATH: &str = ".bdk_example_cbf.db";
+
+type ChangeSet = LocalChangeSet<Keychain, ConfirmationHeightAnchor>;
+
+#[derive(Debug, Clone, Args)]
+struct CBFArgs {}
+
+#[derive(Subcommand, Debug, Clone)]
+enum CBFCommands {
+    Scan {
+        /// The block height to start scanning from
+        #[clap(long, default_value = "0")]
+        start_height: u64,
+        /// The block height to stop scanning at
+        #[clap(long, default_value = "5")]
+        stop_gap: u32,
+        /// Number of scripts to watch for every sync
+        #[clap(long, default_value = "1000")]
+        watchlist_size: u32,
+    },
+}
+
+fn main() -> anyhow::Result<()> {
+    let (args, keymap, index, db, init_changeset) =
+        example_cli::init::<CBFCommands, ChangeSet>(DB_MAGIC, DB_PATH)?;
+
+    let graph = Mutex::new({
+        let mut graph = IndexedTxGraph::new(index);
+        graph.apply_additions(init_changeset.indexed_additions);
+        graph
+    });
+
+    let client = Mutex::new({
+        let client = CBFClient::start_client(Network::Testnet, 1)?;
+        client
+    });
+
+    let cbf_cmd = match args.command {
+        example_cli::Commands::ChainSpecific(cbf_cmd) => cbf_cmd,
+        general_cmd => {
+            let res = example_cli::handle_commands(
+                &graph,
+                &db,
+                &client,
+                &keymap,
+                args.network,
+                |tx| {
+                    client
+                        .lock()
+                        .unwrap()
+                        .submit_transaction(tx.clone())
+                        .map_err(anyhow::Error::from)
+                },
+                general_cmd,
+            );
+            db.lock().unwrap().commit()?;
+            return res;
+        }
+    };
+
+    match cbf_cmd {
+        CBFCommands::Scan {
+            start_height,
+            stop_gap,
+            watchlist_size,
+        } => {
+            println!("Scanning from height {} to {}", start_height, stop_gap);
+            let indexed_additions = {
+                let mut graph = graph.lock().unwrap();
+                client
+                    .lock()
+                    .unwrap()
+                    .scan(watchlist_size, start_height, &mut graph, stop_gap)?
+            };
+
+            let curr_changeset = LocalChangeSet::from(indexed_additions);
+
+            // stage changes to the database
+            let mut db = db.lock().unwrap();
+            db.stage(curr_changeset);
+            db.commit()?;
+
+            println!("commited to database!");
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
### Description

This PR uses the Nakamoto crate to add a CBF syncing logic to BDK. This implementation doesn't create/update a `LocalChain`, it just updates the `IndexedTxGraph`. The syncing logic will do a rescan if the `stop_gap` condition is not met.


### Notes to the reviewers

I'm still not sure what logic to implement when a reorg happens. I will love to hear your thoughts on the subject.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature
