### PR TITLE
release: bump version to 0.29.0

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -69,6 +69,8 @@ jobs:
           cargo update -p zip --precise "0.6.3"
           cargo update -p base64ct --precise "1.5.3"
           cargo update -p rustix --precise "0.37.23"
+          cargo update -p tokio --precise "1.29.1"
+          cargo update -p cc --precise "1.0.81"
       - name: Build
         run: cargo build --features ${{ matrix.features }} --no-default-features
       - name: Clippy
@@ -227,5 +229,7 @@ jobs:
         cargo update -p zip --precise "0.6.3"
         cargo update -p base64ct --precise "1.5.3"
         cargo update -p rustix --precise "0.37.23"
+        cargo update -p tokio --precise "1.29.1"
+        cargo update -p cc --precise "1.0.81"
     - name: Test
       run: cargo test --features test-hardware-signer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.29.0]
+
+### Summary
+
+Because of the esplora-client update to 0.5.0 the 0.28.1 release needs to be yanked and replaced with this 0.29.0 release.
+
 ## [v0.28.1]
 
 ### Summary
@@ -671,4 +677,5 @@ final transaction is created by calling `finish` on the builder.
 [v0.27.1]: https://github.com/bitcoindevkit/bdk/compare/v0.27.0...v0.27.1
 [v0.28.0]: https://github.com/bitcoindevkit/bdk/compare/v0.27.1...v0.28.0
 [v0.28.1]: https://github.com/bitcoindevkit/bdk/compare/v0.28.0...v0.28.1
-[Unreleased]: https://github.com/bitcoindevkit/bdk/compare/v0.28.1...HEAD
+[v0.29.0]: https://github.com/bitcoindevkit/bdk/compare/v0.28.1...v0.29.0
+[Unreleased]: https://github.com/bitcoindevkit/bdk/compare/v0.29.0...HEAD

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk"
-version = "0.28.1"
+version = "0.29.0"
 edition = "2018"
 authors = ["Alekos Filini <alekos.filini@gmail.com>", "Riccardo Casatta <riccardo@casatta.it>"]
 homepage = "https://bitcoindevkit.org"

--- a/README.md
+++ b/README.md
@@ -223,4 +223,8 @@ cargo update -p zip --precise "0.6.3"
 cargo update -p base64ct --precise "1.5.3"
 # rustix 0.38.0 has MSRV 1.65.0
 cargo update -p rustix --precise "0.37.23"
+# tokio 0.30.0 has MSRV 1.63.0
+cargo update -p tokio --precise "1.29.1"
+# cc 1.0.82 is throwing error with rust 1.57.0, "error[E0599]: no method named `retain_mut`..."
+cargo update -p cc --precise "1.0.81"
 ```


### PR DESCRIPTION
Because of the esplora-client update to 0.5.0 the 0.28.1 release needs to be yanked and replaced with this 0.29.0 release.
