### PR TITLE
ci: fix msrv dependency versions for reqest and h2

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -35,6 +35,8 @@ jobs:
           cargo update -p rustls:0.21.6 --precise "0.21.1"
           cargo update -p tokio:1.32.0 --precise "1.29.1"
           cargo update -p flate2:1.0.27 --precise "1.0.26"
+          cargo update -p reqwest --precise "0.11.18"
+          cargo update -p h2 --precise "0.3.20"
       - name: Build
         run: cargo build ${{ matrix.features }}
       - name: Test

--- a/README.md
+++ b/README.md
@@ -65,4 +65,12 @@ cargo update -p log --precise "0.4.18"
 cargo update -p tempfile --precise "3.6.0"
 # rustls 0.21.2 has MSRV 1.60.0+
 cargo update -p rustls:0.21.6 --precise "0.21.1"
+# tokio 1.30 has MSRV 1.63.0+
+cargo update -p tokio:1.32.0 --precise "1.29.1"
+# flate2 1.0.27 has MSRV 1.63.0+
+cargo update -p flate2:1.0.27 --precise "1.0.26"
+# reqwest 0.11.19 has MSRV 1.63.0+
+cargo update -p reqwest --precise "0.11.18"
+# h2 0.3.21 has MSRV 1.63.0+
+cargo update -p h2 --precise "0.3.20"
 ```


### PR DESCRIPTION
### Description

Fix MSRV dependency versions for `reqwest` and`h2`, both latest version now require 1.63.0.

### Notes to the reviewers

- reqwest 0.11.19 has MSRV 1.63.0+, pin to 0.11.18
- h2 0.3.21 has MSRV 1.63.0+, pin to 0.3.20

### Changelog notice

None.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing