### PR TITLE
fix(electrum): Don't ignore multiple coinbase txs

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -72,6 +72,9 @@ jobs:
           cargo update -p cc --precise "1.0.81"
           cargo update -p rustls:0.21.6 --precise "0.21.1"
           cargo update -p flate2:1.0.27 --precise "1.0.26"
+          cargo update -p reqwest --precise "0.11.18"
+          cargo update -p h2 --precise "0.3.20"
+          cargo update -p rustls-webpki --precise "0.100.1"
       - name: Build
         run: cargo build --features ${{ matrix.features }} --no-default-features
       - name: Clippy
@@ -233,5 +236,8 @@ jobs:
         cargo update -p cc --precise "1.0.81"
         cargo update -p rustls:0.21.6 --precise "0.21.1"
         cargo update -p flate2:1.0.27 --precise "1.0.26"
+        cargo update -p reqwest --precise "0.11.18"
+        cargo update -p h2 --precise "0.3.20"
+        cargo update -p rustls-webpki --precise "0.100.1"
     - name: Test
       run: cargo test --features test-hardware-signer

--- a/README.md
+++ b/README.md
@@ -229,4 +229,10 @@ cargo update -p cc --precise "1.0.81"
 cargo update -p rustls:0.21.6 --precise "0.21.1"
 # flate2 1.0.27 has MSRV 1.63.0+
 cargo update -p flate2:1.0.27 --precise "1.0.26"
+# reqwest 0.11.19 has MSRV 1.63.0+
+cargo update -p reqwest --precise "0.11.18"
+# h2 0.3.21 has MSRV 1.63.0+
+cargo update -p h2 --precise "0.3.20"
+# rustls-webpki 0.100.2 has MSRV 1.60+
+cargo update -p rustls-webpki --precise "0.100.2"
 ```

--- a/src/testutils/blockchain_tests.rs
+++ b/src/testutils/blockchain_tests.rs
@@ -1098,18 +1098,18 @@ macro_rules! bdk_blockchain_tests {
                 wallet.sync(&blockchain, SyncOptions::default()).unwrap();
                 assert_eq!(wallet.get_balance().unwrap().immature, 0, "incorrect balance");
 
-                test_client.generate(1, Some(wallet_addr));
+                test_client.generate(2, Some(wallet_addr));
 
                 wallet.sync(&blockchain, SyncOptions::default()).unwrap();
 
-                assert!(wallet.get_balance().unwrap().immature > 0, "incorrect balance after receiving coinbase");
+                assert_eq!(wallet.get_balance().unwrap().immature, 5000000000*2, "incorrect balance after receiving coinbase");
 
                 // make coinbase mature (100 blocks)
                 let node_addr = test_client.get_node_address(None);
                 test_client.generate(100, Some(node_addr));
                 wallet.sync(&blockchain, SyncOptions::default()).unwrap();
 
-                assert!(wallet.get_balance().unwrap().confirmed > 0, "incorrect balance after maturing coinbase");
+                assert_eq!(wallet.get_balance().unwrap().confirmed, 5000000000 * 2, "incorrect balance after maturing coinbase");
 
             }
 


### PR DESCRIPTION
We would previously insert just one coinbase transaction in the database if we caught multiple in the same sync.
When we sync with electrum, before committing to the database, we remove from the update conflicting transactions, using the `make_txs_consistent` function. This function considers two txs to be conflicting if they spend from the same outpoint - but every coinbase transaction spends from the same outpoint!
Here we make sure to avoid filtering out coinbase transactions, by adding a check on the txid just before we do the filtering.

Fixes #1051

### Changelog notice

- Fix a bug when syncing coinbase utxos on electrum

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
