### PR TITLE
refactor: use set_lookahead in set_lookahead_for_all

### DIFF
--- a/crates/chain/src/keychain/txout_index.rs
+++ b/crates/chain/src/keychain/txout_index.rs
@@ -192,8 +192,7 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
     /// [`set_lookahead`]: Self::set_lookahead
     pub fn set_lookahead_for_all(&mut self, lookahead: u32) {
         for keychain in &self.keychains.keys().cloned().collect::<Vec<_>>() {
-            self.lookahead.insert(keychain.clone(), lookahead);
-            self.replenish_lookahead(keychain);
+            self.set_lookahead(keychain, lookahead);
         }
     }
 


### PR DESCRIPTION
### Description

Use set_lookahead in set_lookahead_for_all.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing


