### PR TITLE
Further improve unconfirmed tx conflict resolution

### DIFF
--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -789,6 +789,12 @@ impl<A: Anchor> TxGraph<A> {
                 if conflicting_tx.last_seen_unconfirmed > tx_last_seen {
                     return Ok(None);
                 }
+                if conflicting_tx.last_seen_unconfirmed == *last_seen
+                    && conflicting_tx.txid() > tx.txid()
+                {
+                    // Conflicting tx has priority if txid of conflicting tx > txid of original tx
+                    return Ok(None);
+                }
             }
         }
 

--- a/crates/chain/tests/test_tx_graph_conflicts.rs
+++ b/crates/chain/tests/test_tx_graph_conflicts.rs
@@ -50,10 +50,10 @@ fn test_tx_conflict_handling() {
             tx_templates: &[
                 TxTemplate {
                     tx_name: "tx1",
-                    inputs: &[TxInTemplate::Bogus],
                     outputs: &[TxOutTemplate::new(40000, Some(0))],
                     anchors: &[block_id!(1, "B")],
                     last_seen: None,
+                    ..Default::default()
                 },
                 TxTemplate {
                     tx_name: "tx_conflict_1",
@@ -70,14 +70,12 @@ fn test_tx_conflict_handling() {
                     ..Default::default()
                 },
             ],
-            // correct output if filtered by fee rate: tx1, tx_conflict_1
-            exp_chain_txs: HashSet::from(["tx1", "tx_conflict_1", "tx_conflict_2"]),
-            exp_chain_txouts: HashSet::from([("tx1", 0), ("tx_conflict_1", 0), ("tx_conflict_2", 0)]),
-            // correct output if filtered by fee rate: tx_conflict_1
-            exp_unspents: HashSet::from([("tx_conflict_1", 0), ("tx_conflict_2", 0)]),
+            exp_chain_txs: HashSet::from(["tx1", "tx_conflict_2"]),
+            exp_chain_txouts: HashSet::from([("tx1", 0), ("tx_conflict_2", 0)]),
+            exp_unspents: HashSet::from([("tx_conflict_2", 0)]),
             exp_balance: Balance {
                 immature: 0,
-                trusted_pending: 50000, // correct output if filtered by fee rate: 20000
+                trusted_pending: 30000,
                 untrusted_pending: 0,
                 confirmed: 0,
             },


### PR DESCRIPTION
### Description

Fixes #1102. If a conflicting tx has the same `last_seen`, then we check lexicographical sorting of txids.

### Notes to the reviewers

The tests for this fix exist in the `TxTemplate` structure in #1064 which may need to be merged first.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing