### PR TITLE
fix: remove deprecated `max_satisfaction_weight`

### DIFF
--- a/crates/bdk/src/wallet/mod.rs
+++ b/crates/bdk/src/wallet/mod.rs
@@ -28,7 +28,6 @@ use bdk_chain::{
     Append, BlockId, ChainPosition, ConfirmationTime, ConfirmationTimeAnchor, FullTxOut,
     IndexedTxGraph, Persist, PersistBackend,
 };
-use bitcoin::consensus::encode::serialize;
 use bitcoin::psbt;
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::sighash::{EcdsaSighashType, TapSighashType};
@@ -36,6 +35,7 @@ use bitcoin::{
     absolute, Address, Network, OutPoint, Script, ScriptBuf, Sequence, Transaction, TxOut, Txid,
     Weight, Witness,
 };
+use bitcoin::consensus::encode::serialize;
 use core::fmt;
 use core::ops::Deref;
 use miniscript::psbt::{PsbtExt, PsbtInputExt, PsbtInputSatisfier};
@@ -1288,7 +1288,7 @@ impl<D> Wallet<D> {
                         let satisfaction_weight = self
                             .get_descriptor_for_keychain(keychain)
                             .max_weight_to_satisfy()
-                            .unwrap();
+                            .unwrap() + 4;
                         WeightedUtxo {
                             utxo: Utxo::Local(LocalUtxo {
                                 outpoint: txin.previous_output,
@@ -1298,7 +1298,7 @@ impl<D> Wallet<D> {
                                 derivation_index,
                                 confirmation_time,
                             }),
-                            satisfaction_weight,
+                            satisfaction_weight
                         }
                     }
                     None => {
@@ -1621,7 +1621,7 @@ impl<D> Wallet<D> {
                     utxo,
                     self.get_descriptor_for_keychain(keychain)
                         .max_weight_to_satisfy()
-                        .unwrap(),
+                        .unwrap() + 4,
                 )
             })
             .collect()

--- a/crates/bdk/src/wallet/mod.rs
+++ b/crates/bdk/src/wallet/mod.rs
@@ -56,7 +56,6 @@ pub mod hardwaresigner;
 
 pub use utils::IsDust;
 
-#[allow(deprecated)]
 use coin_selection::DefaultCoinSelectionAlgorithm;
 use signer::{SignOptions, SignerOrdering, SignersContainer, TransactionSigner};
 use tx_builder::{BumpFee, CreateTx, FeePolicy, TxBuilder, TxParams};
@@ -1286,10 +1285,9 @@ impl<D> Wallet<D> {
 
                 let weighted_utxo = match txout_index.index_of_spk(&txout.script_pubkey) {
                     Some(&(keychain, derivation_index)) => {
-                        #[allow(deprecated)]
                         let satisfaction_weight = self
                             .get_descriptor_for_keychain(keychain)
-                            .max_satisfaction_weight()
+                            .max_weight_to_satisfy()
                             .unwrap();
                         WeightedUtxo {
                             utxo: Utxo::Local(LocalUtxo {
@@ -1307,7 +1305,6 @@ impl<D> Wallet<D> {
                         let satisfaction_weight =
                             serialize(&txin.script_sig).len() * 4 + serialize(&txin.witness).len();
                         WeightedUtxo {
-                            satisfaction_weight,
                             utxo: Utxo::Foreign {
                                 outpoint: txin.previous_output,
                                 psbt_input: Box::new(psbt::Input {
@@ -1316,6 +1313,7 @@ impl<D> Wallet<D> {
                                     ..Default::default()
                                 }),
                             },
+                            satisfaction_weight,
                         }
                     }
                 };
@@ -1619,11 +1617,10 @@ impl<D> Wallet<D> {
         self.list_unspent()
             .map(|utxo| {
                 let keychain = utxo.keychain;
-                #[allow(deprecated)]
                 (
                     utxo,
                     self.get_descriptor_for_keychain(keychain)
-                        .max_satisfaction_weight()
+                        .max_weight_to_satisfy()
                         .unwrap(),
                 )
             })

--- a/crates/bdk/src/wallet/mod.rs
+++ b/crates/bdk/src/wallet/mod.rs
@@ -28,6 +28,7 @@ use bdk_chain::{
     Append, BlockId, ChainPosition, ConfirmationTime, ConfirmationTimeAnchor, FullTxOut,
     IndexedTxGraph, Persist, PersistBackend,
 };
+use bitcoin::consensus::encode::serialize;
 use bitcoin::psbt;
 use bitcoin::secp256k1::Secp256k1;
 use bitcoin::sighash::{EcdsaSighashType, TapSighashType};
@@ -35,7 +36,6 @@ use bitcoin::{
     absolute, Address, Network, OutPoint, Script, ScriptBuf, Sequence, Transaction, TxOut, Txid,
     Weight, Witness,
 };
-use bitcoin::consensus::encode::serialize;
 use core::fmt;
 use core::ops::Deref;
 use miniscript::psbt::{PsbtExt, PsbtInputExt, PsbtInputSatisfier};
@@ -1288,7 +1288,8 @@ impl<D> Wallet<D> {
                         let satisfaction_weight = self
                             .get_descriptor_for_keychain(keychain)
                             .max_weight_to_satisfy()
-                            .unwrap() + 4;
+                            .unwrap()
+                            + 4;
                         WeightedUtxo {
                             utxo: Utxo::Local(LocalUtxo {
                                 outpoint: txin.previous_output,
@@ -1298,7 +1299,7 @@ impl<D> Wallet<D> {
                                 derivation_index,
                                 confirmation_time,
                             }),
-                            satisfaction_weight
+                            satisfaction_weight,
                         }
                     }
                     None => {
@@ -1621,7 +1622,8 @@ impl<D> Wallet<D> {
                     utxo,
                     self.get_descriptor_for_keychain(keychain)
                         .max_weight_to_satisfy()
-                        .unwrap() + 4,
+                        .unwrap()
+                        + 4,
                 )
             })
             .collect()

--- a/crates/bdk/src/wallet/tx_builder.rs
+++ b/crates/bdk/src/wallet/tx_builder.rs
@@ -295,8 +295,7 @@ impl<'a, D, Cs: CoinSelectionAlgorithm, Ctx: TxBuilderContext> TxBuilder<'a, D, 
 
             for utxo in utxos {
                 let descriptor = wallet.get_descriptor_for_keychain(utxo.keychain);
-                #[allow(deprecated)]
-                let satisfaction_weight = descriptor.max_satisfaction_weight().unwrap();
+                let satisfaction_weight = descriptor.max_weight_to_satisfy().unwrap();
                 self.params.utxos.push(WeightedUtxo {
                     satisfaction_weight,
                     utxo: Utxo::Local(utxo),
@@ -337,9 +336,10 @@ impl<'a, D, Cs: CoinSelectionAlgorithm, Ctx: TxBuilderContext> TxBuilder<'a, D, 
     /// causing you to pay a fee that is too high. The party who is broadcasting the transaction can
     /// of course check the real input weight matches the expected weight prior to broadcasting.
     ///
-    /// To guarantee the `satisfaction_weight` is correct, you can require the party providing the
+    /// TODO: add notes about the new `max_weight_to_satisfy`
+    /// To guarantee the `max_weight_to_satisfy` is correct, you can require the party providing the
     /// `psbt_input` provide a miniscript descriptor for the input so you can check it against the
-    /// `script_pubkey` and then ask it for the [`max_satisfaction_weight`].
+    /// `script_pubkey` and then ask it for the [`max_weight_to_satisfy`].
     ///
     /// This is an **EXPERIMENTAL** feature, API and other major changes are expected.
     ///
@@ -360,7 +360,7 @@ impl<'a, D, Cs: CoinSelectionAlgorithm, Ctx: TxBuilderContext> TxBuilder<'a, D, 
     ///
     /// [`only_witness_utxo`]: Self::only_witness_utxo
     /// [`finish`]: Self::finish
-    /// [`max_satisfaction_weight`]: miniscript::Descriptor::max_satisfaction_weight
+    /// [`max_weight_to_satisfy`]: miniscript::Descriptor::max_weight_to_satisfy
     pub fn add_foreign_utxo(
         &mut self,
         outpoint: OutPoint,

--- a/crates/bdk/src/wallet/tx_builder.rs
+++ b/crates/bdk/src/wallet/tx_builder.rs
@@ -336,10 +336,12 @@ impl<'a, D, Cs: CoinSelectionAlgorithm, Ctx: TxBuilderContext> TxBuilder<'a, D, 
     /// causing you to pay a fee that is too high. The party who is broadcasting the transaction can
     /// of course check the real input weight matches the expected weight prior to broadcasting.
     ///
-    /// TODO: add notes about the new `max_weight_to_satisfy`
     /// To guarantee the `max_weight_to_satisfy` is correct, you can require the party providing the
     /// `psbt_input` provide a miniscript descriptor for the input so you can check it against the
     /// `script_pubkey` and then ask it for the [`max_weight_to_satisfy`].
+    /// Be aware that `max_weight_to_satisfy` uses `segwit_weight` instead of `legacy_weight`,
+    /// if you want to include only legacy inputs in your transaction, you should remove 1WU
+    /// from each input's `max_weight_to_satisfy` for a more accurate estimate.
     ///
     /// This is an **EXPERIMENTAL** feature, API and other major changes are expected.
     ///

--- a/crates/bdk/src/wallet/tx_builder.rs
+++ b/crates/bdk/src/wallet/tx_builder.rs
@@ -295,7 +295,7 @@ impl<'a, D, Cs: CoinSelectionAlgorithm, Ctx: TxBuilderContext> TxBuilder<'a, D, 
 
             for utxo in utxos {
                 let descriptor = wallet.get_descriptor_for_keychain(utxo.keychain);
-                let satisfaction_weight = descriptor.max_weight_to_satisfy().unwrap();
+                let satisfaction_weight = descriptor.max_weight_to_satisfy().unwrap() + 4;
                 self.params.utxos.push(WeightedUtxo {
                     satisfaction_weight,
                     utxo: Utxo::Local(utxo),

--- a/crates/bdk/tests/wallet.rs
+++ b/crates/bdk/tests/wallet.rs
@@ -1041,10 +1041,9 @@ fn test_add_foreign_utxo() {
         .unwrap()
         .assume_checked();
     let utxo = wallet2.list_unspent().next().expect("must take!");
-    #[allow(deprecated)]
     let foreign_utxo_satisfaction = wallet2
         .get_descriptor_for_keychain(KeychainKind::External)
-        .max_satisfaction_weight()
+        .max_weight_to_satisfy()
         .unwrap();
 
     let psbt_input = psbt::Input {
@@ -1117,10 +1116,9 @@ fn test_calculate_fee_with_missing_foreign_utxo() {
         .unwrap()
         .assume_checked();
     let utxo = wallet2.list_unspent().next().expect("must take!");
-    #[allow(deprecated)]
     let foreign_utxo_satisfaction = wallet2
         .get_descriptor_for_keychain(KeychainKind::External)
-        .max_satisfaction_weight()
+        .max_weight_to_satisfy()
         .unwrap();
 
     let psbt_input = psbt::Input {
@@ -1144,10 +1142,9 @@ fn test_calculate_fee_with_missing_foreign_utxo() {
 fn test_add_foreign_utxo_invalid_psbt_input() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
     let outpoint = wallet.list_unspent().next().expect("must exist").outpoint;
-    #[allow(deprecated)]
     let foreign_utxo_satisfaction = wallet
         .get_descriptor_for_keychain(KeychainKind::External)
-        .max_satisfaction_weight()
+        .max_weight_to_satisfy()
         .unwrap();
 
     let mut builder = wallet.build_tx();
@@ -1166,10 +1163,9 @@ fn test_add_foreign_utxo_where_outpoint_doesnt_match_psbt_input() {
     let tx1 = wallet1.get_tx(txid1).unwrap().tx_node.tx.clone();
     let tx2 = wallet2.get_tx(txid2).unwrap().tx_node.tx.clone();
 
-    #[allow(deprecated)]
     let satisfaction_weight = wallet2
         .get_descriptor_for_keychain(KeychainKind::External)
-        .max_satisfaction_weight()
+        .max_weight_to_satisfy()
         .unwrap();
 
     let mut builder = wallet1.build_tx();
@@ -1211,10 +1207,9 @@ fn test_add_foreign_utxo_only_witness_utxo() {
         .assume_checked();
     let utxo2 = wallet2.list_unspent().next().unwrap();
 
-    #[allow(deprecated)]
     let satisfaction_weight = wallet2
         .get_descriptor_for_keychain(KeychainKind::External)
-        .max_satisfaction_weight()
+        .max_weight_to_satisfy()
         .unwrap();
 
     let mut builder = wallet1.build_tx();
@@ -2907,10 +2902,9 @@ fn test_taproot_foreign_utxo() {
         .assume_checked();
     let utxo = wallet2.list_unspent().next().unwrap();
     let psbt_input = wallet2.get_psbt_input(utxo.clone(), None, false).unwrap();
-    #[allow(deprecated)]
     let foreign_utxo_satisfaction = wallet2
         .get_descriptor_for_keychain(KeychainKind::External)
-        .max_satisfaction_weight()
+        .max_weight_to_satisfy()
         .unwrap();
 
     assert!(


### PR DESCRIPTION
### Description

Closes #1036.

- Change deprecated `max_satisfaction_weight` to `max_weight_to_satisfy`
- Remove `#[allow(deprecated)]` flags

### Notes to the reviewers

I've changed all `max_satisfaction_weight()` to `max_weight_to_satisfy()`
in `Wallet.get_available_utxo()` and `Wallet.build_fee_bump()`.
Checking the docs on the `miniscript` crate for `max_weight_to_satisfy` has the following note:

> Since this method uses `segwit_weight` instead of `legacy_weight`,
> if you want to include only legacy inputs in your transaction,
> you should remove 1WU from each input's `max_weight_to_satisfy`
> for a more accurate estimate.

Hence, I also added 1WU (`4`) to the `max_weight_to_satisfy()` calls.
But I think that there is a better way to do this instead of hardcoding `4`.
Please advise.

### Changelog notice

### Fixed

Replace the deprecated `max_satisfaction_weight` from `rust-miniscript` to `max_weight_to_satisfy`.

### Checklists

#### All Submissions:

* [X] I've signed all my commits
* [X] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [X] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [X] I'm linking the issue being fixed by this PR
