### PR TITLE
feat: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# Set update schedule for GitHub Actions
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"


### PR DESCRIPTION
Fixes #1118.
Adds `dependabot.yml` to `.github/` to check for `"github-action"` updates on a `"weekly"` basis.
This does not touch Rust code or Cargo workflows.

It will  create PRs and we would need to approve them (they would be subject to the same merge policy)
to instantiate the proposed dependabots into `master`.

### Changelog notice

Added dependabot to automatically check GitHub Actions updates.

### Checklists

#### All Submissions:

* [X] I've signed all my commits
* [X] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [X] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [X] I'm linking the issue being fixed by this PR
