### PR TITLE
Remove `TxGraph::missing_heights` as `ChangeSet::missing_heights_from` should have replaced it

### DIFF
--- a/crates/bdk/src/lib.rs
+++ b/crates/bdk/src/lib.rs
@@ -43,6 +43,7 @@ pub use types::*;
 pub use wallet::signer;
 pub use wallet::signer::SignOptions;
 pub use wallet::tx_builder::TxBuilder;
+pub use wallet::Update;
 pub use wallet::Wallet;
 
 /// Get the version of BDK at runtime

--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -579,69 +579,6 @@ impl<A: Clone + Ord> TxGraph<A> {
 }
 
 impl<A: Anchor> TxGraph<A> {
-    /// Find missing block heights of `chain`.
-    ///
-    /// This works by scanning through anchors, and seeing whether the anchor block of the anchor
-    /// exists in the [`LocalChain`]. The returned iterator does not output duplicate heights.
-    pub fn missing_heights<'a>(&'a self, chain: &'a LocalChain) -> impl Iterator<Item = u32> + 'a {
-        // Map of txids to skip.
-        //
-        // Usually, if a height of a tx anchor is missing from the chain, we would want to return
-        // this height in the iterator. The exception is when the tx is confirmed in chain. All the
-        // other missing-height anchors of this tx can be skipped.
-        //
-        // * Some(true)  => skip all anchors of this txid
-        // * Some(false) => do not skip anchors of this txid
-        // * None        => we do not know whether we can skip this txid
-        let mut txids_to_skip = HashMap::<Txid, bool>::new();
-
-        // Keeps track of the last height emitted so we don't double up.
-        let mut last_height_emitted = Option::<u32>::None;
-
-        self.anchors
-            .iter()
-            .filter(move |(_, txid)| {
-                let skip = *txids_to_skip.entry(*txid).or_insert_with(|| {
-                    let tx_anchors = match self.txs.get(txid) {
-                        Some((_, anchors, _)) => anchors,
-                        None => return true,
-                    };
-                    let mut has_missing_height = false;
-                    for anchor_block in tx_anchors.iter().map(Anchor::anchor_block) {
-                        match chain.blocks().get(&anchor_block.height) {
-                            None => {
-                                has_missing_height = true;
-                                continue;
-                            }
-                            Some(chain_hash) => {
-                                if chain_hash == &anchor_block.hash {
-                                    return true;
-                                }
-                            }
-                        }
-                    }
-                    !has_missing_height
-                });
-                #[cfg(feature = "std")]
-                debug_assert!({
-                    println!("txid={} skip={}", txid, skip);
-                    true
-                });
-                !skip
-            })
-            .filter_map(move |(a, _)| {
-                let anchor_block = a.anchor_block();
-                if Some(anchor_block.height) != last_height_emitted
-                    && !chain.blocks().contains_key(&anchor_block.height)
-                {
-                    last_height_emitted = Some(anchor_block.height);
-                    Some(anchor_block.height)
-                } else {
-                    None
-                }
-            })
-    }
-
     /// Get the position of the transaction in `chain` with tip `chain_tip`.
     ///
     /// If the given transaction of `txid` does not exist in the chain of `chain_tip`, `None` is
@@ -1072,7 +1009,7 @@ impl<A> ChangeSet<A> {
     /// This is useful if you want to find which heights you need to fetch data about in order to
     /// confirm or exclude these anchors.
     ///
-    /// See also: [`TxGraph::missing_heights`]
+    /// See also: [`ChangeSet::missing_heights_from`]
     pub fn anchor_heights(&self) -> impl Iterator<Item = u32> + '_
     where
         A: Anchor,

--- a/example-crates/wallet_esplora_async/src/main.rs
+++ b/example-crates/wallet_esplora_async/src/main.rs
@@ -61,11 +61,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         graph: update_graph,
         ..Default::default()
     })?;
-    let missing_heights = wallet
-        .staged()
-        .indexed_tx_graph
-        .graph
-        .missing_heights_from(wallet.local_chain());
+    let missing_heights = wallet.missing_heights().iter().copied();
     let chain_update = client.update_local_chain(prev_tip, missing_heights).await?;
     wallet.apply_update(chain_update.into())?;
     wallet.commit()?;

--- a/example-crates/wallet_esplora_blocking/src/main.rs
+++ b/example-crates/wallet_esplora_blocking/src/main.rs
@@ -60,11 +60,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         last_active_indices,
         ..Default::default()
     })?;
-    let missing_heights = wallet
-        .staged()
-        .indexed_tx_graph
-        .graph
-        .missing_heights_from(wallet.local_chain());
+    let missing_heights = wallet.missing_heights().iter().copied();
     let chain_update = client.update_local_chain(prev_tip, missing_heights)?;
     wallet.apply_update(chain_update.into())?;
     wallet.commit()?;


### PR DESCRIPTION
### Description

`ChangeSet::missing_heights_from` is introduced as a simpler alternative to `TxGraph::missing_heights`. We should remove `TxGraph::missing_heights` and use `ChangeSet::missing_heights_from` instead.

### Notes to the reviewers

WIP

### Changelog notice

Remove `TxGraph::missing_heights` and use `ChangeSet::missing_heights_from` instead.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
