### PR TITLE
test: legacy descriptors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
     "example-crates/wallet_esplora_blocking",
     "example-crates/wallet_esplora_async",
     "nursery/tmp_plan",
-    "nursery/coin_select"
+    "nursery/coin_select",
 ]
 
 [workspace.package]

--- a/crates/bdk/tests/common.rs
+++ b/crates/bdk/tests/common.rs
@@ -108,10 +108,10 @@ pub fn get_funded_wallet(descriptor: &str) -> (Wallet, bitcoin::Txid) {
     get_funded_wallet_with_change(descriptor, None)
 }
 
-// This PKH can be obtained in testnet by using the 12-word seed
-// abandon x 11 + cactus and getting the first receiving address.
+// This PKH WIF was taken from example 5 in
+// https://github.com/libbitcoin/libbitcoin-explorer/wiki/bx-ec-to-wif
 pub fn get_test_pkh() -> &'static str {
-    "pkh(0275d93539d503d824ad0c69a4c23ae480700489de09378ba32c1776cf86d6bb93)"
+    "pkh(cNJFgo1driFnPcBdBX8BrJrpxchBWXwXCvNH5SoSkdcF6JXXwHMm)"
 }
 
 pub fn get_test_wpkh() -> &'static str {

--- a/crates/bdk/tests/common.rs
+++ b/crates/bdk/tests/common.rs
@@ -108,6 +108,12 @@ pub fn get_funded_wallet(descriptor: &str) -> (Wallet, bitcoin::Txid) {
     get_funded_wallet_with_change(descriptor, None)
 }
 
+// This PKH can be obtained in testnet by using the 12-word seed
+// abandon x 11 + cactus and getting the first receiving address.
+pub fn get_test_pkh() -> &'static str {
+    "pkh(0275d93539d503d824ad0c69a4c23ae480700489de09378ba32c1776cf86d6bb93)"
+}
+
 pub fn get_test_wpkh() -> &'static str {
     "wpkh(cVpPVruEDdmutPzisEsYvtST1usBR3ntr8pXSyt6D2YYqXRyPcFW)"
 }

--- a/crates/bdk/tests/wallet.rs
+++ b/crates/bdk/tests/wallet.rs
@@ -591,6 +591,23 @@ fn test_create_tx_absolute_fee() {
 }
 
 #[test]
+fn test_legacy_create_tx_absolute_zero_fee() {
+    let (mut wallet, _) = get_funded_wallet(get_test_pkh());
+    let addr = wallet.get_address(New);
+    let mut builder = wallet.build_tx();
+    builder
+        .drain_to(addr.script_pubkey())
+        .drain_wallet()
+        .fee_absolute(0);
+    let psbt = builder.finish().unwrap();
+    let fee = check_fee!(wallet, psbt);
+
+    assert_eq!(fee.unwrap_or(0), 0);
+    assert_eq!(psbt.unsigned_tx.output.len(), 1);
+    assert_eq!(psbt.unsigned_tx.output[0].value, 50_000 - fee.unwrap_or(0));
+}
+
+#[test]
 fn test_create_tx_absolute_zero_fee() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
     let addr = wallet.get_address(New);

--- a/crates/bdk/tests/wallet.rs
+++ b/crates/bdk/tests/wallet.rs
@@ -1958,7 +1958,7 @@ fn test_legacy_bump_fee_add_input() {
 
     let mut builder = wallet.build_fee_bump(txid).unwrap();
     builder.fee_rate(FeeRate::from_sat_per_vb(50.0));
-    let psbt = builder.finish().unwrap();
+    let mut psbt = builder.finish().unwrap();
     let sent_received = wallet.sent_and_received(&psbt.clone().extract_tx());
     let fee = check_fee!(wallet, psbt);
     assert_eq!(sent_received.0, original_details.0 + 25_000);
@@ -1984,7 +1984,14 @@ fn test_legacy_bump_fee_add_input() {
         sent_received.1
     );
 
-    assert_fee_rate!(psbt, fee.unwrap_or(0), FeeRate::from_sat_per_vb(50.0), @add_signature);
+    // sign the transaction
+    wallet.sign(&mut psbt, SignOptions::default()).unwrap();
+
+    assert_delta!(
+        psbt.fee_rate().unwrap(),
+        FeeRate::from_sat_per_vb(50.0),
+        FeeRate::from_sat_per_vb(1.0)
+    );
 }
 
 #[test]

--- a/crates/bdk/tests/wallet.rs
+++ b/crates/bdk/tests/wallet.rs
@@ -542,6 +542,23 @@ fn test_create_tx_default_fee_rate() {
     assert_fee_rate!(psbt, fee.unwrap_or(0), FeeRate::default(), @add_signature);
 }
 
+// FIXME: Something is going on
+// thread 'test_legacy_create_tx_custom_fee_rate' panicked at 'assertion failed: `(left == right)`
+//  left: `FeeRate(9.537815)`,
+// right: `FeeRate(5.0)`'
+#[test]
+fn test_legacy_create_tx_custom_fee_rate() {
+    let (mut wallet, _) = get_funded_wallet(get_test_pkh());
+    let addr = wallet.get_address(New);
+    let mut builder = wallet.build_tx();
+    builder
+        .add_recipient(addr.script_pubkey(), 25_000)
+        .fee_rate(FeeRate::from_sat_per_vb(5.0));
+    let psbt = builder.finish().unwrap();
+
+    assert_eq!(psbt.fee_rate().unwrap(), FeeRate::from_sat_per_vb(5.0));
+}
+
 #[test]
 fn test_create_tx_custom_fee_rate() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());

--- a/crates/bdk/tests/wallet.rs
+++ b/crates/bdk/tests/wallet.rs
@@ -715,6 +715,17 @@ fn test_create_tx_ordering_respected() {
 }
 
 #[test]
+fn test_legacy_create_tx_default_sighash() {
+    let (mut wallet, _) = get_funded_wallet(get_test_pkh());
+    let addr = wallet.get_address(New);
+    let mut builder = wallet.build_tx();
+    builder.add_recipient(addr.script_pubkey(), 30_000);
+    let psbt = builder.finish().unwrap();
+
+    assert_eq!(psbt.inputs[0].sighash_type, None);
+}
+
+#[test]
 fn test_create_tx_default_sighash() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
     let addr = wallet.get_address(New);
@@ -723,6 +734,22 @@ fn test_create_tx_default_sighash() {
     let psbt = builder.finish().unwrap();
 
     assert_eq!(psbt.inputs[0].sighash_type, None);
+}
+
+#[test]
+fn test_legacy_create_tx_custom_sighash() {
+    let (mut wallet, _) = get_funded_wallet(get_test_pkh());
+    let addr = wallet.get_address(New);
+    let mut builder = wallet.build_tx();
+    builder
+        .add_recipient(addr.script_pubkey(), 30_000)
+        .sighash(EcdsaSighashType::Single.into());
+    let psbt = builder.finish().unwrap();
+
+    assert_eq!(
+        psbt.inputs[0].sighash_type,
+        Some(EcdsaSighashType::Single.into())
+    );
 }
 
 #[test]

--- a/crates/bdk/tests/wallet.rs
+++ b/crates/bdk/tests/wallet.rs
@@ -139,6 +139,22 @@ fn test_get_funded_wallet_tx_fee_rate() {
     assert_eq!(tx_fee_rate.as_sat_per_vb(), 8.849558);
 }
 
+#[test]
+fn test_legacy_get_funded_wallet_tx_fee_rate() {
+    let (wallet, txid) = get_funded_wallet(get_test_pkh());
+
+    let tx = wallet.get_tx(txid).expect("transaction").tx_node.tx;
+    let tx_fee_rate = wallet.calculate_fee_rate(tx).expect("transaction fee rate");
+
+    // The funded wallet contains a tx with a 76_000 sats input and two outputs, one spending 25_000
+    // to a foreign address and one returning 50_000 back to the wallet as change. The remaining 1000
+    // sats are the transaction fee.
+
+    // tx weight = 464 bytes, as vbytes = (464)/4 = 116
+    // fee rate (sats per vbyte) = fee / vbytes = 1000 / 116 = 8.6206896551724137931 rounded to 8.620689
+    assert_eq!(tx_fee_rate.as_sat_per_vb(), 8.620689);
+}
+
 macro_rules! assert_fee_rate {
     ($psbt:expr, $fees:expr, $fee_rate:expr $( ,@dust_change $( $dust_change:expr )* )* $( ,@add_signature $( $add_signature:expr )* )* ) => ({
         let psbt = $psbt.clone();

--- a/crates/bdk/tests/wallet.rs
+++ b/crates/bdk/tests/wallet.rs
@@ -167,7 +167,7 @@ macro_rules! assert_fee_rate {
                 }
         )*
 
-            #[allow(unused_mut)]
+        #[allow(unused_mut)]
         #[allow(unused_assignments)]
         let mut dust_change = false;
         $(
@@ -459,6 +459,16 @@ macro_rules! check_fee {
         assert_eq!(tx_fee, $psbt.fee_amount());
         tx_fee
     }};
+}
+
+/// A floating point assert! that takes an additional third argument `delta`
+/// as a tolerance value when test for equality the first and second argument.
+macro_rules! assert_delta {
+    ($x:expr, $y:expr, $d:expr) => {
+        if !($x - $y < $d || $y - $x < $d) {
+            panic!();
+        }
+    };
 }
 
 #[test]

--- a/crates/bdk/tests/wallet.rs
+++ b/crates/bdk/tests/wallet.rs
@@ -1197,7 +1197,7 @@ fn test_add_foreign_utxo_where_outpoint_doesnt_match_psbt_input() {
                 satisfaction_weight
             )
             .is_ok(),
-        "shoulld be ok when outpoint does match psbt_input"
+        "should be ok when outpoint does match psbt_input"
     );
 }
 

--- a/crates/bdk/tests/wallet.rs
+++ b/crates/bdk/tests/wallet.rs
@@ -557,6 +557,23 @@ fn test_create_tx_custom_fee_rate() {
 }
 
 #[test]
+fn test_legacy_create_tx_absolute_fee() {
+    let (mut wallet, _) = get_funded_wallet(get_test_pkh());
+    let addr = wallet.get_address(New);
+    let mut builder = wallet.build_tx();
+    builder
+        .drain_to(addr.script_pubkey())
+        .drain_wallet()
+        .fee_absolute(100);
+    let psbt = builder.finish().unwrap();
+    let fee = check_fee!(wallet, psbt);
+
+    assert_eq!(fee.unwrap_or(0), 100);
+    assert_eq!(psbt.unsigned_tx.output.len(), 1);
+    assert_eq!(psbt.unsigned_tx.output[0].value, 50_000 - fee.unwrap_or(0));
+}
+
+#[test]
 fn test_create_tx_absolute_fee() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
     let addr = wallet.get_address(New);

--- a/crates/bdk/tests/wallet.rs
+++ b/crates/bdk/tests/wallet.rs
@@ -638,6 +638,19 @@ fn test_create_tx_absolute_high_fee() {
 }
 
 #[test]
+#[should_panic(expected = "InsufficientFunds")]
+fn test_legacy_create_tx_absolute_high_fee() {
+    let (mut wallet, _) = get_funded_wallet(get_test_pkh());
+    let addr = wallet.get_address(New);
+    let mut builder = wallet.build_tx();
+    builder
+        .drain_to(addr.script_pubkey())
+        .drain_wallet()
+        .fee_absolute(60_000);
+    let _ = builder.finish().unwrap();
+}
+
+#[test]
 fn test_create_tx_add_change() {
     use bdk::wallet::tx_builder::TxOrdering;
 


### PR DESCRIPTION
### Description

We currently don't have much tests with legacy descriptors (`pkh`).
This PR adds some, mainly focused on fee stuff.

### Notes to the reviewers

This discussion came up on bitcoindevkit/bdk#1115 and also in bitcoindevkit/bdk_wallet#134 (it doesn't fully close).

### Changelog notice

### Added

- Tests for fee calculation and fee bump with legacy descriptors.

### Checklists

#### All Submissions:

* [X] I've signed all my commits
* [X] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [X] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [X] I'm linking the issue being fixed by this PR
