### PR TITLE
fix: bump electrum version to 0.18

### DIFF
--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -13,5 +13,5 @@ readme = "README.md"
 
 [dependencies]
 bdk_chain = { path = "../chain", version = "0.5.0", features = ["serde", "miniscript"] }
-electrum-client = { version = "0.17" }
+electrum-client = { version = "0.18" }
 #rustls = { version = "=0.21.1", optional = true, features = ["dangerous_configuration"] }


### PR DESCRIPTION
Fixes https://github.com/bitcoindevkit/bdk/issues/1123