### PR TITLE
refactor: add Wallet init fn and call from new and new_no_persist fn

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -39,6 +39,7 @@ jobs:
           cargo update -p reqwest --precise "0.11.18"
           cargo update -p h2 --precise "0.3.20"
           cargo update -p rustls-webpki --precise "0.100.1"
+          cargo update -p tokio-util --precise "0.7.8"
       - name: Build
         run: cargo build ${{ matrix.features }}
       - name: Test

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ cargo update -p reqwest --precise "0.11.18"
 cargo update -p h2 --precise "0.3.20"
 # rustls-webpki has MSRV 1.60.0+
 cargo update -p rustls-webpki --precise "0.100.1"
+# tokio-util 0.7.9 does not build with our MSRV
+cargo update -p tokio-util --precise "0.7.8"
 ```
 
 ## License


### PR DESCRIPTION
### Description

This refactor is to remove unneeded lines to update wallet from db when no db is being used. 

### Notes to the reviewers

@afilini found that by not calling the apply_changeset lines in his no_std project he could save 36kb in his final binary.

https://discord.com/channels/753336465005608961/999098651383189554/11559089254225716313

I'm open to other function names or closing this PR if someone has a nicer way to do this.

### Changelog notice

None.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
