### PR TITLE
ci: replace toolchain

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -17,11 +17,8 @@ jobs:
       - name: Install lcov tools
         run: sudo apt-get install lcov -y
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-            toolchain: stable
-            override: true
-            profile: minimal
             components: llvm-tools-preview
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.2.1

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -12,7 +12,7 @@ jobs:
         rust:
           - version: stable
             clippy: true
-          - version: 1.57.0 # MSRV
+          - version: "1.57.0" # MSRV
         features:
           - --no-default-features
           - --all-features
@@ -20,11 +20,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
             toolchain: ${{ matrix.rust.version }}
-            override: true
-            profile: minimal
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.2.1
       - name: Pin dependencies for MSRV
@@ -56,11 +54,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
-          profile: minimal
           # target: "thumbv6m-none-eabi"
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.2.1
@@ -91,11 +86,8 @@ jobs:
       - run: sudo apt-get update || exit 1
       - run: sudo apt-get install -y libclang-common-10-dev clang-10 libc6-dev-i386 || exit 1
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-            toolchain: stable
-            override: true
-            profile: minimal
             target: "wasm32-unknown-unknown"
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.2.1
@@ -113,11 +105,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-            toolchain: stable
-            override: true
-            profile: minimal
             components: rustfmt
       - name: Check fmt
         run: cargo fmt --all -- --config format_code_in_doc_comments=true --check
@@ -126,16 +115,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
             # we pin clippy instead of using "stable" so that our CI doesn't break
             # at each new cargo release
             toolchain: "1.67.0"
             components: clippy
-            override: true
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.2.1
-      - uses: actions-rs/clippy-check@v1
+      - run: cargo clippy  --all-features --all-targets -- -D warnings
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all-targets -- -D warnings


### PR DESCRIPTION
### Description

This replaces `actions-rs/toolchain` for `dtolnay/rust-toolchain` in all CI runs.

### Notes to the reviewers

Following the discussion in https://github.com/rust-bitcoin/rust-bitcoin/issues/2113,
[`actions-rs/toolchain`](https://github.com/actions-rs/toolchain) is an "Unofficial GitHub Actions for Rust programming language" which has only one person in the organization, @svartalf, which appears to be MIA for a long time.
People are asking in vain for these fixes, check https://github.com/actions-rs/toolchain/issues/221 (almost a year long).
 
There are a bunch of warnings in CI, e.g. https://github.com/bitcoindevkit/bdk/actions/runs/6443147276/job/17499339102#step:6:71.

[`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain) is by a well-established Rust developer, and it is well-maintaned (and has more stars than `actions-rs/toolchain`.

Also [`rust-bitcoin` already replaced `actions-rs/toolchain` with `dtolnay/rust-toolchain` in most every place](https://github.com/rust-bitcoin/rust-bitcoin/issues/2113#issuecomment-1751846698)

### Changelog notice

Replaced `actions-rs/toolchain` with `dtolnay/rust-toolchain` in CI.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

