### PR TITLE
ref(chain): Rename direct_conflicts_of_tx to direct_conflitcs

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -46,6 +46,7 @@ jobs:
           cargo update -p cc --precise "1.0.81"
           cargo update -p byteorder --precise "1.4.3"
           cargo update -p webpki --precise "0.22.2"
+          cargo update -p jobserver --precise "0.1.26"
       - name: Build
         run: cargo build ${{ matrix.features }}
       - name: Test

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ cargo update -p cc --precise "1.0.81"
 cargo update -p byteorder --precise "1.4.3"
 # webpki 0.22.4 requires `ring:0.17.2` which has MSRV 1.61.0+
 cargo update -p webpki --precise "0.22.2"
+# jobserver 0.1.27 has MSRV 1.66.0+
+cargo update -p jobserver --precise "0.1.26"
 ```
 
 ## License

--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -373,7 +373,7 @@ impl<A> TxGraph<A> {
     where
         F: FnMut(usize, Txid) -> Option<O> + 'g,
     {
-        let txids = self.direct_conflicts_of_tx(tx).map(|(_, txid)| txid);
+        let txids = self.direct_conflitcs(tx).map(|(_, txid)| txid);
         TxDescendants::from_multiple_include_root(self, txids, walk_map)
     }
 
@@ -384,7 +384,7 @@ impl<A> TxGraph<A> {
     /// Note that this only returns directly conflicting txids and won't include:
     /// - descendants of conflicting transactions (which are technically also conflicting)
     /// - transactions conflicting with the given transaction's ancestors
-    pub fn direct_conflicts_of_tx<'g>(
+    pub fn direct_conflitcs<'g>(
         &'g self,
         tx: &'g Transaction,
     ) -> impl Iterator<Item = (usize, Txid)> + '_ {


### PR DESCRIPTION
Fixes #1138

### Changelog notice

- rename `TxGraph::direct_conflicts_of_tx` to `TxGraph::direct_conflicts`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing