### PR TITLE
Implement default index_tx method

### DIFF
--- a/crates/chain/src/keychain/txout_index.rs
+++ b/crates/chain/src/keychain/txout_index.rs
@@ -126,14 +126,6 @@ impl<K: Clone + Ord + Debug> Indexer for KeychainTxOutIndex<K> {
         }
     }
 
-    fn index_tx(&mut self, tx: &bitcoin::Transaction) -> Self::ChangeSet {
-        let mut changeset = super::ChangeSet::<K>::default();
-        for (op, txout) in tx.output.iter().enumerate() {
-            changeset.append(self.index_txout(OutPoint::new(tx.txid(), op as u32), txout));
-        }
-        changeset
-    }
-
     fn initial_changeset(&self) -> Self::ChangeSet {
         super::ChangeSet(self.last_revealed.clone())
     }


### PR DESCRIPTION
### Description

This PR fixes bitcoindevkit/bdk_wallet#137 

### Changelog

This PR implements a default implementation for the Indexer's `index_tx` method. It was recommended on one of the reviews of bitcoindevkit/bdk_wallet#137. 


### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [x] I'm linking the issue being fixed by this PR
