### PR TITLE
Get keychain for script

### DIFF
--- a/crates/bdk/src/wallet/mod.rs
+++ b/crates/bdk/src/wallet/mod.rs
@@ -1986,6 +1986,14 @@ impl<D> Wallet<D> {
     pub fn local_chain(&self) -> &LocalChain {
         &self.chain
     }
+
+    /// Get the [`KeychainKind`] and derivation index for a given [`Script`].
+    ///
+    /// This will return `None` if the script is not in the wallet.
+    // TODO: Generalize this implementation once we make the wallet generic over K
+    pub fn which_keychain_derived(&self, spk: &Script) -> Option<&(KeychainKind, u32)> {
+        self.indexed_graph.index.index_of_spk(spk)
+    }
 }
 
 impl<D> AsRef<bdk_chain::tx_graph::TxGraph<ConfirmationTimeAnchor>> for Wallet<D> {

--- a/crates/bdk/tests/wallet.rs
+++ b/crates/bdk/tests/wallet.rs
@@ -61,6 +61,21 @@ fn receive_output_in_latest_block(wallet: &mut Wallet, value: u64) -> OutPoint {
 const P2WPKH_FAKE_WITNESS_SIZE: usize = 106;
 
 #[test]
+fn test_which_keychain_derived_script() {
+    let (mut segwit_wallet, _) = get_funded_wallet(get_test_wpkh());
+    let addr = segwit_wallet.get_address(New);
+    let script = addr.script_pubkey();
+    let keychain = segwit_wallet.which_keychain_derived(&script).unwrap();
+    assert_eq!(keychain.0, KeychainKind::External);
+
+    let (mut taproot_wallet, _) = get_funded_wallet(get_test_tr_single_sig());
+    let addr = taproot_wallet.get_address(New);
+    let script = addr.script_pubkey();
+    let keychain = segwit_wallet.which_keychain_derived(&script);
+    assert!(keychain.is_none());
+}
+
+#[test]
 fn test_descriptor_checksum() {
     let (wallet, _) = get_funded_wallet(get_test_wpkh());
     let checksum = wallet.descriptor_checksum(KeychainKind::External);


### PR DESCRIPTION
### Description

This PR fixes #1042. 

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

It adds a method `which_keychain_derived` that tells us which keychain derived a particular script. This is helpful when trying to figure out if a particular script belongs to our wallet.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
