### PR TITLE
chore: remove bdk dependency on log and dev dependency on env_logger

### DIFF
--- a/crates/bdk/Cargo.toml
+++ b/crates/bdk/Cargo.toml
@@ -13,7 +13,6 @@ edition = "2021"
 rust-version = "1.57"
 
 [dependencies]
-log = "0.4"
 rand = "^0.8"
 miniscript = { version = "10.0.0", features = ["serde"], default-features = false }
 bitcoin = { version = "0.30.0", features = ["serde", "base64", "rand-std"], default-features = false }
@@ -45,7 +44,6 @@ dev-getrandom-wasm = ["getrandom/js"]
 
 [dev-dependencies]
 lazy_static = "1.4"
-env_logger = "0.7"
 assert_matches = "1.5.0"
 tempfile = "3"
 bdk_file_store = { path = "../file_store" }

--- a/crates/bdk/examples/compiler.rs
+++ b/crates/bdk/examples/compiler.rs
@@ -11,14 +11,11 @@
 
 extern crate bdk;
 extern crate bitcoin;
-extern crate log;
 extern crate miniscript;
 extern crate serde_json;
 
 use std::error::Error;
 use std::str::FromStr;
-
-use log::info;
 
 use bitcoin::Network;
 use miniscript::policy::Concrete;
@@ -36,13 +33,9 @@ use bdk::{KeychainKind, Wallet};
 /// This example demonstrates the interaction between a bdk wallet and miniscript policy.
 
 fn main() -> Result<(), Box<dyn Error>> {
-    env_logger::init_from_env(
-        env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
-    );
-
     // We start with a generic miniscript policy string
     let policy_str = "or(10@thresh(4,pk(029ffbe722b147f3035c87cb1c60b9a5947dd49c774cc31e94773478711a929ac0),pk(025f05815e3a1a8a83bfbb03ce016c9a2ee31066b98f567f6227df1d76ec4bd143),pk(025625f41e4a065efc06d5019cbbd56fe8c07595af1231e7cbc03fafb87ebb71ec),pk(02a27c8b850a00f67da3499b60562673dcf5fdfb82b7e17652a7ac54416812aefd),pk(03e618ec5f384d6e19ca9ebdb8e2119e5bef978285076828ce054e55c4daf473e2)),1@and(older(4209713),thresh(2,pk(03deae92101c790b12653231439f27b8897264125ecb2f46f48278603102573165),pk(033841045a531e1adf9910a6ec279589a90b3b8a904ee64ffd692bd08a8996c1aa),pk(02aebf2d10b040eb936a6f02f44ee82f8b34f5c1ccb20ff3949c2b28206b7c1068))))";
-    info!("Compiling policy: \n{}", policy_str);
+    println!("Compiling policy: \n{}", policy_str);
 
     // Parse the string as a [`Concrete`] type miniscript policy.
     let policy = Concrete::<String>::from_str(policy_str)?;
@@ -51,12 +44,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     // `policy.compile()` returns the resulting miniscript from the policy.
     let descriptor = Descriptor::new_wsh(policy.compile()?)?;
 
-    info!("Compiled into following Descriptor: \n{}", descriptor);
+    println!("Compiled into following Descriptor: \n{}", descriptor);
 
     // Create a new wallet from this descriptor
     let mut wallet = Wallet::new_no_persist(&format!("{}", descriptor), None, Network::Regtest)?;
 
-    info!(
+    println!(
         "First derived address from the descriptor: \n{}",
         wallet.get_address(New)
     );
@@ -64,7 +57,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // BDK also has it's own `Policy` structure to represent the spending condition in a more
     // human readable json format.
     let spending_policy = wallet.policies(KeychainKind::External)?;
-    info!(
+    println!(
         "The BDK spending policy: \n{}",
         serde_json::to_string_pretty(&spending_policy)?
     );

--- a/crates/bdk/examples/policy.rs
+++ b/crates/bdk/examples/policy.rs
@@ -10,8 +10,6 @@
 // licenses.
 
 extern crate bdk;
-extern crate env_logger;
-extern crate log;
 use std::error::Error;
 
 use bdk::bitcoin::Network;
@@ -29,10 +27,6 @@ use bdk::wallet::signer::SignersContainer;
 /// one of the Extend Private key.
 
 fn main() -> Result<(), Box<dyn Error>> {
-    env_logger::init_from_env(
-        env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),
-    );
-
     let secp = bitcoin::secp256k1::Secp256k1::new();
 
     // The descriptor used in the example
@@ -48,7 +42,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     // But they can be used as independent tools also.
     let (wallet_desc, keymap) = desc.into_wallet_descriptor(&secp, Network::Testnet)?;
 
-    log::info!("Example Descriptor for policy analysis : {}", wallet_desc);
+    println!("Example Descriptor for policy analysis : {}", wallet_desc);
 
     // Create the signer with the keymap and descriptor.
     let signers_container = SignersContainer::build(keymap, &wallet_desc, &secp);
@@ -60,7 +54,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         .extract_policy(&signers_container, BuildSatisfaction::None, &secp)?
         .expect("We expect a policy");
 
-    log::info!("Derived Policy for the descriptor {:#?}", policy);
+    println!("Derived Policy for the descriptor {:#?}", policy);
 
     Ok(())
 }

--- a/crates/bdk/src/descriptor/mod.rs
+++ b/crates/bdk/src/descriptor/mod.rs
@@ -488,11 +488,6 @@ impl DescriptorMeta for ExtendedDescriptor {
                         ) {
                             Some(derive_path)
                         } else {
-                            log::debug!(
-                                "Key `{}` derived with {} yields an unexpected key",
-                                root_fingerprint,
-                                derive_path
-                            );
                             None
                         }
                     });

--- a/crates/bdk/src/descriptor/policy.rs
+++ b/crates/bdk/src/descriptor/policy.rs
@@ -58,9 +58,6 @@ use miniscript::{
     Descriptor, Miniscript, Satisfier, ScriptContext, SigType, Terminal, ToPublicKey,
 };
 
-#[allow(unused_imports)]
-use log::{debug, error, info, trace};
-
 use crate::descriptor::ExtractPolicy;
 use crate::keys::ExtScriptContext;
 use crate::wallet::signer::{SignerId, SignersContainer};

--- a/crates/bdk/src/lib.rs
+++ b/crates/bdk/src/lib.rs
@@ -19,7 +19,6 @@ pub extern crate alloc;
 pub extern crate bitcoin;
 #[cfg(feature = "hardware-signer")]
 pub extern crate hwi;
-extern crate log;
 pub extern crate miniscript;
 extern crate serde;
 extern crate serde_json;

--- a/crates/bdk/src/wallet/coin_selection.rs
+++ b/crates/bdk/src/wallet/coin_selection.rs
@@ -254,12 +254,6 @@ impl CoinSelectionAlgorithm for LargestFirstCoinSelection {
         target_amount: u64,
         drain_script: &Script,
     ) -> Result<CoinSelectionResult, Error> {
-        log::debug!(
-            "target_amount = `{}`, fee_rate = `{:?}`",
-            target_amount,
-            fee_rate
-        );
-
         // We put the "required UTXOs" first and make sure the optional UTXOs are sorted,
         // initially smallest to largest, before being reversed with `.rev()`.
         let utxos = {
@@ -352,13 +346,6 @@ fn select_sorted_utxos(
                         (TXIN_BASE_WEIGHT + weighted_utxo.satisfaction_weight) as u64,
                     ));
                     **selected_amount += weighted_utxo.utxo.txout().value;
-
-                    log::debug!(
-                        "Selected {}, updated fee_amount = `{}`",
-                        weighted_utxo.utxo.outpoint(),
-                        fee_amount
-                    );
-
                     Some(weighted_utxo.utxo)
                 } else {
                     None

--- a/crates/bdk/src/wallet/mod.rs
+++ b/crates/bdk/src/wallet/mod.rs
@@ -42,8 +42,6 @@ use descriptor::error::Error as DescriptorError;
 use miniscript::psbt::{PsbtExt, PsbtInputExt, PsbtInputSatisfier};
 
 use bdk_chain::tx_graph::CalculateFeeError;
-#[allow(unused_imports)]
-use log::{debug, error, info, trace};
 
 pub mod coin_selection;
 pub mod export;
@@ -1231,7 +1229,6 @@ impl<D> Wallet<D> {
 
         let requirements =
             external_requirements.merge(&internal_requirements.unwrap_or_default())?;
-        debug!("Policy requirements: {:?}", requirements);
 
         let version = match params.version {
             Some(tx_builder::Version(0)) => return Err(CreateTxError::Version0),
@@ -1828,11 +1825,6 @@ impl<D> Wallet<D> {
                 .assume_height
                 .unwrap_or_else(|| self.chain.tip().height());
 
-            debug!(
-                "Input #{} - {}, using `confirmation_height` = {:?}, `current_height` = {:?}",
-                n, input.previous_output, confirmation_height, current_height
-            );
-
             // - Try to derive the descriptor by looking at the txout. If it's in our database, we
             //   know exactly which `keychain` to use, and which derivation index it is
             // - If that fails, try to derive it by looking at the psbt input: the complete logic
@@ -1875,10 +1867,7 @@ impl<D> Wallet<D> {
                                 psbt_input.partial_sigs.clear();
                             }
                         }
-                        Err(e) => {
-                            debug!("satisfy error {:?} for input {}", e, n);
-                            finished = false
-                        }
+                        Err(_) => finished = false,
                     }
                 }
                 None => finished = false,
@@ -2207,11 +2196,6 @@ impl<D> Wallet<D> {
             if let Some(&(keychain, child)) =
                 self.indexed_graph.index.index_of_spk(&out.script_pubkey)
             {
-                debug!(
-                    "Found descriptor for input #{} {:?}/{}",
-                    index, keychain, child
-                );
-
                 let desc = self.get_descriptor_for_keychain(keychain);
                 let desc = desc
                     .at_derivation_index(child)


### PR DESCRIPTION
### Description

As suggested by @TheBlueMatt we shouldn't use the `log` crate because even though it is a rust-lang project is may depend on some other crates that aren't as well maintained. Since we were only use `log` in a few places and not it any other bdk workspace projects except the `bdk` package I removed it. 

### Notes to the reviewers

For consistency I also removed the `env_logger` from the dev dependencies since it was only being used in a few places in a couple examples and println! is adequate for examples. 

### Changelog notice

None

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing