### PR TITLE
For wallet change sets persist and verify descriptor hashes

### DIFF
--- a/crates/chain/src/tx_data_traits.rs
+++ b/crates/chain/src/tx_data_traits.rs
@@ -128,6 +128,17 @@ impl<T> Append for Vec<T> {
     }
 }
 
+impl<T> Append for Option<T> {
+    // If other is Some then replace self's value with other's value, if other is None do nothing.
+    fn append(&mut self, other: Self) {
+        other.and_then(|v| self.replace(v));
+    }
+
+    fn is_empty(&self) -> bool {
+        self.is_none()
+    }
+}
+
 macro_rules! impl_append_for_tuple {
     ($($a:ident $b:tt)*) => {
         impl<$($a),*> Append for ($($a,)*) where $($a: Append),* {

--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -559,10 +559,7 @@ impl<A: Clone + Ord> TxGraph<A> {
         }
 
         for (outpoint, txout) in changeset.txouts {
-            let tx_entry = self
-                .txs
-                .entry(outpoint.txid)
-                .or_insert_with(Default::default);
+            let tx_entry = self.txs.entry(outpoint.txid).or_default();
 
             match tx_entry {
                 (TxNodeInternal::Whole(_), _, _) => { /* do nothing since we already have full tx */
@@ -575,13 +572,13 @@ impl<A: Clone + Ord> TxGraph<A> {
 
         for (anchor, txid) in changeset.anchors {
             if self.anchors.insert((anchor.clone(), txid)) {
-                let (_, anchors, _) = self.txs.entry(txid).or_insert_with(Default::default);
+                let (_, anchors, _) = self.txs.entry(txid).or_default();
                 anchors.insert(anchor);
             }
         }
 
         for (txid, new_last_seen) in changeset.last_seen {
-            let (_, _, last_seen) = self.txs.entry(txid).or_insert_with(Default::default);
+            let (_, _, last_seen) = self.txs.entry(txid).or_default();
             if new_last_seen > *last_seen {
                 *last_seen = new_last_seen;
             }


### PR DESCRIPTION
### Description

fixes #1101, this is an alternative solution to #1203

The idea is rather than making changes in the chain module to handle persisting and verifying descriptor hash values at the wallet level.   Any non-wallet chain module users can reference how we do it for wallet or can develop custom solutions. 

### Notes to the reviewers

I also cleaned up some related wallet module errors. 

And I fixed some new clippy errors by replacing `.or_insert_with(Default::default)` with `.or_default()`.

### Changelog notice

Added

- wallet::ChangeSet now includes the hashes of the wallet descriptors the Wallet was initially created with and on reloading from disk, if a ChangeSet has different descriptor hashes an error is thrown


### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature
