### PR TITLE
ci: pin rustls:0.21.10 version to 0.21.1 for 1.57 MSRV

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -34,7 +34,7 @@ jobs:
           cargo update -p tempfile --precise "3.6.0"
           cargo update -p reqwest --precise "0.11.18"
           cargo update -p hyper-rustls --precise 0.24.0
-          cargo update -p rustls:0.21.9 --precise "0.21.1"
+          cargo update -p rustls:0.21.10 --precise "0.21.1"
           cargo update -p rustls:0.20.9 --precise "0.20.8"
           cargo update -p tokio --precise "1.29.1"
           cargo update -p tokio-util --precise "0.7.8"

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ cargo update -p reqwest --precise "0.11.18"
 # hyper-rustls 0.24.1 has MSRV 1.60.0+
 cargo update -p hyper-rustls --precise 0.24.0
 # rustls 0.21.7 has MSRV 1.60.0+
-cargo update -p rustls:0.21.9 --precise "0.21.1"
+cargo update -p rustls:0.21.10 --precise "0.21.1"
 # rustls 0.20.9 has MSRV 1.60.0+
 cargo update -p rustls:0.20.9 --precise "0.20.8"
 # tokio 1.33 has MSRV 1.63.0+


### PR DESCRIPTION
### Description

Fix CI by pinning rustls:0.21.10 version to 0.21.1 for 1.57 MSRV.

### Notes to the reviewers

This was issue was found in #1188 . 

### Changelog notice

none

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing