### PR TITLE
Fix: apply loaded changeset to indexed_graph when loading a wallet from persistence

### DIFF
--- a/crates/bdk/src/wallet/mod.rs
+++ b/crates/bdk/src/wallet/mod.rs
@@ -517,7 +517,9 @@ impl<D> Wallet<D> {
             create_signers(&mut index, &secp, descriptor, change_descriptor, network)
                 .map_err(LoadError::Descriptor)?;
 
-        let indexed_graph = IndexedTxGraph::new(index);
+        let mut indexed_graph = IndexedTxGraph::new(index);
+        indexed_graph.apply_changeset(changeset.indexed_tx_graph);
+
         let persist = Persist::new(db);
 
         Ok(Wallet {


### PR DESCRIPTION
### Description
This PR applies the tx_graph from the changeset when loading a wallet from persistence. This ensures among other things that the revealed keychain indices get picked up by the new wallet. A test for this has been added/modified from an old test.

### Notes to the reviewers


### Changelog notice
Fix: loading a wallet from persistence now restores keychain indices.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
