### PR TITLE
ci: pin home dependency to 0.5.5 and check_clippy to rust stable version

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -33,7 +33,7 @@ jobs:
           cargo update -p zip --precise "0.6.2"
           cargo update -p time --precise "0.3.20"
           cargo update -p jobserver --precise "0.1.26"
-          cargo update -p reqwest --precise "0.11.19"
+          cargo update -p home --precise "0.5.5"
       - name: Build
         run: cargo build ${{ matrix.features }}
       - name: Test

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -118,9 +118,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-            # we pin clippy instead of using "stable" so that our CI doesn't break
-            # at each new cargo release
-            toolchain: "1.67.0"
+            toolchain: "stable"
             components: clippy
             override: true
       - name: Rust Cache

--- a/README.md
+++ b/README.md
@@ -65,14 +65,14 @@ This library should compile with any combination of features with Rust 1.63.0.
 To build with the MSRV you will need to pin dependencies as follows:
 
 ```shell
-# zip 0.6.3 has MSRV 1.64.0+
+# zip 0.6.3 has MSRV 1.64.0
 cargo update -p zip --precise "0.6.2"
-# time 0.3.21 has MSRV 1.65.0+
+# time 0.3.21 has MSRV 1.65.0
 cargo update -p time --precise "0.3.20"
 # jobserver 0.1.27 has MSRV 1.66.0
 cargo update -p jobserver --precise "0.1.26"
-# reqwest 0.11.20 has MSRV > 1.63.0+
-cargo update -p reqwest --precise "0.11.19"
+# home 0.5.9 has MSRV 1.70.0
+cargo update -p home --precise "0.5.5"
 ```
 
 ## License


### PR DESCRIPTION
### Description

Fixed 1.63 MSRV error by pinning `home` dependency to `0.5.5`, and `clippy` error by changing `check_clippy` job to using rust `stable` version. 

### Notes to the reviewers

It's OK to use rust `stable` version for clippy because we already have a `clippy.toml` file to tell it which version of the clippy rules to check against.

### Changelog notice

None

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

