### PR TITLE
Bump bdk version to 1.0.0-alpha.3

### DIFF
--- a/crates/bdk/Cargo.toml
+++ b/crates/bdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bdk"
 homepage = "https://bitcoindevkit.org"
-version = "1.0.0-alpha.2"
+version = "1.0.0-alpha.3"
 repository = "https://github.com/bitcoindevkit/bdk"
 documentation = "https://docs.rs/bdk"
 description = "A modern, lightweight, descriptor-based wallet library"
@@ -18,7 +18,7 @@ miniscript = { version = "10.0.0", features = ["serde"], default-features = fals
 bitcoin = { version = "0.30.0", features = ["serde", "base64", "rand-std"], default-features = false }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
-bdk_chain = { path = "../chain", version = "0.6.0", features = ["miniscript", "serde"], default-features = false }
+bdk_chain = { path = "../chain", version = "0.7.0", features = ["miniscript", "serde"], default-features = false }
 
 # Optional dependencies
 hwi = { version = "0.7.0", optional = true, features = [ "miniscript"] }

--- a/crates/bitcoind_rpc/Cargo.toml
+++ b/crates/bitcoind_rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_bitcoind_rpc"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"
@@ -16,7 +16,7 @@ readme = "README.md"
 # For no-std, remember to enable the bitcoin/no-std feature
 bitcoin = { version = "0.30", default-features = false }
 bitcoincore-rpc = { version = "0.17" }
-bdk_chain = { path = "../chain", version = "0.6", default-features = false }
+bdk_chain = { path = "../chain", version = "0.7", default-features = false }
 
 [dev-dependencies]
 bitcoind = { version = "0.33", features = ["25_0"] }

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_chain"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"

--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_electrum"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -12,6 +12,6 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bdk_chain = { path = "../chain", version = "0.6.0", default-features = false }
+bdk_chain = { path = "../chain", version = "0.7.0", default-features = false }
 electrum-client = { version = "0.18" }
 #rustls = { version = "=0.21.1", optional = true, features = ["dangerous_configuration"] }

--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bdk_chain = { path = "../chain", version = "0.6.0", default-features = false }
+bdk_chain = { path = "../chain", version = "0.7.0", default-features = false }
 esplora-client = { version = "0.6.0", default-features = false }
 async-trait = { version = "0.1.66", optional = true }
 futures = { version = "0.3.26", optional = true }

--- a/crates/file_store/Cargo.toml
+++ b/crates/file_store/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["Bitcoin Dev Kit Developers"]
 readme = "README.md"
 
 [dependencies]
-bdk_chain = { path = "../chain", version = "0.6.0", features = [ "serde", "miniscript" ] }
+bdk_chain = { path = "../chain", version = "0.7.0", features = [ "serde", "miniscript" ] }
 bincode = { version = "1" }
 serde = { version = "1", features = ["derive"] }
 


### PR DESCRIPTION
### Description

- Bump bdk version to 1.0.0-alpha.3
- Bump bdk_chain to 0.7.0
- Bump bdk_bitcoin_rpc to 0.2.0
- Bump bdk_electrum to 0.5.0

### Notes to the reviewers



### Changelog notice

See #1254 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
