### PR TITLE
fix(typos): existant -> existent

### DIFF
--- a/crates/bdk/src/wallet/mod.rs
+++ b/crates/bdk/src/wallet/mod.rs
@@ -348,7 +348,7 @@ where
 #[cfg(feature = "std")]
 impl<L> std::error::Error for LoadError<L> where L: core::fmt::Display + core::fmt::Debug {}
 
-/// Error type for when we try load a [`Wallet`] from persistence and creating it if non-existant.
+/// Error type for when we try load a [`Wallet`] from persistence and creating it if non-existent.
 ///
 /// Methods [`new_or_load`] and [`new_or_load_with_genesis_hash`] may return this error.
 ///

--- a/crates/bdk/tests/wallet.rs
+++ b/crates/bdk/tests/wallet.rs
@@ -99,7 +99,7 @@ fn new_or_load() {
     let temp_dir = tempfile::tempdir().expect("must create tempdir");
     let file_path = temp_dir.path().join("store.db");
 
-    // init wallet when non-existant
+    // init wallet when non-existent
     let wallet_keychains = {
         let db = bdk_file_store::Store::open_or_create_new(DB_MAGIC, &file_path)
             .expect("must create db");

--- a/crates/file_store/src/store.rs
+++ b/crates/file_store/src/store.rs
@@ -105,7 +105,7 @@ where
         })
     }
 
-    /// Attempt to open existing [`Store`] file; create it if the file is non-existant.
+    /// Attempt to open existing [`Store`] file; create it if the file is non-existent.
     ///
     /// Internally, this calls either [`open`] or [`create_new`].
     ///


### PR DESCRIPTION
### Description

These typos are blocking the Nix typo CI in #1257

### Notes to the reviewers

Blocking #1257

### Changelog notice

- fix: typos in documentation
- 
### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
