### PR TITLE
Bump `bip39` dependency to v2.0

### DIFF
--- a/crates/bdk/Cargo.toml
+++ b/crates/bdk/Cargo.toml
@@ -22,7 +22,7 @@ bdk_chain = { path = "../chain", version = "0.6.0", features = ["miniscript", "s
 
 # Optional dependencies
 hwi = { version = "0.7.0", optional = true, features = [ "miniscript"] }
-bip39 = { version = "1.0.1", optional = true }
+bip39 = { version = "2.0", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = "0.2"


### PR DESCRIPTION
We previously bumped the `bip39` version to 2.0 [in the 0.2X release branch](https://github.com/bitcoindevkit/bdk/pull/875). Back then, bumping it in `master` was [assumed unnecessary](https://github.com/bitcoindevkit/bdk/pull/875#issuecomment-1483990088). It seems this was erroneous, as the current `1.0.1` dependency is present since https://github.com/bitcoindevkit/bdk/pull/793, which was merged before the bump in `release/0.27`.

Here, we therefore bump the crate version in `master` after all.