### PR TITLE
Bump bdk_esplora and bdk_file_store versions for 1.0.0-alpha.3 release

### DIFF
--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_esplora"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"

--- a/crates/file_store/Cargo.toml
+++ b/crates/file_store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_file_store"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bitcoindevkit/bdk"


### PR DESCRIPTION
### Description

These crates need to have their versions bumped because the version of bdk_chain was bumped to 0.7.0 with the 1.0.0-alpha.3 release.

bdk_esplora to 0.5.0
bdk_file_store to 0.3.0

After this PR is merged I'll publish new versions of these crates to crates.io.

### Notes to the reviewers

I should have done this as part of the 1.0.0-alpha.3 release process.  This problem was found when @thunderbiscuit started updating the bdk-ffi project to alpha.3 and we got type mismatch errors for bdk_chain types used in bdk_esplora.