### PR TITLE
doc, example(bdk): fix derivation path in mnemonic_to_descriptors

### DIFF
--- a/crates/bdk/examples/mnemonic_to_descriptors.rs
+++ b/crates/bdk/examples/mnemonic_to_descriptors.rs
@@ -33,8 +33,8 @@ fn main() -> Result<(), anyhow::Error> {
     let mnemonic_with_passphrase = (mnemonic, None);
 
     // define external and internal derivation key path
-    let external_path = DerivationPath::from_str("m/86h/0h/0h/0").unwrap();
-    let internal_path = DerivationPath::from_str("m/86h/0h/0h/1").unwrap();
+    let external_path = DerivationPath::from_str("m/86h/1h/0h/0").unwrap();
+    let internal_path = DerivationPath::from_str("m/86h/1h/0h/1").unwrap();
 
     // generate external and internal descriptor from mnemonic
     let (external_descriptor, ext_keymap) =


### PR DESCRIPTION
This will help avoid confusion with mainnet descriptors.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
