### PR TITLE
chain: set `DEFAULT_LOOKAHEAD` to 25

### DIFF
--- a/crates/chain/src/keychain/txout_index.rs
+++ b/crates/chain/src/keychain/txout_index.rs
@@ -13,7 +13,7 @@ use core::{
 
 use crate::Append;
 
-const DEFAULT_LOOKAHEAD: u32 = 1_000;
+const DEFAULT_LOOKAHEAD: u32 = 25;
 
 /// [`KeychainTxOutIndex`] controls how script pubkeys are revealed for multiple keychains, and
 /// indexes [`TxOut`]s with them.


### PR DESCRIPTION
### Description

Change `DEFAULT_LOOKAHEAD` to 25, as suggested by @LLFourn in #1262.

Fixes #1262

### Checklists

#### All Submissions:

* [X] I've signed all my commits
* [X] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [X] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [X] I'm linking the issue being fixed by this PR
