### PR TITLE
Fix `ConfirmationTime` conversion from `ChainPosition`

### DIFF
--- a/crates/chain/src/chain_data.rs
+++ b/crates/chain/src/chain_data.rs
@@ -81,7 +81,7 @@ impl From<ChainPosition<ConfirmationTimeHeightAnchor>> for ConfirmationTime {
                 height: a.confirmation_height,
                 time: a.confirmation_time,
             },
-            ChainPosition::Unconfirmed(_) => Self::Unconfirmed { last_seen: 0 },
+            ChainPosition::Unconfirmed(last_seen) => Self::Unconfirmed { last_seen },
         }
     }
 }


### PR DESCRIPTION
### Description

We forgot to include the `last_seen` when converting from `ChainPosition` to `ConfirmationTime`.

### Notes to the reviewers

No brainer.

### Changelog notice

* Fix `ConfirmationTime` conversion from `ChainPosition` to include the `last_seen`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
