### PR TITLE
Implement `ElectrumExt` for all that implements `ElectrumApi`

### DIFF
--- a/crates/electrum/src/electrum_ext.rs
+++ b/crates/electrum/src/electrum_ext.rs
@@ -179,7 +179,7 @@ pub trait ElectrumExt {
     ) -> Result<ElectrumUpdate, Error>;
 }
 
-impl ElectrumExt for Client {
+impl<A: ElectrumApi> ElectrumExt for A {
     fn full_scan<K: Ord + Clone>(
         &self,
         prev_tip: CheckPoint,
@@ -303,7 +303,7 @@ impl ElectrumExt for Client {
 
 /// Return a [`CheckPoint`] of the latest tip, that connects with `prev_tip`.
 fn construct_update_tip(
-    client: &Client,
+    client: &impl ElectrumApi,
     prev_tip: CheckPoint,
 ) -> Result<(CheckPoint, Option<u32>), Error> {
     let HeaderNotification { height, .. } = client.block_headers_subscribe()?;
@@ -417,7 +417,7 @@ fn determine_tx_anchor(
 }
 
 fn populate_with_outpoints(
-    client: &Client,
+    client: &impl ElectrumApi,
     cps: &BTreeMap<u32, CheckPoint>,
     relevant_txids: &mut RelevantTxids,
     outpoints: impl IntoIterator<Item = OutPoint>,
@@ -478,7 +478,7 @@ fn populate_with_outpoints(
 }
 
 fn populate_with_txids(
-    client: &Client,
+    client: &impl ElectrumApi,
     cps: &BTreeMap<u32, CheckPoint>,
     relevant_txids: &mut RelevantTxids,
     txids: impl IntoIterator<Item = Txid>,
@@ -514,7 +514,7 @@ fn populate_with_txids(
 }
 
 fn populate_with_spks<I: Ord + Clone>(
-    client: &Client,
+    client: &impl ElectrumApi,
     cps: &BTreeMap<u32, CheckPoint>,
     relevant_txids: &mut RelevantTxids,
     spks: &mut impl Iterator<Item = (I, ScriptBuf)>,


### PR DESCRIPTION
### Description

Implement `ElectrumExt` for all that implements `ElectrumApi`.

I realized this while looking into #1171.

https://github.com/bitcoindevkit/bdk/blob/2196685cca741a249f4a5b53c7609162469714ba/crates/electrum/tests/test_electrum.rs#L54-L55

Line 55 here should not be necessary.

### Changelog notice

* Changed to implement `ElectrumExt` for all that implements `ElectrumApi`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
