### PR TITLE
Expose method that lists txids of `RelevantTxids`

### DIFF
--- a/crates/electrum/src/electrum_ext.rs
+++ b/crates/electrum/src/electrum_ext.rs
@@ -23,6 +23,11 @@ const CHAIN_SUFFIX_LENGTH: u32 = 8;
 pub struct RelevantTxids(HashMap<Txid, BTreeSet<ConfirmationHeightAnchor>>);
 
 impl RelevantTxids {
+    /// List txids fetched from the Electrum server.
+    pub fn txids(&self) -> impl ExactSizeIterator<Item = Txid> + '_ {
+        self.0.keys().copied()
+    }
+
     /// Determine the full transactions that are missing from `graph`.
     ///
     /// Refer to [`RelevantTxids`] for more details.


### PR DESCRIPTION
### Description

Just in case the caller wants to create an update in one go (A.K.A. not pass data back and forth with `TxGraph`).

### Changelog notice

* Added `RelevantTxids::txids` method that returns all relevant txids.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

~* [ ] I've added tests for the new feature~
* [x] I've added docs for the new feature

