### PR TITLE
Fix `last_seen` in Esplora and Electrum chains [WIP]

### DIFF
--- a/crates/esplora/src/blocking_ext.rs
+++ b/crates/esplora/src/blocking_ext.rs
@@ -314,7 +314,7 @@ impl EsploraExt for esplora_client::BlockingClient {
                             if !status.confirmed {
                                 let last_seen = anchor.confirmation_time;
                                 let _ = graph.insert_seen_at(op.txid, last_seen);
-                            } 
+                            }
                             // else, graph.remove_seen_at or similar as the tx is confirmed
                         }
                     }

--- a/crates/esplora/src/blocking_ext.rs
+++ b/crates/esplora/src/blocking_ext.rs
@@ -295,6 +295,10 @@ impl EsploraExt for esplora_client::BlockingClient {
                 let status = self.get_tx_status(&op.txid)?;
                 if let Some(anchor) = anchor_from_status(&status) {
                     let _ = graph.insert_anchor(op.txid, anchor);
+                    if !status.confirmed {
+                        let last_seen = anchor.confirmation_time;
+                        let _ = graph.insert_seen_at(op.txid, last_seen);
+                    }
                 }
             }
 
@@ -307,6 +311,11 @@ impl EsploraExt for esplora_client::BlockingClient {
                         let status = self.get_tx_status(&txid)?;
                         if let Some(anchor) = anchor_from_status(&status) {
                             let _ = graph.insert_anchor(txid, anchor);
+                            if !status.confirmed {
+                                let last_seen = anchor.confirmation_time;
+                                let _ = graph.insert_seen_at(op.txid, last_seen);
+                            } 
+                            // else, graph.remove_seen_at or similar as the tx is confirmed
                         }
                     }
                 }


### PR DESCRIPTION


### Description

The last seen unix time should be set for mempool transactions (#1336). I started working on this in the blocking Esplora client.

### Notes to the reviewers

I decided to check-in with a WIP to get some clarifications from maintainers. There is a method on `tx_graph` that allows an insertion into the map for storing `last_seen` . This method is `insert_seen_at`, which I think could be called `insert_last_seen` without any ambiguity. When a transaction has been confirmed, there is no method to remove the `Txid` from the map so we don't continually store `last_seen` when a TX has been confirmed. 

Should I add a `remove_seen_at` in `tx_graph`? Or if my naming alternative makes sense, add a `remove_last_seen`?

Thanks (:

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
