### PR TITLE
fix: remove deprecated max_satisfaction_weight

### DIFF
--- a/crates/bdk/src/wallet/tx_builder.rs
+++ b/crates/bdk/src/wallet/tx_builder.rs
@@ -314,8 +314,7 @@ impl<'a, D, Cs, Ctx> TxBuilder<'a, D, Cs, Ctx> {
 
             for utxo in utxos {
                 let descriptor = wallet.get_descriptor_for_keychain(utxo.keychain);
-                #[allow(deprecated)]
-                let satisfaction_weight = descriptor.max_satisfaction_weight().unwrap();
+                let satisfaction_weight = descriptor.max_weight_to_satisfy().unwrap();
                 self.params.utxos.push(WeightedUtxo {
                     satisfaction_weight,
                     utxo: Utxo::Local(utxo),
@@ -356,9 +355,9 @@ impl<'a, D, Cs, Ctx> TxBuilder<'a, D, Cs, Ctx> {
     /// causing you to pay a fee that is too high. The party who is broadcasting the transaction can
     /// of course check the real input weight matches the expected weight prior to broadcasting.
     ///
-    /// To guarantee the `satisfaction_weight` is correct, you can require the party providing the
+    /// To guarantee the `max_weight_to_satisfy` is correct, you can require the party providing the
     /// `psbt_input` provide a miniscript descriptor for the input so you can check it against the
-    /// `script_pubkey` and then ask it for the [`max_satisfaction_weight`].
+    /// `script_pubkey` and then ask it for the [`max_weight_to_satisfy`].
     ///
     /// This is an **EXPERIMENTAL** feature, API and other major changes are expected.
     ///
@@ -379,7 +378,7 @@ impl<'a, D, Cs, Ctx> TxBuilder<'a, D, Cs, Ctx> {
     ///
     /// [`only_witness_utxo`]: Self::only_witness_utxo
     /// [`finish`]: Self::finish
-    /// [`max_satisfaction_weight`]: miniscript::Descriptor::max_satisfaction_weight
+    /// [`max_weight_to_satisfy`]: miniscript::Descriptor::max_weight_to_satisfy
     pub fn add_foreign_utxo(
         &mut self,
         outpoint: OutPoint,

--- a/crates/bdk/tests/wallet.rs
+++ b/crates/bdk/tests/wallet.rs
@@ -1171,10 +1171,9 @@ fn test_add_foreign_utxo() {
         .unwrap()
         .assume_checked();
     let utxo = wallet2.list_unspent().next().expect("must take!");
-    #[allow(deprecated)]
     let foreign_utxo_satisfaction = wallet2
         .get_descriptor_for_keychain(KeychainKind::External)
-        .max_satisfaction_weight()
+        .max_weight_to_satisfy()
         .unwrap();
 
     let psbt_input = psbt::Input {
@@ -1247,10 +1246,9 @@ fn test_calculate_fee_with_missing_foreign_utxo() {
         .unwrap()
         .assume_checked();
     let utxo = wallet2.list_unspent().next().expect("must take!");
-    #[allow(deprecated)]
     let foreign_utxo_satisfaction = wallet2
         .get_descriptor_for_keychain(KeychainKind::External)
-        .max_satisfaction_weight()
+        .max_weight_to_satisfy()
         .unwrap();
 
     let psbt_input = psbt::Input {
@@ -1273,10 +1271,9 @@ fn test_calculate_fee_with_missing_foreign_utxo() {
 fn test_add_foreign_utxo_invalid_psbt_input() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
     let outpoint = wallet.list_unspent().next().expect("must exist").outpoint;
-    #[allow(deprecated)]
     let foreign_utxo_satisfaction = wallet
         .get_descriptor_for_keychain(KeychainKind::External)
-        .max_satisfaction_weight()
+        .max_weight_to_satisfy()
         .unwrap();
 
     let mut builder = wallet.build_tx();
@@ -1295,10 +1292,9 @@ fn test_add_foreign_utxo_where_outpoint_doesnt_match_psbt_input() {
     let tx1 = wallet1.get_tx(txid1).unwrap().tx_node.tx.clone();
     let tx2 = wallet2.get_tx(txid2).unwrap().tx_node.tx.clone();
 
-    #[allow(deprecated)]
     let satisfaction_weight = wallet2
         .get_descriptor_for_keychain(KeychainKind::External)
-        .max_satisfaction_weight()
+        .max_weight_to_satisfy()
         .unwrap();
 
     let mut builder = wallet1.build_tx();
@@ -1340,10 +1336,9 @@ fn test_add_foreign_utxo_only_witness_utxo() {
         .assume_checked();
     let utxo2 = wallet2.list_unspent().next().unwrap();
 
-    #[allow(deprecated)]
     let satisfaction_weight = wallet2
         .get_descriptor_for_keychain(KeychainKind::External)
-        .max_satisfaction_weight()
+        .max_weight_to_satisfy()
         .unwrap();
 
     let mut builder = wallet1.build_tx();
@@ -3074,10 +3069,9 @@ fn test_taproot_foreign_utxo() {
         .assume_checked();
     let utxo = wallet2.list_unspent().next().unwrap();
     let psbt_input = wallet2.get_psbt_input(utxo.clone(), None, false).unwrap();
-    #[allow(deprecated)]
     let foreign_utxo_satisfaction = wallet2
         .get_descriptor_for_keychain(KeychainKind::External)
-        .max_satisfaction_weight()
+        .max_weight_to_satisfy()
         .unwrap();
 
     assert!(


### PR DESCRIPTION
### Description
Continuation of #1115.
Closes #1036.

* Change deprecated `max_satisfaction_weight` to `max_weight_to_satisfy`
* Remove `#[allow(deprecated)]` flags

### Notes to the reviewers

I've changed all `max_satisfaction_weight()` to `max_weight_to_satisfy()` in `Wallet.get_available_utxo()` and `Wallet.build_fee_bump()`. Checking the docs on the `miniscript` crate for `max_weight_to_satisfy` has the following note:

We are testing if the underlying descriptor `is.segwit()` or `.is_taproot`,
then adding 4WU if true or leaving as it is otherwise.

Another thing, we are not testing in BDK tests for legacy (pre-segwit) descriptors.
Should I also add them to this PR?

### Changelog notice
### Fixed
Replace the deprecated `max_satisfaction_weight` from `rust-miniscript` to `max_weight_to_satisfy`.

### Checklists
#### All Submissions:
* [x]  I've signed all my commits
* [x]  I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x]  I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:
* [ ]  This pull request breaks the existing API
* [ ]  I've added tests to reproduce the issue which are now passing
* [x]  I'm linking the issue being fixed by this PR
