### PR TITLE
Fix `KeychainTxOutIndex::lookahead_to_target`

### DIFF
--- a/crates/chain/src/keychain/txout_index.rs
+++ b/crates/chain/src/keychain/txout_index.rs
@@ -326,12 +326,17 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
         self.lookahead
     }
 
-    /// Store lookahead scripts until `target_index`.
+    /// Store lookahead scripts until `target_index` (inclusive).
     ///
-    /// This does not change the `lookahead` setting.
+    /// This does not change the global `lookahead` setting.
     pub fn lookahead_to_target(&mut self, keychain: &K, target_index: u32) {
-        let next_index = self.next_store_index(keychain);
-        if let Some(temp_lookahead) = target_index.checked_sub(next_index).filter(|&v| v > 0) {
+        let (next_index, _) = self.next_index(keychain);
+
+        let temp_lookahead = (target_index + 1)
+            .checked_sub(next_index)
+            .filter(|&index| index > 0);
+
+        if let Some(temp_lookahead) = temp_lookahead {
             self.replenish_lookahead(keychain, temp_lookahead);
         }
     }

--- a/crates/chain/tests/test_keychain_txout_index.rs
+++ b/crates/chain/tests/test_keychain_txout_index.rs
@@ -392,11 +392,16 @@ fn test_non_wildcard_derivations() {
 fn lookahead_to_target() {
     #[derive(Default)]
     struct TestCase {
-        lookahead: u32,                      // Global lookahead value
-        external_last_revealed: Option<u32>, // Last revealed index for external keychain
-        internal_last_revealed: Option<u32>, // Last revealed index for internal keychain
-        external_target: Option<u32>,        // Call `lookahead_to_target(External, u32)`
-        internal_target: Option<u32>,        // Call `lookahead_to_target(Internal, u32)`
+        /// Global lookahead value.
+        lookahead: u32,
+        /// Last revealed index for external keychain.
+        external_last_revealed: Option<u32>,
+        /// Last revealed index for internal keychain.
+        internal_last_revealed: Option<u32>,
+        /// Call `lookahead_to_target(External, u32)`.
+        external_target: Option<u32>,
+        /// Call `lookahead_to_target(Internal, u32)`.
+        internal_target: Option<u32>,
     }
 
     let test_cases = &[


### PR DESCRIPTION
### Description

This method was not used (so it was untested) and it was not working. This fixes it.

The old implementation used `.next_store_index` which returned the keychain's last index stored in `.inner` (which include lookahead spks). This is WRONG because `.replenish_lookahead` needs the difference from last revealed.

### Changelog notice

Fix `KeychainTxOutIndex::lookahead_to_target`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [x] I've added tests to reproduce the issue which are now passing
