### PR TITLE
docs: update docs to point to `derivation_of_spk`

### DIFF
--- a/crates/bdk/src/wallet/mod.rs
+++ b/crates/bdk/src/wallet/mod.rs
@@ -815,6 +815,8 @@ impl<D> Wallet<D> {
     }
 
     /// Return whether or not a `script` is part of this wallet (either internal or external)
+    /// Use `derivation_of_spk` function to find the `KeychainKind` for the `script`, or
+    /// None if there's no  associated `Keychain`.
     pub fn is_mine(&self, script: &Script) -> bool {
         self.indexed_graph.index.index_of_spk(script).is_some()
     }


### PR DESCRIPTION
Updated docs  of `Wallet.is_mine()` function to point `derivation_of_spk` function to find whether a `KeychainKind` exits  for the given `script` or not.

fix #1042


* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing


