### PR TITLE
refactor: replace `get_address` & `get_balance` to `address` & `balance` resp

### DIFF
--- a/crates/bdk/README.md
+++ b/crates/bdk/README.md
@@ -75,7 +75,7 @@ fn main() {
     let mut wallet = Wallet::new(descriptor, None, db, Network::Testnet).expect("should create");
 
     // get a new address (this increments revealed derivation index)
-    println!("revealed address: {}", wallet.get_address(AddressIndex::New));
+    println!("revealed address: {}", wallet.address(AddressIndex::New));
     println!("staged changes: {:?}", wallet.staged());
     // persist changes
     wallet.commit().expect("must save");
@@ -101,7 +101,7 @@ fn main() {
 
 <!--     wallet.sync(&blockchain, SyncOptions::default())?; -->
 
-<!--     println!("Descriptor balance: {} SAT", wallet.get_balance()?); -->
+<!--     println!("Descriptor balance: {} SAT", wallet.balance()?); -->
 
 <!--     Ok(()) -->
 <!-- } -->
@@ -120,9 +120,9 @@ fn main() {
 <!--         Network::Testnet, -->
 <!--     )?; -->
 
-<!--     println!("Address #0: {}", wallet.get_address(New)); -->
-<!--     println!("Address #1: {}", wallet.get_address(New)); -->
-<!--     println!("Address #2: {}", wallet.get_address(New)); -->
+<!--     println!("Address #0: {}", wallet.address(New)); -->
+<!--     println!("Address #1: {}", wallet.address(New)); -->
+<!--     println!("Address #2: {}", wallet.address(New)); -->
 
 <!--     Ok(()) -->
 <!-- } -->
@@ -151,7 +151,7 @@ fn main() {
 
 <!--     wallet.sync(&blockchain, SyncOptions::default())?; -->
 
-<!--     let send_to = wallet.get_address(New); -->
+<!--     let send_to = wallet.address(New); -->
 <!--     let (psbt, details) = { -->
 <!--         let mut builder = wallet.build_tx(); -->
 <!--         builder -->

--- a/crates/bdk/examples/compiler.rs
+++ b/crates/bdk/examples/compiler.rs
@@ -51,7 +51,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     println!(
         "First derived address from the descriptor: \n{}",
-        wallet.get_address(New)
+        wallet.address(New)
     );
 
     // BDK also has it's own `Policy` structure to represent the spending condition in a more

--- a/crates/bdk/src/descriptor/template.rs
+++ b/crates/bdk/src/descriptor/template.rs
@@ -82,7 +82,7 @@ impl<T: DescriptorTemplate> IntoWalletDescriptor for T {
 /// let mut wallet = Wallet::new_no_persist(P2Pkh(key), None, Network::Testnet)?;
 ///
 /// assert_eq!(
-///     wallet.get_address(New).to_string(),
+///     wallet.address(New).to_string(),
 ///     "mwJ8hxFYW19JLuc65RCTaP4v1rzVU8cVMT"
 /// );
 /// # Ok::<_, Box<dyn std::error::Error>>(())
@@ -110,7 +110,7 @@ impl<K: IntoDescriptorKey<Legacy>> DescriptorTemplate for P2Pkh<K> {
 /// let mut wallet = Wallet::new_no_persist(P2Wpkh_P2Sh(key), None, Network::Testnet)?;
 ///
 /// assert_eq!(
-///     wallet.get_address(AddressIndex::New).to_string(),
+///     wallet.address(AddressIndex::New).to_string(),
 ///     "2NB4ox5VDRw1ecUv6SnT3VQHPXveYztRqk5"
 /// );
 /// # Ok::<_, Box<dyn std::error::Error>>(())
@@ -139,7 +139,7 @@ impl<K: IntoDescriptorKey<Segwitv0>> DescriptorTemplate for P2Wpkh_P2Sh<K> {
 /// let mut wallet = Wallet::new_no_persist(P2Wpkh(key), None, Network::Testnet)?;
 ///
 /// assert_eq!(
-///     wallet.get_address(New).to_string(),
+///     wallet.address(New).to_string(),
 ///     "tb1q4525hmgw265tl3drrl8jjta7ayffu6jf68ltjd"
 /// );
 /// # Ok::<_, Box<dyn std::error::Error>>(())
@@ -167,7 +167,7 @@ impl<K: IntoDescriptorKey<Segwitv0>> DescriptorTemplate for P2Wpkh<K> {
 /// let mut wallet = Wallet::new_no_persist(P2TR(key), None, Network::Testnet)?;
 ///
 /// assert_eq!(
-///     wallet.get_address(New).to_string(),
+///     wallet.address(New).to_string(),
 ///     "tb1pvjf9t34fznr53u5tqhejz4nr69luzkhlvsdsdfq9pglutrpve2xq7hps46"
 /// );
 /// # Ok::<_, Box<dyn std::error::Error>>(())
@@ -202,7 +202,7 @@ impl<K: IntoDescriptorKey<Tap>> DescriptorTemplate for P2TR<K> {
 ///     Network::Testnet,
 /// )?;
 ///
-/// assert_eq!(wallet.get_address(New).to_string(), "mmogjc7HJEZkrLqyQYqJmxUqFaC7i4uf89");
+/// assert_eq!(wallet.address(New).to_string(), "mmogjc7HJEZkrLqyQYqJmxUqFaC7i4uf89");
 /// assert_eq!(wallet.public_descriptor(KeychainKind::External).unwrap().to_string(), "pkh([c55b303f/44'/1'/0']tpubDCuorCpzvYS2LCD75BR46KHE8GdDeg1wsAgNZeNr6DaB5gQK1o14uErKwKLuFmeemkQ6N2m3rNgvctdJLyr7nwu2yia7413Hhg8WWE44cgT/0/*)#5wrnv0xt");
 /// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
@@ -240,7 +240,7 @@ impl<K: DerivableKey<Legacy>> DescriptorTemplate for Bip44<K> {
 ///     Network::Testnet,
 /// )?;
 ///
-/// assert_eq!(wallet.get_address(New).to_string(), "miNG7dJTzJqNbFS19svRdTCisC65dsubtR");
+/// assert_eq!(wallet.address(New).to_string(), "miNG7dJTzJqNbFS19svRdTCisC65dsubtR");
 /// assert_eq!(wallet.public_descriptor(KeychainKind::External).unwrap().to_string(), "pkh([c55b303f/44'/1'/0']tpubDDDzQ31JkZB7VxUr9bjvBivDdqoFLrDPyLWtLapArAi51ftfmCb2DPxwLQzX65iNcXz1DGaVvyvo6JQ6rTU73r2gqdEo8uov9QKRb7nKCSU/0/*)#cfhumdqz");
 /// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
@@ -277,7 +277,7 @@ impl<K: DerivableKey<Legacy>> DescriptorTemplate for Bip44Public<K> {
 ///     Network::Testnet,
 /// )?;
 ///
-/// assert_eq!(wallet.get_address(New).to_string(), "2N4zkWAoGdUv4NXhSsU8DvS5MB36T8nKHEB");
+/// assert_eq!(wallet.address(New).to_string(), "2N4zkWAoGdUv4NXhSsU8DvS5MB36T8nKHEB");
 /// assert_eq!(wallet.public_descriptor(KeychainKind::External).unwrap().to_string(), "sh(wpkh([c55b303f/49'/1'/0']tpubDDYr4kdnZgjjShzYNjZUZXUUtpXaofdkMaipyS8ThEh45qFmhT4hKYways7UXmg6V7het1QiFo9kf4kYUXyDvV4rHEyvSpys9pjCB3pukxi/0/*))#s9vxlc8e");
 /// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
@@ -315,7 +315,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip49<K> {
 ///     Network::Testnet,
 /// )?;
 ///
-/// assert_eq!(wallet.get_address(New).to_string(), "2N3K4xbVAHoiTQSwxkZjWDfKoNC27pLkYnt");
+/// assert_eq!(wallet.address(New).to_string(), "2N3K4xbVAHoiTQSwxkZjWDfKoNC27pLkYnt");
 /// assert_eq!(wallet.public_descriptor(KeychainKind::External).unwrap().to_string(), "sh(wpkh([c55b303f/49'/1'/0']tpubDC49r947KGK52X5rBWS4BLs5m9SRY3pYHnvRrm7HcybZ3BfdEsGFyzCMzayi1u58eT82ZeyFZwH7DD6Q83E3fM9CpfMtmnTygnLfP59jL9L/0/*))#3tka9g0q");
 /// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
@@ -352,7 +352,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip49Public<K> {
 ///     Network::Testnet,
 /// )?;
 ///
-/// assert_eq!(wallet.get_address(New).to_string(), "tb1qhl85z42h7r4su5u37rvvw0gk8j2t3n9y7zsg4n");
+/// assert_eq!(wallet.address(New).to_string(), "tb1qhl85z42h7r4su5u37rvvw0gk8j2t3n9y7zsg4n");
 /// assert_eq!(wallet.public_descriptor(KeychainKind::External).unwrap().to_string(), "wpkh([c55b303f/84'/1'/0']tpubDDc5mum24DekpNw92t6fHGp8Gr2JjF9J7i4TZBtN6Vp8xpAULG5CFaKsfugWa5imhrQQUZKXe261asP5koDHo5bs3qNTmf3U3o4v9SaB8gg/0/*)#6kfecsmr");
 /// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
@@ -390,7 +390,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip84<K> {
 ///     Network::Testnet,
 /// )?;
 ///
-/// assert_eq!(wallet.get_address(New).to_string(), "tb1qedg9fdlf8cnnqfd5mks6uz5w4kgpk2pr6y4qc7");
+/// assert_eq!(wallet.address(New).to_string(), "tb1qedg9fdlf8cnnqfd5mks6uz5w4kgpk2pr6y4qc7");
 /// assert_eq!(wallet.public_descriptor(KeychainKind::External).unwrap().to_string(), "wpkh([c55b303f/84'/1'/0']tpubDC2Qwo2TFsaNC4ju8nrUJ9mqVT3eSgdmy1yPqhgkjwmke3PRXutNGRYAUo6RCHTcVQaDR3ohNU9we59brGHuEKPvH1ags2nevW5opEE9Z5Q/0/*)#dhu402yv");
 /// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
@@ -427,7 +427,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip84Public<K> {
 ///     Network::Testnet,
 /// )?;
 ///
-/// assert_eq!(wallet.get_address(New).to_string(), "tb1p5unlj09djx8xsjwe97269kqtxqpwpu2epeskgqjfk4lnf69v4tnqpp35qu");
+/// assert_eq!(wallet.address(New).to_string(), "tb1p5unlj09djx8xsjwe97269kqtxqpwpu2epeskgqjfk4lnf69v4tnqpp35qu");
 /// assert_eq!(wallet.public_descriptor(KeychainKind::External).unwrap().to_string(), "tr([c55b303f/86'/1'/0']tpubDCiHofpEs47kx358bPdJmTZHmCDqQ8qw32upCSxHrSEdeeBs2T5Mq6QMB2ukeMqhNBiyhosBvJErteVhfURPGXPv3qLJPw5MVpHUewsbP2m/0/*)#dkgvr5hm");
 /// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```
@@ -465,7 +465,7 @@ impl<K: DerivableKey<Tap>> DescriptorTemplate for Bip86<K> {
 ///     Network::Testnet,
 /// )?;
 ///
-/// assert_eq!(wallet.get_address(New).to_string(), "tb1pwjp9f2k5n0xq73ecuu0c5njvgqr3vkh7yaylmpqvsuuaafymh0msvcmh37");
+/// assert_eq!(wallet.address(New).to_string(), "tb1pwjp9f2k5n0xq73ecuu0c5njvgqr3vkh7yaylmpqvsuuaafymh0msvcmh37");
 /// assert_eq!(wallet.public_descriptor(KeychainKind::External).unwrap().to_string(), "tr([c55b303f/86'/1'/0']tpubDC2Qwo2TFsaNC4ju8nrUJ9mqVT3eSgdmy1yPqhgkjwmke3PRXutNGRYAUo6RCHTcVQaDR3ohNU9we59brGHuEKPvH1ags2nevW5opEE9Z5Q/0/*)#2p65srku");
 /// # Ok::<_, Box<dyn std::error::Error>>(())
 /// ```

--- a/crates/bdk/src/wallet/mod.rs
+++ b/crates/bdk/src/wallet/mod.rs
@@ -180,7 +180,7 @@ impl
 }
 
 /// The address index selection strategy to use to derived an address from the wallet's external
-/// descriptor. See [`Wallet::get_address`]. If you're unsure which one to use use `WalletIndex::New`.
+/// descriptor. See [`Wallet::address`]. If you're unsure which one to use use `WalletIndex::New`.
 #[derive(Debug)]
 pub enum AddressIndex {
     /// Return a new address after incrementing the current descriptor index.
@@ -269,7 +269,7 @@ where
     ///
     /// This panics when the caller requests for an address of derivation index greater than the
     /// BIP32 max index.
-    pub fn get_address(&mut self, address_index: AddressIndex) -> AddressInfo {
+    pub fn address(&mut self, address_index: AddressIndex) -> AddressInfo {
         self.try_get_address(address_index).unwrap()
     }
 
@@ -1177,7 +1177,7 @@ impl<D> Wallet<D> {
 
     /// Return the balance, separated into available, trusted-pending, untrusted-pending and immature
     /// values.
-    pub fn get_balance(&self) -> Balance {
+    pub fn balance(&self) -> Balance {
         self.indexed_graph.graph().balance(
             &self.chain,
             self.chain.tip().block_id(),
@@ -2583,7 +2583,7 @@ macro_rules! doctest_wallet {
             Network::Regtest,
         )
         .unwrap();
-        let address = wallet.get_address(AddressIndex::New).address;
+        let address = wallet.address(AddressIndex::New).address;
         let tx = Transaction {
             version: 1,
             lock_time: absolute::LockTime::ZERO,

--- a/crates/bdk/tests/common.rs
+++ b/crates/bdk/tests/common.rs
@@ -17,7 +17,7 @@ pub fn get_funded_wallet_with_change(
     change: Option<&str>,
 ) -> (Wallet, bitcoin::Txid) {
     let mut wallet = Wallet::new_no_persist(descriptor, change, Network::Regtest).unwrap();
-    let change_address = wallet.get_address(AddressIndex::New).address;
+    let change_address = wallet.address(AddressIndex::New).address;
     let sendto_address = Address::from_str("bcrt1q3qtze4ys45tgdvguj66zrk4fu6hq3a3v9pfly5")
         .expect("address")
         .require_network(Network::Regtest)

--- a/crates/bdk/tests/psbt.rs
+++ b/crates/bdk/tests/psbt.rs
@@ -15,7 +15,7 @@ const PSBT_STR: &str = "cHNidP8BAKACAAAAAqsJSaCMWvfEm4IS9Bfi8Vqz9cM9zxU4IagTn4d6
 fn test_psbt_malformed_psbt_input_legacy() {
     let psbt_bip = Psbt::from_str(PSBT_STR).unwrap();
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let send_to = wallet.get_address(AddressIndex::New);
+    let send_to = wallet.address(AddressIndex::New);
     let mut builder = wallet.build_tx();
     builder.add_recipient(send_to.script_pubkey(), 10_000);
     let mut psbt = builder.finish().unwrap();
@@ -32,7 +32,7 @@ fn test_psbt_malformed_psbt_input_legacy() {
 fn test_psbt_malformed_psbt_input_segwit() {
     let psbt_bip = Psbt::from_str(PSBT_STR).unwrap();
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let send_to = wallet.get_address(AddressIndex::New);
+    let send_to = wallet.address(AddressIndex::New);
     let mut builder = wallet.build_tx();
     builder.add_recipient(send_to.script_pubkey(), 10_000);
     let mut psbt = builder.finish().unwrap();
@@ -48,7 +48,7 @@ fn test_psbt_malformed_psbt_input_segwit() {
 #[should_panic(expected = "InputIndexOutOfRange")]
 fn test_psbt_malformed_tx_input() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let send_to = wallet.get_address(AddressIndex::New);
+    let send_to = wallet.address(AddressIndex::New);
     let mut builder = wallet.build_tx();
     builder.add_recipient(send_to.script_pubkey(), 10_000);
     let mut psbt = builder.finish().unwrap();
@@ -64,7 +64,7 @@ fn test_psbt_malformed_tx_input() {
 fn test_psbt_sign_with_finalized() {
     let psbt_bip = Psbt::from_str(PSBT_STR).unwrap();
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let send_to = wallet.get_address(AddressIndex::New);
+    let send_to = wallet.address(AddressIndex::New);
     let mut builder = wallet.build_tx();
     builder.add_recipient(send_to.script_pubkey(), 10_000);
     let mut psbt = builder.finish().unwrap();
@@ -85,7 +85,7 @@ fn test_psbt_fee_rate_with_witness_utxo() {
     let expected_fee_rate = 1.2345;
 
     let (mut wallet, _) = get_funded_wallet("wpkh(tprv8ZgxMBicQKsPd3EupYiPRhaMooHKUHJxNsTfYuScep13go8QFfHdtkG9nRkFGb7busX4isf6X9dURGCoKgitaApQ6MupRhZMcELAxTBRJgS/*)");
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.drain_to(addr.script_pubkey()).drain_wallet();
     builder.fee_rate(FeeRate::from_sat_per_vb(expected_fee_rate));
@@ -110,7 +110,7 @@ fn test_psbt_fee_rate_with_nonwitness_utxo() {
     let expected_fee_rate = 1.2345;
 
     let (mut wallet, _) = get_funded_wallet("pkh(tprv8ZgxMBicQKsPd3EupYiPRhaMooHKUHJxNsTfYuScep13go8QFfHdtkG9nRkFGb7busX4isf6X9dURGCoKgitaApQ6MupRhZMcELAxTBRJgS/*)");
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.drain_to(addr.script_pubkey()).drain_wallet();
     builder.fee_rate(FeeRate::from_sat_per_vb(expected_fee_rate));
@@ -134,7 +134,7 @@ fn test_psbt_fee_rate_with_missing_txout() {
     let expected_fee_rate = 1.2345;
 
     let (mut wpkh_wallet,  _) = get_funded_wallet("wpkh(tprv8ZgxMBicQKsPd3EupYiPRhaMooHKUHJxNsTfYuScep13go8QFfHdtkG9nRkFGb7busX4isf6X9dURGCoKgitaApQ6MupRhZMcELAxTBRJgS/*)");
-    let addr = wpkh_wallet.get_address(New);
+    let addr = wpkh_wallet.address(New);
     let mut builder = wpkh_wallet.build_tx();
     builder.drain_to(addr.script_pubkey()).drain_wallet();
     builder.fee_rate(FeeRate::from_sat_per_vb(expected_fee_rate));
@@ -146,7 +146,7 @@ fn test_psbt_fee_rate_with_missing_txout() {
     assert!(wpkh_psbt.fee_rate().is_none());
 
     let (mut pkh_wallet,  _) = get_funded_wallet("pkh(tprv8ZgxMBicQKsPd3EupYiPRhaMooHKUHJxNsTfYuScep13go8QFfHdtkG9nRkFGb7busX4isf6X9dURGCoKgitaApQ6MupRhZMcELAxTBRJgS/*)");
-    let addr = pkh_wallet.get_address(New);
+    let addr = pkh_wallet.address(New);
     let mut builder = pkh_wallet.build_tx();
     builder.drain_to(addr.script_pubkey()).drain_wallet();
     builder.fee_rate(FeeRate::from_sat_per_vb(expected_fee_rate));
@@ -167,7 +167,7 @@ fn test_psbt_multiple_internalkey_signers() {
 
     let secp = Secp256k1::new();
     let (mut wallet, _) = get_funded_wallet(get_test_tr_single_sig());
-    let send_to = wallet.get_address(AddressIndex::New);
+    let send_to = wallet.address(AddressIndex::New);
     let mut builder = wallet.build_tx();
     builder.add_recipient(send_to.script_pubkey(), 10_000);
     let mut psbt = builder.finish().unwrap();

--- a/crates/bdk/tests/wallet.rs
+++ b/crates/bdk/tests/wallet.rs
@@ -31,7 +31,7 @@ fn receive_output(wallet: &mut Wallet, value: u64, height: ConfirmationTime) -> 
         lock_time: absolute::LockTime::ZERO,
         input: vec![],
         output: vec![TxOut {
-            script_pubkey: wallet.get_address(LastUnused).script_pubkey(),
+            script_pubkey: wallet.address(LastUnused).script_pubkey(),
             value,
         }],
     };
@@ -199,7 +199,7 @@ fn test_get_funded_wallet_balance() {
     // The funded wallet contains a tx with a 76_000 sats input and two outputs, one spending 25_000
     // to a foreign address and one returning 50_000 back to the wallet as change. The remaining 1000
     // sats are the transaction fee.
-    assert_eq!(wallet.get_balance().confirmed, 50_000);
+    assert_eq!(wallet.balance().confirmed, 50_000);
 }
 
 #[test]
@@ -335,7 +335,7 @@ fn test_create_tx_empty_recipients() {
 #[should_panic(expected = "NoUtxosSelected")]
 fn test_create_tx_manually_selected_empty_utxos() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), 25_000)
@@ -346,7 +346,7 @@ fn test_create_tx_manually_selected_empty_utxos() {
 #[test]
 fn test_create_tx_version_0() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), 25_000)
@@ -357,7 +357,7 @@ fn test_create_tx_version_0() {
 #[test]
 fn test_create_tx_version_1_csv() {
     let (mut wallet, _) = get_funded_wallet(get_test_single_sig_csv());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), 25_000)
@@ -368,7 +368,7 @@ fn test_create_tx_version_1_csv() {
 #[test]
 fn test_create_tx_custom_version() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), 25_000)
@@ -382,7 +382,7 @@ fn test_create_tx_custom_version() {
 fn test_create_tx_default_locktime_is_last_sync_height() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
 
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.add_recipient(addr.script_pubkey(), 25_000);
     let psbt = builder.finish().unwrap();
@@ -395,7 +395,7 @@ fn test_create_tx_default_locktime_is_last_sync_height() {
 #[test]
 fn test_create_tx_fee_sniping_locktime_last_sync() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.add_recipient(addr.script_pubkey(), 25_000);
 
@@ -411,7 +411,7 @@ fn test_create_tx_fee_sniping_locktime_last_sync() {
 #[test]
 fn test_create_tx_default_locktime_cltv() {
     let (mut wallet, _) = get_funded_wallet(get_test_single_sig_cltv());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.add_recipient(addr.script_pubkey(), 25_000);
     let psbt = builder.finish().unwrap();
@@ -422,7 +422,7 @@ fn test_create_tx_default_locktime_cltv() {
 #[test]
 fn test_create_tx_custom_locktime() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), 25_000)
@@ -439,7 +439,7 @@ fn test_create_tx_custom_locktime() {
 #[test]
 fn test_create_tx_custom_locktime_compatible_with_cltv() {
     let (mut wallet, _) = get_funded_wallet(get_test_single_sig_cltv());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), 25_000)
@@ -452,7 +452,7 @@ fn test_create_tx_custom_locktime_compatible_with_cltv() {
 #[test]
 fn test_create_tx_custom_locktime_incompatible_with_cltv() {
     let (mut wallet, _) = get_funded_wallet(get_test_single_sig_cltv());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), 25_000)
@@ -465,7 +465,7 @@ fn test_create_tx_custom_locktime_incompatible_with_cltv() {
 #[test]
 fn test_create_tx_no_rbf_csv() {
     let (mut wallet, _) = get_funded_wallet(get_test_single_sig_csv());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.add_recipient(addr.script_pubkey(), 25_000);
     let psbt = builder.finish().unwrap();
@@ -476,7 +476,7 @@ fn test_create_tx_no_rbf_csv() {
 #[test]
 fn test_create_tx_with_default_rbf_csv() {
     let (mut wallet, _) = get_funded_wallet(get_test_single_sig_csv());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), 25_000)
@@ -490,7 +490,7 @@ fn test_create_tx_with_default_rbf_csv() {
 #[test]
 fn test_create_tx_with_custom_rbf_csv() {
     let (mut wallet, _) = get_funded_wallet(get_test_single_sig_csv());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), 25_000)
@@ -503,7 +503,7 @@ fn test_create_tx_with_custom_rbf_csv() {
 #[test]
 fn test_create_tx_no_rbf_cltv() {
     let (mut wallet, _) = get_funded_wallet(get_test_single_sig_cltv());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.add_recipient(addr.script_pubkey(), 25_000);
     let psbt = builder.finish().unwrap();
@@ -514,7 +514,7 @@ fn test_create_tx_no_rbf_cltv() {
 #[test]
 fn test_create_tx_invalid_rbf_sequence() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), 25_000)
@@ -525,7 +525,7 @@ fn test_create_tx_invalid_rbf_sequence() {
 #[test]
 fn test_create_tx_custom_rbf_sequence() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), 25_000)
@@ -538,7 +538,7 @@ fn test_create_tx_custom_rbf_sequence() {
 #[test]
 fn test_create_tx_default_sequence() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.add_recipient(addr.script_pubkey(), 25_000);
     let psbt = builder.finish().unwrap();
@@ -549,7 +549,7 @@ fn test_create_tx_default_sequence() {
 #[test]
 fn test_create_tx_change_policy_no_internal() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), 25_000)
@@ -572,7 +572,7 @@ macro_rules! check_fee {
 #[test]
 fn test_create_tx_drain_wallet_and_drain_to() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.drain_to(addr.script_pubkey()).drain_wallet();
     let psbt = builder.finish().unwrap();
@@ -588,7 +588,7 @@ fn test_create_tx_drain_wallet_and_drain_to_and_with_recipient() {
     let addr = Address::from_str("2N4eQYCbKUHCCTUjBJeHcJp9ok6J2GZsTDt")
         .unwrap()
         .assume_checked();
-    let drain_addr = wallet.get_address(New);
+    let drain_addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), 20_000)
@@ -614,7 +614,7 @@ fn test_create_tx_drain_wallet_and_drain_to_and_with_recipient() {
 #[test]
 fn test_create_tx_drain_to_and_utxos() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let utxos: Vec<_> = wallet.list_unspent().map(|u| u.outpoint).collect();
     let mut builder = wallet.build_tx();
     builder
@@ -632,7 +632,7 @@ fn test_create_tx_drain_to_and_utxos() {
 #[should_panic(expected = "NoRecipients")]
 fn test_create_tx_drain_to_no_drain_wallet_no_utxos() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let drain_addr = wallet.get_address(New);
+    let drain_addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.drain_to(drain_addr.script_pubkey());
     builder.finish().unwrap();
@@ -641,7 +641,7 @@ fn test_create_tx_drain_to_no_drain_wallet_no_utxos() {
 #[test]
 fn test_create_tx_default_fee_rate() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.add_recipient(addr.script_pubkey(), 25_000);
     let psbt = builder.finish().unwrap();
@@ -653,7 +653,7 @@ fn test_create_tx_default_fee_rate() {
 #[test]
 fn test_create_tx_custom_fee_rate() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), 25_000)
@@ -667,7 +667,7 @@ fn test_create_tx_custom_fee_rate() {
 #[test]
 fn test_create_tx_absolute_fee() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .drain_to(addr.script_pubkey())
@@ -684,7 +684,7 @@ fn test_create_tx_absolute_fee() {
 #[test]
 fn test_create_tx_absolute_zero_fee() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .drain_to(addr.script_pubkey())
@@ -702,7 +702,7 @@ fn test_create_tx_absolute_zero_fee() {
 #[should_panic(expected = "InsufficientFunds")]
 fn test_create_tx_absolute_high_fee() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .drain_to(addr.script_pubkey())
@@ -716,7 +716,7 @@ fn test_create_tx_add_change() {
     use bdk::wallet::tx_builder::TxOrdering;
 
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), 25_000)
@@ -732,7 +732,7 @@ fn test_create_tx_add_change() {
 #[test]
 fn test_create_tx_skip_change_dust() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.add_recipient(addr.script_pubkey(), 49_800);
     let psbt = builder.finish().unwrap();
@@ -747,7 +747,7 @@ fn test_create_tx_skip_change_dust() {
 #[should_panic(expected = "InsufficientFunds")]
 fn test_create_tx_drain_to_dust_amount() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     // very high fee rate, so that the only output would be below dust
     let mut builder = wallet.build_tx();
     builder
@@ -760,7 +760,7 @@ fn test_create_tx_drain_to_dust_amount() {
 #[test]
 fn test_create_tx_ordering_respected() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), 30_000)
@@ -778,7 +778,7 @@ fn test_create_tx_ordering_respected() {
 #[test]
 fn test_create_tx_default_sighash() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.add_recipient(addr.script_pubkey(), 30_000);
     let psbt = builder.finish().unwrap();
@@ -789,7 +789,7 @@ fn test_create_tx_default_sighash() {
 #[test]
 fn test_create_tx_custom_sighash() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), 30_000)
@@ -808,7 +808,7 @@ fn test_create_tx_input_hd_keypaths() {
     use core::str::FromStr;
 
     let (mut wallet, _) = get_funded_wallet("wpkh([d34db33f/44'/0'/0']tpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)");
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.drain_to(addr.script_pubkey()).drain_wallet();
     let psbt = builder.finish().unwrap();
@@ -830,7 +830,7 @@ fn test_create_tx_output_hd_keypaths() {
 
     let (mut wallet, _) = get_funded_wallet("wpkh([d34db33f/44'/0'/0']tpubDEnoLuPdBep9bzw5LoGYpsxUQYheRQ9gcgrJhJEcdKFB9cWQRyYmkCyRoTqeD4tJYiVVgt6A3rN6rWn9RYhR9sBsGxji29LYWHuKKbdb1ev/0/*)");
 
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.drain_to(addr.script_pubkey()).drain_wallet();
     let psbt = builder.finish().unwrap();
@@ -852,7 +852,7 @@ fn test_create_tx_set_redeem_script_p2sh() {
 
     let (mut wallet, _) =
         get_funded_wallet("sh(pk(cVpPVruEDdmutPzisEsYvtST1usBR3ntr8pXSyt6D2YYqXRyPcFW))");
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.drain_to(addr.script_pubkey()).drain_wallet();
     let psbt = builder.finish().unwrap();
@@ -875,7 +875,7 @@ fn test_create_tx_set_witness_script_p2wsh() {
 
     let (mut wallet, _) =
         get_funded_wallet("wsh(pk(cVpPVruEDdmutPzisEsYvtST1usBR3ntr8pXSyt6D2YYqXRyPcFW))");
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.drain_to(addr.script_pubkey()).drain_wallet();
     let psbt = builder.finish().unwrap();
@@ -896,7 +896,7 @@ fn test_create_tx_set_witness_script_p2wsh() {
 fn test_create_tx_set_redeem_witness_script_p2wsh_p2sh() {
     let (mut wallet, _) =
         get_funded_wallet("sh(wsh(pk(cVpPVruEDdmutPzisEsYvtST1usBR3ntr8pXSyt6D2YYqXRyPcFW)))");
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.drain_to(addr.script_pubkey()).drain_wallet();
     let psbt = builder.finish().unwrap();
@@ -914,7 +914,7 @@ fn test_create_tx_set_redeem_witness_script_p2wsh_p2sh() {
 fn test_create_tx_non_witness_utxo() {
     let (mut wallet, _) =
         get_funded_wallet("sh(pk(cVpPVruEDdmutPzisEsYvtST1usBR3ntr8pXSyt6D2YYqXRyPcFW))");
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.drain_to(addr.script_pubkey()).drain_wallet();
     let psbt = builder.finish().unwrap();
@@ -927,7 +927,7 @@ fn test_create_tx_non_witness_utxo() {
 fn test_create_tx_only_witness_utxo() {
     let (mut wallet, _) =
         get_funded_wallet("wsh(pk(cVpPVruEDdmutPzisEsYvtST1usBR3ntr8pXSyt6D2YYqXRyPcFW))");
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .drain_to(addr.script_pubkey())
@@ -943,7 +943,7 @@ fn test_create_tx_only_witness_utxo() {
 fn test_create_tx_shwpkh_has_witness_utxo() {
     let (mut wallet, _) =
         get_funded_wallet("sh(wpkh(cVpPVruEDdmutPzisEsYvtST1usBR3ntr8pXSyt6D2YYqXRyPcFW))");
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.drain_to(addr.script_pubkey()).drain_wallet();
     let psbt = builder.finish().unwrap();
@@ -955,7 +955,7 @@ fn test_create_tx_shwpkh_has_witness_utxo() {
 fn test_create_tx_both_non_witness_utxo_and_witness_utxo_default() {
     let (mut wallet, _) =
         get_funded_wallet("wsh(pk(cVpPVruEDdmutPzisEsYvtST1usBR3ntr8pXSyt6D2YYqXRyPcFW))");
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.drain_to(addr.script_pubkey()).drain_wallet();
     let psbt = builder.finish().unwrap();
@@ -971,7 +971,7 @@ fn test_create_tx_add_utxo() {
         input: vec![],
         output: vec![TxOut {
             value: 25_000,
-            script_pubkey: wallet.get_address(New).address.script_pubkey(),
+            script_pubkey: wallet.address(New).address.script_pubkey(),
         }],
         version: 0,
         lock_time: absolute::LockTime::ZERO,
@@ -1016,7 +1016,7 @@ fn test_create_tx_manually_selected_insufficient() {
         input: vec![],
         output: vec![TxOut {
             value: 25_000,
-            script_pubkey: wallet.get_address(New).address.script_pubkey(),
+            script_pubkey: wallet.address(New).address.script_pubkey(),
         }],
         version: 0,
         lock_time: absolute::LockTime::ZERO,
@@ -1068,7 +1068,7 @@ fn test_create_tx_policy_path_no_csv() {
         input: vec![],
         output: vec![TxOut {
             value: 50_000,
-            script_pubkey: wallet.get_address(New).script_pubkey(),
+            script_pubkey: wallet.address(New).script_pubkey(),
         }],
     };
     wallet
@@ -1140,7 +1140,7 @@ fn test_create_tx_global_xpubs_with_origin() {
     use bitcoin::hashes::hex::FromHex;
 
     let (mut wallet, _) = get_funded_wallet("wpkh([73756c7f/48'/0'/0'/2']tpubDCKxNyM3bLgbEX13Mcd8mYxbVg9ajDkWXMh29hMWBurKfVmBfWAM96QVP3zaUcN51HvkZ3ar4VwP82kC8JZhhux8vFQoJintSpVBwpFvyU3/0/*)");
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), 25_000)
@@ -1407,7 +1407,7 @@ fn test_get_psbt_input() {
 )]
 fn test_create_tx_global_xpubs_origin_missing() {
     let (mut wallet, _) = get_funded_wallet("wpkh(tpubDCKxNyM3bLgbEX13Mcd8mYxbVg9ajDkWXMh29hMWBurKfVmBfWAM96QVP3zaUcN51HvkZ3ar4VwP82kC8JZhhux8vFQoJintSpVBwpFvyU3/0/*)");
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), 25_000)
@@ -1421,7 +1421,7 @@ fn test_create_tx_global_xpubs_master_without_origin() {
     use bitcoin::hashes::hex::FromHex;
 
     let (mut wallet, _) = get_funded_wallet("wpkh(tpubD6NzVbkrYhZ4Y55A58Gv9RSNF5hy84b5AJqYy7sCcjFrkcLpPre8kmgfit6kY1Zs3BLgeypTDBZJM222guPpdz7Cup5yzaMu62u7mYGbwFL/0/*)");
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), 25_000)
@@ -1442,7 +1442,7 @@ fn test_create_tx_global_xpubs_master_without_origin() {
 #[should_panic(expected = "IrreplaceableTransaction")]
 fn test_bump_fee_irreplaceable_tx() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.add_recipient(addr.script_pubkey(), 25_000);
     let psbt = builder.finish().unwrap();
@@ -1459,7 +1459,7 @@ fn test_bump_fee_irreplaceable_tx() {
 #[should_panic(expected = "TransactionConfirmed")]
 fn test_bump_fee_confirmed_tx() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.add_recipient(addr.script_pubkey(), 25_000);
     let psbt = builder.finish().unwrap();
@@ -1484,7 +1484,7 @@ fn test_bump_fee_confirmed_tx() {
 #[should_panic(expected = "FeeRateTooLow")]
 fn test_bump_fee_low_fee_rate() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), 25_000)
@@ -1507,7 +1507,7 @@ fn test_bump_fee_low_fee_rate() {
 #[should_panic(expected = "FeeTooLow")]
 fn test_bump_fee_low_abs() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), 25_000)
@@ -1530,7 +1530,7 @@ fn test_bump_fee_low_abs() {
 #[should_panic(expected = "FeeTooLow")]
 fn test_bump_fee_zero_abs() {
     let (mut wallet, _) = get_funded_wallet(get_test_wpkh());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .add_recipient(addr.script_pubkey(), 25_000)
@@ -1731,7 +1731,7 @@ fn test_bump_fee_drain_wallet() {
         input: vec![],
         output: vec![TxOut {
             value: 25_000,
-            script_pubkey: wallet.get_address(New).script_pubkey(),
+            script_pubkey: wallet.address(New).script_pubkey(),
         }],
     };
     wallet
@@ -1795,7 +1795,7 @@ fn test_bump_fee_remove_output_manually_selected_only() {
         lock_time: absolute::LockTime::ZERO,
         input: vec![],
         output: vec![TxOut {
-            script_pubkey: wallet.get_address(New).script_pubkey(),
+            script_pubkey: wallet.address(New).script_pubkey(),
             value: 25_000,
         }],
     };
@@ -1849,7 +1849,7 @@ fn test_bump_fee_add_input() {
         lock_time: absolute::LockTime::ZERO,
         input: vec![],
         output: vec![TxOut {
-            script_pubkey: wallet.get_address(New).script_pubkey(),
+            script_pubkey: wallet.address(New).script_pubkey(),
             value: 25_000,
         }],
     };
@@ -2318,7 +2318,7 @@ fn test_fee_amount_negative_drain_val() {
 #[test]
 fn test_sign_single_xprv() {
     let (mut wallet, _) = get_funded_wallet("wpkh(tprv8ZgxMBicQKsPd3EupYiPRhaMooHKUHJxNsTfYuScep13go8QFfHdtkG9nRkFGb7busX4isf6X9dURGCoKgitaApQ6MupRhZMcELAxTBRJgS/*)");
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.drain_to(addr.script_pubkey()).drain_wallet();
     let mut psbt = builder.finish().unwrap();
@@ -2333,7 +2333,7 @@ fn test_sign_single_xprv() {
 #[test]
 fn test_sign_single_xprv_with_master_fingerprint_and_path() {
     let (mut wallet, _) = get_funded_wallet("wpkh([d34db33f/84h/1h/0h]tprv8ZgxMBicQKsPd3EupYiPRhaMooHKUHJxNsTfYuScep13go8QFfHdtkG9nRkFGb7busX4isf6X9dURGCoKgitaApQ6MupRhZMcELAxTBRJgS/*)");
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.drain_to(addr.script_pubkey()).drain_wallet();
     let mut psbt = builder.finish().unwrap();
@@ -2348,7 +2348,7 @@ fn test_sign_single_xprv_with_master_fingerprint_and_path() {
 #[test]
 fn test_sign_single_xprv_bip44_path() {
     let (mut wallet, _) = get_funded_wallet("wpkh(tprv8ZgxMBicQKsPd3EupYiPRhaMooHKUHJxNsTfYuScep13go8QFfHdtkG9nRkFGb7busX4isf6X9dURGCoKgitaApQ6MupRhZMcELAxTBRJgS/44'/0'/0'/0/*)");
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.drain_to(addr.script_pubkey()).drain_wallet();
     let mut psbt = builder.finish().unwrap();
@@ -2363,7 +2363,7 @@ fn test_sign_single_xprv_bip44_path() {
 #[test]
 fn test_sign_single_xprv_sh_wpkh() {
     let (mut wallet, _) = get_funded_wallet("sh(wpkh(tprv8ZgxMBicQKsPd3EupYiPRhaMooHKUHJxNsTfYuScep13go8QFfHdtkG9nRkFGb7busX4isf6X9dURGCoKgitaApQ6MupRhZMcELAxTBRJgS/*))");
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.drain_to(addr.script_pubkey()).drain_wallet();
     let mut psbt = builder.finish().unwrap();
@@ -2379,7 +2379,7 @@ fn test_sign_single_xprv_sh_wpkh() {
 fn test_sign_single_wif() {
     let (mut wallet, _) =
         get_funded_wallet("wpkh(cVpPVruEDdmutPzisEsYvtST1usBR3ntr8pXSyt6D2YYqXRyPcFW)");
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.drain_to(addr.script_pubkey()).drain_wallet();
     let mut psbt = builder.finish().unwrap();
@@ -2394,7 +2394,7 @@ fn test_sign_single_wif() {
 #[test]
 fn test_sign_single_xprv_no_hd_keypaths() {
     let (mut wallet, _) = get_funded_wallet("wpkh(tprv8ZgxMBicQKsPd3EupYiPRhaMooHKUHJxNsTfYuScep13go8QFfHdtkG9nRkFGb7busX4isf6X9dURGCoKgitaApQ6MupRhZMcELAxTBRJgS/*)");
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.drain_to(addr.script_pubkey()).drain_wallet();
     let mut psbt = builder.finish().unwrap();
@@ -2479,7 +2479,7 @@ fn test_remove_partial_sigs_after_finalize_sign_option() {
     let (mut wallet, _) = get_funded_wallet("wpkh(tprv8ZgxMBicQKsPd3EupYiPRhaMooHKUHJxNsTfYuScep13go8QFfHdtkG9nRkFGb7busX4isf6X9dURGCoKgitaApQ6MupRhZMcELAxTBRJgS/*)");
 
     for remove_partial_sigs in &[true, false] {
-        let addr = wallet.get_address(New);
+        let addr = wallet.address(New);
         let mut builder = wallet.build_tx();
         builder.drain_to(addr.script_pubkey()).drain_wallet();
         let mut psbt = builder.finish().unwrap();
@@ -2509,7 +2509,7 @@ fn test_try_finalize_sign_option() {
     let (mut wallet, _) = get_funded_wallet("wpkh(tprv8ZgxMBicQKsPd3EupYiPRhaMooHKUHJxNsTfYuScep13go8QFfHdtkG9nRkFGb7busX4isf6X9dURGCoKgitaApQ6MupRhZMcELAxTBRJgS/*)");
 
     for try_finalize in &[true, false] {
-        let addr = wallet.get_address(New);
+        let addr = wallet.address(New);
         let mut builder = wallet.build_tx();
         builder.drain_to(addr.script_pubkey()).drain_wallet();
         let mut psbt = builder.finish().unwrap();
@@ -2543,7 +2543,7 @@ fn test_sign_nonstandard_sighash() {
     let sighash = EcdsaSighashType::NonePlusAnyoneCanPay;
 
     let (mut wallet, _) = get_funded_wallet("wpkh(tprv8ZgxMBicQKsPd3EupYiPRhaMooHKUHJxNsTfYuScep13go8QFfHdtkG9nRkFGb7busX4isf6X9dURGCoKgitaApQ6MupRhZMcELAxTBRJgS/*)");
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .drain_to(addr.script_pubkey())
@@ -2590,11 +2590,11 @@ fn test_unused_address() {
                                  None, Network::Testnet).unwrap();
 
     assert_eq!(
-        wallet.get_address(LastUnused).to_string(),
+        wallet.address(LastUnused).to_string(),
         "tb1q6yn66vajcctph75pvylgkksgpp6nq04ppwct9a"
     );
     assert_eq!(
-        wallet.get_address(LastUnused).to_string(),
+        wallet.address(LastUnused).to_string(),
         "tb1q6yn66vajcctph75pvylgkksgpp6nq04ppwct9a"
     );
 }
@@ -2606,12 +2606,12 @@ fn test_next_unused_address() {
     assert_eq!(wallet.derivation_index(KeychainKind::External), None);
 
     assert_eq!(
-        wallet.get_address(LastUnused).to_string(),
+        wallet.address(LastUnused).to_string(),
         "tb1q6yn66vajcctph75pvylgkksgpp6nq04ppwct9a"
     );
     assert_eq!(wallet.derivation_index(KeychainKind::External), Some(0));
     assert_eq!(
-        wallet.get_address(LastUnused).to_string(),
+        wallet.address(LastUnused).to_string(),
         "tb1q6yn66vajcctph75pvylgkksgpp6nq04ppwct9a"
     );
     assert_eq!(wallet.derivation_index(KeychainKind::External), Some(0));
@@ -2620,7 +2620,7 @@ fn test_next_unused_address() {
     receive_output_in_latest_block(&mut wallet, 25_000);
 
     assert_eq!(
-        wallet.get_address(LastUnused).to_string(),
+        wallet.address(LastUnused).to_string(),
         "tb1q4er7kxx6sssz3q7qp7zsqsdx4erceahhax77d7"
     );
     assert_eq!(wallet.derivation_index(KeychainKind::External), Some(1));
@@ -2632,28 +2632,28 @@ fn test_peek_address_at_index() {
                                  None, Network::Testnet).unwrap();
 
     assert_eq!(
-        wallet.get_address(Peek(1)).to_string(),
+        wallet.address(Peek(1)).to_string(),
         "tb1q4er7kxx6sssz3q7qp7zsqsdx4erceahhax77d7"
     );
 
     assert_eq!(
-        wallet.get_address(Peek(0)).to_string(),
+        wallet.address(Peek(0)).to_string(),
         "tb1q6yn66vajcctph75pvylgkksgpp6nq04ppwct9a"
     );
 
     assert_eq!(
-        wallet.get_address(Peek(2)).to_string(),
+        wallet.address(Peek(2)).to_string(),
         "tb1qzntf2mqex4ehwkjlfdyy3ewdlk08qkvkvrz7x2"
     );
 
     // current new address is not affected
     assert_eq!(
-        wallet.get_address(New).to_string(),
+        wallet.address(New).to_string(),
         "tb1q6yn66vajcctph75pvylgkksgpp6nq04ppwct9a"
     );
 
     assert_eq!(
-        wallet.get_address(New).to_string(),
+        wallet.address(New).to_string(),
         "tb1q4er7kxx6sssz3q7qp7zsqsdx4erceahhax77d7"
     );
 }
@@ -2664,17 +2664,17 @@ fn test_peek_address_at_index_not_derivable() {
                                  None, Network::Testnet).unwrap();
 
     assert_eq!(
-        wallet.get_address(Peek(1)).to_string(),
+        wallet.address(Peek(1)).to_string(),
         "tb1q4er7kxx6sssz3q7qp7zsqsdx4erceahhax77d7"
     );
 
     assert_eq!(
-        wallet.get_address(Peek(0)).to_string(),
+        wallet.address(Peek(0)).to_string(),
         "tb1q4er7kxx6sssz3q7qp7zsqsdx4erceahhax77d7"
     );
 
     assert_eq!(
-        wallet.get_address(Peek(2)).to_string(),
+        wallet.address(Peek(2)).to_string(),
         "tb1q4er7kxx6sssz3q7qp7zsqsdx4erceahhax77d7"
     );
 }
@@ -2686,7 +2686,7 @@ fn test_returns_index_and_address() {
 
     // new index 0
     assert_eq!(
-        wallet.get_address(New),
+        wallet.address(New),
         AddressInfo {
             index: 0,
             address: Address::from_str("tb1q6yn66vajcctph75pvylgkksgpp6nq04ppwct9a")
@@ -2698,7 +2698,7 @@ fn test_returns_index_and_address() {
 
     // new index 1
     assert_eq!(
-        wallet.get_address(New),
+        wallet.address(New),
         AddressInfo {
             index: 1,
             address: Address::from_str("tb1q4er7kxx6sssz3q7qp7zsqsdx4erceahhax77d7")
@@ -2710,7 +2710,7 @@ fn test_returns_index_and_address() {
 
     // peek index 25
     assert_eq!(
-        wallet.get_address(Peek(25)),
+        wallet.address(Peek(25)),
         AddressInfo {
             index: 25,
             address: Address::from_str("tb1qsp7qu0knx3sl6536dzs0703u2w2ag6ppl9d0c2")
@@ -2722,7 +2722,7 @@ fn test_returns_index_and_address() {
 
     // new index 2
     assert_eq!(
-        wallet.get_address(New),
+        wallet.address(New),
         AddressInfo {
             index: 2,
             address: Address::from_str("tb1qzntf2mqex4ehwkjlfdyy3ewdlk08qkvkvrz7x2")
@@ -2745,7 +2745,7 @@ fn test_sending_to_bip350_bech32m_address() {
 }
 
 #[test]
-fn test_get_address() {
+fn test_address() {
     use bdk::descriptor::template::Bip84;
     let key = bitcoin::bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPcx5nBGsR63Pe8KnRUqmbJNENAfGftF3yuXoMMoVJJcYeUw5eVkm9WBPjWYt6HMWYJNesB5HaNVBaFc1M6dRjWSYnmewUMYy").unwrap();
     let mut wallet = Wallet::new_no_persist(
@@ -2756,7 +2756,7 @@ fn test_get_address() {
     .unwrap();
 
     assert_eq!(
-        wallet.get_address(AddressIndex::New),
+        wallet.address(AddressIndex::New),
         AddressInfo {
             index: 0,
             address: Address::from_str("bcrt1qrhgaqu0zvf5q2d0gwwz04w0dh0cuehhqvzpp4w")
@@ -2805,7 +2805,7 @@ fn test_get_address_no_reuse_single_descriptor() {
     let mut used_set = HashSet::new();
 
     (0..3).for_each(|_| {
-        let external_addr = wallet.get_address(AddressIndex::New).address;
+        let external_addr = wallet.address(AddressIndex::New).address;
         assert!(used_set.insert(external_addr));
 
         let internal_addr = wallet.get_internal_address(AddressIndex::New).address;
@@ -2816,7 +2816,7 @@ fn test_get_address_no_reuse_single_descriptor() {
 #[test]
 fn test_taproot_psbt_populate_tap_key_origins() {
     let (mut wallet, _) = get_funded_wallet(get_test_tr_single_sig_xprv());
-    let addr = wallet.get_address(AddressIndex::New);
+    let addr = wallet.address(AddressIndex::New);
 
     let mut builder = wallet.build_tx();
     builder.add_recipient(addr.script_pubkey(), 25_000);
@@ -2851,7 +2851,7 @@ fn test_taproot_psbt_populate_tap_key_origins() {
 #[test]
 fn test_taproot_psbt_populate_tap_key_origins_repeated_key() {
     let (mut wallet, _) = get_funded_wallet(get_test_tr_repeated_key());
-    let addr = wallet.get_address(AddressIndex::New);
+    let addr = wallet.address(AddressIndex::New);
 
     let path = vec![("rn4nre9c".to_string(), vec![0])]
         .into_iter()
@@ -2917,7 +2917,7 @@ fn test_taproot_psbt_input_tap_tree() {
     use bitcoin::taproot;
 
     let (mut wallet, _) = get_funded_wallet(get_test_tr_with_taptree());
-    let addr = wallet.get_address(AddressIndex::Peek(0));
+    let addr = wallet.address(AddressIndex::Peek(0));
 
     let mut builder = wallet.build_tx();
     builder.drain_to(addr.script_pubkey()).drain_wallet();
@@ -2960,7 +2960,7 @@ fn test_taproot_psbt_input_tap_tree() {
 #[test]
 fn test_taproot_sign_missing_witness_utxo() {
     let (mut wallet, _) = get_funded_wallet(get_test_tr_single_sig());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.drain_to(addr.script_pubkey()).drain_wallet();
     let mut psbt = builder.finish().unwrap();
@@ -3000,7 +3000,7 @@ fn test_taproot_sign_missing_witness_utxo() {
 #[test]
 fn test_taproot_sign_using_non_witness_utxo() {
     let (mut wallet, prev_txid) = get_funded_wallet(get_test_tr_single_sig());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder.drain_to(addr.script_pubkey()).drain_wallet();
     let mut psbt = builder.finish().unwrap();
@@ -3067,7 +3067,7 @@ fn test_taproot_foreign_utxo() {
 }
 
 fn test_spend_from_wallet(mut wallet: Wallet) {
-    let addr = wallet.get_address(AddressIndex::New);
+    let addr = wallet.address(AddressIndex::New);
 
     let mut builder = wallet.build_tx();
     builder.add_recipient(addr.script_pubkey(), 25_000);
@@ -3091,7 +3091,7 @@ fn test_spend_from_wallet(mut wallet: Wallet) {
 #[test]
 fn test_taproot_no_key_spend() {
     let (mut wallet, _) = get_funded_wallet(get_test_tr_with_taptree_both_priv());
-    let addr = wallet.get_address(AddressIndex::New);
+    let addr = wallet.address(AddressIndex::New);
 
     let mut builder = wallet.build_tx();
     builder.add_recipient(addr.script_pubkey(), 25_000);
@@ -3126,7 +3126,7 @@ fn test_taproot_script_spend() {
 fn test_taproot_script_spend_sign_all_leaves() {
     use bdk::signer::TapLeavesOptions;
     let (mut wallet, _) = get_funded_wallet(get_test_tr_with_taptree_both_priv());
-    let addr = wallet.get_address(AddressIndex::New);
+    let addr = wallet.address(AddressIndex::New);
 
     let mut builder = wallet.build_tx();
     builder.add_recipient(addr.script_pubkey(), 25_000);
@@ -3157,7 +3157,7 @@ fn test_taproot_script_spend_sign_include_some_leaves() {
     use bitcoin::taproot::TapLeafHash;
 
     let (mut wallet, _) = get_funded_wallet(get_test_tr_with_taptree_both_priv());
-    let addr = wallet.get_address(AddressIndex::New);
+    let addr = wallet.address(AddressIndex::New);
 
     let mut builder = wallet.build_tx();
     builder.add_recipient(addr.script_pubkey(), 25_000);
@@ -3197,7 +3197,7 @@ fn test_taproot_script_spend_sign_exclude_some_leaves() {
     use bitcoin::taproot::TapLeafHash;
 
     let (mut wallet, _) = get_funded_wallet(get_test_tr_with_taptree_both_priv());
-    let addr = wallet.get_address(AddressIndex::New);
+    let addr = wallet.address(AddressIndex::New);
 
     let mut builder = wallet.build_tx();
     builder.add_recipient(addr.script_pubkey(), 25_000);
@@ -3235,7 +3235,7 @@ fn test_taproot_script_spend_sign_exclude_some_leaves() {
 fn test_taproot_script_spend_sign_no_leaves() {
     use bdk::signer::TapLeavesOptions;
     let (mut wallet, _) = get_funded_wallet(get_test_tr_with_taptree_both_priv());
-    let addr = wallet.get_address(AddressIndex::New);
+    let addr = wallet.address(AddressIndex::New);
 
     let mut builder = wallet.build_tx();
     builder.add_recipient(addr.script_pubkey(), 25_000);
@@ -3258,7 +3258,7 @@ fn test_taproot_script_spend_sign_no_leaves() {
 fn test_taproot_sign_derive_index_from_psbt() {
     let (mut wallet, _) = get_funded_wallet(get_test_tr_single_sig_xprv());
 
-    let addr = wallet.get_address(AddressIndex::New);
+    let addr = wallet.address(AddressIndex::New);
 
     let mut builder = wallet.build_tx();
     builder.add_recipient(addr.script_pubkey(), 25_000);
@@ -3279,7 +3279,7 @@ fn test_taproot_sign_derive_index_from_psbt() {
 #[test]
 fn test_taproot_sign_explicit_sighash_all() {
     let (mut wallet, _) = get_funded_wallet(get_test_tr_single_sig());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .drain_to(addr.script_pubkey())
@@ -3299,7 +3299,7 @@ fn test_taproot_sign_non_default_sighash() {
     let sighash = TapSighashType::NonePlusAnyoneCanPay;
 
     let (mut wallet, _) = get_funded_wallet(get_test_tr_single_sig());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let mut builder = wallet.build_tx();
     builder
         .drain_to(addr.script_pubkey())
@@ -3384,7 +3384,7 @@ fn test_spend_coinbase() {
         }],
         output: vec![TxOut {
             value: 25_000,
-            script_pubkey: wallet.get_address(New).address.script_pubkey(),
+            script_pubkey: wallet.address(New).address.script_pubkey(),
         }],
     };
     wallet
@@ -3400,7 +3400,7 @@ fn test_spend_coinbase() {
     let not_yet_mature_time = confirmation_height + COINBASE_MATURITY - 1;
     let maturity_time = confirmation_height + COINBASE_MATURITY;
 
-    let balance = wallet.get_balance();
+    let balance = wallet.balance();
     assert_eq!(
         balance,
         Balance {
@@ -3451,7 +3451,7 @@ fn test_spend_coinbase() {
             hash: BlockHash::all_zeros(),
         })
         .unwrap();
-    let balance = wallet.get_balance();
+    let balance = wallet.balance();
     assert_eq!(
         balance,
         Balance {
@@ -3472,7 +3472,7 @@ fn test_spend_coinbase() {
 fn test_allow_dust_limit() {
     let (mut wallet, _) = get_funded_wallet(get_test_single_sig_cltv());
 
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
 
     let mut builder = wallet.build_tx();
 
@@ -3498,7 +3498,7 @@ fn test_fee_rate_sign_no_grinding_high_r() {
     // instead of 70). We then check that our fee rate and fee calculation is
     // alright.
     let (mut wallet, _) = get_funded_wallet("wpkh(tprv8ZgxMBicQKsPd3EupYiPRhaMooHKUHJxNsTfYuScep13go8QFfHdtkG9nRkFGb7busX4isf6X9dURGCoKgitaApQ6MupRhZMcELAxTBRJgS/*)");
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let fee_rate = FeeRate::from_sat_per_vb(1.0);
     let mut builder = wallet.build_tx();
     let mut data = PushBytesBuf::try_from(vec![0]).unwrap();
@@ -3564,7 +3564,7 @@ fn test_fee_rate_sign_grinding_low_r() {
     // We then check that our fee rate and fee calculation is alright and that our
     // signature is 70 bytes.
     let (mut wallet, _) = get_funded_wallet("wpkh(tprv8ZgxMBicQKsPd3EupYiPRhaMooHKUHJxNsTfYuScep13go8QFfHdtkG9nRkFGb7busX4isf6X9dURGCoKgitaApQ6MupRhZMcELAxTBRJgS/*)");
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
     let fee_rate = FeeRate::from_sat_per_vb(1.0);
     let mut builder = wallet.build_tx();
     builder
@@ -3598,7 +3598,7 @@ fn test_taproot_load_descriptor_duplicated_keys() {
     // Having the same key in multiple taproot leaves is safe and should be accepted by BDK
 
     let (mut wallet, _) = get_funded_wallet(get_test_tr_dup_keys());
-    let addr = wallet.get_address(New);
+    let addr = wallet.address(New);
 
     assert_eq!(
         addr.to_string(),

--- a/crates/bitcoind_rpc/tests/test_emitter.rs
+++ b/crates/bitcoind_rpc/tests/test_emitter.rs
@@ -441,7 +441,7 @@ where
     Ok(())
 }
 
-fn get_balance(
+fn balance(
     recv_chain: &LocalChain,
     recv_graph: &IndexedTxGraph<BlockId, SpkTxOutIndex<()>>,
 ) -> anyhow::Result<Balance> {
@@ -511,7 +511,7 @@ fn tx_can_become_unconfirmed_after_reorg() -> anyhow::Result<()> {
     sync_from_emitter(&mut recv_chain, &mut recv_graph, &mut emitter)?;
 
     assert_eq!(
-        get_balance(&recv_chain, &recv_graph)?,
+        balance(&recv_chain, &recv_graph)?,
         Balance {
             confirmed: SEND_AMOUNT.to_sat() * ADDITIONAL_COUNT as u64,
             ..Balance::default()
@@ -525,7 +525,7 @@ fn tx_can_become_unconfirmed_after_reorg() -> anyhow::Result<()> {
         sync_from_emitter(&mut recv_chain, &mut recv_graph, &mut emitter)?;
 
         assert_eq!(
-            get_balance(&recv_chain, &recv_graph)?,
+            balance(&recv_chain, &recv_graph)?,
             Balance {
                 confirmed: SEND_AMOUNT.to_sat() * (ADDITIONAL_COUNT - reorg_count) as u64,
                 trusted_pending: SEND_AMOUNT.to_sat() * reorg_count as u64,

--- a/crates/hwi/src/signer.rs
+++ b/crates/hwi/src/signer.rs
@@ -83,7 +83,7 @@ impl TransactionSigner for HWISigner {
 //             Arc::new(custom_signer),
 //         );
 //
-//         let addr = wallet.get_address(bdk::wallet::AddressIndex::LastUnused);
+//         let addr = wallet.address(bdk::wallet::AddressIndex::LastUnused);
 //         let mut builder = wallet.build_tx();
 //         builder.drain_to(addr.script_pubkey()).drain_wallet();
 //         let (mut psbt, _) = builder.finish().unwrap();

--- a/example-crates/wallet_electrum/src/main.rs
+++ b/example-crates/wallet_electrum/src/main.rs
@@ -32,7 +32,7 @@ fn main() -> Result<(), anyhow::Error> {
     let address = wallet.try_get_address(bdk::wallet::AddressIndex::New)?;
     println!("Generated Address: {}", address);
 
-    let balance = wallet.get_balance();
+    let balance = wallet.balance();
     println!("Wallet balance before syncing: {} sats", balance.total());
 
     print!("Syncing...");
@@ -76,7 +76,7 @@ fn main() -> Result<(), anyhow::Error> {
     wallet.apply_update(wallet_update)?;
     wallet.commit()?;
 
-    let balance = wallet.get_balance();
+    let balance = wallet.balance();
     println!("Wallet balance after syncing: {} sats", balance.total());
 
     if balance.total() < SEND_AMOUNT {

--- a/example-crates/wallet_esplora_async/src/main.rs
+++ b/example-crates/wallet_esplora_async/src/main.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let address = wallet.try_get_address(AddressIndex::New)?;
     println!("Generated Address: {}", address);
 
-    let balance = wallet.get_balance();
+    let balance = wallet.balance();
     println!("Wallet balance before syncing: {} sats", balance.total());
 
     print!("Syncing...");
@@ -67,7 +67,7 @@ async fn main() -> Result<(), anyhow::Error> {
     wallet.commit()?;
     println!();
 
-    let balance = wallet.get_balance();
+    let balance = wallet.balance();
     println!("Wallet balance after syncing: {} sats", balance.total());
 
     if balance.total() < SEND_AMOUNT {

--- a/example-crates/wallet_esplora_blocking/src/main.rs
+++ b/example-crates/wallet_esplora_blocking/src/main.rs
@@ -29,7 +29,7 @@ fn main() -> Result<(), anyhow::Error> {
     let address = wallet.try_get_address(AddressIndex::New)?;
     println!("Generated Address: {}", address);
 
-    let balance = wallet.get_balance();
+    let balance = wallet.balance();
     println!("Wallet balance before syncing: {} sats", balance.total());
 
     print!("Syncing...");
@@ -67,7 +67,7 @@ fn main() -> Result<(), anyhow::Error> {
     wallet.commit()?;
     println!();
 
-    let balance = wallet.get_balance();
+    let balance = wallet.balance();
     println!("Wallet balance after syncing: {} sats", balance.total());
 
     if balance.total() < SEND_AMOUNT {

--- a/example-crates/wallet_rpc/src/main.rs
+++ b/example-crates/wallet_rpc/src/main.rs
@@ -97,7 +97,7 @@ fn main() -> anyhow::Result<()> {
         start_load_wallet.elapsed().as_secs_f32()
     );
 
-    let balance = wallet.get_balance();
+    let balance = wallet.balance();
     println!("Wallet balance before syncing: {} sats", balance.total());
 
     let wallet_tip = wallet.latest_checkpoint();
@@ -160,7 +160,7 @@ fn main() -> anyhow::Result<()> {
         }
     }
     let wallet_tip_end = wallet.latest_checkpoint();
-    let balance = wallet.get_balance();
+    let balance = wallet.balance();
     println!(
         "Synced {} blocks in {}s",
         blocks_received,


### PR DESCRIPTION

### Description
 Rename the `get_address`  to `address` & `get_balance` to `balance` -> and make subsequent changes in the codebase.
<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

 This is done in order to make methods names according with rust API naming guidelines
<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->



### Checklists

#### All Submissions:


* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing



#### Bugfixes:

* [x] This pull request breaks the existing API
* [x] I'm linking the issue being fixed by this PR

Fix #1221
