### PR TITLE
Replace u64 for unix epoch with Time and u32 for block height with Height

### DIFF
--- a/crates/bdk/src/wallet/export.rs
+++ b/crates/bdk/src/wallet/export.rs
@@ -215,6 +215,7 @@ mod test {
     use core::str::FromStr;
 
     use bdk_chain::{BlockId, ConfirmationTime};
+    use bitcoin::absolute::Time;
     use bitcoin::hashes::Hash;
     use bitcoin::{BlockHash, Network, Transaction};
 
@@ -244,7 +245,7 @@ mod test {
                 transaction,
                 ConfirmationTime::Confirmed {
                     height: 5000,
-                    time: 0,
+                    time: Time::MIN,
                 },
             )
             .unwrap();

--- a/crates/bdk/src/wallet/mod.rs
+++ b/crates/bdk/src/wallet/mod.rs
@@ -2479,7 +2479,7 @@ impl<D> Wallet<D> {
     /// `last_seen` is prioritized.
     pub fn apply_unconfirmed_txs<'t>(
         &mut self,
-        unconfirmed_txs: impl IntoIterator<Item = (&'t Transaction, u64)>,
+        unconfirmed_txs: impl IntoIterator<Item = (&'t Transaction, absolute::Time)>,
     ) where
         D: PersistBackend<ChangeSet>,
     {
@@ -2572,6 +2572,7 @@ fn create_signers<E: IntoWalletDescriptor>(
 macro_rules! doctest_wallet {
     () => {{
         use $crate::bitcoin::{BlockHash, Transaction, absolute, TxOut, Network, hashes::Hash};
+        use $crate::bitcoin::absolute::{LOCK_TIME_THRESHOLD, Time};
         use $crate::chain::{ConfirmationTime, BlockId};
         use $crate::wallet::{AddressIndex, Wallet};
         let descriptor = "tr([73c5da0a/86'/0'/0']tprv8fMn4hSKPRC1oaCPqxDb1JWtgkpeiQvZhsr8W2xuy3GEMkzoArcAWTfJxYb6Wj8XNNDWEjfYKK4wGQXh3ZUXhDF2NcnsALpWTeSwarJt7Vc/0/*)";
@@ -2596,7 +2597,7 @@ macro_rules! doctest_wallet {
         let _ = wallet.insert_checkpoint(BlockId { height: 1_000, hash: BlockHash::all_zeros() });
         let _ = wallet.insert_tx(tx.clone(), ConfirmationTime::Confirmed {
             height: 500,
-            time: 50_000
+            time: Time::from_consensus(LOCK_TIME_THRESHOLD+50_000).unwrap(),
         });
 
         wallet

--- a/crates/bdk/src/wallet/tx_builder.rs
+++ b/crates/bdk/src/wallet/tx_builder.rs
@@ -931,6 +931,7 @@ mod test {
     }
 
     use bdk_chain::ConfirmationTime;
+    use bitcoin::absolute::{Time, LOCK_TIME_THRESHOLD};
     use bitcoin::consensus::deserialize;
     use bitcoin::hashes::hex::FromHex;
 
@@ -1023,7 +1024,9 @@ mod test {
                 txout: Default::default(),
                 keychain: KeychainKind::External,
                 is_spent: false,
-                confirmation_time: ConfirmationTime::Unconfirmed { last_seen: 0 },
+                confirmation_time: ConfirmationTime::Unconfirmed {
+                    last_seen: Time::MIN,
+                },
                 derivation_index: 0,
             },
             LocalOutput {
@@ -1036,7 +1039,7 @@ mod test {
                 is_spent: false,
                 confirmation_time: ConfirmationTime::Confirmed {
                     height: 32,
-                    time: 42,
+                    time: Time::from_consensus(LOCK_TIME_THRESHOLD + 42).unwrap(),
                 },
                 derivation_index: 1,
             },

--- a/crates/bdk/tests/common.rs
+++ b/crates/bdk/tests/common.rs
@@ -3,6 +3,7 @@
 use bdk::{wallet::AddressIndex, KeychainKind, LocalOutput, Wallet};
 use bdk_chain::indexed_tx_graph::Indexer;
 use bdk_chain::{BlockId, ConfirmationTime};
+use bitcoin::absolute::{Time, LOCK_TIME_THRESHOLD};
 use bitcoin::hashes::Hash;
 use bitcoin::{Address, BlockHash, Network, OutPoint, Transaction, TxIn, TxOut, Txid};
 use std::str::FromStr;
@@ -82,7 +83,7 @@ pub fn get_funded_wallet_with_change(
             tx0,
             ConfirmationTime::Confirmed {
                 height: 1_000,
-                time: 100,
+                time: Time::from_consensus(LOCK_TIME_THRESHOLD + 100).unwrap(),
             },
         )
         .unwrap();
@@ -91,7 +92,7 @@ pub fn get_funded_wallet_with_change(
             tx1.clone(),
             ConfirmationTime::Confirmed {
                 height: 2_000,
-                time: 200,
+                time: Time::from_consensus(LOCK_TIME_THRESHOLD + 200).unwrap(),
             },
         )
         .unwrap();

--- a/crates/chain/src/indexed_tx_graph.rs
+++ b/crates/chain/src/indexed_tx_graph.rs
@@ -1,6 +1,7 @@
 //! Contains the [`IndexedTxGraph`] and associated types. Refer to the
 //! [`IndexedTxGraph`] documentation for more.
 use alloc::vec::Vec;
+use bitcoin::absolute::Time;
 use bitcoin::{Block, OutPoint, Transaction, TxOut, Txid};
 
 use crate::{
@@ -116,7 +117,7 @@ where
     ///
     /// This is used for transaction conflict resolution in [`TxGraph`] where the transaction with
     /// the later last-seen is prioritized.
-    pub fn insert_seen_at(&mut self, txid: Txid, seen_at: u64) -> ChangeSet<A, I::ChangeSet> {
+    pub fn insert_seen_at(&mut self, txid: Txid, seen_at: Time) -> ChangeSet<A, I::ChangeSet> {
         self.graph.insert_seen_at(txid, seen_at).into()
     }
 
@@ -165,7 +166,7 @@ where
     /// conflict-resolution in [`TxGraph`] (refer to [`TxGraph::insert_seen_at`] for details).
     pub fn batch_insert_relevant_unconfirmed<'t>(
         &mut self,
-        unconfirmed_txs: impl IntoIterator<Item = (&'t Transaction, u64)>,
+        unconfirmed_txs: impl IntoIterator<Item = (&'t Transaction, Time)>,
     ) -> ChangeSet<A, I::ChangeSet> {
         // The algorithm below allows for non-topologically ordered transactions by using two loops.
         // This is achieved by:
@@ -200,7 +201,7 @@ where
     /// [`batch_insert_relevant_unconfirmed`]: IndexedTxGraph::batch_insert_relevant_unconfirmed
     pub fn batch_insert_unconfirmed(
         &mut self,
-        txs: impl IntoIterator<Item = (Transaction, u64)>,
+        txs: impl IntoIterator<Item = (Transaction, Time)>,
     ) -> ChangeSet<A, I::ChangeSet> {
         let graph = self.graph.batch_insert_unconfirmed(txs);
         let indexer = self.index_tx_graph_changeset(&graph);

--- a/crates/chain/src/tx_data_traits.rs
+++ b/crates/chain/src/tx_data_traits.rs
@@ -17,7 +17,8 @@ use alloc::vec::Vec;
 ///
 /// The example shows different types of anchors:
 /// ```
-/// # use bdk_chain::local_chain::LocalChain;
+/// # use bitcoin::absolute::{LOCK_TIME_THRESHOLD, Time};
+/// use bdk_chain::local_chain::LocalChain;
 /// # use bdk_chain::tx_graph::TxGraph;
 /// # use bdk_chain::BlockId;
 /// # use bdk_chain::ConfirmationHeightAnchor;
@@ -83,7 +84,7 @@ use alloc::vec::Vec;
 ///             hash: Hash::hash("third".as_bytes()),
 ///         },
 ///         confirmation_height: 1,
-///         confirmation_time: 123,
+///         confirmation_time: Time::from_consensus(LOCK_TIME_THRESHOLD + 123).unwrap(),
 ///     },
 /// );
 /// ```

--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -9,6 +9,7 @@ use bdk_chain::{
     local_chain::LocalChain,
     tx_graph, BlockId, ChainPosition, ConfirmationHeightAnchor,
 };
+use bitcoin::absolute::{Time, LOCK_TIME_THRESHOLD};
 use bitcoin::{secp256k1::Secp256k1, OutPoint, Script, ScriptBuf, Transaction, TxIn, TxOut};
 use miniscript::Descriptor;
 
@@ -224,7 +225,12 @@ fn test_list_owned_txouts() {
             )
         }));
 
-    let _ = graph.batch_insert_relevant_unconfirmed([&tx4, &tx5].iter().map(|tx| (*tx, 100)));
+    let _ = graph.batch_insert_relevant_unconfirmed([&tx4, &tx5].iter().map(|tx| {
+        (
+            *tx,
+            Time::from_consensus(LOCK_TIME_THRESHOLD + 100).unwrap(),
+        )
+    }));
 
     // A helper lambda to extract and filter data from the graph.
     let fetch =

--- a/crates/chain/tests/test_tx_graph_conflicts.rs
+++ b/crates/chain/tests/test_tx_graph_conflicts.rs
@@ -4,6 +4,7 @@ mod common;
 use std::collections::{BTreeSet, HashSet};
 
 use bdk_chain::{keychain::Balance, BlockId};
+use bitcoin::absolute::{Time, LOCK_TIME_THRESHOLD};
 use bitcoin::{OutPoint, Script};
 use common::*;
 
@@ -99,14 +100,14 @@ fn test_tx_conflict_handling() {
                     tx_name: "tx_conflict_1",
                     inputs: &[TxInTemplate::PrevTx("tx1", 0)],
                     outputs: &[TxOutTemplate::new(20000, Some(2))],
-                    last_seen: Some(300),
+                    last_seen: Some(Time::from_consensus(LOCK_TIME_THRESHOLD+300).unwrap()),
                     ..Default::default()
                 },
                 TxTemplate {
                     tx_name: "tx_conflict_2",
                     inputs: &[TxInTemplate::PrevTx("tx1", 0)],
                     outputs: &[TxOutTemplate::new(30000, Some(3))],
-                    last_seen: Some(300),
+                    last_seen: Some(Time::from_consensus(LOCK_TIME_THRESHOLD+300).unwrap()),
                     ..Default::default()
                 },
             ],
@@ -135,14 +136,14 @@ fn test_tx_conflict_handling() {
                     tx_name: "tx_conflict_1",
                     inputs: &[TxInTemplate::PrevTx("tx1", 0), TxInTemplate::Bogus],
                     outputs: &[TxOutTemplate::new(20000, Some(2))],
-                    last_seen: Some(200),
+                    last_seen: Some(Time::from_consensus(LOCK_TIME_THRESHOLD+200).unwrap()),
                     ..Default::default()
                 },
                 TxTemplate {
                     tx_name: "tx_conflict_2",
                     inputs: &[TxInTemplate::PrevTx("tx1", 0),  TxInTemplate::PrevTx("tx1", 1)],
                     outputs: &[TxOutTemplate::new(30000, Some(3))],
-                    last_seen: Some(300),
+                    last_seen: Some(Time::from_consensus(LOCK_TIME_THRESHOLD+300).unwrap()),
                     ..Default::default()
                 },
             ],
@@ -170,21 +171,21 @@ fn test_tx_conflict_handling() {
                     tx_name: "tx_conflict_1",
                     inputs: &[TxInTemplate::PrevTx("tx1", 0), TxInTemplate::Bogus],
                     outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    last_seen: Some(200),
+                    last_seen: Some(Time::from_consensus(LOCK_TIME_THRESHOLD+200).unwrap()),
                     ..Default::default()
                 },
                 TxTemplate {
                     tx_name: "tx_conflict_2",
                     inputs: &[TxInTemplate::PrevTx("tx1", 0)],
                     outputs: &[TxOutTemplate::new(30000, Some(2))],
-                    last_seen: Some(300),
+                    last_seen: Some(Time::from_consensus(LOCK_TIME_THRESHOLD+300).unwrap()),
                     ..Default::default()
                 },
                 TxTemplate {
                     tx_name: "tx_conflict_3",
                     inputs: &[TxInTemplate::PrevTx("tx1", 0)],
                     outputs: &[TxOutTemplate::new(40000, Some(3))],
-                    last_seen: Some(400),
+                    last_seen: Some(Time::from_consensus(LOCK_TIME_THRESHOLD+400).unwrap()),
                     ..Default::default()
                 },
             ],
@@ -212,7 +213,7 @@ fn test_tx_conflict_handling() {
                     tx_name: "tx_conflict_1",
                     inputs: &[TxInTemplate::PrevTx("tx1", 0), TxInTemplate::Bogus],
                     outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    last_seen: Some(200),
+                    last_seen: Some(Time::from_consensus(LOCK_TIME_THRESHOLD+200).unwrap()),
                     ..Default::default()
                 },
                 TxTemplate {
@@ -220,7 +221,7 @@ fn test_tx_conflict_handling() {
                     inputs: &[TxInTemplate::PrevTx("tx1", 0)],
                     outputs: &[TxOutTemplate::new(30000, Some(2))],
                     anchors: &[block_id!(4, "Orphaned Block")],
-                    last_seen: Some(300),
+                    last_seen: Some(Time::from_consensus(LOCK_TIME_THRESHOLD+300).unwrap()),
                 },
             ],
             exp_chain_txs: HashSet::from(["tx1", "tx_orphaned_conflict"]),
@@ -247,7 +248,7 @@ fn test_tx_conflict_handling() {
                     tx_name: "tx_conflict_1",
                     inputs: &[TxInTemplate::PrevTx("tx1", 0), TxInTemplate::Bogus],
                     outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    last_seen: Some(200),
+                    last_seen: Some(Time::from_consensus(LOCK_TIME_THRESHOLD+200).unwrap()),
                     ..Default::default()
                 },
                 TxTemplate {
@@ -255,7 +256,7 @@ fn test_tx_conflict_handling() {
                     inputs: &[TxInTemplate::PrevTx("tx1", 0)],
                     outputs: &[TxOutTemplate::new(30000, Some(2))],
                     anchors: &[block_id!(4, "Orphaned Block")],
-                    last_seen: Some(100),
+                    last_seen: Some(Time::from_consensus(LOCK_TIME_THRESHOLD+100).unwrap()),
                 },
             ],
             exp_chain_txs: HashSet::from(["tx1", "tx_conflict_1"]),
@@ -282,21 +283,21 @@ fn test_tx_conflict_handling() {
                     tx_name: "tx_conflict_1",
                     inputs: &[TxInTemplate::PrevTx("tx1", 0), TxInTemplate::Bogus],
                     outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    last_seen: Some(200),
+                    last_seen: Some(Time::from_consensus(LOCK_TIME_THRESHOLD+200).unwrap()),
                     ..Default::default()
                 },
                 TxTemplate {
                     tx_name: "tx_conflict_2",
                     inputs: &[TxInTemplate::PrevTx("tx1", 0)],
                     outputs: &[TxOutTemplate::new(30000, Some(2))],
-                    last_seen: Some(300),
+                    last_seen: Some(Time::from_consensus(LOCK_TIME_THRESHOLD+300).unwrap()),
                     ..Default::default()
                 },
                 TxTemplate {
                     tx_name: "tx_conflict_3",
                     inputs: &[TxInTemplate::PrevTx("tx1", 0)],
                     outputs: &[TxOutTemplate::new(40000, Some(3))],
-                    last_seen: Some(400),
+                    last_seen: Some(Time::from_consensus(LOCK_TIME_THRESHOLD+400).unwrap()),
                     ..Default::default()
                 },
                 TxTemplate {
@@ -324,28 +325,28 @@ fn test_tx_conflict_handling() {
                     tx_name: "A",
                     inputs: &[TxInTemplate::Bogus],
                     outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    last_seen: Some(22),
+                    last_seen: Some(Time::from_consensus(LOCK_TIME_THRESHOLD+22).unwrap()),
                     ..Default::default()
                 },
                 TxTemplate {
                     tx_name: "B",
                     inputs: &[TxInTemplate::PrevTx("A", 0)],
                     outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    last_seen: Some(23),
+                    last_seen: Some(Time::from_consensus(LOCK_TIME_THRESHOLD+23).unwrap()),
                     ..Default::default()
                 },
                 TxTemplate {
                     tx_name: "B'",
                     inputs: &[TxInTemplate::PrevTx("A", 0)],
                     outputs: &[TxOutTemplate::new(20000, Some(2))],
-                    last_seen: Some(24),
+                    last_seen: Some(Time::from_consensus(LOCK_TIME_THRESHOLD+24).unwrap()),
                     ..Default::default()
                 },
                 TxTemplate {
                     tx_name: "C",
                     inputs: &[TxInTemplate::PrevTx("B", 0)],
                     outputs: &[TxOutTemplate::new(30000, Some(3))],
-                    last_seen: Some(25),
+                    last_seen: Some(Time::from_consensus(LOCK_TIME_THRESHOLD+25).unwrap()),
                     ..Default::default()
                 },
             ],
@@ -462,14 +463,14 @@ fn test_tx_conflict_handling() {
                     tx_name: "B",
                     inputs: &[TxInTemplate::PrevTx("A", 0), TxInTemplate::Bogus],
                     outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    last_seen: Some(200),
+                    last_seen: Some(Time::from_consensus(LOCK_TIME_THRESHOLD+200).unwrap()),
                     ..Default::default()
                 },
                 TxTemplate {
                     tx_name: "B'",
                     inputs: &[TxInTemplate::PrevTx("A", 0)],
                     outputs: &[TxOutTemplate::new(30000, Some(2))],
-                    last_seen: Some(300),
+                    last_seen: Some(Time::from_consensus(LOCK_TIME_THRESHOLD+300).unwrap()),
                     ..Default::default()
                 },
                 TxTemplate {
@@ -507,7 +508,7 @@ fn test_tx_conflict_handling() {
                     tx_name: "B",
                     inputs: &[TxInTemplate::PrevTx("A", 0), TxInTemplate::Bogus],
                     outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    last_seen: Some(200),
+                    last_seen: Some(Time::from_consensus(LOCK_TIME_THRESHOLD+200).unwrap()),
                     ..Default::default()
                 },
                 TxTemplate {
@@ -552,7 +553,7 @@ fn test_tx_conflict_handling() {
                     tx_name: "B",
                     inputs: &[TxInTemplate::PrevTx("A", 0), TxInTemplate::Bogus],
                     outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    last_seen: Some(200),
+                    last_seen: Some(Time::from_consensus(LOCK_TIME_THRESHOLD+200).unwrap()),
                     ..Default::default()
                 },
                 TxTemplate {

--- a/crates/electrum/src/electrum_ext.rs
+++ b/crates/electrum/src/electrum_ext.rs
@@ -1,5 +1,5 @@
 use bdk_chain::{
-    bitcoin::{OutPoint, ScriptBuf, Transaction, Txid},
+    bitcoin::{absolute::Time, OutPoint, ScriptBuf, Transaction, Txid},
     local_chain::{self, CheckPoint},
     tx_graph::{self, TxGraph},
     Anchor, BlockId, ConfirmationHeightAnchor, ConfirmationTimeHeightAnchor,
@@ -40,7 +40,7 @@ impl RelevantTxids {
     pub fn into_tx_graph(
         self,
         client: &Client,
-        seen_at: Option<u64>,
+        seen_at: Option<Time>,
         missing: Vec<Txid>,
     ) -> Result<TxGraph<ConfirmationHeightAnchor>, Error> {
         let new_txs = client.batch_transaction_get(&missing)?;
@@ -67,7 +67,7 @@ impl RelevantTxids {
     pub fn into_confirmation_time_tx_graph(
         self,
         client: &Client,
-        seen_at: Option<u64>,
+        seen_at: Option<Time>,
         missing: Vec<Txid>,
     ) -> Result<TxGraph<ConfirmationTimeHeightAnchor>, Error> {
         let graph = self.into_tx_graph(client, seen_at, missing)?;
@@ -108,7 +108,10 @@ impl RelevantTxids {
                         let time_anchor = ConfirmationTimeHeightAnchor {
                             anchor_block: height_anchor.anchor_block,
                             confirmation_height,
-                            confirmation_time,
+                            confirmation_time: Time::from_consensus(
+                                confirmation_time.try_into().expect("consensus time"),
+                            )
+                            .expect("consensus time"),
                         };
                         (time_anchor, txid)
                     })

--- a/crates/esplora/src/lib.rs
+++ b/crates/esplora/src/lib.rs
@@ -16,6 +16,7 @@
 //! [`TxGraph`]: bdk_chain::tx_graph::TxGraph
 //! [`example_esplora`]: https://github.com/bitcoindevkit/bdk/tree/master/example-crates/example_esplora
 
+use bdk_chain::bitcoin::absolute::Time;
 use bdk_chain::{BlockId, ConfirmationTimeHeightAnchor};
 use esplora_client::TxStatus;
 
@@ -42,7 +43,8 @@ fn anchor_from_status(status: &TxStatus) -> Option<ConfirmationTimeHeightAnchor>
         Some(ConfirmationTimeHeightAnchor {
             anchor_block: BlockId { height, hash },
             confirmation_height: height,
-            confirmation_time: time,
+            confirmation_time: Time::from_consensus(time.try_into().expect("consensus time"))
+                .expect("consensus time"),
         })
     } else {
         None

--- a/example-crates/example_bitcoind_rpc_polling/src/main.rs
+++ b/example-crates/example_bitcoind_rpc_polling/src/main.rs
@@ -11,6 +11,7 @@ use bdk_bitcoind_rpc::{
     bitcoincore_rpc::{Auth, Client, RpcApi},
     Emitter,
 };
+use bdk_chain::bitcoin::absolute::Time;
 use bdk_chain::{
     bitcoin::{constants::genesis_block, Block, Transaction},
     indexed_tx_graph, keychain,
@@ -43,7 +44,7 @@ type ChangeSet = (
 #[derive(Debug)]
 enum Emission {
     Block(bdk_bitcoind_rpc::BlockEvent<Block>),
-    Mempool(Vec<(Transaction, u64)>),
+    Mempool(Vec<(Transaction, Time)>),
     Tip(u32),
 }
 

--- a/example-crates/example_electrum/src/main.rs
+++ b/example-crates/example_electrum/src/main.rs
@@ -4,6 +4,7 @@ use std::{
     sync::Mutex,
 };
 
+use bdk_chain::bitcoin::absolute::Time;
 use bdk_chain::{
     bitcoin::{constants::genesis_block, Address, Network, OutPoint, Txid},
     indexed_tx_graph::{self, IndexedTxGraph},
@@ -299,10 +300,13 @@ fn main() -> anyhow::Result<()> {
         relevant_txids.missing_full_txs(graph.graph())
     };
 
-    let now = std::time::UNIX_EPOCH
+    let now: u32 = std::time::UNIX_EPOCH
         .elapsed()
         .expect("must get time")
-        .as_secs();
+        .as_secs()
+        .try_into()
+        .expect("consensus bitcoin time");
+    let now = Time::from_consensus(now).expect("consensus bitcoin time");
 
     let graph_update = relevant_txids.into_tx_graph(&client, Some(now), missing_txids)?;
 

--- a/example-crates/wallet_rpc/src/main.rs
+++ b/example-crates/wallet_rpc/src/main.rs
@@ -1,5 +1,5 @@
 use bdk::{
-    bitcoin::{Block, Network, Transaction},
+    bitcoin::{absolute::Time, Block, Network, Transaction},
     wallet::Wallet,
 };
 use bdk_bitcoind_rpc::{
@@ -73,7 +73,7 @@ impl Args {
 enum Emission {
     SigTerm,
     Block(bdk_bitcoind_rpc::BlockEvent<Block>),
-    Mempool(Vec<(Transaction, u64)>),
+    Mempool(Vec<(Transaction, Time)>),
 }
 
 fn main() -> anyhow::Result<()> {


### PR DESCRIPTION
### Description

Replace instances of `u64` for unix epoch with `bitcoin::absolute::Time` and `u32` for block height with `bitcoin::absolute::Height`.

Fixes bitcoindevkit/bdk_wallet#147

### Notes to the reviewers

Instead of waiting for default implementations for `Time` and `Height` I used `Time::MIN` and `Height::MIN`. Once a default impl is available we should be able to use it internally without affecting our APIs. 

### Changelog notice

Change

- Replace all instances of u64 for unix epoch with bitcoin::absolute::Time.
- Replace all instances of u32 for block height with bitcoin::absolute::Height.

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
