### PR TITLE
ci: fix dependabot for audit and cont_integration workflows

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -5,6 +5,8 @@ on:
     paths:
       - '**/Cargo.toml'
       - '**/Cargo.lock'
+    branches-ignore:
+      - 'dependabot/**'
   schedule:
     - cron: '0 0 * * 0' # Once per week
 

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - 'dependabot/**'
+  pull_request:
 
 name: CI
 


### PR DESCRIPTION
### Description

We are getting errors on dependabot generated PRs. See:

https://github.com/bitcoindevkit/bdk/actions/runs/8310897352
https://github.com/bitcoindevkit/bdk/actions/runs/8310897348

To fix this one of the recommended solutions is to exclude `push` triggered workflow runs for the dependabot created PR branches, `push` trigger is sufficient. See: [Error: 403 "Resource not accessible by integration"](https://docs.github.com/en/code-security/code-scanning/troubleshooting-code-scanning/resource-not-accessible).

### Notes to the reviewers

An alternative fix is to remove the `push` trigger but this seemed like a smaller change and the audit workflow only uses the `push` trigger and I'm not sure if it will break if we switch it to use `pull_request` instead. 

It's a little annoying having dependabot create PRs but since it only triggers on security related issues it's worth having so we don't forget to do those updates.

### Changelog notice

None.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
