### PR TITLE
Bump bdk version to 1.0.0-alpha.8

### DIFF
--- a/crates/bdk/Cargo.toml
+++ b/crates/bdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bdk"
 homepage = "https://bitcoindevkit.org"
-version = "1.0.0-alpha.7"
+version = "1.0.0-alpha.8"
 repository = "https://github.com/bitcoindevkit/bdk"
 documentation = "https://docs.rs/bdk"
 description = "A modern, lightweight, descriptor-based wallet library"

--- a/crates/bitcoind_rpc/Cargo.toml
+++ b/crates/bitcoind_rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_bitcoind_rpc"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"
@@ -19,7 +19,7 @@ bitcoincore-rpc = { version = "0.17" }
 bdk_chain = { path = "../chain", version = "0.11", default-features = false }
 
 [dev-dependencies]
-bdk_testenv = { path = "../testenv", default_features = false }
+bdk_testenv = { path = "../testenv", version = "0.1.0", default_features = false }
 anyhow = { version = "1" }
 
 [features]

--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_electrum"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -17,6 +17,6 @@ electrum-client = { version = "0.18" }
 #rustls = { version = "=0.21.1", optional = true, features = ["dangerous_configuration"] }
 
 [dev-dependencies]
-bdk_testenv = { path = "../testenv", default-features = false }
+bdk_testenv = { path = "../testenv", version = "0.1.0", default-features = false }
 electrsd = { version= "0.25.0", features = ["bitcoind_25_0", "esplora_a33e97e1", "legacy"] }
 anyhow = "1"

--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_esplora"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -22,7 +22,7 @@ bitcoin = { version = "0.30.0", optional = true, default-features = false }
 miniscript = { version = "10.0.0", optional = true, default-features = false }
 
 [dev-dependencies]
-bdk_testenv = { path = "../testenv", default_features = false }
+bdk_testenv = { path = "../testenv", version = "0.1.0", default_features = false }
 electrsd = { version= "0.25.0", features = ["bitcoind_25_0", "esplora_a33e97e1", "legacy"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 

--- a/crates/file_store/Cargo.toml
+++ b/crates/file_store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_file_store"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bitcoindevkit/bdk"

--- a/crates/hwi/Cargo.toml
+++ b/crates/hwi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_hwi"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"


### PR DESCRIPTION
### Description

Bump versions:

bdk version to 1.0.0-alpha.8
bdk_bitcoind_rpc to 0.7.0
bdk_electrum to 0.10.0
bdk_esplora to 0.10.0
bdk_file_store to 0.8.0
bdk_hwi to 0.2.0

fixes #1388

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

