### PR TITLE
Fix cargo manifest for `bdk_testenv`

### DIFF
--- a/crates/testenv/Cargo.toml
+++ b/crates/testenv/Cargo.toml
@@ -2,6 +2,13 @@
 name = "bdk_testenv"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.63"
+homepage = "https://bitcoindevkit.org"
+repository = "https://github.com/bitcoindevkit/bdk"
+documentation = "https://docs.rs/bdk_testenv"
+description = "Testing framework for BDK chain sources."
+license = "MIT OR Apache-2.0"
+readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
### Description

This will make the `bdk_testenv` crate actually publishable.

### Changelog notice

* Fix cargo manifest of `bdk_testenv`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
