### PR TITLE
bdk_hwi, set cargo bdk version to 1.0.0-alpha.8

### DIFF
--- a/crates/hwi/Cargo.toml
+++ b/crates/hwi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_hwi"
-version = "0.2.0"
+version = "0.1.0"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -9,5 +9,5 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-bdk_wallet = { path = "../wallet" }
+bdk_wallet = { path = "../wallet", version = "1.0.0-alpha.11"}
 hwi = { version = "0.8.0", features = [ "miniscript"] }

--- a/crates/hwi/README.md
+++ b/crates/hwi/README.md
@@ -1,0 +1,3 @@
+# BDK HWI Signer
+
+This crate contains `HWISigner`, an implementation of a `TransactionSigner` to be used with hardware wallets.


### PR DESCRIPTION
### Description

Need to set a specific version for the `bdk_wallet` dependency in order to be able to publish `bdk_hwi` to crates.io. I also added a README file since it is also a warning if a crate is published without one.

```shell
cargo publish -p bdk_hwi
    Updating crates.io index
error: all dependencies must have a version specified when publishing.
dependency `bdk` does not specify a version
Note: The published dependency will use the version from crates.io,
the `path` specification will be removed from the dependency declaration.
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
