### PR TITLE
Introduce proptesting, starting with `CheckPoint::range`

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -33,6 +33,7 @@ jobs:
           cargo update -p zstd-sys --precise "2.0.8+zstd.1.5.5"
           cargo update -p time --precise "0.3.20"
           cargo update -p home --precise "0.5.5"
+          cargo update -p proptest --precise "1.2.0"
       - name: Build
         run: cargo build ${{ matrix.features }}
       - name: Test

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ cargo update -p time --precise "0.3.20"
 cargo update -p jobserver --precise "0.1.26"
 # home 0.5.9 has MSRV 1.70.0
 cargo update -p home --precise "0.5.5"
+# proptest 1.4.0 has MSRV 1.65.0
+cargo update -p proptest --precise "1.2.0"
 ```
 
 ## License

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -23,6 +23,7 @@ miniscript = { version = "10.0.0", optional = true, default-features = false }
 
 [dev-dependencies]
 rand = "0.8"
+proptest = "1.2.0"
 
 [features]
 default = ["std"]


### PR DESCRIPTION
### Description

This is based on bitcoindevkit/bdk#1369. It made sense for me to introduce the `CheckPoint::range` test as a proptest. I think we should also start introducing it for other methods too.

### Changelog notice

* Added proptest for `CheckPoint::range`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
