### PR TITLE
Test the bitcoin `v0.32.0-rc1` release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,55 @@ members = [
 
 [workspace.package]
 authors = ["Bitcoin Dev Kit Developers"]
+
+[patch.crates-io.electrsd]
+git = "https://github.com/tcharding/electrsd"
+branch = "test-bitcoin"
+
+[patch.crates-io.esplora-client]
+git = "https://github.com/tcharding/rust-esplora-client"
+branch = "test-bitcoin"
+
+[patch.crates-io.electrum-client]
+git = "https://github.com/tcharding/rust-electrum-client"
+branch = "test-bitcoin"
+
+[patch.crates-io.hwi]
+git = "https://github.com/tcharding/rust-hwi"
+branch = "test-bitcoin"
+
+[patch.crates-io.miniscript]
+git = "https://github.com/tcharding/rust-miniscript"
+branch = "test-bitcoin"
+
+[patch.crates-io.bitcoind]
+git = "https://github.com/tcharding/bitcoind/"
+branch = "test-bitcoin"
+
+[patch.crates-io.bitcoincore-rpc]
+git = "https://github.com/tcharding/rust-bitcoincore-rpc"
+branch = "test-bitcoin"
+
+[patch.crates-io.base58ck]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "rc1-fixes"
+
+[patch.crates-io.bitcoin]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "rc1-fixes"
+
+[patch.crates-io.bitcoin_hashes]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "rc1-fixes"
+
+[patch.crates-io.bitcoin-internals]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "rc1-fixes"
+
+[patch.crates-io.bitcoin-io]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "rc1-fixes"
+
+[patch.crates-io.bitcoin-units]
+git = "https://github.com/rust-bitcoin/rust-bitcoin"
+branch = "rc1-fixes"

--- a/crates/bdk/Cargo.toml
+++ b/crates/bdk/Cargo.toml
@@ -14,8 +14,8 @@ rust-version = "1.63"
 
 [dependencies]
 rand = "^0.8"
-miniscript = { version = "10.0.0", features = ["serde"], default-features = false }
-bitcoin = { version = "0.30.0", features = ["serde", "base64", "rand-std"], default-features = false }
+miniscript = { version = "11.0.0", features = ["serde"], default-features = false }
+bitcoin = { version = "0.31.0", features = ["serde", "base64", "rand-std"], default-features = false }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 bdk_chain = { path = "../chain", version = "0.11.0", features = ["miniscript", "serde"], default-features = false }

--- a/crates/bdk/Cargo.toml
+++ b/crates/bdk/Cargo.toml
@@ -14,11 +14,11 @@ rust-version = "1.63"
 
 [dependencies]
 rand = "^0.8"
-miniscript = { version = "11.0.0", features = ["serde"], default-features = false }
-bitcoin = { version = "0.31.0", features = ["serde", "base64", "rand-std"], default-features = false }
+miniscript = { version = "12.0.0", features = ["serde"], default-features = false }
+bitcoin = { version = "0.32.0-rc1", features = ["serde", "base64", "rand-std"], default-features = false }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
-bdk_chain = { path = "../chain", version = "0.11.0", features = ["miniscript", "serde"], default-features = false }
+bdk_chain = { path = "../chain", features = ["miniscript", "serde"], default-features = false }
 
 # Optional dependencies
 bip39 = { version = "2.0", optional = true }

--- a/crates/bdk/src/descriptor/dsl.rs
+++ b/crates/bdk/src/descriptor/dsl.rs
@@ -702,10 +702,10 @@ macro_rules! fragment {
         $crate::keys::make_pkh($key, &secp)
     });
     ( after ( $value:expr ) ) => ({
-        $crate::impl_leaf_opcode_value!(After, $crate::miniscript::AbsLockTime::from_consensus($value))
+        $crate::impl_leaf_opcode_value!(After, $crate::miniscript::AbsLockTime::from_consensus($value).expect("TODO: Handle error"))
     });
     ( older ( $value:expr ) ) => ({
-        $crate::impl_leaf_opcode_value!(Older, $crate::bitcoin::Sequence($value)) // TODO!!
+        $crate::impl_leaf_opcode_value!(Older, $crate::miniscript::RelLockTime::from_consensus($value).expect("TODO: Handle error"))
     });
     ( sha256 ( $hash:expr ) ) => ({
         $crate::impl_leaf_opcode_value!(Sha256, $hash)
@@ -768,7 +768,11 @@ macro_rules! fragment {
     ( multi_vec ( $thresh:expr, $keys:expr ) ) => ({
         let secp = $crate::bitcoin::secp256k1::Secp256k1::new();
 
-        $crate::keys::make_multi($thresh, $crate::miniscript::Terminal::Multi, $keys, &secp)
+        let fun = |k, pks| {
+            let thresh = $crate::miniscript::Threshold::new(k, pks).expect("TODO: Handle this error");
+            $crate::miniscript::Terminal::Multi(thresh)
+        };
+        $crate::keys::make_multi($thresh, fun, $keys, &secp)
     });
     ( multi ( $thresh:expr $(, $key:expr )+ ) ) => ({
         $crate::group_multi_keys!( $( $key ),* )
@@ -777,7 +781,11 @@ macro_rules! fragment {
     ( multi_a_vec ( $thresh:expr, $keys:expr ) ) => ({
         let secp = $crate::bitcoin::secp256k1::Secp256k1::new();
 
-        $crate::keys::make_multi($thresh, $crate::miniscript::Terminal::MultiA, $keys, &secp)
+        let fun = |k, pks| {
+            let thresh = $crate::miniscript::Threshold::new(k, pks).expect("TODO: Handle this error");
+            $crate::miniscript::Terminal::MultiA(thresh)
+        };
+        $crate::keys::make_multi($thresh, fun, $keys, &secp)
     });
     ( multi_a ( $thresh:expr $(, $key:expr )+ ) ) => ({
         $crate::group_multi_keys!( $( $key ),* )

--- a/crates/bdk/src/descriptor/error.rs
+++ b/crates/bdk/src/descriptor/error.rs
@@ -41,7 +41,7 @@ pub enum Error {
     /// Miniscript error
     Miniscript(miniscript::Error),
     /// Hex decoding error
-    Hex(bitcoin::hashes::hex::Error),
+    Hex(bitcoin::hex::HexToBytesError),
 }
 
 impl From<crate::keys::KeyError> for Error {
@@ -110,8 +110,8 @@ impl From<miniscript::Error> for Error {
     }
 }
 
-impl From<bitcoin::hashes::hex::Error> for Error {
-    fn from(err: bitcoin::hashes::hex::Error) -> Self {
+impl From<bitcoin::hex::HexToBytesError> for Error {
+    fn from(err: bitcoin::hex::HexToBytesError) -> Self {
         Error::Hex(err)
     }
 }

--- a/crates/bdk/src/descriptor/error.rs
+++ b/crates/bdk/src/descriptor/error.rs
@@ -37,7 +37,7 @@ pub enum Error {
     /// Error during base58 decoding
     Base58(bitcoin::base58::Error),
     /// Key-related error
-    Pk(bitcoin::key::Error),
+    Pk(bitcoin::key::ParsePublicKeyError),
     /// Miniscript error
     Miniscript(miniscript::Error),
     /// Hex decoding error
@@ -98,8 +98,8 @@ impl From<bitcoin::base58::Error> for Error {
     }
 }
 
-impl From<bitcoin::key::Error> for Error {
-    fn from(err: bitcoin::key::Error) -> Self {
+impl From<bitcoin::key::ParsePublicKeyError> for Error {
+    fn from(err: bitcoin::key::ParsePublicKeyError) -> Self {
         Error::Pk(err)
     }
 }

--- a/crates/bdk/src/descriptor/mod.rs
+++ b/crates/bdk/src/descriptor/mod.rs
@@ -229,7 +229,7 @@ impl IntoWalletDescriptor for DescriptorTemplateOut {
                 let pk = match pk {
                     DescriptorPublicKey::XPub(ref xpub) => {
                         let mut xpub = xpub.clone();
-                        xpub.xkey.network = self.network;
+                        xpub.xkey.network = self.network.into();
 
                         DescriptorPublicKey::XPub(xpub)
                     }
@@ -264,11 +264,11 @@ impl IntoWalletDescriptor for DescriptorTemplateOut {
             .map(|(mut k, mut v)| {
                 match (&mut k, &mut v) {
                     (DescriptorPublicKey::XPub(xpub), DescriptorSecretKey::XPrv(xprv)) => {
-                        xpub.xkey.network = network;
-                        xprv.xkey.network = network;
+                        xpub.xkey.network = network.into();
+                        xprv.xkey.network = network.into();
                     }
                     (_, DescriptorSecretKey::Single(key)) => {
-                        key.key.network = network;
+                        key.key.network = network.into();
                     }
                     _ => {}
                 }
@@ -606,8 +606,8 @@ mod test {
     use assert_matches::assert_matches;
     use bitcoin::hex::FromHex;
     use bitcoin::secp256k1::Secp256k1;
-    use bitcoin::ScriptBuf;
     use bitcoin::{bip32, Psbt};
+    use bitcoin::{NetworkKind, ScriptBuf};
 
     use super::*;
     use crate::psbt::PsbtUtils;
@@ -743,7 +743,7 @@ mod test {
             .unwrap();
 
         let mut xprv_testnet = xprv;
-        xprv_testnet.network = Network::Testnet;
+        xprv_testnet.network = NetworkKind::Test;
 
         let xpub_testnet = bip32::Xpub::from_priv(&secp, &xprv_testnet);
         let desc_pubkey = DescriptorPublicKey::XPub(DescriptorXKey {

--- a/crates/bdk/src/descriptor/policy.rs
+++ b/crates/bdk/src/descriptor/policy.rs
@@ -1137,7 +1137,7 @@ impl ExtractPolicy for Descriptor<DescriptorPublicKey> {
                 let key_spend_sig =
                     miniscript::Tap::make_signature(tr.internal_key(), signers, build_sat, secp);
 
-                if tr.taptree().is_none() {
+                if tr.tap_tree().is_none() {
                     Ok(Some(key_spend_sig))
                 } else {
                     let mut items = vec![key_spend_sig];
@@ -1184,8 +1184,8 @@ mod test {
         secp: &SecpCtx,
     ) -> (DescriptorKey<Ctx>, DescriptorKey<Ctx>, Fingerprint) {
         let path = bip32::DerivationPath::from_str(path).unwrap();
-        let tprv = bip32::ExtendedPrivKey::from_str(tprv).unwrap();
-        let tpub = bip32::ExtendedPubKey::from_priv(secp, &tprv);
+        let tprv = bip32::Xpriv::from_str(tprv).unwrap();
+        let tpub = bip32::Xpub::from_priv(secp, &tprv);
         let fingerprint = tprv.fingerprint(secp);
         let prvkey = (tprv, path.clone()).into_descriptor_key().unwrap();
         let pubkey = (tpub, path).into_descriptor_key().unwrap();

--- a/crates/bdk/src/descriptor/template.rs
+++ b/crates/bdk/src/descriptor/template.rs
@@ -195,7 +195,7 @@ impl<K: IntoDescriptorKey<Tap>> DescriptorTemplate for P2TR<K> {
 /// # use bdk::wallet::AddressIndex::New;
 /// use bdk::template::Bip44;
 ///
-/// let key = bitcoin::bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPeZRHk4rTG6orPS2CRNFX3njhUXx5vj9qGog5ZMH4uGReDWN5kCkY3jmWEtWause41CDvBRXD1shKknAMKxT99o9qUTRVC6m")?;
+/// let key = bitcoin::bip32::Xpriv::from_str("tprv8ZgxMBicQKsPeZRHk4rTG6orPS2CRNFX3njhUXx5vj9qGog5ZMH4uGReDWN5kCkY3jmWEtWause41CDvBRXD1shKknAMKxT99o9qUTRVC6m")?;
 /// let mut wallet = Wallet::new_no_persist(
 ///     Bip44(key.clone(), KeychainKind::External),
 ///     Some(Bip44(key, KeychainKind::Internal)),
@@ -232,7 +232,7 @@ impl<K: DerivableKey<Legacy>> DescriptorTemplate for Bip44<K> {
 /// # use bdk::wallet::AddressIndex::New;
 /// use bdk::template::Bip44Public;
 ///
-/// let key = bitcoin::bip32::ExtendedPubKey::from_str("tpubDDDzQ31JkZB7VxUr9bjvBivDdqoFLrDPyLWtLapArAi51ftfmCb2DPxwLQzX65iNcXz1DGaVvyvo6JQ6rTU73r2gqdEo8uov9QKRb7nKCSU")?;
+/// let key = bitcoin::bip32::Xpub::from_str("tpubDDDzQ31JkZB7VxUr9bjvBivDdqoFLrDPyLWtLapArAi51ftfmCb2DPxwLQzX65iNcXz1DGaVvyvo6JQ6rTU73r2gqdEo8uov9QKRb7nKCSU")?;
 /// let fingerprint = bitcoin::bip32::Fingerprint::from_str("c55b303f")?;
 /// let mut wallet = Wallet::new_no_persist(
 ///     Bip44Public(key.clone(), fingerprint, KeychainKind::External),
@@ -270,7 +270,7 @@ impl<K: DerivableKey<Legacy>> DescriptorTemplate for Bip44Public<K> {
 /// # use bdk::wallet::AddressIndex::New;
 /// use bdk::template::Bip49;
 ///
-/// let key = bitcoin::bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPeZRHk4rTG6orPS2CRNFX3njhUXx5vj9qGog5ZMH4uGReDWN5kCkY3jmWEtWause41CDvBRXD1shKknAMKxT99o9qUTRVC6m")?;
+/// let key = bitcoin::bip32::Xpriv::from_str("tprv8ZgxMBicQKsPeZRHk4rTG6orPS2CRNFX3njhUXx5vj9qGog5ZMH4uGReDWN5kCkY3jmWEtWause41CDvBRXD1shKknAMKxT99o9qUTRVC6m")?;
 /// let mut wallet = Wallet::new_no_persist(
 ///     Bip49(key.clone(), KeychainKind::External),
 ///     Some(Bip49(key, KeychainKind::Internal)),
@@ -307,7 +307,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip49<K> {
 /// # use bdk::wallet::AddressIndex::New;
 /// use bdk::template::Bip49Public;
 ///
-/// let key = bitcoin::bip32::ExtendedPubKey::from_str("tpubDC49r947KGK52X5rBWS4BLs5m9SRY3pYHnvRrm7HcybZ3BfdEsGFyzCMzayi1u58eT82ZeyFZwH7DD6Q83E3fM9CpfMtmnTygnLfP59jL9L")?;
+/// let key = bitcoin::bip32::Xpub::from_str("tpubDC49r947KGK52X5rBWS4BLs5m9SRY3pYHnvRrm7HcybZ3BfdEsGFyzCMzayi1u58eT82ZeyFZwH7DD6Q83E3fM9CpfMtmnTygnLfP59jL9L")?;
 /// let fingerprint = bitcoin::bip32::Fingerprint::from_str("c55b303f")?;
 /// let mut wallet = Wallet::new_no_persist(
 ///     Bip49Public(key.clone(), fingerprint, KeychainKind::External),
@@ -345,7 +345,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip49Public<K> {
 /// # use bdk::wallet::AddressIndex::New;
 /// use bdk::template::Bip84;
 ///
-/// let key = bitcoin::bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPeZRHk4rTG6orPS2CRNFX3njhUXx5vj9qGog5ZMH4uGReDWN5kCkY3jmWEtWause41CDvBRXD1shKknAMKxT99o9qUTRVC6m")?;
+/// let key = bitcoin::bip32::Xpriv::from_str("tprv8ZgxMBicQKsPeZRHk4rTG6orPS2CRNFX3njhUXx5vj9qGog5ZMH4uGReDWN5kCkY3jmWEtWause41CDvBRXD1shKknAMKxT99o9qUTRVC6m")?;
 /// let mut wallet = Wallet::new_no_persist(
 ///     Bip84(key.clone(), KeychainKind::External),
 ///     Some(Bip84(key, KeychainKind::Internal)),
@@ -382,7 +382,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip84<K> {
 /// # use bdk::wallet::AddressIndex::New;
 /// use bdk::template::Bip84Public;
 ///
-/// let key = bitcoin::bip32::ExtendedPubKey::from_str("tpubDC2Qwo2TFsaNC4ju8nrUJ9mqVT3eSgdmy1yPqhgkjwmke3PRXutNGRYAUo6RCHTcVQaDR3ohNU9we59brGHuEKPvH1ags2nevW5opEE9Z5Q")?;
+/// let key = bitcoin::bip32::Xpub::from_str("tpubDC2Qwo2TFsaNC4ju8nrUJ9mqVT3eSgdmy1yPqhgkjwmke3PRXutNGRYAUo6RCHTcVQaDR3ohNU9we59brGHuEKPvH1ags2nevW5opEE9Z5Q")?;
 /// let fingerprint = bitcoin::bip32::Fingerprint::from_str("c55b303f")?;
 /// let mut wallet = Wallet::new_no_persist(
 ///     Bip84Public(key.clone(), fingerprint, KeychainKind::External),
@@ -420,7 +420,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip84Public<K> {
 /// # use bdk::wallet::AddressIndex::New;
 /// use bdk::template::Bip86;
 ///
-/// let key = bitcoin::bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPeZRHk4rTG6orPS2CRNFX3njhUXx5vj9qGog5ZMH4uGReDWN5kCkY3jmWEtWause41CDvBRXD1shKknAMKxT99o9qUTRVC6m")?;
+/// let key = bitcoin::bip32::Xpriv::from_str("tprv8ZgxMBicQKsPeZRHk4rTG6orPS2CRNFX3njhUXx5vj9qGog5ZMH4uGReDWN5kCkY3jmWEtWause41CDvBRXD1shKknAMKxT99o9qUTRVC6m")?;
 /// let mut wallet = Wallet::new_no_persist(
 ///     Bip86(key.clone(), KeychainKind::External),
 ///     Some(Bip86(key, KeychainKind::Internal)),
@@ -457,7 +457,7 @@ impl<K: DerivableKey<Tap>> DescriptorTemplate for Bip86<K> {
 /// # use bdk::wallet::AddressIndex::New;
 /// use bdk::template::Bip86Public;
 ///
-/// let key = bitcoin::bip32::ExtendedPubKey::from_str("tpubDC2Qwo2TFsaNC4ju8nrUJ9mqVT3eSgdmy1yPqhgkjwmke3PRXutNGRYAUo6RCHTcVQaDR3ohNU9we59brGHuEKPvH1ags2nevW5opEE9Z5Q")?;
+/// let key = bitcoin::bip32::Xpub::from_str("tpubDC2Qwo2TFsaNC4ju8nrUJ9mqVT3eSgdmy1yPqhgkjwmke3PRXutNGRYAUo6RCHTcVQaDR3ohNU9we59brGHuEKPvH1ags2nevW5opEE9Z5Q")?;
 /// let fingerprint = bitcoin::bip32::Fingerprint::from_str("c55b303f")?;
 /// let mut wallet = Wallet::new_no_persist(
 ///     Bip86Public(key.clone(), fingerprint, KeychainKind::External),
@@ -567,7 +567,7 @@ mod test {
     fn test_bip44_template_cointype() {
         use bitcoin::bip32::ChildNumber::{self, Hardened};
 
-        let xprvkey = bitcoin::bip32::ExtendedPrivKey::from_str("xprv9s21ZrQH143K2fpbqApQL69a4oKdGVnVN52R82Ft7d1pSqgKmajF62acJo3aMszZb6qQ22QsVECSFxvf9uyxFUvFYQMq3QbtwtRSMjLAhMf").unwrap();
+        let xprvkey = bitcoin::bip32::Xpriv::from_str("xprv9s21ZrQH143K2fpbqApQL69a4oKdGVnVN52R82Ft7d1pSqgKmajF62acJo3aMszZb6qQ22QsVECSFxvf9uyxFUvFYQMq3QbtwtRSMjLAhMf").unwrap();
         assert_eq!(Network::Bitcoin, xprvkey.network);
         let xdesc = Bip44(xprvkey, KeychainKind::Internal)
             .build(Network::Bitcoin)
@@ -581,7 +581,7 @@ mod test {
             assert_matches!(coin_type, Hardened { index: 0 });
         }
 
-        let tprvkey = bitcoin::bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPcx5nBGsR63Pe8KnRUqmbJNENAfGftF3yuXoMMoVJJcYeUw5eVkm9WBPjWYt6HMWYJNesB5HaNVBaFc1M6dRjWSYnmewUMYy").unwrap();
+        let tprvkey = bitcoin::bip32::Xpriv::from_str("tprv8ZgxMBicQKsPcx5nBGsR63Pe8KnRUqmbJNENAfGftF3yuXoMMoVJJcYeUw5eVkm9WBPjWYt6HMWYJNesB5HaNVBaFc1M6dRjWSYnmewUMYy").unwrap();
         assert_eq!(Network::Testnet, tprvkey.network);
         let tdesc = Bip44(tprvkey, KeychainKind::Internal)
             .build(Network::Testnet)
@@ -740,7 +740,7 @@ mod test {
     // BIP44 `pkh(key/44'/0'/0'/{0,1}/*)`
     #[test]
     fn test_bip44_template() {
-        let prvkey = bitcoin::bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPcx5nBGsR63Pe8KnRUqmbJNENAfGftF3yuXoMMoVJJcYeUw5eVkm9WBPjWYt6HMWYJNesB5HaNVBaFc1M6dRjWSYnmewUMYy").unwrap();
+        let prvkey = bitcoin::bip32::Xpriv::from_str("tprv8ZgxMBicQKsPcx5nBGsR63Pe8KnRUqmbJNENAfGftF3yuXoMMoVJJcYeUw5eVkm9WBPjWYt6HMWYJNesB5HaNVBaFc1M6dRjWSYnmewUMYy").unwrap();
         check(
             Bip44(prvkey, KeychainKind::External).build(Network::Bitcoin),
             false,
@@ -770,7 +770,7 @@ mod test {
     // BIP44 public `pkh(key/{0,1}/*)`
     #[test]
     fn test_bip44_public_template() {
-        let pubkey = bitcoin::bip32::ExtendedPubKey::from_str("tpubDDDzQ31JkZB7VxUr9bjvBivDdqoFLrDPyLWtLapArAi51ftfmCb2DPxwLQzX65iNcXz1DGaVvyvo6JQ6rTU73r2gqdEo8uov9QKRb7nKCSU").unwrap();
+        let pubkey = bitcoin::bip32::Xpub::from_str("tpubDDDzQ31JkZB7VxUr9bjvBivDdqoFLrDPyLWtLapArAi51ftfmCb2DPxwLQzX65iNcXz1DGaVvyvo6JQ6rTU73r2gqdEo8uov9QKRb7nKCSU").unwrap();
         let fingerprint = bitcoin::bip32::Fingerprint::from_str("c55b303f").unwrap();
         check(
             Bip44Public(pubkey, fingerprint, KeychainKind::External).build(Network::Bitcoin),
@@ -801,7 +801,7 @@ mod test {
     // BIP49 `sh(wpkh(key/49'/0'/0'/{0,1}/*))`
     #[test]
     fn test_bip49_template() {
-        let prvkey = bitcoin::bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPcx5nBGsR63Pe8KnRUqmbJNENAfGftF3yuXoMMoVJJcYeUw5eVkm9WBPjWYt6HMWYJNesB5HaNVBaFc1M6dRjWSYnmewUMYy").unwrap();
+        let prvkey = bitcoin::bip32::Xpriv::from_str("tprv8ZgxMBicQKsPcx5nBGsR63Pe8KnRUqmbJNENAfGftF3yuXoMMoVJJcYeUw5eVkm9WBPjWYt6HMWYJNesB5HaNVBaFc1M6dRjWSYnmewUMYy").unwrap();
         check(
             Bip49(prvkey, KeychainKind::External).build(Network::Bitcoin),
             true,
@@ -831,7 +831,7 @@ mod test {
     // BIP49 public `sh(wpkh(key/{0,1}/*))`
     #[test]
     fn test_bip49_public_template() {
-        let pubkey = bitcoin::bip32::ExtendedPubKey::from_str("tpubDC49r947KGK52X5rBWS4BLs5m9SRY3pYHnvRrm7HcybZ3BfdEsGFyzCMzayi1u58eT82ZeyFZwH7DD6Q83E3fM9CpfMtmnTygnLfP59jL9L").unwrap();
+        let pubkey = bitcoin::bip32::Xpub::from_str("tpubDC49r947KGK52X5rBWS4BLs5m9SRY3pYHnvRrm7HcybZ3BfdEsGFyzCMzayi1u58eT82ZeyFZwH7DD6Q83E3fM9CpfMtmnTygnLfP59jL9L").unwrap();
         let fingerprint = bitcoin::bip32::Fingerprint::from_str("c55b303f").unwrap();
         check(
             Bip49Public(pubkey, fingerprint, KeychainKind::External).build(Network::Bitcoin),
@@ -862,7 +862,7 @@ mod test {
     // BIP84 `wpkh(key/84'/0'/0'/{0,1}/*)`
     #[test]
     fn test_bip84_template() {
-        let prvkey = bitcoin::bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPcx5nBGsR63Pe8KnRUqmbJNENAfGftF3yuXoMMoVJJcYeUw5eVkm9WBPjWYt6HMWYJNesB5HaNVBaFc1M6dRjWSYnmewUMYy").unwrap();
+        let prvkey = bitcoin::bip32::Xpriv::from_str("tprv8ZgxMBicQKsPcx5nBGsR63Pe8KnRUqmbJNENAfGftF3yuXoMMoVJJcYeUw5eVkm9WBPjWYt6HMWYJNesB5HaNVBaFc1M6dRjWSYnmewUMYy").unwrap();
         check(
             Bip84(prvkey, KeychainKind::External).build(Network::Bitcoin),
             true,
@@ -892,7 +892,7 @@ mod test {
     // BIP84 public `wpkh(key/{0,1}/*)`
     #[test]
     fn test_bip84_public_template() {
-        let pubkey = bitcoin::bip32::ExtendedPubKey::from_str("tpubDC2Qwo2TFsaNC4ju8nrUJ9mqVT3eSgdmy1yPqhgkjwmke3PRXutNGRYAUo6RCHTcVQaDR3ohNU9we59brGHuEKPvH1ags2nevW5opEE9Z5Q").unwrap();
+        let pubkey = bitcoin::bip32::Xpub::from_str("tpubDC2Qwo2TFsaNC4ju8nrUJ9mqVT3eSgdmy1yPqhgkjwmke3PRXutNGRYAUo6RCHTcVQaDR3ohNU9we59brGHuEKPvH1ags2nevW5opEE9Z5Q").unwrap();
         let fingerprint = bitcoin::bip32::Fingerprint::from_str("c55b303f").unwrap();
         check(
             Bip84Public(pubkey, fingerprint, KeychainKind::External).build(Network::Bitcoin),
@@ -924,7 +924,7 @@ mod test {
     // Used addresses in test vector in https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki
     #[test]
     fn test_bip86_template() {
-        let prvkey = bitcoin::bip32::ExtendedPrivKey::from_str("xprv9s21ZrQH143K3GJpoapnV8SFfukcVBSfeCficPSGfubmSFDxo1kuHnLisriDvSnRRuL2Qrg5ggqHKNVpxR86QEC8w35uxmGoggxtQTPvfUu").unwrap();
+        let prvkey = bitcoin::bip32::Xpriv::from_str("xprv9s21ZrQH143K3GJpoapnV8SFfukcVBSfeCficPSGfubmSFDxo1kuHnLisriDvSnRRuL2Qrg5ggqHKNVpxR86QEC8w35uxmGoggxtQTPvfUu").unwrap();
         check(
             Bip86(prvkey, KeychainKind::External).build(Network::Bitcoin),
             false,
@@ -955,7 +955,7 @@ mod test {
     // Used addresses in test vector in https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki
     #[test]
     fn test_bip86_public_template() {
-        let pubkey = bitcoin::bip32::ExtendedPubKey::from_str("xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ").unwrap();
+        let pubkey = bitcoin::bip32::Xpub::from_str("xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ").unwrap();
         let fingerprint = bitcoin::bip32::Fingerprint::from_str("73c5da0a").unwrap();
         check(
             Bip86Public(pubkey, fingerprint, KeychainKind::External).build(Network::Bitcoin),

--- a/crates/bdk/src/descriptor/template.rs
+++ b/crates/bdk/src/descriptor/template.rs
@@ -559,6 +559,7 @@ mod test {
     use crate::descriptor::{DescriptorError, DescriptorMeta};
     use crate::keys::ValidNetworks;
     use assert_matches::assert_matches;
+    use bitcoin::NetworkKind;
     use miniscript::descriptor::{DescriptorPublicKey, KeyMap};
     use miniscript::Descriptor;
 
@@ -568,7 +569,7 @@ mod test {
         use bitcoin::bip32::ChildNumber::{self, Hardened};
 
         let xprvkey = bitcoin::bip32::Xpriv::from_str("xprv9s21ZrQH143K2fpbqApQL69a4oKdGVnVN52R82Ft7d1pSqgKmajF62acJo3aMszZb6qQ22QsVECSFxvf9uyxFUvFYQMq3QbtwtRSMjLAhMf").unwrap();
-        assert_eq!(Network::Bitcoin, xprvkey.network);
+        assert_eq!(NetworkKind::Main, xprvkey.network);
         let xdesc = Bip44(xprvkey, KeychainKind::Internal)
             .build(Network::Bitcoin)
             .unwrap();
@@ -582,7 +583,7 @@ mod test {
         }
 
         let tprvkey = bitcoin::bip32::Xpriv::from_str("tprv8ZgxMBicQKsPcx5nBGsR63Pe8KnRUqmbJNENAfGftF3yuXoMMoVJJcYeUw5eVkm9WBPjWYt6HMWYJNesB5HaNVBaFc1M6dRjWSYnmewUMYy").unwrap();
-        assert_eq!(Network::Testnet, tprvkey.network);
+        assert_eq!(NetworkKind::Test, tprvkey.network);
         let tdesc = Bip44(tprvkey, KeychainKind::Internal)
             .build(Network::Testnet)
             .unwrap();

--- a/crates/bdk/src/keys/bip39.rs
+++ b/crates/bdk/src/keys/bip39.rs
@@ -57,7 +57,7 @@ pub type MnemonicWithPassphrase = (Mnemonic, Option<String>);
 #[cfg_attr(docsrs, doc(cfg(feature = "keys-bip39")))]
 impl<Ctx: ScriptContext> DerivableKey<Ctx> for Seed {
     fn into_extended_key(self) -> Result<ExtendedKey<Ctx>, KeyError> {
-        Ok(bip32::ExtendedPrivKey::new_master(Network::Bitcoin, &self[..])?.into())
+        Ok(bip32::Xpriv::new_master(Network::Bitcoin, &self[..])?.into())
     }
 
     fn into_descriptor_key(

--- a/crates/bdk/src/psbt/mod.rs
+++ b/crates/bdk/src/psbt/mod.rs
@@ -9,12 +9,12 @@
 // You may not use this file except in accordance with one or both of these
 // licenses.
 
-//! Additional functions on the `rust-bitcoin` `PartiallySignedTransaction` structure.
+//! Additional functions on the `rust-bitcoin` `Psbt` structure.
 
 use alloc::vec::Vec;
-use bitcoin::psbt::PartiallySignedTransaction as Psbt;
 use bitcoin::Amount;
 use bitcoin::FeeRate;
+use bitcoin::Psbt;
 use bitcoin::TxOut;
 
 // TODO upstream the functions here to `rust-bitcoin`?
@@ -29,7 +29,7 @@ pub trait PsbtUtils {
     fn fee_amount(&self) -> Option<u64>;
 
     /// The transaction's fee rate. This value will only be accurate if calculated AFTER the
-    /// `PartiallySignedTransaction` is finalized and all witness/signature data is added to the
+    /// `Psbt` is finalized and all witness/signature data is added to the
     /// transaction.
     /// If the PSBT is missing a TxOut for an input returns None.
     fn fee_rate(&self) -> Option<FeeRate>;
@@ -54,8 +54,13 @@ impl PsbtUtils for Psbt {
         let utxos: Option<Vec<TxOut>> = (0..tx.input.len()).map(|i| self.get_utxo_for(i)).collect();
 
         utxos.map(|inputs| {
-            let input_amount: u64 = inputs.iter().map(|i| i.value).sum();
-            let output_amount: u64 = self.unsigned_tx.output.iter().map(|o| o.value).sum();
+            let input_amount: u64 = inputs.iter().map(|i| i.value.to_sat()).sum();
+            let output_amount: u64 = self
+                .unsigned_tx
+                .output
+                .iter()
+                .map(|o| o.value.to_sat())
+                .sum();
             input_amount
                 .checked_sub(output_amount)
                 .expect("input amount must be greater than output amount")
@@ -64,9 +69,7 @@ impl PsbtUtils for Psbt {
 
     fn fee_rate(&self) -> Option<FeeRate> {
         let fee_amount = self.fee_amount();
-        fee_amount.map(|fee| {
-            let weight = self.clone().extract_tx().weight();
-            Amount::from_sat(fee) / weight
-        })
+        let weight = self.clone().extract_tx().ok()?.weight();
+        fee_amount.map(|fee| Amount::from_sat(fee) / weight)
     }
 }

--- a/crates/bdk/src/wallet/coin_selection.rs
+++ b/crates/bdk/src/wallet/coin_selection.rs
@@ -316,7 +316,7 @@ pub fn decide_change(remaining_amount: u64, fee_rate: FeeRate, drain_script: &Sc
     let drain_val = remaining_amount.saturating_sub(change_fee);
 
     if drain_val.is_dust(drain_script) {
-        let dust_threshold = drain_script.dust_value().to_sat();
+        let dust_threshold = drain_script.minimal_non_dust().to_sat();
         Excess::NoChange {
             dust_threshold,
             change_fee,

--- a/crates/bdk/src/wallet/export.rs
+++ b/crates/bdk/src/wallet/export.rs
@@ -216,7 +216,7 @@ mod test {
 
     use bdk_chain::{BlockId, ConfirmationTime};
     use bitcoin::hashes::Hash;
-    use bitcoin::{BlockHash, Network, Transaction};
+    use bitcoin::{transaction, BlockHash, Network, Transaction};
 
     use super::*;
     use crate::wallet::Wallet;
@@ -230,7 +230,7 @@ mod test {
         let transaction = Transaction {
             input: vec![],
             output: vec![],
-            version: 0,
+            version: transaction::Version::non_standard(0),
             lock_time: bitcoin::absolute::LockTime::ZERO,
         };
         wallet

--- a/crates/bdk/src/wallet/export.rs
+++ b/crates/bdk/src/wallet/export.rs
@@ -166,7 +166,7 @@ impl FullyNodedExport {
         fn check_ms<Ctx: ScriptContext>(
             terminal: &Terminal<String, Ctx>,
         ) -> Result<(), &'static str> {
-            if let Terminal::Multi(_, _) = terminal {
+            if let Terminal::Multi(_) = terminal {
                 Ok(())
             } else {
                 Err("The descriptor contains operators not supported by Bitcoin Core")

--- a/crates/bdk/src/wallet/hardwaresigner.rs
+++ b/crates/bdk/src/wallet/hardwaresigner.rs
@@ -48,8 +48,8 @@
 //! ```
 
 use bitcoin::bip32::Fingerprint;
-use bitcoin::psbt::PartiallySignedTransaction;
 use bitcoin::secp256k1::{All, Secp256k1};
+use bitcoin::Psbt;
 
 use hwi::error::Error;
 use hwi::types::{HWIChain, HWIDevice};
@@ -87,7 +87,7 @@ impl SignerCommon for HWISigner {
 impl TransactionSigner for HWISigner {
     fn sign_transaction(
         &self,
-        psbt: &mut PartiallySignedTransaction,
+        psbt: &mut Psbt,
         _sign_options: &crate::SignOptions,
         _secp: &crate::wallet::utils::SecpCtx,
     ) -> Result<(), SignerError> {

--- a/crates/bdk/src/wallet/mod.rs
+++ b/crates/bdk/src/wallet/mod.rs
@@ -30,14 +30,14 @@ use bdk_chain::{
     Append, BlockId, ChainPosition, ConfirmationTime, ConfirmationTimeHeightAnchor, FullTxOut,
     IndexedTxGraph, Persist, PersistBackend,
 };
+use bitcoin::constants::genesis_block;
 use bitcoin::secp256k1::{All, Secp256k1};
 use bitcoin::sighash::{EcdsaSighashType, TapSighashType};
 use bitcoin::{
-    absolute, Address, Block, FeeRate, Network, OutPoint, Script, ScriptBuf, Sequence, Transaction,
-    TxOut, Txid, Weight, Witness,
+    absolute, psbt, Address, Block, FeeRate, Network, OutPoint, Script, ScriptBuf, Sequence,
+    Transaction, TxOut, Txid, Witness,
 };
-use bitcoin::{consensus::encode::serialize, BlockHash};
-use bitcoin::{constants::genesis_block, psbt};
+use bitcoin::{consensus::encode::serialize, transaction, Amount, BlockHash, Psbt};
 use core::fmt;
 use core::ops::Deref;
 use descriptor::error::Error as DescriptorError;
@@ -945,11 +945,11 @@ impl<D> Wallet<D> {
     /// ```
     ///
     /// ```rust, no_run
-    /// # use bitcoin::psbt::PartiallySignedTransaction;
+    /// # use bitcoin::Psbt;
     /// # use bdk::Wallet;
     /// # let mut wallet: Wallet<()> = todo!();
-    /// # let mut psbt: PartiallySignedTransaction = todo!();
-    /// let tx = &psbt.clone().extract_tx();
+    /// # let mut psbt: Psbt = todo!();
+    /// let tx = &psbt.clone().extract_tx().expect("tx");
     /// let fee = wallet.calculate_fee(tx).expect("fee");
     /// ```
     /// [`insert_txout`]: Self::insert_txout
@@ -976,12 +976,12 @@ impl<D> Wallet<D> {
     /// ```
     ///
     /// ```rust, no_run
-    /// # use bitcoin::psbt::PartiallySignedTransaction;
+    /// # use bitcoin::Psbt;
     /// # use bdk::Wallet;
     /// # let mut wallet: Wallet<()> = todo!();
-    /// # let mut psbt: PartiallySignedTransaction = todo!();
-    /// let tx = psbt.clone().extract_tx();
-    /// let fee_rate = wallet.calculate_fee_rate(&tx).expect("fee rate");
+    /// # let mut psbt: Psbt = todo!();
+    /// let tx = &psbt.clone().extract_tx().expect("tx");
+    /// let fee_rate = wallet.calculate_fee_rate(tx).expect("fee rate");
     /// ```
     /// [`insert_txout`]: Self::insert_txout
     pub fn calculate_fee_rate(&self, tx: &Transaction) -> Result<FeeRate, CalculateFeeError> {
@@ -1007,11 +1007,11 @@ impl<D> Wallet<D> {
     /// ```
     ///
     /// ```rust, no_run
-    /// # use bitcoin::psbt::PartiallySignedTransaction;
+    /// # use bitcoin::Psbt;
     /// # use bdk::Wallet;
     /// # let mut wallet: Wallet<()> = todo!();
-    /// # let mut psbt: PartiallySignedTransaction = todo!();
-    /// let tx = &psbt.clone().extract_tx();
+    /// # let mut psbt: Psbt = todo!();
+    /// let tx = &psbt.clone().extract_tx().expect("tx");
     /// let (sent, received) = wallet.sent_and_received(tx);
     /// ```
     pub fn sent_and_received(&self, tx: &Transaction) -> (u64, u64) {
@@ -1261,7 +1261,7 @@ impl<D> Wallet<D> {
         &mut self,
         coin_selection: Cs,
         params: TxParams,
-    ) -> Result<psbt::PartiallySignedTransaction, CreateTxError<D::WriteError>>
+    ) -> Result<Psbt, CreateTxError<D::WriteError>>
     where
         D: PersistBackend<ChangeSet>,
     {
@@ -1455,7 +1455,7 @@ impl<D> Wallet<D> {
         };
 
         let mut tx = Transaction {
-            version,
+            version: transaction::Version::non_standard(version),
             lock_time,
             input: vec![],
             output: vec![],
@@ -1485,7 +1485,7 @@ impl<D> Wallet<D> {
 
             let new_out = TxOut {
                 script_pubkey: script_pubkey.clone(),
-                value,
+                value: Amount::from_sat(value),
             };
 
             tx.output.push(new_out);
@@ -1494,17 +1494,6 @@ impl<D> Wallet<D> {
         }
 
         fee_amount += (fee_rate * tx.weight()).to_sat();
-
-        // Segwit transactions' header is 2WU larger than legacy txs' header,
-        // as they contain a witness marker (1WU) and a witness flag (1WU) (see BIP144).
-        // At this point we really don't know if the resulting transaction will be segwit
-        // or legacy, so we just add this 2WU to the fee_amount - overshooting the fee amount
-        // is better than undershooting it.
-        // If we pass a fee_amount that is slightly higher than the final fee_amount, we
-        // end up with a transaction with a slightly higher fee rate than the requested one.
-        // If, instead, we undershoot, we may end up with a feerate lower than the requested one
-        // - we might come up with non broadcastable txs!
-        fee_amount += (fee_rate * Weight::from_wu(2)).to_sat();
 
         if params.change_policy != tx_builder::ChangeSpendPolicy::ChangeAllowed
             && internal_descriptor.is_none()
@@ -1594,7 +1583,7 @@ impl<D> Wallet<D> {
 
                 // create drain output
                 let drain_output = TxOut {
-                    value: *amount,
+                    value: Amount::from_sat(*amount),
                     script_pubkey: drain_script,
                 };
 
@@ -1640,7 +1629,7 @@ impl<D> Wallet<D> {
     ///     builder.finish()?
     /// };
     /// let _ = wallet.sign(&mut psbt, SignOptions::default())?;
-    /// let tx = psbt.extract_tx();
+    /// let tx = psbt.clone().extract_tx().expect("tx");
     /// // broadcast tx but it's taking too long to confirm so we want to bump the fee
     /// let mut psbt =  {
     ///     let mut builder = wallet.build_fee_bump(tx.txid())?;
@@ -1764,11 +1753,11 @@ impl<D> Wallet<D> {
 
         let params = TxParams {
             // TODO: figure out what rbf option should be?
-            version: Some(tx_builder::Version(tx.version)),
+            version: Some(tx_builder::Version(tx.version.0)),
             recipients: tx
                 .output
                 .into_iter()
-                .map(|txout| (txout.script_pubkey, txout.value))
+                .map(|txout| (txout.script_pubkey, txout.value.to_sat()))
                 .collect(),
             utxos: original_utxos,
             bumping_fee: Some(tx_builder::PreviousFee {
@@ -1814,11 +1803,7 @@ impl<D> Wallet<D> {
     /// let finalized = wallet.sign(&mut psbt, SignOptions::default())?;
     /// assert!(finalized, "we should have signed all the inputs");
     /// # Ok::<(),anyhow::Error>(())
-    pub fn sign(
-        &self,
-        psbt: &mut psbt::PartiallySignedTransaction,
-        sign_options: SignOptions,
-    ) -> Result<bool, SignerError> {
+    pub fn sign(&self, psbt: &mut Psbt, sign_options: SignOptions) -> Result<bool, SignerError> {
         // This adds all the PSBT metadata for the inputs, which will help us later figure out how
         // to derive our keys
         self.update_psbt_with_descriptor(psbt)
@@ -1898,7 +1883,7 @@ impl<D> Wallet<D> {
     /// The [`SignOptions`] can be used to tweak the behavior of the finalizer.
     pub fn finalize_psbt(
         &self,
-        psbt: &mut psbt::PartiallySignedTransaction,
+        psbt: &mut Psbt,
         sign_options: SignOptions,
     ) -> Result<bool, SignerError> {
         let chain_tip = self.chain.tip().block_id();
@@ -2124,7 +2109,7 @@ impl<D> Wallet<D> {
                 if must_only_use_confirmed_tx && !confirmation_time.is_confirmed() {
                     return false;
                 }
-                if tx.is_coin_base() {
+                if tx.is_coinbase() {
                     debug_assert!(
                         confirmation_time.is_confirmed(),
                         "coinbase must always be confirmed"
@@ -2173,11 +2158,11 @@ impl<D> Wallet<D> {
         tx: Transaction,
         selected: Vec<Utxo>,
         params: TxParams,
-    ) -> Result<psbt::PartiallySignedTransaction, CreateTxError<D::WriteError>>
+    ) -> Result<Psbt, CreateTxError<D::WriteError>>
     where
         D: PersistBackend<ChangeSet>,
     {
-        let mut psbt = psbt::PartiallySignedTransaction::from_unsigned_tx(tx)?;
+        let mut psbt = Psbt::from_unsigned_tx(tx)?;
 
         if params.add_global_xpubs {
             let all_xpubs = self
@@ -2233,7 +2218,7 @@ impl<D> Wallet<D> {
                     let is_taproot = foreign_psbt_input
                         .witness_utxo
                         .as_ref()
-                        .map(|txout| txout.script_pubkey.is_v1_p2tr())
+                        .map(|txout| txout.script_pubkey.is_p2tr())
                         .unwrap_or(false);
                     if !is_taproot
                         && !params.only_witness_utxo
@@ -2295,10 +2280,7 @@ impl<D> Wallet<D> {
         Ok(psbt_input)
     }
 
-    fn update_psbt_with_descriptor(
-        &self,
-        psbt: &mut psbt::PartiallySignedTransaction,
-    ) -> Result<(), MiniscriptPsbtError> {
+    fn update_psbt_with_descriptor(&self, psbt: &mut Psbt) -> Result<(), MiniscriptPsbtError> {
         // We need to borrow `psbt` mutably within the loops, so we have to allocate a vec for all
         // the input utxos and outputs
         let utxos = (0..psbt.inputs.len())
@@ -2602,11 +2584,11 @@ macro_rules! doctest_wallet {
         .unwrap();
         let address = wallet.get_address(AddressIndex::New).address;
         let tx = Transaction {
-            version: 1,
+            version: transaction::Version::ONE,
             lock_time: absolute::LockTime::ZERO,
             input: vec![],
             output: vec![TxOut {
-                value: 500_000,
+                value: Amount::from_sat(500_000),
                 script_pubkey: address.script_pubkey(),
             }],
         };

--- a/crates/bdk/src/wallet/tx_builder.rs
+++ b/crates/bdk/src/wallet/tx_builder.rs
@@ -316,7 +316,7 @@ impl<'a, D, Cs, Ctx> TxBuilder<'a, D, Cs, Ctx> {
                 let descriptor = wallet.get_descriptor_for_keychain(utxo.keychain);
                 let satisfaction_weight = descriptor.max_weight_to_satisfy().unwrap();
                 self.params.utxos.push(WeightedUtxo {
-                    satisfaction_weight,
+                    satisfaction_weight: satisfaction_weight.to_wu() as usize,
                     utxo: Utxo::Local(utxo),
                 });
             }
@@ -404,9 +404,9 @@ impl<'a, D, Cs, Ctx> TxBuilder<'a, D, Cs, Ctx> {
         if psbt_input.witness_utxo.is_none() {
             match psbt_input.non_witness_utxo.as_ref() {
                 Some(tx) => {
-                    if tx.txid() != outpoint.txid {
+                    if tx.compute_txid() != outpoint.txid {
                         return Err(AddForeignUtxoError::InvalidTxid {
-                            input_txid: tx.txid(),
+                            input_txid: tx.compute_txid(),
                             foreign_utxo: outpoint,
                         });
                     }

--- a/crates/bdk/src/wallet/tx_builder.rs
+++ b/crates/bdk/src/wallet/tx_builder.rs
@@ -46,7 +46,7 @@ use core::fmt;
 use core::marker::PhantomData;
 
 use bdk_chain::PersistBackend;
-use bitcoin::psbt::{self, PartiallySignedTransaction as Psbt};
+use bitcoin::psbt::{self, Psbt};
 use bitcoin::script::PushBytes;
 use bitcoin::{absolute, FeeRate, OutPoint, ScriptBuf, Sequence, Transaction, Txid};
 
@@ -927,7 +927,8 @@ mod test {
 
     use bdk_chain::ConfirmationTime;
     use bitcoin::consensus::deserialize;
-    use bitcoin::hashes::hex::FromHex;
+    use bitcoin::hex::FromHex;
+    use bitcoin::TxOut;
 
     use super::*;
 
@@ -998,7 +999,7 @@ mod test {
             .unwrap()
         );
 
-        assert_eq!(tx.output[0].value, 800);
+        assert_eq!(tx.output[0].value.to_sat(), 800);
         assert_eq!(tx.output[1].script_pubkey, ScriptBuf::from(vec![0xAA]));
         assert_eq!(
             tx.output[2].script_pubkey,
@@ -1015,7 +1016,7 @@ mod test {
                     txid: bitcoin::Txid::from_slice(&[0; 32]).unwrap(),
                     vout: 0,
                 },
-                txout: Default::default(),
+                txout: TxOut::NULL,
                 keychain: KeychainKind::External,
                 is_spent: false,
                 confirmation_time: ConfirmationTime::Unconfirmed { last_seen: 0 },
@@ -1026,7 +1027,7 @@ mod test {
                     txid: bitcoin::Txid::from_slice(&[0; 32]).unwrap(),
                     vout: 1,
                 },
-                txout: Default::default(),
+                txout: TxOut::NULL,
                 keychain: KeychainKind::Internal,
                 is_spent: false,
                 confirmation_time: ConfirmationTime::Confirmed {

--- a/crates/bdk/src/wallet/utils.rs
+++ b/crates/bdk/src/wallet/utils.rs
@@ -138,7 +138,7 @@ mod test {
             .require_network(Network::Bitcoin)
             .unwrap()
             .script_pubkey();
-        assert!(script_p2wpkh.is_v0_p2wpkh());
+        assert!(script_p2wpkh.is_p2wpkh());
         assert!(293.is_dust(&script_p2wpkh));
         assert!(!294.is_dust(&script_p2wpkh));
     }

--- a/crates/bdk/src/wallet/utils.rs
+++ b/crates/bdk/src/wallet/utils.rs
@@ -10,7 +10,7 @@
 // licenses.
 
 use bitcoin::secp256k1::{All, Secp256k1};
-use bitcoin::{absolute, Script, Sequence};
+use bitcoin::{absolute, relative, Script, Sequence};
 
 use miniscript::{MiniscriptKey, Satisfier, ToPublicKey};
 
@@ -26,7 +26,7 @@ pub trait IsDust {
 
 impl IsDust for u64 {
     fn is_dust(&self, script: &Script) -> bool {
-        *self < script.dust_value().to_sat()
+        *self < script.minimal_non_dust().to_sat()
     }
 }
 
@@ -95,7 +95,7 @@ impl Older {
 }
 
 impl<Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk> for Older {
-    fn check_older(&self, n: Sequence) -> bool {
+    fn check_older(&self, n: relative::LockTime) -> bool {
         if let Some(current_height) = self.current_height {
             // TODO: test >= / >
             current_height

--- a/crates/bdk/tests/common.rs
+++ b/crates/bdk/tests/common.rs
@@ -4,7 +4,10 @@ use bdk::{wallet::AddressIndex, KeychainKind, LocalOutput, Wallet};
 use bdk_chain::indexed_tx_graph::Indexer;
 use bdk_chain::{BlockId, ConfirmationTime};
 use bitcoin::hashes::Hash;
-use bitcoin::{Address, BlockHash, FeeRate, Network, OutPoint, Transaction, TxIn, TxOut, Txid};
+use bitcoin::{
+    transaction, Address, Amount, BlockHash, FeeRate, Network, OutPoint, Transaction, TxIn, TxOut,
+    Txid,
+};
 use std::str::FromStr;
 
 // Return a fake wallet that appears to be funded for testing.
@@ -24,7 +27,7 @@ pub fn get_funded_wallet_with_change(
         .unwrap();
 
     let tx0 = Transaction {
-        version: 1,
+        version: transaction::Version::ONE,
         lock_time: bitcoin::absolute::LockTime::ZERO,
         input: vec![TxIn {
             previous_output: OutPoint {
@@ -36,13 +39,13 @@ pub fn get_funded_wallet_with_change(
             witness: Default::default(),
         }],
         output: vec![TxOut {
-            value: 76_000,
+            value: Amount::from_sat(76_000),
             script_pubkey: change_address.script_pubkey(),
         }],
     };
 
     let tx1 = Transaction {
-        version: 1,
+        version: transaction::Version::ONE,
         lock_time: bitcoin::absolute::LockTime::ZERO,
         input: vec![TxIn {
             previous_output: OutPoint {
@@ -55,11 +58,11 @@ pub fn get_funded_wallet_with_change(
         }],
         output: vec![
             TxOut {
-                value: 50_000,
+                value: Amount::from_sat(50_000),
                 script_pubkey: change_address.script_pubkey(),
             },
             TxOut {
-                value: 25_000,
+                value: Amount::from_sat(25_000),
                 script_pubkey: sendto_address.script_pubkey(),
             },
         ],

--- a/crates/bdk/tests/common.rs
+++ b/crates/bdk/tests/common.rs
@@ -49,7 +49,7 @@ pub fn get_funded_wallet_with_change(
         lock_time: bitcoin::absolute::LockTime::ZERO,
         input: vec![TxIn {
             previous_output: OutPoint {
-                txid: tx0.txid(),
+                txid: tx0.compute_txid(),
                 vout: 0,
             },
             script_sig: Default::default(),
@@ -99,7 +99,7 @@ pub fn get_funded_wallet_with_change(
         )
         .unwrap();
 
-    (wallet, tx1.txid())
+    (wallet, tx1.compute_txid())
 }
 
 // Return a fake wallet that appears to be funded for testing.

--- a/crates/bdk/tests/psbt.rs
+++ b/crates/bdk/tests/psbt.rs
@@ -1,9 +1,7 @@
-use bdk::bitcoin::FeeRate;
-use bdk::bitcoin::TxIn;
+use bdk::bitcoin::{Amount, FeeRate, Psbt, TxIn};
 use bdk::wallet::AddressIndex;
 use bdk::wallet::AddressIndex::New;
 use bdk::{psbt, SignOptions};
-use bitcoin::psbt::PartiallySignedTransaction as Psbt;
 use core::str::FromStr;
 mod common;
 use common::*;
@@ -163,7 +161,7 @@ fn test_psbt_multiple_internalkey_signers() {
     use bdk::signer::{SignerContext, SignerOrdering, SignerWrapper};
     use bdk::KeychainKind;
     use bitcoin::key::TapTweak;
-    use bitcoin::secp256k1::{schnorr, KeyPair, Message, Secp256k1, XOnlyPublicKey};
+    use bitcoin::secp256k1::{schnorr, Keypair, Message, Secp256k1, XOnlyPublicKey};
     use bitcoin::sighash::{Prevouts, SighashCache, TapSighashType};
     use bitcoin::{PrivateKey, TxOut};
     use std::sync::Arc;
@@ -172,7 +170,7 @@ fn test_psbt_multiple_internalkey_signers() {
     let wif = "cNJmN3fH9DDbDt131fQNkVakkpzawJBSeybCUNmP1BovpmGQ45xG";
     let desc = format!("tr({})", wif);
     let prv = PrivateKey::from_wif(wif).unwrap();
-    let keypair = KeyPair::from_secret_key(&secp, &prv.inner);
+    let keypair = Keypair::from_secret_key(&secp, &prv.inner);
 
     let (mut wallet, _) = get_funded_wallet(&desc);
     let to_spend = wallet.get_balance().total();
@@ -205,7 +203,7 @@ fn test_psbt_multiple_internalkey_signers() {
     // the prevout we're spending
     let prevouts = &[TxOut {
         script_pubkey: send_to.script_pubkey(),
-        value: to_spend,
+        value: Amount::from_sat(to_spend),
     }];
     let prevouts = Prevouts::All(prevouts);
     let input_index = 0;

--- a/crates/bitcoind_rpc/Cargo.toml
+++ b/crates/bitcoind_rpc/Cargo.toml
@@ -14,9 +14,9 @@ readme = "README.md"
 
 [dependencies]
 # For no-std, remember to enable the bitcoin/no-std feature
-bitcoin = { version = "0.31", default-features = false }
-bitcoincore-rpc = { version = "0.18" }
-bdk_chain = { path = "../chain", version = "0.11", default-features = false }
+bitcoin = { version = "0.32.0-rc1", default-features = false }
+bitcoincore-rpc = { version = "0.19" }
+bdk_chain = { path = "../chain", default-features = false }
 
 [dev-dependencies]
 bdk_testenv = { path = "../testenv", version = "0.1.0", default_features = false }

--- a/crates/bitcoind_rpc/Cargo.toml
+++ b/crates/bitcoind_rpc/Cargo.toml
@@ -14,8 +14,8 @@ readme = "README.md"
 
 [dependencies]
 # For no-std, remember to enable the bitcoin/no-std feature
-bitcoin = { version = "0.30", default-features = false }
-bitcoincore-rpc = { version = "0.17" }
+bitcoin = { version = "0.31", default-features = false }
+bitcoincore-rpc = { version = "0.18" }
 bdk_chain = { path = "../chain", version = "0.11", default-features = false }
 
 [dev-dependencies]

--- a/crates/bitcoind_rpc/tests/test_emitter.rs
+++ b/crates/bitcoind_rpc/tests/test_emitter.rs
@@ -350,7 +350,7 @@ fn tx_can_become_unconfirmed_after_reorg() -> anyhow::Result<()> {
         .rpc_client()
         .get_new_address(None, None)?
         .assume_checked();
-    let spk_to_track = ScriptBuf::new_v0_p2wsh(&WScriptHash::all_zeros());
+    let spk_to_track = ScriptBuf::new_p2wsh(&WScriptHash::all_zeros());
     let addr_to_track = Address::from_script(&spk_to_track, bitcoin::Network::Regtest)?;
 
     // setup receiver

--- a/crates/bitcoind_rpc/tests/test_emitter.rs
+++ b/crates/bitcoind_rpc/tests/test_emitter.rs
@@ -206,7 +206,7 @@ fn test_into_tx_graph() -> anyhow::Result<()> {
                 .graph
                 .txs
                 .iter()
-                .map(|tx| tx.txid())
+                .map(|tx| tx.compute_txid())
                 .collect::<BTreeSet<Txid>>(),
             exp_txids,
             "changeset should have the 3 mempool transactions",
@@ -453,7 +453,7 @@ fn mempool_avoids_re_emission() -> anyhow::Result<()> {
     let emitted_txids = emitter
         .mempool()?
         .into_iter()
-        .map(|(tx, _)| tx.txid())
+        .map(|(tx, _)| tx.compute_txid())
         .collect::<BTreeSet<Txid>>();
     assert_eq!(
         emitted_txids, exp_txids,
@@ -522,7 +522,7 @@ fn mempool_re_emits_if_tx_introduction_height_not_reached() -> anyhow::Result<()
         emitter
             .mempool()?
             .into_iter()
-            .map(|(tx, _)| tx.txid())
+            .map(|(tx, _)| tx.compute_txid())
             .collect::<BTreeSet<_>>(),
         tx_introductions.iter().map(|&(_, txid)| txid).collect(),
         "first mempool emission should include all txs",
@@ -531,7 +531,7 @@ fn mempool_re_emits_if_tx_introduction_height_not_reached() -> anyhow::Result<()
         emitter
             .mempool()?
             .into_iter()
-            .map(|(tx, _)| tx.txid())
+            .map(|(tx, _)| tx.compute_txid())
             .collect::<BTreeSet<_>>(),
         tx_introductions.iter().map(|&(_, txid)| txid).collect(),
         "second mempool emission should still include all txs",
@@ -551,7 +551,7 @@ fn mempool_re_emits_if_tx_introduction_height_not_reached() -> anyhow::Result<()
             let emitted_txids = emitter
                 .mempool()?
                 .into_iter()
-                .map(|(tx, _)| tx.txid())
+                .map(|(tx, _)| tx.compute_txid())
                 .collect::<BTreeSet<_>>();
             assert_eq!(
                 emitted_txids, exp_txids,
@@ -609,7 +609,7 @@ fn mempool_during_reorg() -> anyhow::Result<()> {
         emitter
             .mempool()?
             .into_iter()
-            .map(|(tx, _)| tx.txid())
+            .map(|(tx, _)| tx.compute_txid())
             .collect::<BTreeSet<_>>(),
         env.rpc_client()
             .get_raw_mempool()?
@@ -646,7 +646,7 @@ fn mempool_during_reorg() -> anyhow::Result<()> {
             let mempool = emitter
                 .mempool()?
                 .into_iter()
-                .map(|(tx, _)| tx.txid())
+                .map(|(tx, _)| tx.compute_txid())
                 .collect::<BTreeSet<_>>();
             let exp_mempool = tx_introductions
                 .iter()
@@ -661,7 +661,7 @@ fn mempool_during_reorg() -> anyhow::Result<()> {
             let mempool = emitter
                 .mempool()?
                 .into_iter()
-                .map(|(tx, _)| tx.txid())
+                .map(|(tx, _)| tx.compute_txid())
                 .collect::<BTreeSet<_>>();
             let exp_mempool = tx_introductions
                 .iter()

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -14,12 +14,12 @@ readme = "README.md"
 
 [dependencies]
 # For no-std, remember to enable the bitcoin/no-std feature
-bitcoin = { version = "0.30.0", default-features = false }
+bitcoin = { version = "0.31.0", default-features = false }
 serde_crate = { package = "serde", version = "1", optional = true, features = ["derive", "rc"] }
 
 # Use hashbrown as a feature flag to have HashSet and HashMap from it.
 hashbrown = { version = "0.9.1", optional = true, features = ["serde"] }
-miniscript = { version = "10.0.0", optional = true, default-features = false }
+miniscript = { version = "11.0.0", optional = true, default-features = false }
 
 [dev-dependencies]
 rand = "0.8"

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_chain"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"
@@ -14,12 +14,12 @@ readme = "README.md"
 
 [dependencies]
 # For no-std, remember to enable the bitcoin/no-std feature
-bitcoin = { version = "0.31.0", default-features = false }
+bitcoin = { version = "0.32.0-rc1", default-features = false }
 serde_crate = { package = "serde", version = "1", optional = true, features = ["derive", "rc"] }
 
 # Use hashbrown as a feature flag to have HashSet and HashMap from it.
 hashbrown = { version = "0.9.1", optional = true, features = ["serde"] }
-miniscript = { version = "11.0.0", optional = true, default-features = false }
+miniscript = { version = "12.0.0", optional = true, default-features = false }
 
 [dev-dependencies]
 rand = "0.8"

--- a/crates/chain/src/descriptor_ext.rs
+++ b/crates/chain/src/descriptor_ext.rs
@@ -12,7 +12,7 @@ impl DescriptorExt for Descriptor<DescriptorPublicKey> {
         self.at_derivation_index(0)
             .expect("descriptor can't have hardened derivation")
             .script_pubkey()
-            .dust_value()
+            .minimal_non_dust()
             .to_sat()
     }
 }

--- a/crates/chain/src/indexed_tx_graph.rs
+++ b/crates/chain/src/indexed_tx_graph.rs
@@ -144,7 +144,7 @@ where
         let mut graph = tx_graph::ChangeSet::default();
         for (tx, anchors) in txs {
             if self.index.is_tx_relevant(tx) {
-                let txid = tx.txid();
+                let txid = tx.compute_txid();
                 graph.append(self.graph.insert_tx(tx.clone()));
                 for anchor in anchors {
                     graph.append(self.graph.insert_anchor(txid, anchor));
@@ -235,7 +235,7 @@ where
         for (tx_pos, tx) in block.txdata.iter().enumerate() {
             changeset.indexer.append(self.index.index_tx(tx));
             if self.index.is_tx_relevant(tx) {
-                let txid = tx.txid();
+                let txid = tx.compute_txid();
                 let anchor = A::from_block_position(block, block_id, tx_pos);
                 changeset.graph.append(self.graph.insert_tx(tx.clone()));
                 changeset
@@ -262,7 +262,7 @@ where
         let mut graph = tx_graph::ChangeSet::default();
         for (tx_pos, tx) in block.txdata.iter().enumerate() {
             let anchor = A::from_block_position(&block, block_id, tx_pos);
-            graph.append(self.graph.insert_anchor(tx.txid(), anchor));
+            graph.append(self.graph.insert_anchor(tx.compute_txid(), anchor));
             graph.append(self.graph.insert_tx(tx.clone()));
         }
         let indexer = self.index_tx_graph_changeset(&graph);

--- a/crates/chain/src/keychain/txout_index.rs
+++ b/crates/chain/src/keychain/txout_index.rs
@@ -129,7 +129,7 @@ impl<K: Clone + Ord + Debug> Indexer for KeychainTxOutIndex<K> {
     fn index_tx(&mut self, tx: &bitcoin::Transaction) -> Self::ChangeSet {
         let mut changeset = super::ChangeSet::<K>::default();
         for (op, txout) in tx.output.iter().enumerate() {
-            changeset.append(self.index_txout(OutPoint::new(tx.txid(), op as u32), txout));
+            changeset.append(self.index_txout(OutPoint::new(tx.compute_txid(), op as u32), txout));
         }
         changeset
     }

--- a/crates/chain/src/spk_txout_index.rs
+++ b/crates/chain/src/spk_txout_index.rs
@@ -86,7 +86,7 @@ impl<I: Clone + Ord> SpkTxOutIndex<I> {
     /// 2. When getting new data from the chain, you usually scan it before incorporating it into your chain state.
     pub fn scan(&mut self, tx: &Transaction) -> BTreeSet<I> {
         let mut scanned_indices = BTreeSet::new();
-        let txid = tx.txid();
+        let txid = tx.compute_txid();
         for (i, txout) in tx.output.iter().enumerate() {
             let op = OutPoint::new(txid, i as u32);
             if let Some(spk_i) = self.scan_txout(op, txout) {

--- a/crates/chain/src/spk_txout_index.rs
+++ b/crates/chain/src/spk_txout_index.rs
@@ -4,7 +4,7 @@ use crate::{
     collections::{hash_map::Entry, BTreeMap, BTreeSet, HashMap},
     indexed_tx_graph::Indexer,
 };
-use bitcoin::{self, OutPoint, Script, ScriptBuf, Transaction, TxOut, Txid};
+use bitcoin::{OutPoint, Script, ScriptBuf, Transaction, TxOut, Txid};
 
 /// An index storing [`TxOut`]s that have a script pubkey that matches those in a list.
 ///
@@ -281,12 +281,12 @@ impl<I: Clone + Ord> SpkTxOutIndex<I> {
 
         for txin in &tx.input {
             if let Some((_, txout)) = self.txout(txin.previous_output) {
-                sent += txout.value;
+                sent += txout.value.to_sat();
             }
         }
         for txout in &tx.output {
             if self.index_of_spk(&txout.script_pubkey).is_some() {
-                received += txout.value;
+                received += txout.value.to_sat();
             }
         }
 

--- a/crates/chain/src/tx_data_traits.rs
+++ b/crates/chain/src/tx_data_traits.rs
@@ -43,7 +43,7 @@ use alloc::vec::Vec;
 /// let mut graph_a = TxGraph::<BlockId>::default();
 /// let _ = graph_a.insert_tx(tx.clone());
 /// graph_a.insert_anchor(
-///     tx.txid(),
+///     tx.compute_txid(),
 ///     BlockId {
 ///         height: 1,
 ///         hash: Hash::hash("first".as_bytes()),
@@ -58,7 +58,7 @@ use alloc::vec::Vec;
 /// let mut graph_b = TxGraph::<ConfirmationHeightAnchor>::default();
 /// let _ = graph_b.insert_tx(tx.clone());
 /// graph_b.insert_anchor(
-///     tx.txid(),
+///     tx.compute_txid(),
 ///     ConfirmationHeightAnchor {
 ///         anchor_block: BlockId {
 ///             height: 2,
@@ -76,7 +76,7 @@ use alloc::vec::Vec;
 /// let mut graph_c = TxGraph::<ConfirmationTimeHeightAnchor>::default();
 /// let _ = graph_c.insert_tx(tx.clone());
 /// graph_c.insert_anchor(
-///     tx.txid(),
+///     tx.compute_txid(),
 ///     ConfirmationTimeHeightAnchor {
 ///         anchor_block: BlockId {
 ///             height: 2,

--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -319,7 +319,7 @@ impl<A> TxGraph<A> {
     ///
     /// [`insert_txout`]: Self::insert_txout
     pub fn calculate_fee(&self, tx: &Transaction) -> Result<u64, CalculateFeeError> {
-        if tx.is_coin_base() {
+        if tx.is_coinbase() {
             return Ok(0);
         }
 
@@ -331,7 +331,7 @@ impl<A> TxGraph<A> {
                     (sum, missing_outpoints)
                 }
                 Some(txout) => {
-                    sum += txout.value as i64;
+                    sum += txout.value.to_sat() as i64;
                     (sum, missing_outpoints)
                 }
             },
@@ -343,7 +343,7 @@ impl<A> TxGraph<A> {
         let outputs_sum = tx
             .output
             .iter()
-            .map(|txout| txout.value as i64)
+            .map(|txout| txout.value.to_sat() as i64)
             .sum::<i64>();
 
         let fee = inputs_sum - outputs_sum;
@@ -807,7 +807,7 @@ impl<A: Anchor> TxGraph<A> {
             TxNodeInternal::Whole(tx) => {
                 // A coinbase tx that is not anchored in the best chain cannot be unconfirmed and
                 // should always be filtered out.
-                if tx.as_ref().is_coin_base() {
+                if tx.is_coinbase() {
                     return Ok(None);
                 }
                 tx.clone()
@@ -1063,7 +1063,7 @@ impl<A: Anchor> TxGraph<A> {
                             txout,
                             chain_position,
                             spent_by,
-                            is_on_coinbase: tx_node.tx.as_ref().is_coin_base(),
+                            is_on_coinbase: tx_node.tx.is_coinbase(),
                         },
                     )))
                 },
@@ -1166,16 +1166,16 @@ impl<A: Anchor> TxGraph<A> {
             match &txout.chain_position {
                 ChainPosition::Confirmed(_) => {
                     if txout.is_confirmed_and_spendable(chain_tip.height) {
-                        confirmed += txout.txout.value;
+                        confirmed += txout.txout.value.to_sat();
                     } else if !txout.is_mature(chain_tip.height) {
-                        immature += txout.txout.value;
+                        immature += txout.txout.value.to_sat();
                     }
                 }
                 ChainPosition::Unconfirmed(_) => {
                     if trust_predicate(&spk_i, &txout.txout.script_pubkey) {
-                        trusted_pending += txout.txout.value;
+                        trusted_pending += txout.txout.value.to_sat();
                     } else {
-                        untrusted_pending += txout.txout.value;
+                        untrusted_pending += txout.txout.value.to_sat();
                     }
                 }
             }

--- a/crates/chain/tests/common/mod.rs
+++ b/crates/chain/tests/common/mod.rs
@@ -70,7 +70,7 @@ macro_rules! changeset {
 #[allow(unused)]
 pub fn new_tx(lt: u32) -> bitcoin::Transaction {
     bitcoin::Transaction {
-        version: 0x00,
+        version: bitcoin::transaction::Version::non_standard(0x00),
         lock_time: bitcoin::absolute::LockTime::from_consensus(lt),
         input: vec![],
         output: vec![],

--- a/crates/chain/tests/common/tx_template.rs
+++ b/crates/chain/tests/common/tx_template.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 
 use bdk_chain::{tx_graph::TxGraph, Anchor, SpkTxOutIndex};
 use bitcoin::{
-    locktime::absolute::LockTime, secp256k1::Secp256k1, OutPoint, ScriptBuf, Sequence, Transaction,
-    TxIn, TxOut, Txid, Witness,
+    locktime::absolute::LockTime, secp256k1::Secp256k1, transaction, Amount, OutPoint, ScriptBuf,
+    Sequence, Transaction, TxIn, TxOut, Txid, Witness,
 };
 use miniscript::Descriptor;
 
@@ -68,7 +68,7 @@ pub fn init_graph<'a, A: Anchor + Clone + 'a>(
 
     for (bogus_txin_vout, tx_tmp) in tx_templates.into_iter().enumerate() {
         let tx = Transaction {
-            version: 0,
+            version: transaction::Version::non_standard(0),
             lock_time: LockTime::ZERO,
             input: tx_tmp
                 .inputs
@@ -111,11 +111,11 @@ pub fn init_graph<'a, A: Anchor + Clone + 'a>(
                 .iter()
                 .map(|output| match &output.spk_index {
                     None => TxOut {
-                        value: output.value,
+                        value: Amount::from_sat(output.value),
                         script_pubkey: ScriptBuf::new(),
                     },
                     Some(index) => TxOut {
-                        value: output.value,
+                        value: Amount::from_sat(output.value),
                         script_pubkey: spk_index.spk_at_index(index).unwrap().to_owned(),
                     },
                 })

--- a/crates/chain/tests/common/tx_template.rs
+++ b/crates/chain/tests/common/tx_template.rs
@@ -122,14 +122,14 @@ pub fn init_graph<'a, A: Anchor + Clone + 'a>(
                 .collect(),
         };
 
-        tx_ids.insert(tx_tmp.tx_name, tx.txid());
+        tx_ids.insert(tx_tmp.tx_name, tx.compute_txid());
         spk_index.scan(&tx);
         let _ = graph.insert_tx(tx.clone());
         for anchor in tx_tmp.anchors.iter() {
-            let _ = graph.insert_anchor(tx.txid(), anchor.clone());
+            let _ = graph.insert_anchor(tx.compute_txid(), anchor.clone());
         }
         if let Some(seen_at) = tx_tmp.last_seen {
-            let _ = graph.insert_seen_at(tx.txid(), seen_at);
+            let _ = graph.insert_seen_at(tx.compute_txid(), seen_at);
         }
     }
     (graph, spk_index, tx_ids)

--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -9,7 +9,9 @@ use bdk_chain::{
     local_chain::LocalChain,
     tx_graph, ChainPosition, ConfirmationHeightAnchor,
 };
-use bitcoin::{secp256k1::Secp256k1, OutPoint, Script, ScriptBuf, Transaction, TxIn, TxOut};
+use bitcoin::{
+    secp256k1::Secp256k1, Amount, OutPoint, Script, ScriptBuf, Transaction, TxIn, TxOut,
+};
 use miniscript::Descriptor;
 
 /// Ensure [`IndexedTxGraph::insert_relevant_txs`] can successfully index transactions NOT presented
@@ -35,11 +37,11 @@ fn insert_relevant_txs() {
     let tx_a = Transaction {
         output: vec![
             TxOut {
-                value: 10_000,
+                value: Amount::from_sat(10_000),
                 script_pubkey: spk_0,
             },
             TxOut {
-                value: 20_000,
+                value: Amount::from_sat(20_000),
                 script_pubkey: spk_1,
             },
         ],
@@ -154,7 +156,7 @@ fn test_list_owned_txouts() {
             ..Default::default()
         }],
         output: vec![TxOut {
-            value: 70000,
+            value: Amount::from_sat(70000),
             script_pubkey: trusted_spks[0].to_owned(),
         }],
         ..common::new_tx(0)
@@ -163,7 +165,7 @@ fn test_list_owned_txouts() {
     // tx2 is an incoming transaction received at untrusted keychain at block 1.
     let tx2 = Transaction {
         output: vec![TxOut {
-            value: 30000,
+            value: Amount::from_sat(30000),
             script_pubkey: untrusted_spks[0].to_owned(),
         }],
         ..common::new_tx(0)
@@ -176,7 +178,7 @@ fn test_list_owned_txouts() {
             ..Default::default()
         }],
         output: vec![TxOut {
-            value: 10000,
+            value: Amount::from_sat(10000),
             script_pubkey: trusted_spks[1].to_owned(),
         }],
         ..common::new_tx(0)
@@ -185,7 +187,7 @@ fn test_list_owned_txouts() {
     // tx4 is an external transaction receiving at untrusted keychain, unconfirmed.
     let tx4 = Transaction {
         output: vec![TxOut {
-            value: 20000,
+            value: Amount::from_sat(20000),
             script_pubkey: untrusted_spks[1].to_owned(),
         }],
         ..common::new_tx(0)
@@ -194,7 +196,7 @@ fn test_list_owned_txouts() {
     // tx5 is spending tx3 and receiving change at trusted keychain, unconfirmed.
     let tx5 = Transaction {
         output: vec![TxOut {
-            value: 15000,
+            value: Amount::from_sat(15000),
             script_pubkey: trusted_spks[2].to_owned(),
         }],
         ..common::new_tx(0)

--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -50,7 +50,7 @@ fn insert_relevant_txs() {
 
     let tx_b = Transaction {
         input: vec![TxIn {
-            previous_output: OutPoint::new(tx_a.txid(), 0),
+            previous_output: OutPoint::new(tx_a.compute_txid(), 0),
             ..Default::default()
         }],
         ..common::new_tx(1)
@@ -58,7 +58,7 @@ fn insert_relevant_txs() {
 
     let tx_c = Transaction {
         input: vec![TxIn {
-            previous_output: OutPoint::new(tx_a.txid(), 1),
+            previous_output: OutPoint::new(tx_a.compute_txid(), 1),
             ..Default::default()
         }],
         ..common::new_tx(2)
@@ -174,7 +174,7 @@ fn test_list_owned_txouts() {
     // tx3 spends tx2 and gives a change back in trusted keychain. Confirmed at Block 2.
     let tx3 = Transaction {
         input: vec![TxIn {
-            previous_output: OutPoint::new(tx2.txid(), 0),
+            previous_output: OutPoint::new(tx2.compute_txid(), 0),
             ..Default::default()
         }],
         output: vec![TxOut {
@@ -326,16 +326,22 @@ fn test_list_owned_txouts() {
             balance,
         ) = fetch(0, &graph);
 
-        assert_eq!(confirmed_txouts_txid, [tx1.txid()].into());
+        assert_eq!(confirmed_txouts_txid, [tx1.compute_txid()].into());
         assert_eq!(
             unconfirmed_txouts_txid,
-            [tx2.txid(), tx3.txid(), tx4.txid(), tx5.txid()].into()
+            [
+                tx2.compute_txid(),
+                tx3.compute_txid(),
+                tx4.compute_txid(),
+                tx5.compute_txid()
+            ]
+            .into()
         );
 
-        assert_eq!(confirmed_utxos_txid, [tx1.txid()].into());
+        assert_eq!(confirmed_utxos_txid, [tx1.compute_txid()].into());
         assert_eq!(
             unconfirmed_utxos_txid,
-            [tx3.txid(), tx4.txid(), tx5.txid()].into()
+            [tx3.compute_txid(), tx4.compute_txid(), tx5.compute_txid()].into()
         );
 
         assert_eq!(
@@ -360,17 +366,20 @@ fn test_list_owned_txouts() {
         ) = fetch(1, &graph);
 
         // tx2 gets into confirmed txout set
-        assert_eq!(confirmed_txouts_txid, [tx1.txid(), tx2.txid()].into());
+        assert_eq!(
+            confirmed_txouts_txid,
+            [tx1.compute_txid(), tx2.compute_txid()].into()
+        );
         assert_eq!(
             unconfirmed_txouts_txid,
-            [tx3.txid(), tx4.txid(), tx5.txid()].into()
+            [tx3.compute_txid(), tx4.compute_txid(), tx5.compute_txid()].into()
         );
 
         // tx2 doesn't get into confirmed utxos set
-        assert_eq!(confirmed_utxos_txid, [tx1.txid()].into());
+        assert_eq!(confirmed_utxos_txid, [tx1.compute_txid()].into());
         assert_eq!(
             unconfirmed_utxos_txid,
-            [tx3.txid(), tx4.txid(), tx5.txid()].into()
+            [tx3.compute_txid(), tx4.compute_txid(), tx5.compute_txid()].into()
         );
 
         assert_eq!(
@@ -397,13 +406,22 @@ fn test_list_owned_txouts() {
         // tx3 now gets into the confirmed txout set
         assert_eq!(
             confirmed_txouts_txid,
-            [tx1.txid(), tx2.txid(), tx3.txid()].into()
+            [tx1.compute_txid(), tx2.compute_txid(), tx3.compute_txid()].into()
         );
-        assert_eq!(unconfirmed_txouts_txid, [tx4.txid(), tx5.txid()].into());
+        assert_eq!(
+            unconfirmed_txouts_txid,
+            [tx4.compute_txid(), tx5.compute_txid()].into()
+        );
 
         // tx3 also gets into confirmed utxo set
-        assert_eq!(confirmed_utxos_txid, [tx1.txid(), tx3.txid()].into());
-        assert_eq!(unconfirmed_utxos_txid, [tx4.txid(), tx5.txid()].into());
+        assert_eq!(
+            confirmed_utxos_txid,
+            [tx1.compute_txid(), tx3.compute_txid()].into()
+        );
+        assert_eq!(
+            unconfirmed_utxos_txid,
+            [tx4.compute_txid(), tx5.compute_txid()].into()
+        );
 
         assert_eq!(
             balance,
@@ -428,12 +446,21 @@ fn test_list_owned_txouts() {
 
         assert_eq!(
             confirmed_txouts_txid,
-            [tx1.txid(), tx2.txid(), tx3.txid()].into()
+            [tx1.compute_txid(), tx2.compute_txid(), tx3.compute_txid()].into()
         );
-        assert_eq!(unconfirmed_txouts_txid, [tx4.txid(), tx5.txid()].into());
+        assert_eq!(
+            unconfirmed_txouts_txid,
+            [tx4.compute_txid(), tx5.compute_txid()].into()
+        );
 
-        assert_eq!(confirmed_utxos_txid, [tx1.txid(), tx3.txid()].into());
-        assert_eq!(unconfirmed_utxos_txid, [tx4.txid(), tx5.txid()].into());
+        assert_eq!(
+            confirmed_utxos_txid,
+            [tx1.compute_txid(), tx3.compute_txid()].into()
+        );
+        assert_eq!(
+            unconfirmed_utxos_txid,
+            [tx4.compute_txid(), tx5.compute_txid()].into()
+        );
 
         // Coinbase is still immature
         assert_eq!(

--- a/crates/chain/tests/test_keychain_txout_index.rs
+++ b/crates/chain/tests/test_keychain_txout_index.rs
@@ -9,7 +9,7 @@ use bdk_chain::{
     Append,
 };
 
-use bitcoin::{secp256k1::Secp256k1, OutPoint, ScriptBuf, Transaction, TxOut};
+use bitcoin::{secp256k1::Secp256k1, Amount, OutPoint, ScriptBuf, Transaction, TxOut};
 use miniscript::{Descriptor, DescriptorPublicKey};
 
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
@@ -176,14 +176,14 @@ fn test_lookahead() {
                         .at_derivation_index(external_index)
                         .unwrap()
                         .script_pubkey(),
-                    value: 10_000,
+                    value: Amount::from_sat(10_000),
                 },
                 TxOut {
                     script_pubkey: internal_desc
                         .at_derivation_index(internal_index)
                         .unwrap()
                         .script_pubkey(),
-                    value: 10_000,
+                    value: Amount::from_sat(10_000),
                 },
             ],
             ..common::new_tx(external_index)
@@ -238,7 +238,7 @@ fn test_scan_with_lookahead() {
         let op = OutPoint::new(h!("fake tx"), spk_i);
         let txout = TxOut {
             script_pubkey: spk.clone(),
-            value: 0,
+            value: Amount::ZERO,
         };
 
         let changeset = txout_index.index_txout(op, &txout);
@@ -264,7 +264,7 @@ fn test_scan_with_lookahead() {
     let op = OutPoint::new(h!("fake tx"), 41);
     let txout = TxOut {
         script_pubkey: spk_41,
-        value: 0,
+        value: Amount::ZERO,
     };
     let changeset = txout_index.index_txout(op, &txout);
     assert!(changeset.is_empty());

--- a/crates/chain/tests/test_spk_txout_index.rs
+++ b/crates/chain/tests/test_spk_txout_index.rs
@@ -1,5 +1,5 @@
 use bdk_chain::{indexed_tx_graph::Indexer, SpkTxOutIndex};
-use bitcoin::{absolute, OutPoint, ScriptBuf, Transaction, TxIn, TxOut};
+use bitcoin::{absolute, transaction, Amount, OutPoint, ScriptBuf, Transaction, TxIn, TxOut};
 
 #[test]
 fn spk_txout_sent_and_received() {
@@ -11,11 +11,11 @@ fn spk_txout_sent_and_received() {
     index.insert_spk(1, spk2.clone());
 
     let tx1 = Transaction {
-        version: 0x02,
+        version: transaction::Version::TWO,
         lock_time: absolute::LockTime::ZERO,
         input: vec![],
         output: vec![TxOut {
-            value: 42_000,
+            value: Amount::from_sat(42_000),
             script_pubkey: spk1.clone(),
         }],
     };
@@ -30,7 +30,7 @@ fn spk_txout_sent_and_received() {
     );
 
     let tx2 = Transaction {
-        version: 0x1,
+        version: transaction::Version::ONE,
         lock_time: absolute::LockTime::ZERO,
         input: vec![TxIn {
             previous_output: OutPoint {
@@ -41,12 +41,12 @@ fn spk_txout_sent_and_received() {
         }],
         output: vec![
             TxOut {
-                value: 20_000,
+                value: Amount::from_sat(20_000),
                 script_pubkey: spk2,
             },
             TxOut {
                 script_pubkey: spk1,
-                value: 30_000,
+                value: Amount::from_sat(30_000),
             },
         ],
     };
@@ -73,11 +73,11 @@ fn mark_used() {
     assert!(spk_index.is_used(&1));
 
     let tx1 = Transaction {
-        version: 0x02,
+        version: transaction::Version::TWO,
         lock_time: absolute::LockTime::ZERO,
         input: vec![],
         output: vec![TxOut {
-            value: 42_000,
+            value: Amount::from_sat(42_000),
             script_pubkey: spk1,
         }],
     };

--- a/crates/chain/tests/test_spk_txout_index.rs
+++ b/crates/chain/tests/test_spk_txout_index.rs
@@ -34,7 +34,7 @@ fn spk_txout_sent_and_received() {
         lock_time: absolute::LockTime::ZERO,
         input: vec![TxIn {
             previous_output: OutPoint {
-                txid: tx1.txid(),
+                txid: tx1.compute_txid(),
                 vout: 0,
             },
             ..Default::default()

--- a/crates/chain/tests/test_tx_graph.rs
+++ b/crates/chain/tests/test_tx_graph.rs
@@ -128,11 +128,11 @@ fn insert_txouts() {
 
         // Mark it as confirmed.
         assert_eq!(
-            graph.insert_anchor(update_txs.txid(), conf_anchor),
+            graph.insert_anchor(update_txs.compute_txid(), conf_anchor),
             ChangeSet {
                 txs: [].into(),
                 txouts: [].into(),
-                anchors: [(conf_anchor, update_txs.txid())].into(),
+                anchors: [(conf_anchor, update_txs.compute_txid())].into(),
                 last_seen: [].into()
             }
         );
@@ -147,7 +147,11 @@ fn insert_txouts() {
         ChangeSet {
             txs: [Arc::new(update_txs.clone())].into(),
             txouts: update_ops.clone().into(),
-            anchors: [(conf_anchor, update_txs.txid()), (unconf_anchor, h!("tx2"))].into(),
+            anchors: [
+                (conf_anchor, update_txs.compute_txid()),
+                (unconf_anchor, h!("tx2"))
+            ]
+            .into(),
             last_seen: [(h!("tx2"), 1000000)].into()
         }
     );
@@ -181,7 +185,9 @@ fn insert_txouts() {
     );
 
     assert_eq!(
-        graph.tx_outputs(update_txs.txid()).expect("should exists"),
+        graph
+            .tx_outputs(update_txs.compute_txid())
+            .expect("should exists"),
         [(
             0u32,
             &TxOut {
@@ -198,7 +204,11 @@ fn insert_txouts() {
         ChangeSet {
             txs: [Arc::new(update_txs.clone())].into(),
             txouts: update_ops.into_iter().chain(original_ops).collect(),
-            anchors: [(conf_anchor, update_txs.txid()), (unconf_anchor, h!("tx2"))].into(),
+            anchors: [
+                (conf_anchor, update_txs.compute_txid()),
+                (unconf_anchor, h!("tx2"))
+            ]
+            .into(),
             last_seen: [(h!("tx2"), 1000000)].into()
         }
     );
@@ -233,7 +243,7 @@ fn insert_tx_graph_keeps_track_of_spend() {
     };
 
     let op = OutPoint {
-        txid: tx1.txid(),
+        txid: tx1.compute_txid(),
         vout: 0,
     };
 
@@ -259,7 +269,7 @@ fn insert_tx_graph_keeps_track_of_spend() {
 
     assert_eq!(
         graph1.outspends(op),
-        &iter::once(tx2.txid()).collect::<HashSet<_>>()
+        &iter::once(tx2.compute_txid()).collect::<HashSet<_>>()
     );
     assert_eq!(graph2.outspends(op), graph1.outspends(op));
 }
@@ -279,7 +289,9 @@ fn insert_tx_can_retrieve_full_tx_from_graph() {
     let mut graph = TxGraph::<()>::default();
     let _ = graph.insert_tx(tx.clone());
     assert_eq!(
-        graph.get_tx(tx.txid()).map(|tx| tx.as_ref().clone()),
+        graph
+            .get_tx(tx.compute_txid())
+            .map(|tx| tx.as_ref().clone()),
         Some(tx)
     );
 }
@@ -299,7 +311,7 @@ fn insert_tx_displaces_txouts() {
 
     let changeset = tx_graph.insert_txout(
         OutPoint {
-            txid: tx.txid(),
+            txid: tx.compute_txid(),
             vout: 0,
         },
         TxOut {
@@ -312,7 +324,7 @@ fn insert_tx_displaces_txouts() {
 
     let _ = tx_graph.insert_txout(
         OutPoint {
-            txid: tx.txid(),
+            txid: tx.compute_txid(),
             vout: 0,
         },
         TxOut {
@@ -326,7 +338,7 @@ fn insert_tx_displaces_txouts() {
     assert_eq!(
         tx_graph
             .get_txout(OutPoint {
-                txid: tx.txid(),
+                txid: tx.compute_txid(),
                 vout: 0
             })
             .unwrap()
@@ -335,7 +347,7 @@ fn insert_tx_displaces_txouts() {
     );
     assert_eq!(
         tx_graph.get_txout(OutPoint {
-            txid: tx.txid(),
+            txid: tx.compute_txid(),
             vout: 1
         }),
         None
@@ -359,7 +371,7 @@ fn insert_txout_does_not_displace_tx() {
 
     let _ = tx_graph.insert_txout(
         OutPoint {
-            txid: tx.txid(),
+            txid: tx.compute_txid(),
             vout: 0,
         },
         TxOut {
@@ -370,7 +382,7 @@ fn insert_txout_does_not_displace_tx() {
 
     let _ = tx_graph.insert_txout(
         OutPoint {
-            txid: tx.txid(),
+            txid: tx.compute_txid(),
             vout: 0,
         },
         TxOut {
@@ -382,7 +394,7 @@ fn insert_txout_does_not_displace_tx() {
     assert_eq!(
         tx_graph
             .get_txout(OutPoint {
-                txid: tx.txid(),
+                txid: tx.compute_txid(),
                 vout: 0
             })
             .unwrap()
@@ -391,7 +403,7 @@ fn insert_txout_does_not_displace_tx() {
     );
     assert_eq!(
         tx_graph.get_txout(OutPoint {
-            txid: tx.txid(),
+            txid: tx.compute_txid(),
             vout: 1
         }),
         None
@@ -441,14 +453,14 @@ fn test_calculate_fee() {
         input: vec![
             TxIn {
                 previous_output: OutPoint {
-                    txid: intx1.txid(),
+                    txid: intx1.compute_txid(),
                     vout: 0,
                 },
                 ..Default::default()
             },
             TxIn {
                 previous_output: OutPoint {
-                    txid: intx2.txid(),
+                    txid: intx2.compute_txid(),
                     vout: 0,
                 },
                 ..Default::default()
@@ -541,7 +553,7 @@ fn test_walk_ancestors() {
     // tx_b0 spends tx_a0
     let tx_b0 = Transaction {
         input: vec![TxIn {
-            previous_output: OutPoint::new(tx_a0.txid(), 0),
+            previous_output: OutPoint::new(tx_a0.compute_txid(), 0),
             ..TxIn::default()
         }],
         output: vec![TxOut::NULL, TxOut::NULL],
@@ -551,7 +563,7 @@ fn test_walk_ancestors() {
     // tx_b1 spends tx_a0
     let tx_b1 = Transaction {
         input: vec![TxIn {
-            previous_output: OutPoint::new(tx_a0.txid(), 1),
+            previous_output: OutPoint::new(tx_a0.compute_txid(), 1),
             ..TxIn::default()
         }],
         output: vec![TxOut::NULL],
@@ -570,7 +582,7 @@ fn test_walk_ancestors() {
     // tx_c0 spends tx_b0
     let tx_c0 = Transaction {
         input: vec![TxIn {
-            previous_output: OutPoint::new(tx_b0.txid(), 0),
+            previous_output: OutPoint::new(tx_b0.compute_txid(), 0),
             ..TxIn::default()
         }],
         output: vec![TxOut::NULL],
@@ -580,7 +592,7 @@ fn test_walk_ancestors() {
     // tx_c1 spends tx_b0
     let tx_c1 = Transaction {
         input: vec![TxIn {
-            previous_output: OutPoint::new(tx_b0.txid(), 1),
+            previous_output: OutPoint::new(tx_b0.compute_txid(), 1),
             ..TxIn::default()
         }],
         output: vec![TxOut::NULL],
@@ -591,11 +603,11 @@ fn test_walk_ancestors() {
     let tx_c2 = Transaction {
         input: vec![
             TxIn {
-                previous_output: OutPoint::new(tx_b1.txid(), 0),
+                previous_output: OutPoint::new(tx_b1.compute_txid(), 0),
                 ..TxIn::default()
             },
             TxIn {
-                previous_output: OutPoint::new(tx_b2.txid(), 0),
+                previous_output: OutPoint::new(tx_b2.compute_txid(), 0),
                 ..TxIn::default()
             },
         ],
@@ -615,7 +627,7 @@ fn test_walk_ancestors() {
     // tx_d0 spends tx_c1
     let tx_d0 = Transaction {
         input: vec![TxIn {
-            previous_output: OutPoint::new(tx_c1.txid(), 0),
+            previous_output: OutPoint::new(tx_c1.compute_txid(), 0),
             ..TxIn::default()
         }],
         output: vec![TxOut::NULL],
@@ -626,11 +638,11 @@ fn test_walk_ancestors() {
     let tx_d1 = Transaction {
         input: vec![
             TxIn {
-                previous_output: OutPoint::new(tx_c2.txid(), 0),
+                previous_output: OutPoint::new(tx_c2.compute_txid(), 0),
                 ..TxIn::default()
             },
             TxIn {
-                previous_output: OutPoint::new(tx_c3.txid(), 0),
+                previous_output: OutPoint::new(tx_c3.compute_txid(), 0),
                 ..TxIn::default()
             },
         ],
@@ -641,7 +653,7 @@ fn test_walk_ancestors() {
     // tx_e0 spends tx_d1
     let tx_e0 = Transaction {
         input: vec![TxIn {
-            previous_output: OutPoint::new(tx_d1.txid(), 0),
+            previous_output: OutPoint::new(tx_d1.compute_txid(), 0),
             ..TxIn::default()
         }],
         output: vec![TxOut::NULL],
@@ -663,7 +675,7 @@ fn test_walk_ancestors() {
     ]);
 
     [&tx_a0, &tx_b1].iter().for_each(|&tx| {
-        let changeset = graph.insert_anchor(tx.txid(), tip.block_id());
+        let changeset = graph.insert_anchor(tx.compute_txid(), tip.block_id());
         assert!(!changeset.is_empty());
     });
 
@@ -680,7 +692,7 @@ fn test_walk_ancestors() {
         // Only traverse unconfirmed ancestors of tx_e0 this time
         graph
             .walk_ancestors(tx_e0.clone(), |depth, tx| {
-                let tx_node = graph.get_tx_node(tx.txid())?;
+                let tx_node = graph.get_tx_node(tx.compute_txid())?;
                 for block in tx_node.anchors {
                     match local_chain.is_block_in_chain(block.anchor_block(), tip.block_id()) {
                         Ok(Some(true)) => return None,
@@ -744,15 +756,15 @@ fn test_conflicting_descendants() {
     // tx_b spends tx_a
     let tx_b = Transaction {
         input: vec![TxIn {
-            previous_output: OutPoint::new(tx_a.txid(), 0),
+            previous_output: OutPoint::new(tx_a.compute_txid(), 0),
             ..TxIn::default()
         }],
         output: vec![TxOut::NULL],
         ..common::new_tx(2)
     };
 
-    let txid_a = tx_a.txid();
-    let txid_b = tx_b.txid();
+    let txid_a = tx_a.compute_txid();
+    let txid_b = tx_b.compute_txid();
 
     let mut graph = TxGraph::<()>::default();
     let _ = graph.insert_tx(tx_a);
@@ -776,7 +788,7 @@ fn test_descendants_no_repeat() {
     let txs_b = (0..3)
         .map(|vout| Transaction {
             input: vec![TxIn {
-                previous_output: OutPoint::new(tx_a.txid(), vout),
+                previous_output: OutPoint::new(tx_a.compute_txid(), vout),
                 ..TxIn::default()
             }],
             output: vec![TxOut::NULL],
@@ -787,7 +799,7 @@ fn test_descendants_no_repeat() {
     let txs_c = (0..2)
         .map(|vout| Transaction {
             input: vec![TxIn {
-                previous_output: OutPoint::new(txs_b[vout as usize].txid(), vout),
+                previous_output: OutPoint::new(txs_b[vout as usize].compute_txid(), vout),
                 ..TxIn::default()
             }],
             output: vec![TxOut::NULL],
@@ -798,11 +810,11 @@ fn test_descendants_no_repeat() {
     let tx_d = Transaction {
         input: vec![
             TxIn {
-                previous_output: OutPoint::new(txs_c[0].txid(), 0),
+                previous_output: OutPoint::new(txs_c[0].compute_txid(), 0),
                 ..TxIn::default()
             },
             TxIn {
-                previous_output: OutPoint::new(txs_c[1].txid(), 0),
+                previous_output: OutPoint::new(txs_c[1].compute_txid(), 0),
                 ..TxIn::default()
             },
         ],
@@ -812,7 +824,7 @@ fn test_descendants_no_repeat() {
 
     let tx_e = Transaction {
         input: vec![TxIn {
-            previous_output: OutPoint::new(tx_d.txid(), 0),
+            previous_output: OutPoint::new(tx_d.compute_txid(), 0),
             ..TxIn::default()
         }],
         output: vec![TxOut::NULL],
@@ -846,11 +858,11 @@ fn test_descendants_no_repeat() {
         .chain(core::iter::once(&tx_e))
     {
         let _ = graph.insert_tx(tx.clone());
-        expected_txids.push(tx.txid());
+        expected_txids.push(tx.compute_txid());
     }
 
     let descendants = graph
-        .walk_descendants(tx_a.txid(), |_, txid| Some(txid))
+        .walk_descendants(tx_a.compute_txid(), |_, txid| Some(txid))
         .collect::<Vec<_>>();
 
     assert_eq!(descendants, expected_txids);
@@ -886,7 +898,7 @@ fn test_chain_spends() {
     // The first confirmed transaction spends vout: 0. And is confirmed at block 98.
     let tx_1 = Transaction {
         input: vec![TxIn {
-            previous_output: OutPoint::new(tx_0.txid(), 0),
+            previous_output: OutPoint::new(tx_0.compute_txid(), 0),
             ..TxIn::default()
         }],
         output: vec![
@@ -905,7 +917,7 @@ fn test_chain_spends() {
     // The second transactions spends vout:1, and is unconfirmed.
     let tx_2 = Transaction {
         input: vec![TxIn {
-            previous_output: OutPoint::new(tx_0.txid(), 1),
+            previous_output: OutPoint::new(tx_0.compute_txid(), 1),
             ..TxIn::default()
         }],
         output: vec![
@@ -929,7 +941,7 @@ fn test_chain_spends() {
 
     for (ht, tx) in [(95, &tx_0), (98, &tx_1)] {
         let _ = graph.insert_anchor(
-            tx.txid(),
+            tx.compute_txid(),
             ConfirmationHeightAnchor {
                 anchor_block: tip.block_id(),
                 confirmation_height: ht,
@@ -939,19 +951,23 @@ fn test_chain_spends() {
 
     // Assert that confirmed spends are returned correctly.
     assert_eq!(
-        graph.get_chain_spend(&local_chain, tip.block_id(), OutPoint::new(tx_0.txid(), 0)),
+        graph.get_chain_spend(
+            &local_chain,
+            tip.block_id(),
+            OutPoint::new(tx_0.compute_txid(), 0)
+        ),
         Some((
             ChainPosition::Confirmed(&ConfirmationHeightAnchor {
                 anchor_block: tip.block_id(),
                 confirmation_height: 98
             }),
-            tx_1.txid(),
+            tx_1.compute_txid(),
         )),
     );
 
     // Check if chain position is returned correctly.
     assert_eq!(
-        graph.get_chain_position(&local_chain, tip.block_id(), tx_0.txid()),
+        graph.get_chain_position(&local_chain, tip.block_id(), tx_0.compute_txid()),
         // Some(ObservedAs::Confirmed(&local_chain.get_block(95).expect("block expected"))),
         Some(ChainPosition::Confirmed(&ConfirmationHeightAnchor {
             anchor_block: tip.block_id(),
@@ -961,25 +977,33 @@ fn test_chain_spends() {
 
     // Even if unconfirmed tx has a last_seen of 0, it can still be part of a chain spend.
     assert_eq!(
-        graph.get_chain_spend(&local_chain, tip.block_id(), OutPoint::new(tx_0.txid(), 1)),
-        Some((ChainPosition::Unconfirmed(0), tx_2.txid())),
+        graph.get_chain_spend(
+            &local_chain,
+            tip.block_id(),
+            OutPoint::new(tx_0.compute_txid(), 1)
+        ),
+        Some((ChainPosition::Unconfirmed(0), tx_2.compute_txid())),
     );
 
     // Mark the unconfirmed as seen and check correct ObservedAs status is returned.
-    let _ = graph.insert_seen_at(tx_2.txid(), 1234567);
+    let _ = graph.insert_seen_at(tx_2.compute_txid(), 1234567);
 
     // Check chain spend returned correctly.
     assert_eq!(
         graph
-            .get_chain_spend(&local_chain, tip.block_id(), OutPoint::new(tx_0.txid(), 1))
+            .get_chain_spend(
+                &local_chain,
+                tip.block_id(),
+                OutPoint::new(tx_0.compute_txid(), 1)
+            )
             .unwrap(),
-        (ChainPosition::Unconfirmed(1234567), tx_2.txid())
+        (ChainPosition::Unconfirmed(1234567), tx_2.compute_txid())
     );
 
     // A conflicting transaction that conflicts with tx_1.
     let tx_1_conflict = Transaction {
         input: vec![TxIn {
-            previous_output: OutPoint::new(tx_0.txid(), 0),
+            previous_output: OutPoint::new(tx_0.compute_txid(), 0),
             ..Default::default()
         }],
         ..common::new_tx(0)
@@ -988,13 +1012,13 @@ fn test_chain_spends() {
 
     // Because this tx conflicts with an already confirmed transaction, chain position should return none.
     assert!(graph
-        .get_chain_position(&local_chain, tip.block_id(), tx_1_conflict.txid())
+        .get_chain_position(&local_chain, tip.block_id(), tx_1_conflict.compute_txid())
         .is_none());
 
     // Another conflicting tx that conflicts with tx_2.
     let tx_2_conflict = Transaction {
         input: vec![TxIn {
-            previous_output: OutPoint::new(tx_0.txid(), 1),
+            previous_output: OutPoint::new(tx_0.compute_txid(), 1),
             ..Default::default()
         }],
         ..common::new_tx(0)
@@ -1002,12 +1026,12 @@ fn test_chain_spends() {
 
     // Insert in graph and mark it as seen.
     let _ = graph.insert_tx(tx_2_conflict.clone());
-    let _ = graph.insert_seen_at(tx_2_conflict.txid(), 1234568);
+    let _ = graph.insert_seen_at(tx_2_conflict.compute_txid(), 1234568);
 
     // This should return a valid observation with correct last seen.
     assert_eq!(
         graph
-            .get_chain_position(&local_chain, tip.block_id(), tx_2_conflict.txid())
+            .get_chain_position(&local_chain, tip.block_id(), tx_2_conflict.compute_txid())
             .expect("position expected"),
         ChainPosition::Unconfirmed(1234568)
     );
@@ -1015,14 +1039,21 @@ fn test_chain_spends() {
     // Chain_spend now catches the new transaction as the spend.
     assert_eq!(
         graph
-            .get_chain_spend(&local_chain, tip.block_id(), OutPoint::new(tx_0.txid(), 1))
+            .get_chain_spend(
+                &local_chain,
+                tip.block_id(),
+                OutPoint::new(tx_0.compute_txid(), 1)
+            )
             .expect("expect observation"),
-        (ChainPosition::Unconfirmed(1234568), tx_2_conflict.txid())
+        (
+            ChainPosition::Unconfirmed(1234568),
+            tx_2_conflict.compute_txid()
+        )
     );
 
     // Chain position of the `tx_2` is now none, as it is older than `tx_2_conflict`
     assert!(graph
-        .get_chain_position(&local_chain, tip.block_id(), tx_2.txid())
+        .get_chain_position(&local_chain, tip.block_id(), tx_2.compute_txid())
         .is_none());
 }
 
@@ -1243,7 +1274,7 @@ fn call_map_anchors_with_non_deterministic_anchor() {
 
     for tx_node in full_txs_vec.iter() {
         let new_txnode = new_txs.next().unwrap();
-        assert_eq!(new_txnode.txid, tx_node.txid);
+        assert_eq!(new_txnode.compute_txid(), tx_node.compute_txid());
         assert_eq!(new_txnode.tx, tx_node.tx);
         assert_eq!(
             new_txnode.last_seen_unconfirmed,

--- a/crates/chain/tests/test_tx_graph_conflicts.rs
+++ b/crates/chain/tests/test_tx_graph_conflicts.rs
@@ -596,7 +596,7 @@ fn test_tx_conflict_handling() {
 
         let txs = tx_graph
             .list_chain_txs(&local_chain, chain_tip)
-            .map(|tx| tx.tx_node.txid)
+            .map(|tx| tx.tx_node.compute_txid())
             .collect::<BTreeSet<_>>();
         let exp_txs = scenario
             .exp_chain_txs

--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -12,11 +12,11 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bdk_chain = { path = "../chain", version = "0.11.0", default-features = false }
-electrum-client = { version = "0.19" }
+bdk_chain = { path = "../chain", default-features = false }
+electrum-client = { version = "0.20" }
 #rustls = { version = "=0.21.1", optional = true, features = ["dangerous_configuration"] }
 
 [dev-dependencies]
 bdk_testenv = { path = "../testenv", default-features = false }
-electrsd = { version= "0.27.1", features = ["bitcoind_25_0", "esplora_a33e97e1", "legacy"] }
+electrsd = { version= "0.28.0", features = ["bitcoind_25_0", "esplora_a33e97e1", "legacy"] }
 anyhow = "1"

--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 
 [dependencies]
 bdk_chain = { path = "../chain", version = "0.11.0", default-features = false }
-electrum-client = { version = "0.18" }
+electrum-client = { version = "0.19" }
 #rustls = { version = "=0.21.1", optional = true, features = ["dangerous_configuration"] }
 
 [dev-dependencies]
-bdk_testenv = { path = "../testenv", version = "0.1.0", default-features = false }
-electrsd = { version= "0.25.0", features = ["bitcoind_25_0", "esplora_a33e97e1", "legacy"] }
+bdk_testenv = { path = "../testenv", default-features = false }
+electrsd = { version= "0.27.1", features = ["bitcoind_25_0", "esplora_a33e97e1", "legacy"] }
 anyhow = "1"

--- a/crates/electrum/src/electrum_ext.rs
+++ b/crates/electrum/src/electrum_ext.rs
@@ -426,7 +426,7 @@ fn populate_with_outpoints(
     for outpoint in outpoints {
         let txid = outpoint.txid;
         let tx = client.transaction_get(&txid)?;
-        debug_assert_eq!(tx.txid(), txid);
+        debug_assert_eq!(tx.compute_txid(), txid);
         let txout = match tx.output.get(outpoint.vout as usize) {
             Some(txout) => txout,
             None => continue,

--- a/crates/electrum/tests/test_electrum.rs
+++ b/crates/electrum/tests/test_electrum.rs
@@ -40,7 +40,7 @@ fn scan_detects_confirmed_tx() -> Result<()> {
         .client
         .get_new_address(None, None)?
         .assume_checked();
-    let spk_to_track = ScriptBuf::new_v0_p2wsh(&WScriptHash::all_zeros());
+    let spk_to_track = ScriptBuf::new_p2wsh(&WScriptHash::all_zeros());
     let addr_to_track = Address::from_script(&spk_to_track, bdk_chain::bitcoin::Network::Regtest)?;
 
     // Setup receiver.
@@ -106,7 +106,7 @@ fn tx_can_become_unconfirmed_after_reorg() -> Result<()> {
         .client
         .get_new_address(None, None)?
         .assume_checked();
-    let spk_to_track = ScriptBuf::new_v0_p2wsh(&WScriptHash::all_zeros());
+    let spk_to_track = ScriptBuf::new_p2wsh(&WScriptHash::all_zeros());
     let addr_to_track = Address::from_script(&spk_to_track, bdk_chain::bitcoin::Network::Regtest)?;
 
     // Setup receiver.

--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -13,17 +13,17 @@ readme = "README.md"
 
 [dependencies]
 bdk_chain = { path = "../chain", version = "0.11.0", default-features = false }
-esplora-client = { version = "0.6.0", default-features = false }
+esplora-client = { version = "0.7.0", default-features = false }
 async-trait = { version = "0.1.66", optional = true }
 futures = { version = "0.3.26", optional = true }
 
 # use these dependencies if you need to enable their /no-std features
-bitcoin = { version = "0.30.0", optional = true, default-features = false }
-miniscript = { version = "10.0.0", optional = true, default-features = false }
+bitcoin = { version = "0.31.0", optional = true, default-features = false }
+miniscript = { version = "11.0.0", optional = true, default-features = false }
 
 [dev-dependencies]
-bdk_testenv = { path = "../testenv", version = "0.1.0", default_features = false }
-electrsd = { version= "0.25.0", features = ["bitcoind_25_0", "esplora_a33e97e1", "legacy"] }
+bdk_testenv = { path = "../testenv", default_features = false }
+electrsd = { version= "0.27.1", features = ["bitcoind_25_0", "esplora_a33e97e1", "legacy"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 
 [features]

--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -12,18 +12,18 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bdk_chain = { path = "../chain", version = "0.11.0", default-features = false }
-esplora-client = { version = "0.7.0", default-features = false }
+bdk_chain = { path = "../chain", default-features = false }
+esplora-client = { version = "0.8.0", default-features = false }
 async-trait = { version = "0.1.66", optional = true }
 futures = { version = "0.3.26", optional = true }
 
 # use these dependencies if you need to enable their /no-std features
-bitcoin = { version = "0.31.0", optional = true, default-features = false }
-miniscript = { version = "11.0.0", optional = true, default-features = false }
+bitcoin = { version = "0.32.0-rc1", optional = true, default-features = false }
+miniscript = { version = "12.0.0", optional = true, default-features = false }
 
 [dev-dependencies]
 bdk_testenv = { path = "../testenv", default_features = false }
-electrsd = { version= "0.27.1", features = ["bitcoind_25_0", "esplora_a33e97e1", "legacy"] }
+electrsd = { version= "0.28.0", features = ["bitcoind_25_0", "esplora_a33e97e1", "legacy"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 
 [features]

--- a/crates/esplora/src/async_ext.rs
+++ b/crates/esplora/src/async_ext.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use bdk_chain::collections::btree_map;
 use bdk_chain::{
-    bitcoin::{BlockHash, OutPoint, ScriptBuf, TxOut, Txid},
+    bitcoin::{Amount, BlockHash, OutPoint, ScriptBuf, TxOut, Txid},
     collections::BTreeMap,
     local_chain::{self, CheckPoint},
     BlockId, ConfirmationTimeHeightAnchor, TxGraph,
@@ -228,7 +228,7 @@ impl EsploraAsyncExt for esplora_client::AsyncClient {
                                 },
                                 TxOut {
                                     script_pubkey: prevout.scriptpubkey.clone(),
-                                    value: prevout.value,
+                                    value: Amount::from_sat(prevout.value),
                                 },
                             ))
                         });

--- a/crates/esplora/src/blocking_ext.rs
+++ b/crates/esplora/src/blocking_ext.rs
@@ -3,7 +3,7 @@ use std::thread::JoinHandle;
 use bdk_chain::collections::btree_map;
 use bdk_chain::collections::BTreeMap;
 use bdk_chain::{
-    bitcoin::{BlockHash, OutPoint, ScriptBuf, TxOut, Txid},
+    bitcoin::{Amount, BlockHash, OutPoint, ScriptBuf, TxOut, Txid},
     local_chain::{self, CheckPoint},
     BlockId, ConfirmationTimeHeightAnchor, TxGraph,
 };
@@ -218,7 +218,7 @@ impl EsploraExt for esplora_client::BlockingClient {
                                 },
                                 TxOut {
                                     script_pubkey: prevout.scriptpubkey.clone(),
-                                    value: prevout.value,
+                                    value: Amount::from_sat(prevout.value),
                                 },
                             ))
                         });

--- a/crates/esplora/tests/blocking_ext.rs
+++ b/crates/esplora/tests/blocking_ext.rs
@@ -30,7 +30,7 @@ macro_rules! local_chain {
 pub fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
     let env = TestEnv::new()?;
     let base_url = format!("http://{}", &env.electrsd.esplora_url.clone().unwrap());
-    let client = Builder::new(base_url.as_str()).build_blocking()?;
+    let client = Builder::new(base_url.as_str()).build_blocking();
 
     let receive_address0 =
         Address::from_str("bcrt1qc6fweuf4xjvz4x3gx3t9e0fh4hvqyu2qw4wvxm")?.assume_checked();
@@ -111,7 +111,7 @@ pub fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
 pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     let env = TestEnv::new()?;
     let base_url = format!("http://{}", &env.electrsd.esplora_url.clone().unwrap());
-    let client = Builder::new(base_url.as_str()).build_blocking()?;
+    let client = Builder::new(base_url.as_str()).build_blocking();
     let _block_hashes = env.mine_blocks(101, None)?;
 
     // Now let's test the gap limit. First of all get a chain of 10 addresses.
@@ -215,7 +215,7 @@ fn update_local_chain() -> anyhow::Result<()> {
     // so new blocks can be seen by Electrs
     let env = env.reset_electrsd()?;
     let base_url = format!("http://{}", &env.electrsd.esplora_url.clone().unwrap());
-    let client = Builder::new(base_url.as_str()).build_blocking()?;
+    let client = Builder::new(base_url.as_str()).build_blocking();
 
     struct TestCase {
         name: &'static str,

--- a/crates/file_store/Cargo.toml
+++ b/crates/file_store/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["Bitcoin Dev Kit Developers"]
 readme = "README.md"
 
 [dependencies]
-bdk_chain = { path = "../chain", version = "0.11.0", features = [ "serde", "miniscript" ] }
+bdk_chain = { path = "../chain", features = [ "serde", "miniscript" ] }
 bincode = { version = "1" }
 serde = { version = "1", features = ["derive"] }
 

--- a/crates/hwi/Cargo.toml
+++ b/crates/hwi/Cargo.toml
@@ -10,4 +10,4 @@ readme = "README.md"
 
 [dependencies]
 bdk = { path = "../bdk" }
-hwi = { version = "0.7.0", features = [ "miniscript"] }
+hwi = { version = "0.8.0", features = [ "miniscript"] }

--- a/crates/hwi/src/signer.rs
+++ b/crates/hwi/src/signer.rs
@@ -1,6 +1,6 @@
 use bdk::bitcoin::bip32::Fingerprint;
-use bdk::bitcoin::psbt::PartiallySignedTransaction;
 use bdk::bitcoin::secp256k1::{All, Secp256k1};
+use bdk::bitcoin::Psbt;
 
 use hwi::error::Error;
 use hwi::types::{HWIChain, HWIDevice};
@@ -37,7 +37,7 @@ impl SignerCommon for HWISigner {
 impl TransactionSigner for HWISigner {
     fn sign_transaction(
         &self,
-        psbt: &mut PartiallySignedTransaction,
+        psbt: &mut Psbt,
         _sign_options: &bdk::SignOptions,
         _secp: &Secp256k1<All>,
     ) -> Result<(), SignerError> {

--- a/crates/testenv/Cargo.toml
+++ b/crates/testenv/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitcoincore-rpc = { version = "0.17" }
+bitcoincore-rpc = { version = "0.18" }
 bdk_chain = { path = "../chain", version = "0.11", default-features = false }
-electrsd = { version= "0.25.0", features = ["bitcoind_25_0", "esplora_a33e97e1", "legacy"] }
+electrsd = { version= "0.27.1", features = ["bitcoind_25_0", "esplora_a33e97e1", "legacy"] }
 anyhow = { version = "1" }
 
 [features]

--- a/crates/testenv/Cargo.toml
+++ b/crates/testenv/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitcoincore-rpc = { version = "0.18" }
-bdk_chain = { path = "../chain", version = "0.11", default-features = false }
-electrsd = { version= "0.27.1", features = ["bitcoind_25_0", "esplora_a33e97e1", "legacy"] }
+bitcoincore-rpc = { version = "0.19" }
+bdk_chain = { path = "../chain", default-features = false }
+electrsd = { version= "0.28.0", features = ["bitcoind_25_0", "esplora_a33e97e1", "legacy"] }
 anyhow = { version = "1" }
 
 [features]

--- a/crates/testenv/src/lib.rs
+++ b/crates/testenv/src/lib.rs
@@ -1,7 +1,7 @@
 use bdk_chain::bitcoin::{
     address::NetworkChecked, block::Header, hash_types::TxMerkleNode, hashes::Hash,
-    secp256k1::rand::random, Address, Amount, Block, BlockHash, CompactTarget, ScriptBuf,
-    ScriptHash, Transaction, TxIn, TxOut, Txid,
+    secp256k1::rand::random, transaction, Address, Amount, Block, BlockHash, CompactTarget,
+    ScriptBuf, ScriptHash, Transaction, TxIn, TxOut, Txid,
 };
 use bitcoincore_rpc::{
     bitcoincore_rpc_json::{GetBlockTemplateModes, GetBlockTemplateRules},
@@ -109,7 +109,7 @@ impl TestEnv {
         )?;
 
         let txdata = vec![Transaction {
-            version: 1,
+            version: transaction::Version::ONE,
             lock_time: bdk_chain::bitcoin::absolute::LockTime::from_height(0)?,
             input: vec![TxIn {
                 previous_output: bdk_chain::bitcoin::OutPoint::default(),
@@ -122,7 +122,7 @@ impl TestEnv {
                 witness: bdk_chain::bitcoin::Witness::new(),
             }],
             output: vec![TxOut {
-                value: 0,
+                value: Amount::ZERO,
                 script_pubkey: ScriptBuf::new_p2sh(&ScriptHash::all_zeros()),
             }],
         }];

--- a/example-crates/example_cli/src/lib.rs
+++ b/example-crates/example_cli/src/lib.rs
@@ -633,7 +633,7 @@ where
 
             match (broadcast)(chain_specific, &transaction) {
                 Ok(_) => {
-                    println!("Broadcasted Tx : {}", transaction.txid());
+                    println!("Broadcasted Tx : {}", transaction.compute_txid());
 
                     let keychain_changeset = graph.lock().unwrap().insert_tx(transaction);
 

--- a/example-crates/example_esplora/src/main.rs
+++ b/example-crates/example_esplora/src/main.rs
@@ -86,7 +86,7 @@ impl EsploraArgs {
             _ => panic!("unsupported network"),
         });
 
-        let client = esplora_client::Builder::new(esplora_url).build_blocking()?;
+        let client = esplora_client::Builder::new(esplora_url).build_blocking();
         Ok(client)
     }
 }

--- a/example-crates/wallet_electrum/src/main.rs
+++ b/example-crates/wallet_electrum/src/main.rs
@@ -99,7 +99,7 @@ fn main() -> Result<(), anyhow::Error> {
     let finalized = wallet.sign(&mut psbt, SignOptions::default())?;
     assert!(finalized);
 
-    let tx = psbt.extract_tx();
+    let tx = psbt.extract_tx()?;
     client.transaction_broadcast(&tx)?;
     println!("Tx broadcasted! Txid: {}", tx.txid());
 

--- a/example-crates/wallet_electrum/src/main.rs
+++ b/example-crates/wallet_electrum/src/main.rs
@@ -101,7 +101,7 @@ fn main() -> Result<(), anyhow::Error> {
 
     let tx = psbt.extract_tx()?;
     client.transaction_broadcast(&tx)?;
-    println!("Tx broadcasted! Txid: {}", tx.txid());
+    println!("Tx broadcasted! Txid: {}", tx.compute_txid());
 
     Ok(())
 }

--- a/example-crates/wallet_esplora_async/src/main.rs
+++ b/example-crates/wallet_esplora_async/src/main.rs
@@ -90,7 +90,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let finalized = wallet.sign(&mut psbt, SignOptions::default())?;
     assert!(finalized);
 
-    let tx = psbt.extract_tx();
+    let tx = psbt.extract_tx()?;
     client.broadcast(&tx).await?;
     println!("Tx broadcasted! Txid: {}", tx.txid());
 

--- a/example-crates/wallet_esplora_async/src/main.rs
+++ b/example-crates/wallet_esplora_async/src/main.rs
@@ -92,7 +92,7 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let tx = psbt.extract_tx()?;
     client.broadcast(&tx).await?;
-    println!("Tx broadcasted! Txid: {}", tx.txid());
+    println!("Tx broadcasted! Txid: {}", tx.compute_txid());
 
     Ok(())
 }

--- a/example-crates/wallet_esplora_blocking/src/main.rs
+++ b/example-crates/wallet_esplora_blocking/src/main.rs
@@ -92,7 +92,7 @@ fn main() -> Result<(), anyhow::Error> {
 
     let tx = psbt.extract_tx()?;
     client.broadcast(&tx)?;
-    println!("Tx broadcasted! Txid: {}", tx.txid());
+    println!("Tx broadcasted! Txid: {}", tx.compute_txid());
 
     Ok(())
 }

--- a/example-crates/wallet_esplora_blocking/src/main.rs
+++ b/example-crates/wallet_esplora_blocking/src/main.rs
@@ -34,7 +34,7 @@ fn main() -> Result<(), anyhow::Error> {
 
     print!("Syncing...");
     let client =
-        esplora_client::Builder::new("https://blockstream.info/testnet/api").build_blocking()?;
+        esplora_client::Builder::new("https://blockstream.info/testnet/api").build_blocking();
 
     let prev_tip = wallet.latest_checkpoint();
     let keychain_spks = wallet
@@ -90,7 +90,7 @@ fn main() -> Result<(), anyhow::Error> {
     let finalized = wallet.sign(&mut psbt, SignOptions::default())?;
     assert!(finalized);
 
-    let tx = psbt.extract_tx();
+    let tx = psbt.extract_tx()?;
     client.broadcast(&tx)?;
     println!("Tx broadcasted! Txid: {}", tx.txid());
 

--- a/nursery/coin_select/src/coin_selector.rs
+++ b/nursery/coin_select/src/coin_selector.rs
@@ -96,7 +96,7 @@ impl CoinSelectorOpt {
     ) -> Self {
         let mut tx = Transaction {
             input: vec![],
-            version: 1,
+            version: transaction::Version::ONE,
             lock_time: absolute::LockTime::ZERO,
             output: txouts.to_vec(),
         };
@@ -112,7 +112,7 @@ impl CoinSelectorOpt {
             target_value: if txouts.is_empty() {
                 None
             } else {
-                Some(txouts.iter().map(|txout| txout.value).sum())
+                Some(txouts.iter().map(|txout| txout.value.to_sat()).sum())
             },
             ..Self::from_weights(
                 base_weight.to_wu() as u32,

--- a/nursery/coin_select/src/lib.rs
+++ b/nursery/coin_select/src/lib.rs
@@ -12,7 +12,7 @@ use bdk_chain::{
     bitcoin,
     collections::{BTreeSet, HashMap},
 };
-use bitcoin::{absolute, Transaction, TxOut};
+use bitcoin::{absolute, transaction, Transaction, TxOut};
 use core::fmt::{Debug, Display};
 
 mod coin_selector;
@@ -29,5 +29,5 @@ pub const TXIN_BASE_WEIGHT: u32 = (32 + 4 + 4) * 4;
 // Shamelessly copied from
 // https://github.com/rust-bitcoin/rust-miniscript/blob/d5615acda1a7fdc4041a11c1736af139b8c7ebe8/src/util.rs#L8
 pub(crate) fn varint_size(v: usize) -> u32 {
-    bitcoin::VarInt(v as u64).len() as u32
+    bitcoin::VarInt(v as u64).size() as u32
 }

--- a/nursery/tmp_plan/src/lib.rs
+++ b/nursery/tmp_plan/src/lib.rs
@@ -17,14 +17,13 @@
 use bdk_chain::{bitcoin, collections::*, miniscript};
 use bitcoin::{
     absolute,
-    address::WitnessVersion,
     bip32::{DerivationPath, Fingerprint, KeySource},
     blockdata::transaction::Sequence,
     ecdsa,
     hashes::{hash160, ripemd160, sha256},
     secp256k1::Secp256k1,
     taproot::{self, LeafVersion, TapLeafHash},
-    ScriptBuf, TxIn, Witness,
+    ScriptBuf, TxIn, Witness, WitnessVersion,
 };
 use miniscript::{
     descriptor::{InnerXKey, Tr},
@@ -32,7 +31,7 @@ use miniscript::{
 };
 
 pub(crate) fn varint_len(v: usize) -> usize {
-    bitcoin::VarInt(v as u64).len() as usize
+    bitcoin::VarInt(v as u64).size() as usize
 }
 
 mod plan_impls;

--- a/nursery/tmp_plan/src/plan_impls.rs
+++ b/nursery/tmp_plan/src/plan_impls.rs
@@ -240,7 +240,7 @@ fn plan_steps<Ak: Clone + CanDerive, Ctx: ScriptContext>(
             if max_sequence.is_height_locked() == older.is_height_locked() {
                 if max_sequence.to_consensus_u32() >= older.to_consensus_u32() {
                     Some(TermPlan {
-                        min_sequence: Some(*older),
+                        min_sequence: Some((*older).into()),
                         ..Default::default()
                     })
                 } else {
@@ -319,7 +319,7 @@ fn plan_steps<Ak: Clone + CanDerive, Ctx: ScriptContext>(
             }
         }
         Terminal::Thresh(_, _) => todo!(),
-        Terminal::Multi(_, _) => todo!(),
-        Terminal::MultiA(_, _) => todo!(),
+        Terminal::Multi(_) => todo!(),
+        Terminal::MultiA(_) => todo!(),
     }
 }

--- a/nursery/tmp_plan/src/requirements.rs
+++ b/nursery/tmp_plan/src/requirements.rs
@@ -3,12 +3,11 @@ use core::ops::Deref;
 
 use bitcoin::{
     bip32,
-    hashes::{hash160, ripemd160, sha256},
+    hashes::{hash160, ripemd160, sha256, Hash},
     key::XOnlyPublicKey,
-    psbt::Prevouts,
-    secp256k1::{KeyPair, Message, PublicKey, Signing, Verification},
+    secp256k1::{Keypair, Message, PublicKey, Signing, Verification},
     sighash,
-    sighash::{EcdsaSighashType, SighashCache, TapSighashType},
+    sighash::{EcdsaSighashType, Prevouts, SighashCache, TapSighashType},
     taproot, Transaction, TxOut,
 };
 
@@ -163,11 +162,11 @@ impl RequiredSignatures<DescriptorPublicKey> {
 
                 let tweak =
                     taproot::TapTweakHash::from_key_and_tweak(x_only_pubkey, merkle_root.clone());
-                let keypair = KeyPair::from_secret_key(&secp, &secret_key.clone())
+                let keypair = Keypair::from_secret_key(&secp, &secret_key.clone())
                     .add_xonly_tweak(&secp, &tweak.to_scalar())
                     .unwrap();
 
-                let msg = Message::from_slice(sighash.as_ref()).expect("Sighashes are 32 bytes");
+                let msg = Message::from_digest(sighash.to_byte_array());
                 let sig = secp.sign_schnorr_no_aux_rand(&msg, &keypair);
 
                 let bitcoin_sig = taproot::Signature {
@@ -209,9 +208,8 @@ impl RequiredSignatures<DescriptorPublicKey> {
                                 todo!();
                             }
                         };
-                        let keypair = KeyPair::from_secret_key(&secp, &secret_key.clone());
-                        let msg =
-                            Message::from_slice(sighash.as_ref()).expect("Sighashes are 32 bytes");
+                        let keypair = Keypair::from_secret_key(&secp, &secret_key.clone());
+                        let msg = Message::from_digest(sighash.to_byte_array());
                         let sig = secp.sign_schnorr_no_aux_rand(&msg, &keypair);
                         let bitcoin_sig = taproot::Signature {
                             sig,


### PR DESCRIPTION
Please excuse the noise if this is not of interest to you guys right now. No action required from the `bdk` team - this is just informational and so the `rust-bitcoin` team can see that bitcoin rc1 release is ok. 

Test the latest bitcoin release candidate. Includes an unreleased patched version of `rust-miniscript` (`master` branch + depend on bitcoin rc release).

Notes:

- This wouldn't have been too hard if I knew my way around the codebase and didn't try to rush. The new `miniscript::Threshold` usage took me down a dark path for a while :) 
- Leaves a few calls to `expect` that require more invasive error handling improvements
- Uses the ugly `weight.to_wu() as usize` instead of using the new `Weight` type more thoroughly
- Uses `network.into()` liberally instead of using the new `NetworkKind` more thoroughly
- The `Sequence` / `RelLockTime` stuff is a bit rough too


But I believe this proves the rc1 release is pretty good as it is.

`cargo test  --color=always --workspace --all-features --all-targets` passes all tests on my machine.
