### PR TITLE
test rebase: Upgrade miniscript/bitcoin dependency

### DIFF
--- a/crates/bdk/Cargo.toml
+++ b/crates/bdk/Cargo.toml
@@ -14,8 +14,8 @@ rust-version = "1.63"
 
 [dependencies]
 rand = "^0.8"
-miniscript = { version = "10.0.0", features = ["serde"], default-features = false }
-bitcoin = { version = "0.30.0", features = ["serde", "base64", "rand-std"], default-features = false }
+miniscript = { version = "11.0.0", features = ["serde"], default-features = false }
+bitcoin = { version = "0.31.0", features = ["serde", "base64", "rand-std"], default-features = false }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 bdk_chain = { path = "../chain", version = "0.11.0", features = ["miniscript", "serde"], default-features = false }

--- a/crates/bdk/src/descriptor/error.rs
+++ b/crates/bdk/src/descriptor/error.rs
@@ -41,7 +41,7 @@ pub enum Error {
     /// Miniscript error
     Miniscript(miniscript::Error),
     /// Hex decoding error
-    Hex(bitcoin::hashes::hex::Error),
+    Hex(bitcoin::hex::HexToBytesError),
 }
 
 impl From<crate::keys::KeyError> for Error {
@@ -110,8 +110,8 @@ impl From<miniscript::Error> for Error {
     }
 }
 
-impl From<bitcoin::hashes::hex::Error> for Error {
-    fn from(err: bitcoin::hashes::hex::Error) -> Self {
+impl From<bitcoin::hex::HexToBytesError> for Error {
+    fn from(err: bitcoin::hex::HexToBytesError) -> Self {
         Error::Hex(err)
     }
 }

--- a/crates/bdk/src/descriptor/policy.rs
+++ b/crates/bdk/src/descriptor/policy.rs
@@ -1137,7 +1137,7 @@ impl ExtractPolicy for Descriptor<DescriptorPublicKey> {
                 let key_spend_sig =
                     miniscript::Tap::make_signature(tr.internal_key(), signers, build_sat, secp);
 
-                if tr.taptree().is_none() {
+                if tr.tap_tree().is_none() {
                     Ok(Some(key_spend_sig))
                 } else {
                     let mut items = vec![key_spend_sig];
@@ -1184,8 +1184,8 @@ mod test {
         secp: &SecpCtx,
     ) -> (DescriptorKey<Ctx>, DescriptorKey<Ctx>, Fingerprint) {
         let path = bip32::DerivationPath::from_str(path).unwrap();
-        let tprv = bip32::ExtendedPrivKey::from_str(tprv).unwrap();
-        let tpub = bip32::ExtendedPubKey::from_priv(secp, &tprv);
+        let tprv = bip32::Xpriv::from_str(tprv).unwrap();
+        let tpub = bip32::Xpub::from_priv(secp, &tprv);
         let fingerprint = tprv.fingerprint(secp);
         let prvkey = (tprv, path.clone()).into_descriptor_key().unwrap();
         let pubkey = (tpub, path).into_descriptor_key().unwrap();

--- a/crates/bdk/src/descriptor/template.rs
+++ b/crates/bdk/src/descriptor/template.rs
@@ -195,7 +195,7 @@ impl<K: IntoDescriptorKey<Tap>> DescriptorTemplate for P2TR<K> {
 /// # use bdk::wallet::AddressIndex::New;
 /// use bdk::template::Bip44;
 ///
-/// let key = bitcoin::bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPeZRHk4rTG6orPS2CRNFX3njhUXx5vj9qGog5ZMH4uGReDWN5kCkY3jmWEtWause41CDvBRXD1shKknAMKxT99o9qUTRVC6m")?;
+/// let key = bitcoin::bip32::Xpriv::from_str("tprv8ZgxMBicQKsPeZRHk4rTG6orPS2CRNFX3njhUXx5vj9qGog5ZMH4uGReDWN5kCkY3jmWEtWause41CDvBRXD1shKknAMKxT99o9qUTRVC6m")?;
 /// let mut wallet = Wallet::new_no_persist(
 ///     Bip44(key.clone(), KeychainKind::External),
 ///     Some(Bip44(key, KeychainKind::Internal)),
@@ -232,7 +232,7 @@ impl<K: DerivableKey<Legacy>> DescriptorTemplate for Bip44<K> {
 /// # use bdk::wallet::AddressIndex::New;
 /// use bdk::template::Bip44Public;
 ///
-/// let key = bitcoin::bip32::ExtendedPubKey::from_str("tpubDDDzQ31JkZB7VxUr9bjvBivDdqoFLrDPyLWtLapArAi51ftfmCb2DPxwLQzX65iNcXz1DGaVvyvo6JQ6rTU73r2gqdEo8uov9QKRb7nKCSU")?;
+/// let key = bitcoin::bip32::Xpub::from_str("tpubDDDzQ31JkZB7VxUr9bjvBivDdqoFLrDPyLWtLapArAi51ftfmCb2DPxwLQzX65iNcXz1DGaVvyvo6JQ6rTU73r2gqdEo8uov9QKRb7nKCSU")?;
 /// let fingerprint = bitcoin::bip32::Fingerprint::from_str("c55b303f")?;
 /// let mut wallet = Wallet::new_no_persist(
 ///     Bip44Public(key.clone(), fingerprint, KeychainKind::External),
@@ -270,7 +270,7 @@ impl<K: DerivableKey<Legacy>> DescriptorTemplate for Bip44Public<K> {
 /// # use bdk::wallet::AddressIndex::New;
 /// use bdk::template::Bip49;
 ///
-/// let key = bitcoin::bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPeZRHk4rTG6orPS2CRNFX3njhUXx5vj9qGog5ZMH4uGReDWN5kCkY3jmWEtWause41CDvBRXD1shKknAMKxT99o9qUTRVC6m")?;
+/// let key = bitcoin::bip32::Xpriv::from_str("tprv8ZgxMBicQKsPeZRHk4rTG6orPS2CRNFX3njhUXx5vj9qGog5ZMH4uGReDWN5kCkY3jmWEtWause41CDvBRXD1shKknAMKxT99o9qUTRVC6m")?;
 /// let mut wallet = Wallet::new_no_persist(
 ///     Bip49(key.clone(), KeychainKind::External),
 ///     Some(Bip49(key, KeychainKind::Internal)),
@@ -307,7 +307,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip49<K> {
 /// # use bdk::wallet::AddressIndex::New;
 /// use bdk::template::Bip49Public;
 ///
-/// let key = bitcoin::bip32::ExtendedPubKey::from_str("tpubDC49r947KGK52X5rBWS4BLs5m9SRY3pYHnvRrm7HcybZ3BfdEsGFyzCMzayi1u58eT82ZeyFZwH7DD6Q83E3fM9CpfMtmnTygnLfP59jL9L")?;
+/// let key = bitcoin::bip32::Xpub::from_str("tpubDC49r947KGK52X5rBWS4BLs5m9SRY3pYHnvRrm7HcybZ3BfdEsGFyzCMzayi1u58eT82ZeyFZwH7DD6Q83E3fM9CpfMtmnTygnLfP59jL9L")?;
 /// let fingerprint = bitcoin::bip32::Fingerprint::from_str("c55b303f")?;
 /// let mut wallet = Wallet::new_no_persist(
 ///     Bip49Public(key.clone(), fingerprint, KeychainKind::External),
@@ -345,7 +345,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip49Public<K> {
 /// # use bdk::wallet::AddressIndex::New;
 /// use bdk::template::Bip84;
 ///
-/// let key = bitcoin::bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPeZRHk4rTG6orPS2CRNFX3njhUXx5vj9qGog5ZMH4uGReDWN5kCkY3jmWEtWause41CDvBRXD1shKknAMKxT99o9qUTRVC6m")?;
+/// let key = bitcoin::bip32::Xpriv::from_str("tprv8ZgxMBicQKsPeZRHk4rTG6orPS2CRNFX3njhUXx5vj9qGog5ZMH4uGReDWN5kCkY3jmWEtWause41CDvBRXD1shKknAMKxT99o9qUTRVC6m")?;
 /// let mut wallet = Wallet::new_no_persist(
 ///     Bip84(key.clone(), KeychainKind::External),
 ///     Some(Bip84(key, KeychainKind::Internal)),
@@ -382,7 +382,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip84<K> {
 /// # use bdk::wallet::AddressIndex::New;
 /// use bdk::template::Bip84Public;
 ///
-/// let key = bitcoin::bip32::ExtendedPubKey::from_str("tpubDC2Qwo2TFsaNC4ju8nrUJ9mqVT3eSgdmy1yPqhgkjwmke3PRXutNGRYAUo6RCHTcVQaDR3ohNU9we59brGHuEKPvH1ags2nevW5opEE9Z5Q")?;
+/// let key = bitcoin::bip32::Xpub::from_str("tpubDC2Qwo2TFsaNC4ju8nrUJ9mqVT3eSgdmy1yPqhgkjwmke3PRXutNGRYAUo6RCHTcVQaDR3ohNU9we59brGHuEKPvH1ags2nevW5opEE9Z5Q")?;
 /// let fingerprint = bitcoin::bip32::Fingerprint::from_str("c55b303f")?;
 /// let mut wallet = Wallet::new_no_persist(
 ///     Bip84Public(key.clone(), fingerprint, KeychainKind::External),
@@ -420,7 +420,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip84Public<K> {
 /// # use bdk::wallet::AddressIndex::New;
 /// use bdk::template::Bip86;
 ///
-/// let key = bitcoin::bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPeZRHk4rTG6orPS2CRNFX3njhUXx5vj9qGog5ZMH4uGReDWN5kCkY3jmWEtWause41CDvBRXD1shKknAMKxT99o9qUTRVC6m")?;
+/// let key = bitcoin::bip32::Xpriv::from_str("tprv8ZgxMBicQKsPeZRHk4rTG6orPS2CRNFX3njhUXx5vj9qGog5ZMH4uGReDWN5kCkY3jmWEtWause41CDvBRXD1shKknAMKxT99o9qUTRVC6m")?;
 /// let mut wallet = Wallet::new_no_persist(
 ///     Bip86(key.clone(), KeychainKind::External),
 ///     Some(Bip86(key, KeychainKind::Internal)),
@@ -457,7 +457,7 @@ impl<K: DerivableKey<Tap>> DescriptorTemplate for Bip86<K> {
 /// # use bdk::wallet::AddressIndex::New;
 /// use bdk::template::Bip86Public;
 ///
-/// let key = bitcoin::bip32::ExtendedPubKey::from_str("tpubDC2Qwo2TFsaNC4ju8nrUJ9mqVT3eSgdmy1yPqhgkjwmke3PRXutNGRYAUo6RCHTcVQaDR3ohNU9we59brGHuEKPvH1ags2nevW5opEE9Z5Q")?;
+/// let key = bitcoin::bip32::Xpub::from_str("tpubDC2Qwo2TFsaNC4ju8nrUJ9mqVT3eSgdmy1yPqhgkjwmke3PRXutNGRYAUo6RCHTcVQaDR3ohNU9we59brGHuEKPvH1ags2nevW5opEE9Z5Q")?;
 /// let fingerprint = bitcoin::bip32::Fingerprint::from_str("c55b303f")?;
 /// let mut wallet = Wallet::new_no_persist(
 ///     Bip86Public(key.clone(), fingerprint, KeychainKind::External),
@@ -567,7 +567,7 @@ mod test {
     fn test_bip44_template_cointype() {
         use bitcoin::bip32::ChildNumber::{self, Hardened};
 
-        let xprvkey = bitcoin::bip32::ExtendedPrivKey::from_str("xprv9s21ZrQH143K2fpbqApQL69a4oKdGVnVN52R82Ft7d1pSqgKmajF62acJo3aMszZb6qQ22QsVECSFxvf9uyxFUvFYQMq3QbtwtRSMjLAhMf").unwrap();
+        let xprvkey = bitcoin::bip32::Xpriv::from_str("xprv9s21ZrQH143K2fpbqApQL69a4oKdGVnVN52R82Ft7d1pSqgKmajF62acJo3aMszZb6qQ22QsVECSFxvf9uyxFUvFYQMq3QbtwtRSMjLAhMf").unwrap();
         assert_eq!(Network::Bitcoin, xprvkey.network);
         let xdesc = Bip44(xprvkey, KeychainKind::Internal)
             .build(Network::Bitcoin)
@@ -581,7 +581,7 @@ mod test {
             assert_matches!(coin_type, Hardened { index: 0 });
         }
 
-        let tprvkey = bitcoin::bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPcx5nBGsR63Pe8KnRUqmbJNENAfGftF3yuXoMMoVJJcYeUw5eVkm9WBPjWYt6HMWYJNesB5HaNVBaFc1M6dRjWSYnmewUMYy").unwrap();
+        let tprvkey = bitcoin::bip32::Xpriv::from_str("tprv8ZgxMBicQKsPcx5nBGsR63Pe8KnRUqmbJNENAfGftF3yuXoMMoVJJcYeUw5eVkm9WBPjWYt6HMWYJNesB5HaNVBaFc1M6dRjWSYnmewUMYy").unwrap();
         assert_eq!(Network::Testnet, tprvkey.network);
         let tdesc = Bip44(tprvkey, KeychainKind::Internal)
             .build(Network::Testnet)
@@ -740,7 +740,7 @@ mod test {
     // BIP44 `pkh(key/44'/0'/0'/{0,1}/*)`
     #[test]
     fn test_bip44_template() {
-        let prvkey = bitcoin::bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPcx5nBGsR63Pe8KnRUqmbJNENAfGftF3yuXoMMoVJJcYeUw5eVkm9WBPjWYt6HMWYJNesB5HaNVBaFc1M6dRjWSYnmewUMYy").unwrap();
+        let prvkey = bitcoin::bip32::Xpriv::from_str("tprv8ZgxMBicQKsPcx5nBGsR63Pe8KnRUqmbJNENAfGftF3yuXoMMoVJJcYeUw5eVkm9WBPjWYt6HMWYJNesB5HaNVBaFc1M6dRjWSYnmewUMYy").unwrap();
         check(
             Bip44(prvkey, KeychainKind::External).build(Network::Bitcoin),
             false,
@@ -770,7 +770,7 @@ mod test {
     // BIP44 public `pkh(key/{0,1}/*)`
     #[test]
     fn test_bip44_public_template() {
-        let pubkey = bitcoin::bip32::ExtendedPubKey::from_str("tpubDDDzQ31JkZB7VxUr9bjvBivDdqoFLrDPyLWtLapArAi51ftfmCb2DPxwLQzX65iNcXz1DGaVvyvo6JQ6rTU73r2gqdEo8uov9QKRb7nKCSU").unwrap();
+        let pubkey = bitcoin::bip32::Xpub::from_str("tpubDDDzQ31JkZB7VxUr9bjvBivDdqoFLrDPyLWtLapArAi51ftfmCb2DPxwLQzX65iNcXz1DGaVvyvo6JQ6rTU73r2gqdEo8uov9QKRb7nKCSU").unwrap();
         let fingerprint = bitcoin::bip32::Fingerprint::from_str("c55b303f").unwrap();
         check(
             Bip44Public(pubkey, fingerprint, KeychainKind::External).build(Network::Bitcoin),
@@ -801,7 +801,7 @@ mod test {
     // BIP49 `sh(wpkh(key/49'/0'/0'/{0,1}/*))`
     #[test]
     fn test_bip49_template() {
-        let prvkey = bitcoin::bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPcx5nBGsR63Pe8KnRUqmbJNENAfGftF3yuXoMMoVJJcYeUw5eVkm9WBPjWYt6HMWYJNesB5HaNVBaFc1M6dRjWSYnmewUMYy").unwrap();
+        let prvkey = bitcoin::bip32::Xpriv::from_str("tprv8ZgxMBicQKsPcx5nBGsR63Pe8KnRUqmbJNENAfGftF3yuXoMMoVJJcYeUw5eVkm9WBPjWYt6HMWYJNesB5HaNVBaFc1M6dRjWSYnmewUMYy").unwrap();
         check(
             Bip49(prvkey, KeychainKind::External).build(Network::Bitcoin),
             true,
@@ -831,7 +831,7 @@ mod test {
     // BIP49 public `sh(wpkh(key/{0,1}/*))`
     #[test]
     fn test_bip49_public_template() {
-        let pubkey = bitcoin::bip32::ExtendedPubKey::from_str("tpubDC49r947KGK52X5rBWS4BLs5m9SRY3pYHnvRrm7HcybZ3BfdEsGFyzCMzayi1u58eT82ZeyFZwH7DD6Q83E3fM9CpfMtmnTygnLfP59jL9L").unwrap();
+        let pubkey = bitcoin::bip32::Xpub::from_str("tpubDC49r947KGK52X5rBWS4BLs5m9SRY3pYHnvRrm7HcybZ3BfdEsGFyzCMzayi1u58eT82ZeyFZwH7DD6Q83E3fM9CpfMtmnTygnLfP59jL9L").unwrap();
         let fingerprint = bitcoin::bip32::Fingerprint::from_str("c55b303f").unwrap();
         check(
             Bip49Public(pubkey, fingerprint, KeychainKind::External).build(Network::Bitcoin),
@@ -862,7 +862,7 @@ mod test {
     // BIP84 `wpkh(key/84'/0'/0'/{0,1}/*)`
     #[test]
     fn test_bip84_template() {
-        let prvkey = bitcoin::bip32::ExtendedPrivKey::from_str("tprv8ZgxMBicQKsPcx5nBGsR63Pe8KnRUqmbJNENAfGftF3yuXoMMoVJJcYeUw5eVkm9WBPjWYt6HMWYJNesB5HaNVBaFc1M6dRjWSYnmewUMYy").unwrap();
+        let prvkey = bitcoin::bip32::Xpriv::from_str("tprv8ZgxMBicQKsPcx5nBGsR63Pe8KnRUqmbJNENAfGftF3yuXoMMoVJJcYeUw5eVkm9WBPjWYt6HMWYJNesB5HaNVBaFc1M6dRjWSYnmewUMYy").unwrap();
         check(
             Bip84(prvkey, KeychainKind::External).build(Network::Bitcoin),
             true,
@@ -892,7 +892,7 @@ mod test {
     // BIP84 public `wpkh(key/{0,1}/*)`
     #[test]
     fn test_bip84_public_template() {
-        let pubkey = bitcoin::bip32::ExtendedPubKey::from_str("tpubDC2Qwo2TFsaNC4ju8nrUJ9mqVT3eSgdmy1yPqhgkjwmke3PRXutNGRYAUo6RCHTcVQaDR3ohNU9we59brGHuEKPvH1ags2nevW5opEE9Z5Q").unwrap();
+        let pubkey = bitcoin::bip32::Xpub::from_str("tpubDC2Qwo2TFsaNC4ju8nrUJ9mqVT3eSgdmy1yPqhgkjwmke3PRXutNGRYAUo6RCHTcVQaDR3ohNU9we59brGHuEKPvH1ags2nevW5opEE9Z5Q").unwrap();
         let fingerprint = bitcoin::bip32::Fingerprint::from_str("c55b303f").unwrap();
         check(
             Bip84Public(pubkey, fingerprint, KeychainKind::External).build(Network::Bitcoin),
@@ -924,7 +924,7 @@ mod test {
     // Used addresses in test vector in https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki
     #[test]
     fn test_bip86_template() {
-        let prvkey = bitcoin::bip32::ExtendedPrivKey::from_str("xprv9s21ZrQH143K3GJpoapnV8SFfukcVBSfeCficPSGfubmSFDxo1kuHnLisriDvSnRRuL2Qrg5ggqHKNVpxR86QEC8w35uxmGoggxtQTPvfUu").unwrap();
+        let prvkey = bitcoin::bip32::Xpriv::from_str("xprv9s21ZrQH143K3GJpoapnV8SFfukcVBSfeCficPSGfubmSFDxo1kuHnLisriDvSnRRuL2Qrg5ggqHKNVpxR86QEC8w35uxmGoggxtQTPvfUu").unwrap();
         check(
             Bip86(prvkey, KeychainKind::External).build(Network::Bitcoin),
             false,
@@ -955,7 +955,7 @@ mod test {
     // Used addresses in test vector in https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki
     #[test]
     fn test_bip86_public_template() {
-        let pubkey = bitcoin::bip32::ExtendedPubKey::from_str("xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ").unwrap();
+        let pubkey = bitcoin::bip32::Xpub::from_str("xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ").unwrap();
         let fingerprint = bitcoin::bip32::Fingerprint::from_str("73c5da0a").unwrap();
         check(
             Bip86Public(pubkey, fingerprint, KeychainKind::External).build(Network::Bitcoin),

--- a/crates/bdk/src/keys/bip39.rs
+++ b/crates/bdk/src/keys/bip39.rs
@@ -57,7 +57,7 @@ pub type MnemonicWithPassphrase = (Mnemonic, Option<String>);
 #[cfg_attr(docsrs, doc(cfg(feature = "keys-bip39")))]
 impl<Ctx: ScriptContext> DerivableKey<Ctx> for Seed {
     fn into_extended_key(self) -> Result<ExtendedKey<Ctx>, KeyError> {
-        Ok(bip32::ExtendedPrivKey::new_master(Network::Bitcoin, &self[..])?.into())
+        Ok(bip32::Xpriv::new_master(Network::Bitcoin, &self[..])?.into())
     }
 
     fn into_descriptor_key(

--- a/crates/bdk/src/psbt/mod.rs
+++ b/crates/bdk/src/psbt/mod.rs
@@ -9,12 +9,12 @@
 // You may not use this file except in accordance with one or both of these
 // licenses.
 
-//! Additional functions on the `rust-bitcoin` `PartiallySignedTransaction` structure.
+//! Additional functions on the `rust-bitcoin` `Psbt` structure.
 
 use alloc::vec::Vec;
-use bitcoin::psbt::PartiallySignedTransaction as Psbt;
 use bitcoin::Amount;
 use bitcoin::FeeRate;
+use bitcoin::Psbt;
 use bitcoin::TxOut;
 
 // TODO upstream the functions here to `rust-bitcoin`?
@@ -29,7 +29,7 @@ pub trait PsbtUtils {
     fn fee_amount(&self) -> Option<u64>;
 
     /// The transaction's fee rate. This value will only be accurate if calculated AFTER the
-    /// `PartiallySignedTransaction` is finalized and all witness/signature data is added to the
+    /// `Psbt` is finalized and all witness/signature data is added to the
     /// transaction.
     /// If the PSBT is missing a TxOut for an input returns None.
     fn fee_rate(&self) -> Option<FeeRate>;
@@ -54,8 +54,13 @@ impl PsbtUtils for Psbt {
         let utxos: Option<Vec<TxOut>> = (0..tx.input.len()).map(|i| self.get_utxo_for(i)).collect();
 
         utxos.map(|inputs| {
-            let input_amount: u64 = inputs.iter().map(|i| i.value).sum();
-            let output_amount: u64 = self.unsigned_tx.output.iter().map(|o| o.value).sum();
+            let input_amount: u64 = inputs.iter().map(|i| i.value.to_sat()).sum();
+            let output_amount: u64 = self
+                .unsigned_tx
+                .output
+                .iter()
+                .map(|o| o.value.to_sat())
+                .sum();
             input_amount
                 .checked_sub(output_amount)
                 .expect("input amount must be greater than output amount")
@@ -64,9 +69,7 @@ impl PsbtUtils for Psbt {
 
     fn fee_rate(&self) -> Option<FeeRate> {
         let fee_amount = self.fee_amount();
-        fee_amount.map(|fee| {
-            let weight = self.clone().extract_tx().weight();
-            Amount::from_sat(fee) / weight
-        })
+        let weight = self.clone().extract_tx().ok()?.weight();
+        fee_amount.map(|fee| Amount::from_sat(fee) / weight)
     }
 }

--- a/crates/bdk/src/wallet/export.rs
+++ b/crates/bdk/src/wallet/export.rs
@@ -216,7 +216,7 @@ mod test {
 
     use bdk_chain::{BlockId, ConfirmationTime};
     use bitcoin::hashes::Hash;
-    use bitcoin::{BlockHash, Network, Transaction};
+    use bitcoin::{transaction, BlockHash, Network, Transaction};
 
     use super::*;
     use crate::wallet::Wallet;
@@ -230,7 +230,7 @@ mod test {
         let transaction = Transaction {
             input: vec![],
             output: vec![],
-            version: 0,
+            version: transaction::Version::non_standard(0),
             lock_time: bitcoin::absolute::LockTime::ZERO,
         };
         wallet

--- a/crates/bdk/src/wallet/hardwaresigner.rs
+++ b/crates/bdk/src/wallet/hardwaresigner.rs
@@ -48,8 +48,8 @@
 //! ```
 
 use bitcoin::bip32::Fingerprint;
-use bitcoin::psbt::PartiallySignedTransaction;
 use bitcoin::secp256k1::{All, Secp256k1};
+use bitcoin::Psbt;
 
 use hwi::error::Error;
 use hwi::types::{HWIChain, HWIDevice};
@@ -87,7 +87,7 @@ impl SignerCommon for HWISigner {
 impl TransactionSigner for HWISigner {
     fn sign_transaction(
         &self,
-        psbt: &mut PartiallySignedTransaction,
+        psbt: &mut Psbt,
         _sign_options: &crate::SignOptions,
         _secp: &crate::wallet::utils::SecpCtx,
     ) -> Result<(), SignerError> {

--- a/crates/bdk/src/wallet/mod.rs
+++ b/crates/bdk/src/wallet/mod.rs
@@ -30,14 +30,14 @@ use bdk_chain::{
     Append, BlockId, ChainPosition, ConfirmationTime, ConfirmationTimeHeightAnchor, FullTxOut,
     IndexedTxGraph, Persist, PersistBackend,
 };
+use bitcoin::constants::genesis_block;
 use bitcoin::secp256k1::{All, Secp256k1};
 use bitcoin::sighash::{EcdsaSighashType, TapSighashType};
 use bitcoin::{
-    absolute, Address, Block, FeeRate, Network, OutPoint, Script, ScriptBuf, Sequence, Transaction,
-    TxOut, Txid, Weight, Witness,
+    absolute, psbt, Address, Block, FeeRate, Network, OutPoint, Script, ScriptBuf, Sequence,
+    Transaction, TxOut, Txid, Witness,
 };
-use bitcoin::{consensus::encode::serialize, BlockHash};
-use bitcoin::{constants::genesis_block, psbt};
+use bitcoin::{consensus::encode::serialize, transaction, Amount, BlockHash, Psbt};
 use core::fmt;
 use core::ops::Deref;
 use descriptor::error::Error as DescriptorError;
@@ -945,11 +945,11 @@ impl<D> Wallet<D> {
     /// ```
     ///
     /// ```rust, no_run
-    /// # use bitcoin::psbt::PartiallySignedTransaction;
+    /// # use bitcoin::Psbt;
     /// # use bdk::Wallet;
     /// # let mut wallet: Wallet<()> = todo!();
-    /// # let mut psbt: PartiallySignedTransaction = todo!();
-    /// let tx = &psbt.clone().extract_tx();
+    /// # let mut psbt: Psbt = todo!();
+    /// let tx = &psbt.clone().extract_tx().expect("tx");
     /// let fee = wallet.calculate_fee(tx).expect("fee");
     /// ```
     /// [`insert_txout`]: Self::insert_txout
@@ -976,12 +976,12 @@ impl<D> Wallet<D> {
     /// ```
     ///
     /// ```rust, no_run
-    /// # use bitcoin::psbt::PartiallySignedTransaction;
+    /// # use bitcoin::Psbt;
     /// # use bdk::Wallet;
     /// # let mut wallet: Wallet<()> = todo!();
-    /// # let mut psbt: PartiallySignedTransaction = todo!();
-    /// let tx = psbt.clone().extract_tx();
-    /// let fee_rate = wallet.calculate_fee_rate(&tx).expect("fee rate");
+    /// # let mut psbt: Psbt = todo!();
+    /// let tx = &psbt.clone().extract_tx().expect("tx");
+    /// let fee_rate = wallet.calculate_fee_rate(tx).expect("fee rate");
     /// ```
     /// [`insert_txout`]: Self::insert_txout
     pub fn calculate_fee_rate(&self, tx: &Transaction) -> Result<FeeRate, CalculateFeeError> {
@@ -1007,11 +1007,11 @@ impl<D> Wallet<D> {
     /// ```
     ///
     /// ```rust, no_run
-    /// # use bitcoin::psbt::PartiallySignedTransaction;
+    /// # use bitcoin::Psbt;
     /// # use bdk::Wallet;
     /// # let mut wallet: Wallet<()> = todo!();
-    /// # let mut psbt: PartiallySignedTransaction = todo!();
-    /// let tx = &psbt.clone().extract_tx();
+    /// # let mut psbt: Psbt = todo!();
+    /// let tx = &psbt.clone().extract_tx().expect("tx");
     /// let (sent, received) = wallet.sent_and_received(tx);
     /// ```
     pub fn sent_and_received(&self, tx: &Transaction) -> (u64, u64) {
@@ -1261,7 +1261,7 @@ impl<D> Wallet<D> {
         &mut self,
         coin_selection: Cs,
         params: TxParams,
-    ) -> Result<psbt::PartiallySignedTransaction, CreateTxError<D::WriteError>>
+    ) -> Result<Psbt, CreateTxError<D::WriteError>>
     where
         D: PersistBackend<ChangeSet>,
     {
@@ -1455,7 +1455,7 @@ impl<D> Wallet<D> {
         };
 
         let mut tx = Transaction {
-            version,
+            version: transaction::Version::non_standard(version),
             lock_time,
             input: vec![],
             output: vec![],
@@ -1485,7 +1485,7 @@ impl<D> Wallet<D> {
 
             let new_out = TxOut {
                 script_pubkey: script_pubkey.clone(),
-                value,
+                value: Amount::from_sat(value),
             };
 
             tx.output.push(new_out);
@@ -1494,17 +1494,6 @@ impl<D> Wallet<D> {
         }
 
         fee_amount += (fee_rate * tx.weight()).to_sat();
-
-        // Segwit transactions' header is 2WU larger than legacy txs' header,
-        // as they contain a witness marker (1WU) and a witness flag (1WU) (see BIP144).
-        // At this point we really don't know if the resulting transaction will be segwit
-        // or legacy, so we just add this 2WU to the fee_amount - overshooting the fee amount
-        // is better than undershooting it.
-        // If we pass a fee_amount that is slightly higher than the final fee_amount, we
-        // end up with a transaction with a slightly higher fee rate than the requested one.
-        // If, instead, we undershoot, we may end up with a feerate lower than the requested one
-        // - we might come up with non broadcastable txs!
-        fee_amount += (fee_rate * Weight::from_wu(2)).to_sat();
 
         if params.change_policy != tx_builder::ChangeSpendPolicy::ChangeAllowed
             && internal_descriptor.is_none()
@@ -1594,7 +1583,7 @@ impl<D> Wallet<D> {
 
                 // create drain output
                 let drain_output = TxOut {
-                    value: *amount,
+                    value: Amount::from_sat(*amount),
                     script_pubkey: drain_script,
                 };
 
@@ -1640,7 +1629,7 @@ impl<D> Wallet<D> {
     ///     builder.finish()?
     /// };
     /// let _ = wallet.sign(&mut psbt, SignOptions::default())?;
-    /// let tx = psbt.extract_tx();
+    /// let tx = psbt.clone().extract_tx().expect("tx");
     /// // broadcast tx but it's taking too long to confirm so we want to bump the fee
     /// let mut psbt =  {
     ///     let mut builder = wallet.build_fee_bump(tx.txid())?;
@@ -1764,11 +1753,11 @@ impl<D> Wallet<D> {
 
         let params = TxParams {
             // TODO: figure out what rbf option should be?
-            version: Some(tx_builder::Version(tx.version)),
+            version: Some(tx_builder::Version(tx.version.0)),
             recipients: tx
                 .output
                 .into_iter()
-                .map(|txout| (txout.script_pubkey, txout.value))
+                .map(|txout| (txout.script_pubkey, txout.value.to_sat()))
                 .collect(),
             utxos: original_utxos,
             bumping_fee: Some(tx_builder::PreviousFee {
@@ -1814,11 +1803,7 @@ impl<D> Wallet<D> {
     /// let finalized = wallet.sign(&mut psbt, SignOptions::default())?;
     /// assert!(finalized, "we should have signed all the inputs");
     /// # Ok::<(),anyhow::Error>(())
-    pub fn sign(
-        &self,
-        psbt: &mut psbt::PartiallySignedTransaction,
-        sign_options: SignOptions,
-    ) -> Result<bool, SignerError> {
+    pub fn sign(&self, psbt: &mut Psbt, sign_options: SignOptions) -> Result<bool, SignerError> {
         // This adds all the PSBT metadata for the inputs, which will help us later figure out how
         // to derive our keys
         self.update_psbt_with_descriptor(psbt)
@@ -1898,7 +1883,7 @@ impl<D> Wallet<D> {
     /// The [`SignOptions`] can be used to tweak the behavior of the finalizer.
     pub fn finalize_psbt(
         &self,
-        psbt: &mut psbt::PartiallySignedTransaction,
+        psbt: &mut Psbt,
         sign_options: SignOptions,
     ) -> Result<bool, SignerError> {
         let chain_tip = self.chain.tip().block_id();
@@ -2124,7 +2109,7 @@ impl<D> Wallet<D> {
                 if must_only_use_confirmed_tx && !confirmation_time.is_confirmed() {
                     return false;
                 }
-                if tx.is_coin_base() {
+                if tx.is_coinbase() {
                     debug_assert!(
                         confirmation_time.is_confirmed(),
                         "coinbase must always be confirmed"
@@ -2173,11 +2158,11 @@ impl<D> Wallet<D> {
         tx: Transaction,
         selected: Vec<Utxo>,
         params: TxParams,
-    ) -> Result<psbt::PartiallySignedTransaction, CreateTxError<D::WriteError>>
+    ) -> Result<Psbt, CreateTxError<D::WriteError>>
     where
         D: PersistBackend<ChangeSet>,
     {
-        let mut psbt = psbt::PartiallySignedTransaction::from_unsigned_tx(tx)?;
+        let mut psbt = Psbt::from_unsigned_tx(tx)?;
 
         if params.add_global_xpubs {
             let all_xpubs = self
@@ -2233,7 +2218,7 @@ impl<D> Wallet<D> {
                     let is_taproot = foreign_psbt_input
                         .witness_utxo
                         .as_ref()
-                        .map(|txout| txout.script_pubkey.is_v1_p2tr())
+                        .map(|txout| txout.script_pubkey.is_p2tr())
                         .unwrap_or(false);
                     if !is_taproot
                         && !params.only_witness_utxo
@@ -2295,10 +2280,7 @@ impl<D> Wallet<D> {
         Ok(psbt_input)
     }
 
-    fn update_psbt_with_descriptor(
-        &self,
-        psbt: &mut psbt::PartiallySignedTransaction,
-    ) -> Result<(), MiniscriptPsbtError> {
+    fn update_psbt_with_descriptor(&self, psbt: &mut Psbt) -> Result<(), MiniscriptPsbtError> {
         // We need to borrow `psbt` mutably within the loops, so we have to allocate a vec for all
         // the input utxos and outputs
         let utxos = (0..psbt.inputs.len())
@@ -2602,11 +2584,11 @@ macro_rules! doctest_wallet {
         .unwrap();
         let address = wallet.get_address(AddressIndex::New).address;
         let tx = Transaction {
-            version: 1,
+            version: transaction::Version::ONE,
             lock_time: absolute::LockTime::ZERO,
             input: vec![],
             output: vec![TxOut {
-                value: 500_000,
+                value: Amount::from_sat(500_000),
                 script_pubkey: address.script_pubkey(),
             }],
         };

--- a/crates/bdk/src/wallet/tx_builder.rs
+++ b/crates/bdk/src/wallet/tx_builder.rs
@@ -46,7 +46,7 @@ use core::fmt;
 use core::marker::PhantomData;
 
 use bdk_chain::PersistBackend;
-use bitcoin::psbt::{self, PartiallySignedTransaction as Psbt};
+use bitcoin::psbt::{self, Psbt};
 use bitcoin::script::PushBytes;
 use bitcoin::{absolute, FeeRate, OutPoint, ScriptBuf, Sequence, Transaction, Txid};
 
@@ -927,7 +927,8 @@ mod test {
 
     use bdk_chain::ConfirmationTime;
     use bitcoin::consensus::deserialize;
-    use bitcoin::hashes::hex::FromHex;
+    use bitcoin::hex::FromHex;
+    use bitcoin::TxOut;
 
     use super::*;
 
@@ -998,7 +999,7 @@ mod test {
             .unwrap()
         );
 
-        assert_eq!(tx.output[0].value, 800);
+        assert_eq!(tx.output[0].value.to_sat(), 800);
         assert_eq!(tx.output[1].script_pubkey, ScriptBuf::from(vec![0xAA]));
         assert_eq!(
             tx.output[2].script_pubkey,
@@ -1015,7 +1016,7 @@ mod test {
                     txid: bitcoin::Txid::from_slice(&[0; 32]).unwrap(),
                     vout: 0,
                 },
-                txout: Default::default(),
+                txout: TxOut::NULL,
                 keychain: KeychainKind::External,
                 is_spent: false,
                 confirmation_time: ConfirmationTime::Unconfirmed { last_seen: 0 },
@@ -1026,7 +1027,7 @@ mod test {
                     txid: bitcoin::Txid::from_slice(&[0; 32]).unwrap(),
                     vout: 1,
                 },
-                txout: Default::default(),
+                txout: TxOut::NULL,
                 keychain: KeychainKind::Internal,
                 is_spent: false,
                 confirmation_time: ConfirmationTime::Confirmed {

--- a/crates/bdk/src/wallet/utils.rs
+++ b/crates/bdk/src/wallet/utils.rs
@@ -138,7 +138,7 @@ mod test {
             .require_network(Network::Bitcoin)
             .unwrap()
             .script_pubkey();
-        assert!(script_p2wpkh.is_v0_p2wpkh());
+        assert!(script_p2wpkh.is_p2wpkh());
         assert!(293.is_dust(&script_p2wpkh));
         assert!(!294.is_dust(&script_p2wpkh));
     }

--- a/crates/bdk/tests/common.rs
+++ b/crates/bdk/tests/common.rs
@@ -4,7 +4,10 @@ use bdk::{wallet::AddressIndex, KeychainKind, LocalOutput, Wallet};
 use bdk_chain::indexed_tx_graph::Indexer;
 use bdk_chain::{BlockId, ConfirmationTime};
 use bitcoin::hashes::Hash;
-use bitcoin::{Address, BlockHash, FeeRate, Network, OutPoint, Transaction, TxIn, TxOut, Txid};
+use bitcoin::{
+    transaction, Address, Amount, BlockHash, FeeRate, Network, OutPoint, Transaction, TxIn, TxOut,
+    Txid,
+};
 use std::str::FromStr;
 
 // Return a fake wallet that appears to be funded for testing.
@@ -24,7 +27,7 @@ pub fn get_funded_wallet_with_change(
         .unwrap();
 
     let tx0 = Transaction {
-        version: 1,
+        version: transaction::Version::ONE,
         lock_time: bitcoin::absolute::LockTime::ZERO,
         input: vec![TxIn {
             previous_output: OutPoint {
@@ -36,13 +39,13 @@ pub fn get_funded_wallet_with_change(
             witness: Default::default(),
         }],
         output: vec![TxOut {
-            value: 76_000,
+            value: Amount::from_sat(76_000),
             script_pubkey: change_address.script_pubkey(),
         }],
     };
 
     let tx1 = Transaction {
-        version: 1,
+        version: transaction::Version::ONE,
         lock_time: bitcoin::absolute::LockTime::ZERO,
         input: vec![TxIn {
             previous_output: OutPoint {
@@ -55,11 +58,11 @@ pub fn get_funded_wallet_with_change(
         }],
         output: vec![
             TxOut {
-                value: 50_000,
+                value: Amount::from_sat(50_000),
                 script_pubkey: change_address.script_pubkey(),
             },
             TxOut {
-                value: 25_000,
+                value: Amount::from_sat(25_000),
                 script_pubkey: sendto_address.script_pubkey(),
             },
         ],

--- a/crates/bdk/tests/psbt.rs
+++ b/crates/bdk/tests/psbt.rs
@@ -1,9 +1,7 @@
-use bdk::bitcoin::FeeRate;
-use bdk::bitcoin::TxIn;
+use bdk::bitcoin::{Amount, FeeRate, Psbt, TxIn};
 use bdk::wallet::AddressIndex;
 use bdk::wallet::AddressIndex::New;
 use bdk::{psbt, SignOptions};
-use bitcoin::psbt::PartiallySignedTransaction as Psbt;
 use core::str::FromStr;
 mod common;
 use common::*;
@@ -163,7 +161,7 @@ fn test_psbt_multiple_internalkey_signers() {
     use bdk::signer::{SignerContext, SignerOrdering, SignerWrapper};
     use bdk::KeychainKind;
     use bitcoin::key::TapTweak;
-    use bitcoin::secp256k1::{schnorr, KeyPair, Message, Secp256k1, XOnlyPublicKey};
+    use bitcoin::secp256k1::{schnorr, Keypair, Message, Secp256k1, XOnlyPublicKey};
     use bitcoin::sighash::{Prevouts, SighashCache, TapSighashType};
     use bitcoin::{PrivateKey, TxOut};
     use std::sync::Arc;
@@ -172,7 +170,7 @@ fn test_psbt_multiple_internalkey_signers() {
     let wif = "cNJmN3fH9DDbDt131fQNkVakkpzawJBSeybCUNmP1BovpmGQ45xG";
     let desc = format!("tr({})", wif);
     let prv = PrivateKey::from_wif(wif).unwrap();
-    let keypair = KeyPair::from_secret_key(&secp, &prv.inner);
+    let keypair = Keypair::from_secret_key(&secp, &prv.inner);
 
     let (mut wallet, _) = get_funded_wallet(&desc);
     let to_spend = wallet.get_balance().total();
@@ -205,7 +203,7 @@ fn test_psbt_multiple_internalkey_signers() {
     // the prevout we're spending
     let prevouts = &[TxOut {
         script_pubkey: send_to.script_pubkey(),
-        value: to_spend,
+        value: Amount::from_sat(to_spend),
     }];
     let prevouts = Prevouts::All(prevouts);
     let input_index = 0;

--- a/crates/bitcoind_rpc/Cargo.toml
+++ b/crates/bitcoind_rpc/Cargo.toml
@@ -14,8 +14,8 @@ readme = "README.md"
 
 [dependencies]
 # For no-std, remember to enable the bitcoin/no-std feature
-bitcoin = { version = "0.30", default-features = false }
-bitcoincore-rpc = { version = "0.17" }
+bitcoin = { version = "0.31", default-features = false }
+bitcoincore-rpc = { version = "0.18" }
 bdk_chain = { path = "../chain", version = "0.11", default-features = false }
 
 [dev-dependencies]

--- a/crates/bitcoind_rpc/tests/test_emitter.rs
+++ b/crates/bitcoind_rpc/tests/test_emitter.rs
@@ -350,7 +350,7 @@ fn tx_can_become_unconfirmed_after_reorg() -> anyhow::Result<()> {
         .rpc_client()
         .get_new_address(None, None)?
         .assume_checked();
-    let spk_to_track = ScriptBuf::new_v0_p2wsh(&WScriptHash::all_zeros());
+    let spk_to_track = ScriptBuf::new_p2wsh(&WScriptHash::all_zeros());
     let addr_to_track = Address::from_script(&spk_to_track, bitcoin::Network::Regtest)?;
 
     // setup receiver

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -14,12 +14,12 @@ readme = "README.md"
 
 [dependencies]
 # For no-std, remember to enable the bitcoin/no-std feature
-bitcoin = { version = "0.30.0", default-features = false }
+bitcoin = { version = "0.31.0", default-features = false }
 serde_crate = { package = "serde", version = "1", optional = true, features = ["derive", "rc"] }
 
 # Use hashbrown as a feature flag to have HashSet and HashMap from it.
 hashbrown = { version = "0.9.1", optional = true, features = ["serde"] }
-miniscript = { version = "10.0.0", optional = true, default-features = false }
+miniscript = { version = "11.0.0", optional = true, default-features = false }
 
 [dev-dependencies]
 rand = "0.8"

--- a/crates/chain/src/spk_txout_index.rs
+++ b/crates/chain/src/spk_txout_index.rs
@@ -4,7 +4,7 @@ use crate::{
     collections::{hash_map::Entry, BTreeMap, BTreeSet, HashMap},
     indexed_tx_graph::Indexer,
 };
-use bitcoin::{self, OutPoint, Script, ScriptBuf, Transaction, TxOut, Txid};
+use bitcoin::{OutPoint, Script, ScriptBuf, Transaction, TxOut, Txid};
 
 /// An index storing [`TxOut`]s that have a script pubkey that matches those in a list.
 ///
@@ -281,12 +281,12 @@ impl<I: Clone + Ord> SpkTxOutIndex<I> {
 
         for txin in &tx.input {
             if let Some((_, txout)) = self.txout(txin.previous_output) {
-                sent += txout.value;
+                sent += txout.value.to_sat();
             }
         }
         for txout in &tx.output {
             if self.index_of_spk(&txout.script_pubkey).is_some() {
-                received += txout.value;
+                received += txout.value.to_sat();
             }
         }
 

--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -319,7 +319,7 @@ impl<A> TxGraph<A> {
     ///
     /// [`insert_txout`]: Self::insert_txout
     pub fn calculate_fee(&self, tx: &Transaction) -> Result<u64, CalculateFeeError> {
-        if tx.is_coin_base() {
+        if tx.is_coinbase() {
             return Ok(0);
         }
 
@@ -331,7 +331,7 @@ impl<A> TxGraph<A> {
                     (sum, missing_outpoints)
                 }
                 Some(txout) => {
-                    sum += txout.value as i64;
+                    sum += txout.value.to_sat() as i64;
                     (sum, missing_outpoints)
                 }
             },
@@ -343,7 +343,7 @@ impl<A> TxGraph<A> {
         let outputs_sum = tx
             .output
             .iter()
-            .map(|txout| txout.value as i64)
+            .map(|txout| txout.value.to_sat() as i64)
             .sum::<i64>();
 
         let fee = inputs_sum - outputs_sum;
@@ -870,7 +870,7 @@ impl<A: Anchor> TxGraph<A> {
             TxNodeInternal::Whole(tx) => {
                 // A coinbase tx that is not anchored in the best chain cannot be unconfirmed and
                 // should always be filtered out.
-                if tx.as_ref().is_coin_base() {
+                if tx.is_coinbase() {
                     return Ok(None);
                 }
                 tx.clone()
@@ -1126,7 +1126,7 @@ impl<A: Anchor> TxGraph<A> {
                             txout,
                             chain_position,
                             spent_by,
-                            is_on_coinbase: tx_node.tx.as_ref().is_coin_base(),
+                            is_on_coinbase: tx_node.tx.is_coinbase(),
                         },
                     )))
                 },
@@ -1229,16 +1229,16 @@ impl<A: Anchor> TxGraph<A> {
             match &txout.chain_position {
                 ChainPosition::Confirmed(_) => {
                     if txout.is_confirmed_and_spendable(chain_tip.height) {
-                        confirmed += txout.txout.value;
+                        confirmed += txout.txout.value.to_sat();
                     } else if !txout.is_mature(chain_tip.height) {
-                        immature += txout.txout.value;
+                        immature += txout.txout.value.to_sat();
                     }
                 }
                 ChainPosition::Unconfirmed(_) => {
                     if trust_predicate(&spk_i, &txout.txout.script_pubkey) {
-                        trusted_pending += txout.txout.value;
+                        trusted_pending += txout.txout.value.to_sat();
                     } else {
-                        untrusted_pending += txout.txout.value;
+                        untrusted_pending += txout.txout.value.to_sat();
                     }
                 }
             }

--- a/crates/chain/tests/common/mod.rs
+++ b/crates/chain/tests/common/mod.rs
@@ -70,7 +70,7 @@ macro_rules! changeset {
 #[allow(unused)]
 pub fn new_tx(lt: u32) -> bitcoin::Transaction {
     bitcoin::Transaction {
-        version: 0x00,
+        version: bitcoin::transaction::Version::non_standard(0x00),
         lock_time: bitcoin::absolute::LockTime::from_consensus(lt),
         input: vec![],
         output: vec![],

--- a/crates/chain/tests/common/tx_template.rs
+++ b/crates/chain/tests/common/tx_template.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 
 use bdk_chain::{tx_graph::TxGraph, Anchor, SpkTxOutIndex};
 use bitcoin::{
-    locktime::absolute::LockTime, secp256k1::Secp256k1, OutPoint, ScriptBuf, Sequence, Transaction,
-    TxIn, TxOut, Txid, Witness,
+    locktime::absolute::LockTime, secp256k1::Secp256k1, transaction, Amount, OutPoint, ScriptBuf,
+    Sequence, Transaction, TxIn, TxOut, Txid, Witness,
 };
 use miniscript::Descriptor;
 
@@ -68,7 +68,7 @@ pub fn init_graph<'a, A: Anchor + Clone + 'a>(
 
     for (bogus_txin_vout, tx_tmp) in tx_templates.into_iter().enumerate() {
         let tx = Transaction {
-            version: 0,
+            version: transaction::Version::non_standard(0),
             lock_time: LockTime::ZERO,
             input: tx_tmp
                 .inputs
@@ -111,11 +111,11 @@ pub fn init_graph<'a, A: Anchor + Clone + 'a>(
                 .iter()
                 .map(|output| match &output.spk_index {
                     None => TxOut {
-                        value: output.value,
+                        value: Amount::from_sat(output.value),
                         script_pubkey: ScriptBuf::new(),
                     },
                     Some(index) => TxOut {
-                        value: output.value,
+                        value: Amount::from_sat(output.value),
                         script_pubkey: spk_index.spk_at_index(index).unwrap().to_owned(),
                     },
                 })

--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -9,7 +9,9 @@ use bdk_chain::{
     local_chain::LocalChain,
     tx_graph, ChainPosition, ConfirmationHeightAnchor,
 };
-use bitcoin::{secp256k1::Secp256k1, OutPoint, Script, ScriptBuf, Transaction, TxIn, TxOut};
+use bitcoin::{
+    secp256k1::Secp256k1, Amount, OutPoint, Script, ScriptBuf, Transaction, TxIn, TxOut,
+};
 use miniscript::Descriptor;
 
 /// Ensure [`IndexedTxGraph::insert_relevant_txs`] can successfully index transactions NOT presented
@@ -35,11 +37,11 @@ fn insert_relevant_txs() {
     let tx_a = Transaction {
         output: vec![
             TxOut {
-                value: 10_000,
+                value: Amount::from_sat(10_000),
                 script_pubkey: spk_0,
             },
             TxOut {
-                value: 20_000,
+                value: Amount::from_sat(20_000),
                 script_pubkey: spk_1,
             },
         ],
@@ -154,7 +156,7 @@ fn test_list_owned_txouts() {
             ..Default::default()
         }],
         output: vec![TxOut {
-            value: 70000,
+            value: Amount::from_sat(70000),
             script_pubkey: trusted_spks[0].to_owned(),
         }],
         ..common::new_tx(0)
@@ -163,7 +165,7 @@ fn test_list_owned_txouts() {
     // tx2 is an incoming transaction received at untrusted keychain at block 1.
     let tx2 = Transaction {
         output: vec![TxOut {
-            value: 30000,
+            value: Amount::from_sat(30000),
             script_pubkey: untrusted_spks[0].to_owned(),
         }],
         ..common::new_tx(0)
@@ -176,7 +178,7 @@ fn test_list_owned_txouts() {
             ..Default::default()
         }],
         output: vec![TxOut {
-            value: 10000,
+            value: Amount::from_sat(10000),
             script_pubkey: trusted_spks[1].to_owned(),
         }],
         ..common::new_tx(0)
@@ -185,7 +187,7 @@ fn test_list_owned_txouts() {
     // tx4 is an external transaction receiving at untrusted keychain, unconfirmed.
     let tx4 = Transaction {
         output: vec![TxOut {
-            value: 20000,
+            value: Amount::from_sat(20000),
             script_pubkey: untrusted_spks[1].to_owned(),
         }],
         ..common::new_tx(0)
@@ -194,7 +196,7 @@ fn test_list_owned_txouts() {
     // tx5 is spending tx3 and receiving change at trusted keychain, unconfirmed.
     let tx5 = Transaction {
         output: vec![TxOut {
-            value: 15000,
+            value: Amount::from_sat(15000),
             script_pubkey: trusted_spks[2].to_owned(),
         }],
         ..common::new_tx(0)

--- a/crates/chain/tests/test_keychain_txout_index.rs
+++ b/crates/chain/tests/test_keychain_txout_index.rs
@@ -9,7 +9,7 @@ use bdk_chain::{
     Append,
 };
 
-use bitcoin::{secp256k1::Secp256k1, OutPoint, ScriptBuf, Transaction, TxOut};
+use bitcoin::{secp256k1::Secp256k1, Amount, OutPoint, ScriptBuf, Transaction, TxOut};
 use miniscript::{Descriptor, DescriptorPublicKey};
 
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
@@ -176,14 +176,14 @@ fn test_lookahead() {
                         .at_derivation_index(external_index)
                         .unwrap()
                         .script_pubkey(),
-                    value: 10_000,
+                    value: Amount::from_sat(10_000),
                 },
                 TxOut {
                     script_pubkey: internal_desc
                         .at_derivation_index(internal_index)
                         .unwrap()
                         .script_pubkey(),
-                    value: 10_000,
+                    value: Amount::from_sat(10_000),
                 },
             ],
             ..common::new_tx(external_index)
@@ -238,7 +238,7 @@ fn test_scan_with_lookahead() {
         let op = OutPoint::new(h!("fake tx"), spk_i);
         let txout = TxOut {
             script_pubkey: spk.clone(),
-            value: 0,
+            value: Amount::ZERO,
         };
 
         let changeset = txout_index.index_txout(op, &txout);
@@ -264,7 +264,7 @@ fn test_scan_with_lookahead() {
     let op = OutPoint::new(h!("fake tx"), 41);
     let txout = TxOut {
         script_pubkey: spk_41,
-        value: 0,
+        value: Amount::ZERO,
     };
     let changeset = txout_index.index_txout(op, &txout);
     assert!(changeset.is_empty());

--- a/crates/chain/tests/test_spk_txout_index.rs
+++ b/crates/chain/tests/test_spk_txout_index.rs
@@ -1,5 +1,5 @@
 use bdk_chain::{indexed_tx_graph::Indexer, SpkTxOutIndex};
-use bitcoin::{absolute, OutPoint, ScriptBuf, Transaction, TxIn, TxOut};
+use bitcoin::{absolute, transaction, Amount, OutPoint, ScriptBuf, Transaction, TxIn, TxOut};
 
 #[test]
 fn spk_txout_sent_and_received() {
@@ -11,11 +11,11 @@ fn spk_txout_sent_and_received() {
     index.insert_spk(1, spk2.clone());
 
     let tx1 = Transaction {
-        version: 0x02,
+        version: transaction::Version::TWO,
         lock_time: absolute::LockTime::ZERO,
         input: vec![],
         output: vec![TxOut {
-            value: 42_000,
+            value: Amount::from_sat(42_000),
             script_pubkey: spk1.clone(),
         }],
     };
@@ -30,7 +30,7 @@ fn spk_txout_sent_and_received() {
     );
 
     let tx2 = Transaction {
-        version: 0x1,
+        version: transaction::Version::ONE,
         lock_time: absolute::LockTime::ZERO,
         input: vec![TxIn {
             previous_output: OutPoint {
@@ -41,12 +41,12 @@ fn spk_txout_sent_and_received() {
         }],
         output: vec![
             TxOut {
-                value: 20_000,
+                value: Amount::from_sat(20_000),
                 script_pubkey: spk2,
             },
             TxOut {
                 script_pubkey: spk1,
-                value: 30_000,
+                value: Amount::from_sat(30_000),
             },
         ],
     };
@@ -73,11 +73,11 @@ fn mark_used() {
     assert!(spk_index.is_used(&1));
 
     let tx1 = Transaction {
-        version: 0x02,
+        version: transaction::Version::TWO,
         lock_time: absolute::LockTime::ZERO,
         input: vec![],
         output: vec![TxOut {
-            value: 42_000,
+            value: Amount::from_sat(42_000),
             script_pubkey: spk1,
         }],
     };

--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 
 [dependencies]
 bdk_chain = { path = "../chain", version = "0.11.0", default-features = false }
-electrum-client = { version = "0.18" }
+electrum-client = { version = "0.19" }
 #rustls = { version = "=0.21.1", optional = true, features = ["dangerous_configuration"] }
 
 [dev-dependencies]
-bdk_testenv = { path = "../testenv", version = "0.1.0", default-features = false }
-electrsd = { version= "0.25.0", features = ["bitcoind_25_0", "esplora_a33e97e1", "legacy"] }
+bdk_testenv = { path = "../testenv", default-features = false }
+electrsd = { version= "0.27.1", features = ["bitcoind_25_0", "esplora_a33e97e1", "legacy"] }
 anyhow = "1"

--- a/crates/electrum/tests/test_electrum.rs
+++ b/crates/electrum/tests/test_electrum.rs
@@ -40,7 +40,7 @@ fn scan_detects_confirmed_tx() -> Result<()> {
         .client
         .get_new_address(None, None)?
         .assume_checked();
-    let spk_to_track = ScriptBuf::new_v0_p2wsh(&WScriptHash::all_zeros());
+    let spk_to_track = ScriptBuf::new_p2wsh(&WScriptHash::all_zeros());
     let addr_to_track = Address::from_script(&spk_to_track, bdk_chain::bitcoin::Network::Regtest)?;
 
     // Setup receiver.
@@ -106,7 +106,7 @@ fn tx_can_become_unconfirmed_after_reorg() -> Result<()> {
         .client
         .get_new_address(None, None)?
         .assume_checked();
-    let spk_to_track = ScriptBuf::new_v0_p2wsh(&WScriptHash::all_zeros());
+    let spk_to_track = ScriptBuf::new_p2wsh(&WScriptHash::all_zeros());
     let addr_to_track = Address::from_script(&spk_to_track, bdk_chain::bitcoin::Network::Regtest)?;
 
     // Setup receiver.

--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -13,17 +13,17 @@ readme = "README.md"
 
 [dependencies]
 bdk_chain = { path = "../chain", version = "0.11.0", default-features = false }
-esplora-client = { version = "0.6.0", default-features = false }
+esplora-client = { version = "0.7.0", default-features = false }
 async-trait = { version = "0.1.66", optional = true }
 futures = { version = "0.3.26", optional = true }
 
 # use these dependencies if you need to enable their /no-std features
-bitcoin = { version = "0.30.0", optional = true, default-features = false }
-miniscript = { version = "10.0.0", optional = true, default-features = false }
+bitcoin = { version = "0.31.0", optional = true, default-features = false }
+miniscript = { version = "11.0.0", optional = true, default-features = false }
 
 [dev-dependencies]
-bdk_testenv = { path = "../testenv", version = "0.1.0", default_features = false }
-electrsd = { version= "0.25.0", features = ["bitcoind_25_0", "esplora_a33e97e1", "legacy"] }
+bdk_testenv = { path = "../testenv", default_features = false }
+electrsd = { version= "0.27.1", features = ["bitcoind_25_0", "esplora_a33e97e1", "legacy"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 
 [features]

--- a/crates/esplora/src/async_ext.rs
+++ b/crates/esplora/src/async_ext.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use bdk_chain::collections::btree_map;
 use bdk_chain::{
-    bitcoin::{BlockHash, OutPoint, ScriptBuf, TxOut, Txid},
+    bitcoin::{Amount, BlockHash, OutPoint, ScriptBuf, TxOut, Txid},
     collections::BTreeMap,
     local_chain::{self, CheckPoint},
     BlockId, ConfirmationTimeHeightAnchor, TxGraph,
@@ -228,7 +228,7 @@ impl EsploraAsyncExt for esplora_client::AsyncClient {
                                 },
                                 TxOut {
                                     script_pubkey: prevout.scriptpubkey.clone(),
-                                    value: prevout.value,
+                                    value: Amount::from_sat(prevout.value),
                                 },
                             ))
                         });

--- a/crates/esplora/src/blocking_ext.rs
+++ b/crates/esplora/src/blocking_ext.rs
@@ -3,7 +3,7 @@ use std::thread::JoinHandle;
 use bdk_chain::collections::btree_map;
 use bdk_chain::collections::BTreeMap;
 use bdk_chain::{
-    bitcoin::{BlockHash, OutPoint, ScriptBuf, TxOut, Txid},
+    bitcoin::{Amount, BlockHash, OutPoint, ScriptBuf, TxOut, Txid},
     local_chain::{self, CheckPoint},
     BlockId, ConfirmationTimeHeightAnchor, TxGraph,
 };
@@ -218,7 +218,7 @@ impl EsploraExt for esplora_client::BlockingClient {
                                 },
                                 TxOut {
                                     script_pubkey: prevout.scriptpubkey.clone(),
-                                    value: prevout.value,
+                                    value: Amount::from_sat(prevout.value),
                                 },
                             ))
                         });

--- a/crates/esplora/tests/blocking_ext.rs
+++ b/crates/esplora/tests/blocking_ext.rs
@@ -30,7 +30,7 @@ macro_rules! local_chain {
 pub fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
     let env = TestEnv::new()?;
     let base_url = format!("http://{}", &env.electrsd.esplora_url.clone().unwrap());
-    let client = Builder::new(base_url.as_str()).build_blocking()?;
+    let client = Builder::new(base_url.as_str()).build_blocking();
 
     let receive_address0 =
         Address::from_str("bcrt1qc6fweuf4xjvz4x3gx3t9e0fh4hvqyu2qw4wvxm")?.assume_checked();
@@ -111,7 +111,7 @@ pub fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
 pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     let env = TestEnv::new()?;
     let base_url = format!("http://{}", &env.electrsd.esplora_url.clone().unwrap());
-    let client = Builder::new(base_url.as_str()).build_blocking()?;
+    let client = Builder::new(base_url.as_str()).build_blocking();
     let _block_hashes = env.mine_blocks(101, None)?;
 
     // Now let's test the gap limit. First of all get a chain of 10 addresses.
@@ -215,7 +215,7 @@ fn update_local_chain() -> anyhow::Result<()> {
     // so new blocks can be seen by Electrs
     let env = env.reset_electrsd()?;
     let base_url = format!("http://{}", &env.electrsd.esplora_url.clone().unwrap());
-    let client = Builder::new(base_url.as_str()).build_blocking()?;
+    let client = Builder::new(base_url.as_str()).build_blocking();
 
     struct TestCase {
         name: &'static str,

--- a/crates/hwi/Cargo.toml
+++ b/crates/hwi/Cargo.toml
@@ -10,4 +10,4 @@ readme = "README.md"
 
 [dependencies]
 bdk = { path = "../bdk" }
-hwi = { version = "0.7.0", features = [ "miniscript"] }
+hwi = { version = "0.8.0", features = [ "miniscript"] }

--- a/crates/hwi/src/signer.rs
+++ b/crates/hwi/src/signer.rs
@@ -1,6 +1,6 @@
 use bdk::bitcoin::bip32::Fingerprint;
-use bdk::bitcoin::psbt::PartiallySignedTransaction;
 use bdk::bitcoin::secp256k1::{All, Secp256k1};
+use bdk::bitcoin::Psbt;
 
 use hwi::error::Error;
 use hwi::types::{HWIChain, HWIDevice};
@@ -37,7 +37,7 @@ impl SignerCommon for HWISigner {
 impl TransactionSigner for HWISigner {
     fn sign_transaction(
         &self,
-        psbt: &mut PartiallySignedTransaction,
+        psbt: &mut Psbt,
         _sign_options: &bdk::SignOptions,
         _secp: &Secp256k1<All>,
     ) -> Result<(), SignerError> {

--- a/crates/testenv/Cargo.toml
+++ b/crates/testenv/Cargo.toml
@@ -13,9 +13,9 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bitcoincore-rpc = { version = "0.17" }
+bitcoincore-rpc = { version = "0.18" }
 bdk_chain = { path = "../chain", version = "0.11", default-features = false }
-electrsd = { version= "0.25.0", features = ["bitcoind_25_0", "esplora_a33e97e1", "legacy"] }
+electrsd = { version= "0.27.1", features = ["bitcoind_25_0", "esplora_a33e97e1", "legacy"] }
 anyhow = { version = "1" }
 
 [features]

--- a/crates/testenv/src/lib.rs
+++ b/crates/testenv/src/lib.rs
@@ -1,7 +1,7 @@
 use bdk_chain::bitcoin::{
     address::NetworkChecked, block::Header, hash_types::TxMerkleNode, hashes::Hash,
-    secp256k1::rand::random, Address, Amount, Block, BlockHash, CompactTarget, ScriptBuf,
-    ScriptHash, Transaction, TxIn, TxOut, Txid,
+    secp256k1::rand::random, transaction, Address, Amount, Block, BlockHash, CompactTarget,
+    ScriptBuf, ScriptHash, Transaction, TxIn, TxOut, Txid,
 };
 use bitcoincore_rpc::{
     bitcoincore_rpc_json::{GetBlockTemplateModes, GetBlockTemplateRules},
@@ -109,7 +109,7 @@ impl TestEnv {
         )?;
 
         let txdata = vec![Transaction {
-            version: 1,
+            version: transaction::Version::ONE,
             lock_time: bdk_chain::bitcoin::absolute::LockTime::from_height(0)?,
             input: vec![TxIn {
                 previous_output: bdk_chain::bitcoin::OutPoint::default(),
@@ -122,7 +122,7 @@ impl TestEnv {
                 witness: bdk_chain::bitcoin::Witness::new(),
             }],
             output: vec![TxOut {
-                value: 0,
+                value: Amount::ZERO,
                 script_pubkey: ScriptBuf::new_p2sh(&ScriptHash::all_zeros()),
             }],
         }];

--- a/example-crates/example_esplora/src/main.rs
+++ b/example-crates/example_esplora/src/main.rs
@@ -86,7 +86,7 @@ impl EsploraArgs {
             _ => panic!("unsupported network"),
         });
 
-        let client = esplora_client::Builder::new(esplora_url).build_blocking()?;
+        let client = esplora_client::Builder::new(esplora_url).build_blocking();
         Ok(client)
     }
 }

--- a/example-crates/wallet_electrum/src/main.rs
+++ b/example-crates/wallet_electrum/src/main.rs
@@ -101,7 +101,7 @@ fn main() -> Result<(), anyhow::Error> {
     let finalized = wallet.sign(&mut psbt, SignOptions::default())?;
     assert!(finalized);
 
-    let tx = psbt.extract_tx();
+    let tx = psbt.extract_tx()?;
     client.transaction_broadcast(&tx)?;
     println!("Tx broadcasted! Txid: {}", tx.txid());
 

--- a/example-crates/wallet_esplora_async/src/main.rs
+++ b/example-crates/wallet_esplora_async/src/main.rs
@@ -93,7 +93,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let finalized = wallet.sign(&mut psbt, SignOptions::default())?;
     assert!(finalized);
 
-    let tx = psbt.extract_tx();
+    let tx = psbt.extract_tx()?;
     client.broadcast(&tx).await?;
     println!("Tx broadcasted! Txid: {}", tx.txid());
 

--- a/example-crates/wallet_esplora_blocking/src/main.rs
+++ b/example-crates/wallet_esplora_blocking/src/main.rs
@@ -34,7 +34,7 @@ fn main() -> Result<(), anyhow::Error> {
 
     print!("Syncing...");
     let client =
-        esplora_client::Builder::new("https://blockstream.info/testnet/api").build_blocking()?;
+        esplora_client::Builder::new("https://blockstream.info/testnet/api").build_blocking();
 
     let prev_tip = wallet.latest_checkpoint();
     let keychain_spks = wallet
@@ -93,7 +93,7 @@ fn main() -> Result<(), anyhow::Error> {
     let finalized = wallet.sign(&mut psbt, SignOptions::default())?;
     assert!(finalized);
 
-    let tx = psbt.extract_tx();
+    let tx = psbt.extract_tx()?;
     client.broadcast(&tx)?;
     println!("Tx broadcasted! Txid: {}", tx.txid());
 

--- a/nursery/coin_select/src/coin_selector.rs
+++ b/nursery/coin_select/src/coin_selector.rs
@@ -96,7 +96,7 @@ impl CoinSelectorOpt {
     ) -> Self {
         let mut tx = Transaction {
             input: vec![],
-            version: 1,
+            version: transaction::Version::ONE,
             lock_time: absolute::LockTime::ZERO,
             output: txouts.to_vec(),
         };
@@ -112,7 +112,7 @@ impl CoinSelectorOpt {
             target_value: if txouts.is_empty() {
                 None
             } else {
-                Some(txouts.iter().map(|txout| txout.value).sum())
+                Some(txouts.iter().map(|txout| txout.value.to_sat()).sum())
             },
             ..Self::from_weights(
                 base_weight.to_wu() as u32,

--- a/nursery/coin_select/src/lib.rs
+++ b/nursery/coin_select/src/lib.rs
@@ -12,7 +12,7 @@ use bdk_chain::{
     bitcoin,
     collections::{BTreeSet, HashMap},
 };
-use bitcoin::{absolute, Transaction, TxOut};
+use bitcoin::{absolute, transaction, Transaction, TxOut};
 use core::fmt::{Debug, Display};
 
 mod coin_selector;
@@ -29,5 +29,5 @@ pub const TXIN_BASE_WEIGHT: u32 = (32 + 4 + 4) * 4;
 // Shamelessly copied from
 // https://github.com/rust-bitcoin/rust-miniscript/blob/d5615acda1a7fdc4041a11c1736af139b8c7ebe8/src/util.rs#L8
 pub(crate) fn varint_size(v: usize) -> u32 {
-    bitcoin::VarInt(v as u64).len() as u32
+    bitcoin::VarInt(v as u64).size() as u32
 }

--- a/nursery/tmp_plan/src/lib.rs
+++ b/nursery/tmp_plan/src/lib.rs
@@ -17,14 +17,13 @@
 use bdk_chain::{bitcoin, collections::*, miniscript};
 use bitcoin::{
     absolute,
-    address::WitnessVersion,
     bip32::{DerivationPath, Fingerprint, KeySource},
     blockdata::transaction::Sequence,
     ecdsa,
     hashes::{hash160, ripemd160, sha256},
     secp256k1::Secp256k1,
     taproot::{self, LeafVersion, TapLeafHash},
-    ScriptBuf, TxIn, Witness,
+    ScriptBuf, TxIn, Witness, WitnessVersion,
 };
 use miniscript::{
     descriptor::{InnerXKey, Tr},
@@ -32,7 +31,7 @@ use miniscript::{
 };
 
 pub(crate) fn varint_len(v: usize) -> usize {
-    bitcoin::VarInt(v as u64).len() as usize
+    bitcoin::VarInt(v as u64).size() as usize
 }
 
 mod plan_impls;

--- a/nursery/tmp_plan/src/requirements.rs
+++ b/nursery/tmp_plan/src/requirements.rs
@@ -3,12 +3,11 @@ use core::ops::Deref;
 
 use bitcoin::{
     bip32,
-    hashes::{hash160, ripemd160, sha256},
+    hashes::{hash160, ripemd160, sha256, Hash},
     key::XOnlyPublicKey,
-    psbt::Prevouts,
-    secp256k1::{KeyPair, Message, PublicKey, Signing, Verification},
+    secp256k1::{Keypair, Message, PublicKey, Signing, Verification},
     sighash,
-    sighash::{EcdsaSighashType, SighashCache, TapSighashType},
+    sighash::{EcdsaSighashType, Prevouts, SighashCache, TapSighashType},
     taproot, Transaction, TxOut,
 };
 
@@ -163,11 +162,11 @@ impl RequiredSignatures<DescriptorPublicKey> {
 
                 let tweak =
                     taproot::TapTweakHash::from_key_and_tweak(x_only_pubkey, merkle_root.clone());
-                let keypair = KeyPair::from_secret_key(&secp, &secret_key.clone())
+                let keypair = Keypair::from_secret_key(&secp, &secret_key.clone())
                     .add_xonly_tweak(&secp, &tweak.to_scalar())
                     .unwrap();
 
-                let msg = Message::from_slice(sighash.as_ref()).expect("Sighashes are 32 bytes");
+                let msg = Message::from_digest(sighash.to_byte_array());
                 let sig = secp.sign_schnorr_no_aux_rand(&msg, &keypair);
 
                 let bitcoin_sig = taproot::Signature {
@@ -209,9 +208,8 @@ impl RequiredSignatures<DescriptorPublicKey> {
                                 todo!();
                             }
                         };
-                        let keypair = KeyPair::from_secret_key(&secp, &secret_key.clone());
-                        let msg =
-                            Message::from_slice(sighash.as_ref()).expect("Sighashes are 32 bytes");
+                        let keypair = Keypair::from_secret_key(&secp, &secret_key.clone());
+                        let msg = Message::from_digest(sighash.to_byte_array());
                         let sig = secp.sign_schnorr_no_aux_rand(&msg, &keypair);
                         let bitcoin_sig = taproot::Signature {
                             sig,


### PR DESCRIPTION
Upgrade:

- bitcoin to v0.31.0
- miniscript to v11.0.0

Note: The bitcoin upgrade includes improvements to the `Transaction::weight()` function, it appears those guys did good, we no longer need to add the 2 additional weight units "just in case".

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
