### PR TITLE
refactor(chain)!: Rename `unmark_used` -> `mark_unused`

### DIFF
--- a/crates/bdk/src/wallet/mod.rs
+++ b/crates/bdk/src/wallet/mod.rs
@@ -2008,9 +2008,9 @@ impl<D> Wallet<D> {
         let txout_index = &mut self.indexed_graph.index;
         for txout in &tx.output {
             if let Some((keychain, index)) = txout_index.index_of_spk(&txout.script_pubkey) {
-                // NOTE: unmark_used will **not** make something unused if it has actually been used
+                // NOTE: mark_unused will **not** make something unused if it has actually been used
                 // by a tx in the tracker. It only removes the superficial marking.
-                txout_index.unmark_used(keychain, index);
+                txout_index.mark_unused(keychain, index);
             }
         }
     }

--- a/crates/chain/src/keychain/txout_index.rs
+++ b/crates/chain/src/keychain/txout_index.rs
@@ -246,11 +246,11 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
     ///
     /// This is useful when you want to reserve a script pubkey for something but don't want to add
     /// the transaction output using it to the index yet. Other callers will consider `index` on
-    /// `keychain` used until you call [`unmark_used`].
+    /// `keychain` used until you call [`mark_unused`].
     ///
     /// This calls [`SpkTxOutIndex::mark_used`] internally.
     ///
-    /// [`unmark_used`]: Self::unmark_used
+    /// [`mark_unused`]: Self::mark_unused
     pub fn mark_used(&mut self, keychain: K, index: u32) -> bool {
         self.inner.mark_used(&(keychain, index))
     }
@@ -261,11 +261,11 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
     /// Note that if `self` has scanned an output with this script pubkey, then this will have no
     /// effect.
     ///
-    /// This calls [`SpkTxOutIndex::unmark_used`] internally.
+    /// This calls [`SpkTxOutIndex::mark_unused`] internally.
     ///
     /// [`mark_used`]: Self::mark_used
-    pub fn unmark_used(&mut self, keychain: K, index: u32) -> bool {
-        self.inner.unmark_used(&(keychain, index))
+    pub fn mark_unused(&mut self, keychain: K, index: u32) -> bool {
+        self.inner.mark_unused(&(keychain, index))
     }
 
     /// Computes total input value going from script pubkeys in the index (sent) and the total output

--- a/crates/chain/src/spk_txout_index.rs
+++ b/crates/chain/src/spk_txout_index.rs
@@ -239,9 +239,9 @@ impl<I: Clone + Ord> SpkTxOutIndex<I> {
     ///
     /// This is useful when you want to reserve a script pubkey for something but don't want to add
     /// the transaction output using it to the index yet. Other callers will consider the `index` used
-    /// until you call [`unmark_used`].
+    /// until you call [`mark_unused`].
     ///
-    /// [`unmark_used`]: Self::unmark_used
+    /// [`mark_unused`]: Self::mark_unused
     pub fn mark_used(&mut self, index: &I) -> bool {
         self.unused.remove(index)
     }
@@ -253,7 +253,7 @@ impl<I: Clone + Ord> SpkTxOutIndex<I> {
     /// effect.
     ///
     /// [`mark_used`]: Self::mark_used
-    pub fn unmark_used(&mut self, index: &I) -> bool {
+    pub fn mark_unused(&mut self, index: &I) -> bool {
         // we cannot set the index as unused when it does not exist
         if !self.spks.contains_key(index) {
             return false;

--- a/crates/chain/tests/test_spk_txout_index.rs
+++ b/crates/chain/tests/test_spk_txout_index.rs
@@ -67,7 +67,7 @@ fn mark_used() {
     assert!(!spk_index.is_used(&1));
     spk_index.mark_used(&1);
     assert!(spk_index.is_used(&1));
-    spk_index.unmark_used(&1);
+    spk_index.mark_unused(&1);
     assert!(!spk_index.is_used(&1));
     spk_index.mark_used(&1);
     assert!(spk_index.is_used(&1));
@@ -83,18 +83,18 @@ fn mark_used() {
     };
 
     spk_index.index_tx(&tx1);
-    spk_index.unmark_used(&1);
+    spk_index.mark_unused(&1);
     assert!(
         spk_index.is_used(&1),
-        "even though we unmark_used it doesn't matter because there was a tx scanned that used it"
+        "even though we mark_unused it doesn't matter because there was a tx scanned that used it"
     );
 }
 
 #[test]
-fn unmark_used_does_not_result_in_invalid_representation() {
+fn mark_unused_does_not_result_in_invalid_representation() {
     let mut spk_index = SpkTxOutIndex::default();
-    assert!(!spk_index.unmark_used(&0));
-    assert!(!spk_index.unmark_used(&1));
-    assert!(!spk_index.unmark_used(&2));
+    assert!(!spk_index.mark_unused(&0));
+    assert!(!spk_index.mark_unused(&1));
+    assert!(!spk_index.mark_unused(&2));
     assert!(spk_index.unused_spks(..).collect::<Vec<_>>().is_empty());
 }

--- a/example-crates/example_cli/src/lib.rs
+++ b/example-crates/example_cli/src/lib.rs
@@ -649,7 +649,7 @@ where
                 Err(e) => {
                     if let Some((keychain, index)) = change_index {
                         // We failed to broadcast, so allow our change address to be used in the future
-                        graph.lock().unwrap().index.unmark_used(keychain, index);
+                        graph.lock().unwrap().index.mark_unused(keychain, index);
                     }
                     Err(e)
                 }


### PR DESCRIPTION
The name `mark_unused` more closely describes the [actual behavior of `SpkTxOutIndex`](https://github.com/bitcoindevkit/bdk/blob/358e842dcda0eb867d229881823c76dba1d7cce1/crates/chain/src/spk_txout_index.rs#L256) and is more discoverable due to its similarity to the related `mark_used`.

### Notes to the reviewers

Not a high priority, as it's only a name change.

cc https://github.com/bitcoindevkit/bdk/issues/898#issuecomment-2047904240

### Changelog notice

Changed:

- Renamed `SpkTxOutIndex::unmark_used` to `mark_unused`
- Renamed `KeychainTxOutIndex::unmark_used` to `mark_unused`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [x] This pull request breaks the existing API
