### PR TITLE
refactor(chain)!: Change tx_last_seen to `Option<u64>`

### DIFF
--- a/crates/bitcoind_rpc/tests/test_emitter.rs
+++ b/crates/bitcoind_rpc/tests/test_emitter.rs
@@ -392,7 +392,6 @@ fn tx_can_become_unconfirmed_after_reorg() -> anyhow::Result<()> {
             get_balance(&recv_chain, &recv_graph)?,
             Balance {
                 confirmed: SEND_AMOUNT * (ADDITIONAL_COUNT - reorg_count) as u64,
-                trusted_pending: SEND_AMOUNT * reorg_count as u64,
                 ..Balance::default()
             },
             "reorg_count: {}",

--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -258,6 +258,19 @@ impl<A> TxGraph<A> {
             })
     }
 
+    /// Iterate over graph transactions with no anchors or last-seen.
+    pub fn txs_with_no_anchor_or_last_seen(
+        &self,
+    ) -> impl Iterator<Item = TxNode<'_, Arc<Transaction>, A>> {
+        self.full_txs().filter_map(|tx| {
+            if tx.anchors.is_empty() && tx.last_seen_unconfirmed.is_none() {
+                Some(tx)
+            } else {
+                None
+            }
+        })
+    }
+
     /// Get a transaction by txid. This only returns `Some` for full transactions.
     ///
     /// Refer to [`get_txout`] for getting a specific [`TxOut`].

--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -981,10 +981,10 @@ impl<A: Anchor> TxGraph<A> {
     /// If the [`ChainOracle`] implementation (`chain`) fails, an error will be returned with the
     /// returned item.
     ///
-    /// If the [`ChainOracle`] is infallible, [`list_chain_txs`] can be used instead.
+    /// If the [`ChainOracle`] is infallible, [`list_canonical_txs`] can be used instead.
     ///
-    /// [`list_chain_txs`]: Self::list_chain_txs
-    pub fn try_list_chain_txs<'a, C: ChainOracle + 'a>(
+    /// [`list_canonical_txs`]: Self::list_canonical_txs
+    pub fn try_list_canonical_txs<'a, C: ChainOracle + 'a>(
         &'a self,
         chain: &'a C,
         chain_tip: BlockId,
@@ -1003,15 +1003,15 @@ impl<A: Anchor> TxGraph<A> {
 
     /// List graph transactions that are in `chain` with `chain_tip`.
     ///
-    /// This is the infallible version of [`try_list_chain_txs`].
+    /// This is the infallible version of [`try_list_canonical_txs`].
     ///
-    /// [`try_list_chain_txs`]: Self::try_list_chain_txs
-    pub fn list_chain_txs<'a, C: ChainOracle + 'a>(
+    /// [`try_list_canonical_txs`]: Self::try_list_canonical_txs
+    pub fn list_canonical_txs<'a, C: ChainOracle + 'a>(
         &'a self,
         chain: &'a C,
         chain_tip: BlockId,
     ) -> impl Iterator<Item = CanonicalTx<'a, Arc<Transaction>, A>> {
-        self.try_list_chain_txs(chain, chain_tip)
+        self.try_list_canonical_txs(chain, chain_tip)
             .map(|r| r.expect("oracle is infallible"))
     }
 

--- a/crates/chain/tests/common/tx_template.rs
+++ b/crates/chain/tests/common/tx_template.rs
@@ -131,9 +131,7 @@ pub fn init_graph<'a, A: Anchor + Clone + 'a>(
         for anchor in tx_tmp.anchors.iter() {
             let _ = graph.insert_anchor(tx.compute_txid(), anchor.clone());
         }
-        if let Some(seen_at) = tx_tmp.last_seen {
-            let _ = graph.insert_seen_at(tx.compute_txid(), seen_at);
-        }
+        let _ = graph.insert_seen_at(tx.compute_txid(), tx_tmp.last_seen.unwrap_or(0));
     }
     (graph, spk_index, tx_ids)
 }

--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -520,3 +520,147 @@ fn test_list_owned_txouts() {
         );
     }
 }
+
+/// Given a `LocalChain`, `IndexedTxGraph`, and a `Transaction`, when we insert some anchor
+/// (possibly non-canonical) and/or a last-seen timestamp into the graph, we expect the
+/// result of `get_chain_position` in these cases:
+///
+/// - tx with no anchors or last_seen has no `ChainPosition`
+/// - tx with any last_seen will be `Unconfirmed`
+/// - tx with an anchor in best chain will be `Confirmed`
+/// - tx with an anchor not in best chain (no last_seen) has no `ChainPosition`
+#[test]
+fn test_get_chain_position() {
+    use bdk_chain::local_chain::CheckPoint;
+    use bdk_chain::BlockId;
+    use bdk_chain::SpkTxOutIndex;
+
+    struct TestCase<A> {
+        name: &'static str,
+        tx: Transaction,
+        anchor: Option<A>,
+        last_seen: Option<u64>,
+        exp_pos: Option<ChainPosition<A>>,
+    }
+
+    // addr: bcrt1qc6fweuf4xjvz4x3gx3t9e0fh4hvqyu2qw4wvxm
+    let spk = ScriptBuf::from_hex("0014c692ecf13534982a9a2834565cbd37add8027140").unwrap();
+    let mut graph = IndexedTxGraph::new({
+        let mut index = SpkTxOutIndex::default();
+        let _ = index.insert_spk(0u32, spk.clone());
+        index
+    });
+
+    // Anchors to test
+    let blocks = vec![block_id!(0, "g"), block_id!(1, "A"), block_id!(2, "B")];
+
+    let cp = CheckPoint::from_block_ids(blocks.clone()).unwrap();
+    let chain = LocalChain::from_tip(cp).unwrap();
+
+    // The test will insert a transaction into the indexed tx graph
+    // along with any anchors and timestamps, then check the value
+    // returned by `get_chain_position`.
+    fn run(
+        chain: &LocalChain,
+        graph: &mut IndexedTxGraph<BlockId, SpkTxOutIndex<u32>>,
+        test: TestCase<BlockId>,
+    ) {
+        let TestCase {
+            name,
+            tx,
+            anchor,
+            last_seen,
+            exp_pos,
+        } = test;
+
+        // add data to graph
+        let txid = tx.compute_txid();
+        let _ = graph.insert_tx(tx);
+        if let Some(anchor) = anchor {
+            let _ = graph.insert_anchor(txid, anchor);
+        }
+        if let Some(seen_at) = last_seen {
+            let _ = graph.insert_seen_at(txid, seen_at);
+        }
+
+        // check chain position
+        let res = graph
+            .graph()
+            .get_chain_position(chain, chain.tip().block_id(), txid);
+        assert_eq!(
+            res.map(ChainPosition::cloned),
+            exp_pos,
+            "failed test case: {name}"
+        );
+    }
+
+    [
+        TestCase {
+            name: "tx no anchors or last_seen - no chain pos",
+            tx: Transaction {
+                output: vec![TxOut {
+                    value: Amount::ONE_BTC,
+                    script_pubkey: spk.clone(),
+                }],
+                ..common::new_tx(0)
+            },
+            anchor: None,
+            last_seen: None,
+            exp_pos: None,
+        },
+        TestCase {
+            name: "tx last_seen - unconfirmed",
+            tx: Transaction {
+                output: vec![TxOut {
+                    value: Amount::ONE_BTC,
+                    script_pubkey: spk.clone(),
+                }],
+                ..common::new_tx(1)
+            },
+            anchor: None,
+            last_seen: Some(2),
+            exp_pos: Some(ChainPosition::Unconfirmed(2)),
+        },
+        TestCase {
+            name: "tx anchor in best chain - confirmed",
+            tx: Transaction {
+                output: vec![TxOut {
+                    value: Amount::ONE_BTC,
+                    script_pubkey: spk.clone(),
+                }],
+                ..common::new_tx(2)
+            },
+            anchor: Some(blocks[1]),
+            last_seen: None,
+            exp_pos: Some(ChainPosition::Confirmed(blocks[1])),
+        },
+        TestCase {
+            name: "tx unknown anchor with last_seen - unconfirmed",
+            tx: Transaction {
+                output: vec![TxOut {
+                    value: Amount::ONE_BTC,
+                    script_pubkey: spk.clone(),
+                }],
+                ..common::new_tx(3)
+            },
+            anchor: Some(block_id!(2, "B'")),
+            last_seen: Some(2),
+            exp_pos: Some(ChainPosition::Unconfirmed(2)),
+        },
+        TestCase {
+            name: "tx unknown anchor - no chain pos",
+            tx: Transaction {
+                output: vec![TxOut {
+                    value: Amount::ONE_BTC,
+                    script_pubkey: spk.clone(),
+                }],
+                ..common::new_tx(4)
+            },
+            anchor: Some(block_id!(2, "B'")),
+            last_seen: None,
+            exp_pos: None,
+        },
+    ]
+    .into_iter()
+    .for_each(|t| run(&chain, &mut graph, t));
+}

--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -116,8 +116,8 @@ fn insert_relevant_txs() {
 /// tx1: A Coinbase, sending 70000 sats to "trusted" address. [Block 0]
 /// tx2: A external Receive, sending 30000 sats to "untrusted" address. [Block 1]
 /// tx3: Internal Spend. Spends tx2 and returns change of 10000 to "trusted" address. [Block 2]
-/// tx4: Mempool tx, sending 20000 sats to "trusted" address.
-/// tx5: Mempool tx, sending 15000 sats to "untested" address.
+/// tx4: Mempool tx, sending 20000 sats to "untrusted" address.
+/// tx5: Mempool tx, sending 15000 sats to "trusted" address.
 /// tx6: Complete unrelated tx. [Block 3]
 ///
 /// Different transactions are added via `insert_relevant_txs`.
@@ -160,7 +160,7 @@ fn test_list_owned_txouts() {
     let mut untrusted_spks: Vec<ScriptBuf> = Vec::new();
 
     {
-        // we need to scope here to take immutanble reference of the graph
+        // we need to scope here to take immutable reference of the graph
         for _ in 0..10 {
             let ((_, script), _) = graph
                 .index
@@ -226,7 +226,7 @@ fn test_list_owned_txouts() {
         ..common::new_tx(0)
     };
 
-    // tx5 is spending tx3 and receiving change at trusted keychain, unconfirmed.
+    // tx5 is an external transaction receiving at trusted keychain, unconfirmed.
     let tx5 = Transaction {
         output: vec![TxOut {
             value: Amount::from_sat(15000),
@@ -239,7 +239,7 @@ fn test_list_owned_txouts() {
     let tx6 = common::new_tx(0);
 
     // Insert transactions into graph with respective anchors
-    // For unconfirmed txs we pass in `None`.
+    // Insert unconfirmed txs with a last_seen timestamp
 
     let _ =
         graph.batch_insert_relevant([&tx1, &tx2, &tx3, &tx6].iter().enumerate().map(|(i, tx)| {
@@ -290,9 +290,6 @@ fn test_list_owned_txouts() {
                 graph.index.outpoints().iter().cloned(),
                 |_, spk: &Script| trusted_spks.contains(&spk.to_owned()),
             );
-
-            assert_eq!(txouts.len(), 5);
-            assert_eq!(utxos.len(), 4);
 
             let confirmed_txouts_txid = txouts
                 .iter()
@@ -359,29 +356,25 @@ fn test_list_owned_txouts() {
             balance,
         ) = fetch(0, &graph);
 
+        // tx1 is a confirmed txout and is unspent
+        // tx4, tx5 are unconfirmed
         assert_eq!(confirmed_txouts_txid, [tx1.compute_txid()].into());
         assert_eq!(
             unconfirmed_txouts_txid,
-            [
-                tx2.compute_txid(),
-                tx3.compute_txid(),
-                tx4.compute_txid(),
-                tx5.compute_txid()
-            ]
-            .into()
+            [tx4.compute_txid(), tx5.compute_txid()].into()
         );
 
         assert_eq!(confirmed_utxos_txid, [tx1.compute_txid()].into());
         assert_eq!(
             unconfirmed_utxos_txid,
-            [tx3.compute_txid(), tx4.compute_txid(), tx5.compute_txid()].into()
+            [tx4.compute_txid(), tx5.compute_txid()].into()
         );
 
         assert_eq!(
             balance,
             Balance {
                 immature: Amount::from_sat(70000),          // immature coinbase
-                trusted_pending: Amount::from_sat(25000),   // tx3 + tx5
+                trusted_pending: Amount::from_sat(15000),   // tx5
                 untrusted_pending: Amount::from_sat(20000), // tx4
                 confirmed: Amount::ZERO                     // Nothing is confirmed yet
             }
@@ -405,23 +398,26 @@ fn test_list_owned_txouts() {
         );
         assert_eq!(
             unconfirmed_txouts_txid,
-            [tx3.compute_txid(), tx4.compute_txid(), tx5.compute_txid()].into()
+            [tx4.compute_txid(), tx5.compute_txid()].into()
         );
 
-        // tx2 doesn't get into confirmed utxos set
-        assert_eq!(confirmed_utxos_txid, [tx1.compute_txid()].into());
+        // tx2 gets into confirmed utxos set
+        assert_eq!(
+            confirmed_utxos_txid,
+            [tx1.compute_txid(), tx2.compute_txid()].into()
+        );
         assert_eq!(
             unconfirmed_utxos_txid,
-            [tx3.compute_txid(), tx4.compute_txid(), tx5.compute_txid()].into()
+            [tx4.compute_txid(), tx5.compute_txid()].into()
         );
 
         assert_eq!(
             balance,
             Balance {
                 immature: Amount::from_sat(70000),          // immature coinbase
-                trusted_pending: Amount::from_sat(25000),   // tx3 + tx5
+                trusted_pending: Amount::from_sat(15000),   // tx5
                 untrusted_pending: Amount::from_sat(20000), // tx4
-                confirmed: Amount::ZERO                     // Nothing is confirmed yet
+                confirmed: Amount::from_sat(30_000)         // tx2 got confirmed
             }
         );
     }
@@ -477,6 +473,7 @@ fn test_list_owned_txouts() {
             balance,
         ) = fetch(98, &graph);
 
+        // no change compared to block 2
         assert_eq!(
             confirmed_txouts_txid,
             [tx1.compute_txid(), tx2.compute_txid(), tx3.compute_txid()].into()
@@ -502,14 +499,14 @@ fn test_list_owned_txouts() {
                 immature: Amount::from_sat(70000),          // immature coinbase
                 trusted_pending: Amount::from_sat(15000),   // tx5
                 untrusted_pending: Amount::from_sat(20000), // tx4
-                confirmed: Amount::from_sat(10000)          // tx1 got matured
+                confirmed: Amount::from_sat(10000)          // tx3 is confirmed
             }
         );
     }
 
     // AT Block 99
     {
-        let (_, _, _, _, balance) = fetch(100, &graph);
+        let (_, _, _, _, balance) = fetch(99, &graph);
 
         // Coinbase maturity hits
         assert_eq!(

--- a/crates/chain/tests/test_tx_graph.rs
+++ b/crates/chain/tests/test_tx_graph.rs
@@ -1127,6 +1127,8 @@ fn transactions_inserted_into_tx_graph_are_not_canonical_until_they_have_an_anch
     let mut graph = TxGraph::<BlockId>::new(txs);
     let full_txs: Vec<_> = graph.full_txs().collect();
     assert_eq!(full_txs.len(), 2);
+    let unseen_txs: Vec<_> = graph.txs_with_no_anchor_or_last_seen().collect();
+    assert_eq!(unseen_txs.len(), 2);
 
     // chain
     let blocks: BTreeMap<u32, BlockHash> = [(0, h!("g")), (1, h!("A")), (2, h!("B"))]
@@ -1154,6 +1156,7 @@ fn transactions_inserted_into_tx_graph_are_not_canonical_until_they_have_an_anch
         .map(|tx| tx.tx_node.txid)
         .collect();
     assert!(canonical_txids.contains(&txids[1]));
+    assert!(graph.txs_with_no_anchor_or_last_seen().next().is_none());
 }
 
 #[test]

--- a/crates/chain/tests/test_tx_graph_conflicts.rs
+++ b/crates/chain/tests/test_tx_graph_conflicts.rs
@@ -15,7 +15,7 @@ struct Scenario<'a> {
     name: &'a str,
     /// Transaction templates
     tx_templates: &'a [TxTemplate<'a, BlockId>],
-    /// Names of txs that must exist in the output of `list_chain_txs`
+    /// Names of txs that must exist in the output of `list_canonical_txs`
     exp_chain_txs: HashSet<&'a str>,
     /// Outpoints that must exist in the output of `filter_chain_txouts`
     exp_chain_txouts: HashSet<(&'a str, u32)>,
@@ -27,7 +27,7 @@ struct Scenario<'a> {
 
 /// This test ensures that [`TxGraph`] will reliably filter out irrelevant transactions when
 /// presented with multiple conflicting transaction scenarios using the [`TxTemplate`] structure.
-/// This test also checks that [`TxGraph::list_chain_txs`], [`TxGraph::filter_chain_txouts`],
+/// This test also checks that [`TxGraph::list_canonical_txs`], [`TxGraph::filter_chain_txouts`],
 /// [`TxGraph::filter_chain_unspents`], and [`TxGraph::balance`] return correct data.
 #[test]
 fn test_tx_conflict_handling() {
@@ -597,7 +597,7 @@ fn test_tx_conflict_handling() {
         let (tx_graph, spk_index, exp_tx_ids) = init_graph(scenario.tx_templates.iter());
 
         let txs = tx_graph
-            .list_chain_txs(&local_chain, chain_tip)
+            .list_canonical_txs(&local_chain, chain_tip)
             .map(|tx| tx.tx_node.txid)
             .collect::<BTreeSet<_>>();
         let exp_txs = scenario
@@ -607,7 +607,7 @@ fn test_tx_conflict_handling() {
             .collect::<BTreeSet<_>>();
         assert_eq!(
             txs, exp_txs,
-            "\n[{}] 'list_chain_txs' failed",
+            "\n[{}] 'list_canonical_txs' failed",
             scenario.name
         );
 

--- a/crates/electrum/tests/test_electrum.rs
+++ b/crates/electrum/tests/test_electrum.rs
@@ -198,17 +198,14 @@ fn tx_can_become_unconfirmed_after_reorg() -> anyhow::Result<()> {
             .apply_update(update.chain_update)
             .map_err(|err| anyhow::anyhow!("LocalChain update error: {:?}", err))?;
 
-        // Check to see if a new anchor is added during current reorg.
-        if !initial_anchors.is_superset(update.graph_update.all_anchors()) {
-            println!("New anchor added at reorg depth {}", depth);
-        }
+        // Check that no new anchors are added during current reorg.
+        assert!(initial_anchors.is_superset(update.graph_update.all_anchors()));
         let _ = recv_graph.apply_update(update.graph_update);
 
         assert_eq!(
             get_balance(&recv_chain, &recv_graph)?,
             Balance {
                 confirmed: SEND_AMOUNT * (REORG_COUNT - depth) as u64,
-                trusted_pending: SEND_AMOUNT * depth as u64,
                 ..Balance::default()
             },
             "reorg_count: {}",

--- a/crates/wallet/src/wallet/export.rs
+++ b/crates/wallet/src/wallet/export.rs
@@ -214,7 +214,7 @@ mod test {
     use core::str::FromStr;
 
     use crate::std::string::ToString;
-    use bdk_chain::{BlockId, ConfirmationTime};
+    use bdk_chain::{BlockId, ConfirmationTimeHeightAnchor};
     use bitcoin::hashes::Hash;
     use bitcoin::{transaction, BlockHash, Network, Transaction};
 
@@ -229,21 +229,21 @@ mod test {
             version: transaction::Version::non_standard(0),
             lock_time: bitcoin::absolute::LockTime::ZERO,
         };
-        wallet
-            .insert_checkpoint(BlockId {
-                height: 5001,
-                hash: BlockHash::all_zeros(),
-            })
-            .unwrap();
-        wallet
-            .insert_tx(
-                transaction,
-                ConfirmationTime::Confirmed {
-                    height: 5000,
-                    time: 0,
-                },
-            )
-            .unwrap();
+        let txid = transaction.compute_txid();
+        let block_id = BlockId {
+            height: 5001,
+            hash: BlockHash::all_zeros(),
+        };
+        wallet.insert_checkpoint(block_id).unwrap();
+        wallet.insert_tx(transaction);
+        wallet.insert_anchor(
+            txid,
+            ConfirmationTimeHeightAnchor {
+                confirmation_height: 5000,
+                confirmation_time: 0,
+                anchor_block: block_id,
+            },
+        );
         wallet
     }
 

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -27,7 +27,7 @@ use bdk_chain::{
         self, ApplyHeaderError, CannotConnectError, CheckPoint, CheckPointIter, LocalChain,
     },
     spk_client::{FullScanRequest, FullScanResult, SyncRequest, SyncResult},
-    tx_graph::{CanonicalTx, TxGraph},
+    tx_graph::{CanonicalTx, TxGraph, TxNode},
     Append, BlockId, ChainPosition, ConfirmationTime, ConfirmationTimeHeightAnchor, FullTxOut,
     Indexed, IndexedTxGraph,
 };
@@ -2248,6 +2248,14 @@ impl Wallet {
     /// Get a reference to the inner [`TxGraph`].
     pub fn tx_graph(&self) -> &TxGraph<ConfirmationTimeHeightAnchor> {
         self.indexed_graph.graph()
+    }
+
+    /// Iterate over transactions in the wallet that are unseen and unanchored likely
+    /// because they haven't been broadcast.
+    pub fn unbroadcast_transactions(
+        &self,
+    ) -> impl Iterator<Item = TxNode<'_, Arc<Transaction>, ConfirmationTimeHeightAnchor>> {
+        self.tx_graph().txs_with_no_anchor_or_last_seen()
     }
 
     /// Get a reference to the inner [`KeychainTxOutIndex`].

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -1091,7 +1091,7 @@ impl Wallet {
     {
         self.indexed_graph
             .graph()
-            .list_chain_txs(&self.chain, self.chain.tip().block_id())
+            .list_canonical_txs(&self.chain, self.chain.tip().block_id())
     }
 
     /// Return the balance, separated into available, trusted-pending, untrusted-pending and immature

--- a/crates/wallet/tests/common.rs
+++ b/crates/wallet/tests/common.rs
@@ -1,7 +1,8 @@
 #![allow(unused)]
 
 use bdk_chain::indexed_tx_graph::Indexer;
-use bdk_chain::{BlockId, ConfirmationTime, ConfirmationTimeHeightAnchor};
+use bdk_chain::{BlockId, ConfirmationTime, ConfirmationTimeHeightAnchor, TxGraph};
+use bdk_wallet::wallet::Update;
 use bdk_wallet::{KeychainKind, LocalOutput, Wallet};
 use bitcoin::hashes::Hash;
 use bitcoin::{
@@ -212,6 +213,13 @@ pub fn insert_anchor_from_conf(wallet: &mut Wallet, txid: Txid, position: Confir
             })
             .expect("confirmation height cannot be greater than tip");
 
-        wallet.insert_anchor(txid, anchor);
+        let mut graph = TxGraph::default();
+        let _ = graph.insert_anchor(txid, anchor);
+        wallet
+            .apply_update(Update {
+                graph,
+                ..Default::default()
+            })
+            .unwrap();
     }
 }

--- a/crates/wallet/tests/wallet.rs
+++ b/crates/wallet/tests/wallet.rs
@@ -50,7 +50,7 @@ fn receive_output(wallet: &mut Wallet, value: u64, height: ConfirmationTime) -> 
             insert_anchor_from_conf(wallet, txid, height);
         }
         ConfirmationTime::Unconfirmed { last_seen } => {
-            wallet.insert_seen_at(txid, last_seen);
+            insert_seen_at(wallet, txid, last_seen);
         }
     }
 
@@ -66,6 +66,18 @@ fn receive_output_in_latest_block(wallet: &mut Wallet, value: u64) -> OutPoint {
         ConfirmationTime::Confirmed { height, time: 0 }
     };
     receive_output(wallet, value, anchor)
+}
+
+fn insert_seen_at(wallet: &mut Wallet, txid: Txid, seen_at: u64) {
+    use bdk_wallet::wallet::Update;
+    let mut graph = bdk_chain::TxGraph::default();
+    let _ = graph.insert_seen_at(txid, seen_at);
+    wallet
+        .apply_update(Update {
+            graph,
+            ..Default::default()
+        })
+        .unwrap();
 }
 
 // The satisfaction size of a P2WPKH is 112 WU =
@@ -1291,7 +1303,7 @@ fn test_create_tx_policy_path_no_csv() {
     };
     let txid = tx.compute_txid();
     wallet.insert_tx(tx);
-    wallet.insert_seen_at(txid, 0);
+    insert_seen_at(&mut wallet, txid, 0);
 
     let external_policy = wallet.policies(KeychainKind::External).unwrap().unwrap();
     let root_id = external_policy.id;
@@ -1683,7 +1695,7 @@ fn test_bump_fee_irreplaceable_tx() {
     let tx = psbt.extract_tx().expect("failed to extract tx");
     let txid = tx.compute_txid();
     wallet.insert_tx(tx);
-    wallet.insert_seen_at(txid, 0);
+    insert_seen_at(&mut wallet, txid, 0);
     wallet.build_fee_bump(txid).unwrap().finish().unwrap();
 }
 
@@ -1727,7 +1739,7 @@ fn test_bump_fee_low_fee_rate() {
     let txid = tx.compute_txid();
 
     wallet.insert_tx(tx);
-    wallet.insert_seen_at(txid, 0);
+    insert_seen_at(&mut wallet, txid, 0);
 
     let mut builder = wallet.build_fee_bump(txid).unwrap();
     builder.fee_rate(FeeRate::BROADCAST_MIN);
@@ -1759,7 +1771,7 @@ fn test_bump_fee_low_abs() {
     let txid = tx.compute_txid();
 
     wallet.insert_tx(tx);
-    wallet.insert_seen_at(txid, 0);
+    insert_seen_at(&mut wallet, txid, 0);
 
     let mut builder = wallet.build_fee_bump(txid).unwrap();
     builder.fee_absolute(Amount::from_sat(10));
@@ -1780,7 +1792,7 @@ fn test_bump_fee_zero_abs() {
     let tx = psbt.extract_tx().expect("failed to extract tx");
     let txid = tx.compute_txid();
     wallet.insert_tx(tx);
-    wallet.insert_seen_at(txid, 0);
+    insert_seen_at(&mut wallet, txid, 0);
 
     let mut builder = wallet.build_fee_bump(txid).unwrap();
     builder.fee_absolute(Amount::ZERO);
@@ -1805,7 +1817,7 @@ fn test_bump_fee_reduce_change() {
     let tx = psbt.extract_tx().expect("failed to extract tx");
     let txid = tx.compute_txid();
     wallet.insert_tx(tx);
-    wallet.insert_seen_at(txid, 0);
+    insert_seen_at(&mut wallet, txid, 0);
 
     let feerate = FeeRate::from_sat_per_kwu(625); // 2.5 sat/vb
     let mut builder = wallet.build_fee_bump(txid).unwrap();
@@ -1902,7 +1914,7 @@ fn test_bump_fee_reduce_single_recipient() {
     let original_fee = check_fee!(wallet, psbt);
     let txid = tx.compute_txid();
     wallet.insert_tx(tx);
-    wallet.insert_seen_at(txid, 0);
+    insert_seen_at(&mut wallet, txid, 0);
 
     let feerate = FeeRate::from_sat_per_kwu(625); // 2.5 sat/vb
     let mut builder = wallet.build_fee_bump(txid).unwrap();
@@ -1949,7 +1961,7 @@ fn test_bump_fee_absolute_reduce_single_recipient() {
     let original_sent_received = wallet.sent_and_received(&tx);
     let txid = tx.compute_txid();
     wallet.insert_tx(tx);
-    wallet.insert_seen_at(txid, 0);
+    insert_seen_at(&mut wallet, txid, 0);
 
     let mut builder = wallet.build_fee_bump(txid).unwrap();
     builder
@@ -2024,7 +2036,7 @@ fn test_bump_fee_drain_wallet() {
 
     let txid = tx.compute_txid();
     wallet.insert_tx(tx);
-    wallet.insert_seen_at(txid, 0);
+    insert_seen_at(&mut wallet, txid, 0);
     assert_eq!(original_sent_received.0, Amount::from_sat(25_000));
 
     // for the new feerate, it should be enough to reduce the output, but since we specify
@@ -2089,7 +2101,7 @@ fn test_bump_fee_remove_output_manually_selected_only() {
     let original_sent_received = wallet.sent_and_received(&tx);
     let txid = tx.compute_txid();
     wallet.insert_tx(tx);
-    wallet.insert_seen_at(txid, 0);
+    insert_seen_at(&mut wallet, txid, 0);
     assert_eq!(original_sent_received.0, Amount::from_sat(25_000));
 
     let mut builder = wallet.build_fee_bump(txid).unwrap();
@@ -2136,7 +2148,7 @@ fn test_bump_fee_add_input() {
     let original_details = wallet.sent_and_received(&tx);
     let txid = tx.compute_txid();
     wallet.insert_tx(tx);
-    wallet.insert_seen_at(txid, 0);
+    insert_seen_at(&mut wallet, txid, 0);
 
     let mut builder = wallet.build_fee_bump(txid).unwrap();
     builder.fee_rate(FeeRate::from_sat_per_vb_unchecked(50));
@@ -2192,7 +2204,7 @@ fn test_bump_fee_absolute_add_input() {
     let original_sent_received = wallet.sent_and_received(&tx);
     let txid = tx.compute_txid();
     wallet.insert_tx(tx);
-    wallet.insert_seen_at(txid, 0);
+    insert_seen_at(&mut wallet, txid, 0);
 
     let mut builder = wallet.build_fee_bump(txid).unwrap();
     builder.fee_absolute(Amount::from_sat(6_000));
@@ -2257,7 +2269,7 @@ fn test_bump_fee_no_change_add_input_and_change() {
     let tx = psbt.extract_tx().expect("failed to extract tx");
     let txid = tx.compute_txid();
     wallet.insert_tx(tx);
-    wallet.insert_seen_at(txid, 0);
+    insert_seen_at(&mut wallet, txid, 0);
 
     // Now bump the fees, the wallet should add an extra input and a change output, and leave
     // the original output untouched.
@@ -2326,7 +2338,7 @@ fn test_bump_fee_add_input_change_dust() {
     assert_eq!(tx.output.len(), 2);
     let txid = tx.compute_txid();
     wallet.insert_tx(tx);
-    wallet.insert_seen_at(txid, 0);
+    insert_seen_at(&mut wallet, txid, 0);
 
     let mut builder = wallet.build_fee_bump(txid).unwrap();
     // We set a fee high enough that during rbf we are forced to add
@@ -2396,7 +2408,7 @@ fn test_bump_fee_force_add_input() {
         txin.witness.push([0x00; P2WPKH_FAKE_WITNESS_SIZE]); // fake signature
     }
     wallet.insert_tx(tx.clone());
-    wallet.insert_seen_at(txid, 0);
+    insert_seen_at(&mut wallet, txid, 0);
     // the new fee_rate is low enough that just reducing the change would be fine, but we force
     // the addition of an extra input with `add_utxo()`
     let mut builder = wallet.build_fee_bump(txid).unwrap();
@@ -2462,7 +2474,7 @@ fn test_bump_fee_absolute_force_add_input() {
         txin.witness.push([0x00; P2WPKH_FAKE_WITNESS_SIZE]); // fake signature
     }
     wallet.insert_tx(tx.clone());
-    wallet.insert_seen_at(txid, 0);
+    insert_seen_at(&mut wallet, txid, 0);
 
     // the new fee_rate is low enough that just reducing the change would be fine, but we force
     // the addition of an extra input with `add_utxo()`
@@ -2540,7 +2552,7 @@ fn test_bump_fee_unconfirmed_inputs_only() {
         txin.witness.push([0x00; P2WPKH_FAKE_WITNESS_SIZE]); // fake signature
     }
     wallet.insert_tx(tx);
-    wallet.insert_seen_at(txid, 0);
+    insert_seen_at(&mut wallet, txid, 0);
     let mut builder = wallet.build_fee_bump(txid).unwrap();
     builder.fee_rate(FeeRate::from_sat_per_vb_unchecked(25));
     builder.finish().unwrap();
@@ -2572,7 +2584,7 @@ fn test_bump_fee_unconfirmed_input() {
         txin.witness.push([0x00; P2WPKH_FAKE_WITNESS_SIZE]); // fake signature
     }
     wallet.insert_tx(tx);
-    wallet.insert_seen_at(txid, 0);
+    insert_seen_at(&mut wallet, txid, 0);
 
     let mut builder = wallet.build_fee_bump(txid).unwrap();
     builder
@@ -4107,7 +4119,7 @@ fn test_insert_tx_balance_and_utxos() {
     let tx = psbt.extract_tx().unwrap();
     let txid = tx.compute_txid();
     let _ = wallet.insert_tx(tx);
-    wallet.insert_seen_at(txid, 2);
+    insert_seen_at(&mut wallet, txid, 2);
     assert!(wallet.list_unspent().next().is_none());
     assert_eq!(wallet.balance().total().to_sat(), 0);
 }

--- a/example-crates/example_electrum/src/main.rs
+++ b/example-crates/example_electrum/src/main.rs
@@ -277,7 +277,7 @@ fn main() -> anyhow::Result<()> {
             if unconfirmed {
                 let unconfirmed_txids = graph
                     .graph()
-                    .list_chain_txs(&*chain, chain_tip.block_id())
+                    .list_canonical_txs(&*chain, chain_tip.block_id())
                     .filter(|canonical_tx| !canonical_tx.chain_position.is_confirmed())
                     .map(|canonical_tx| canonical_tx.tx_node.txid)
                     .collect::<Vec<Txid>>();

--- a/example-crates/example_esplora/src/main.rs
+++ b/example-crates/example_esplora/src/main.rs
@@ -307,7 +307,7 @@ fn main() -> anyhow::Result<()> {
                     // `EsploraExt::update_tx_graph_without_keychain`.
                     let unconfirmed_txids = graph
                         .graph()
-                        .list_chain_txs(&*chain, local_tip.block_id())
+                        .list_canonical_txs(&*chain, local_tip.block_id())
                         .filter(|canonical_tx| !canonical_tx.chain_position.is_confirmed())
                         .map(|canonical_tx| canonical_tx.tx_node.txid)
                         .collect::<Vec<Txid>>();


### PR DESCRIPTION
The PR changes the type of last_seen to `Option<u64>` for `txs` member of `TxGraph`.

This fixes an issue where unbroadcast and otherwise non-canonical transactions were returned from methods `list_chain_txs` and `Wallet::transactions` because every new tx inserted had a last_seen of 0 making it appear unconfirmed.

fixes #1446 
fixes #1396 

### Notes to the reviewers

### Changelog notice

Changed
- Member `last_seen_unconfirmed` of `TxNode` is changed to `Option<u64>`
- Renamed `TxGraph` method `list_chain_txs` to `list_canonical_txs`
- Changed `Wallet::insert_tx` to take a single `tx: Transaction` as parameter

Added
- Add method `txs_with_no_anchor_or_last_seen` for `TxGraph`
- Add method `unbroadcast_transactions` for `Wallet`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [x] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
