### PR TITLE
fix: Cargo clippy lints

### DIFF
--- a/crates/bdk/src/wallet/export.rs
+++ b/crates/bdk/src/wallet/export.rs
@@ -53,7 +53,8 @@
 //! # Ok::<_, Box<dyn std::error::Error>>(())
 //! ```
 
-use alloc::string::{String, ToString};
+use alloc::string::String;
+use core::fmt;
 use core::str::FromStr;
 use serde::{Deserialize, Serialize};
 
@@ -79,9 +80,9 @@ pub struct FullyNodedExport {
     pub label: String,
 }
 
-impl ToString for FullyNodedExport {
-    fn to_string(&self) -> String {
-        serde_json::to_string(self).unwrap()
+impl fmt::Display for FullyNodedExport {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", serde_json::to_string(self).unwrap())
     }
 }
 
@@ -213,6 +214,7 @@ impl FullyNodedExport {
 mod test {
     use core::str::FromStr;
 
+    use crate::std::string::ToString;
     use bdk_chain::{BlockId, ConfirmationTime};
     use bitcoin::hashes::Hash;
     use bitcoin::{transaction, BlockHash, Network, Transaction};

--- a/crates/chain/src/local_chain.rs
+++ b/crates/chain/src/local_chain.rs
@@ -265,7 +265,7 @@ impl Iterator for CheckPointIter {
 
     fn next(&mut self) -> Option<Self::Item> {
         let current = self.current.clone()?;
-        self.current = current.prev.clone();
+        self.current.clone_from(&current.prev);
         Some(CheckPoint(current))
     }
 }
@@ -359,7 +359,7 @@ impl LocalChain {
     /// The [`BTreeMap`] enforces the height order. However, the caller must ensure the blocks are
     /// all of the same chain.
     pub fn from_blocks(blocks: BTreeMap<u32, BlockHash>) -> Result<Self, MissingGenesisError> {
-        if blocks.get(&0).is_none() {
+        if !blocks.contains_key(&0) {
             return Err(MissingGenesisError);
         }
 

--- a/crates/chain/src/spk_client.rs
+++ b/crates/chain/src/spk_client.rs
@@ -255,6 +255,9 @@ impl<K: Ord + Clone> FullScanRequest<K> {
         spks: impl IntoIterator<IntoIter = impl Iterator<Item = (u32, ScriptBuf)> + Send + 'static>,
     ) -> Self {
         match self.spks_by_keychain.remove(&keychain) {
+            // clippy here suggests to remove `into_iter` from `spks.into_iter()`, but doing so
+            // results in a compilation error
+            #[allow(clippy::useless_conversion)]
             Some(keychain_spks) => self
                 .spks_by_keychain
                 .insert(keychain, Box::new(keychain_spks.chain(spks.into_iter()))),

--- a/crates/chain/src/spk_iter.rs
+++ b/crates/chain/src/spk_iter.rs
@@ -260,6 +260,7 @@ mod test {
     }
 
     // The following dummy traits were created to test if SpkIterator is working properly.
+    #[allow(unused)]
     trait TestSendStatic: Send + 'static {
         fn test(&self) -> u32 {
             20

--- a/crates/chain/src/spk_txout_index.rs
+++ b/crates/chain/src/spk_txout_index.rs
@@ -229,7 +229,7 @@ impl<I: Clone + Ord> SpkTxOutIndex<I> {
     /// Here, "unused" means that after the script pubkey was stored in the index, the index has
     /// never scanned a transaction output with it.
     pub fn is_used(&self, index: &I) -> bool {
-        self.unused.get(index).is_none()
+        !self.unused.contains(index)
     }
 
     /// Marks the script pubkey at `index` as used even though it hasn't seen an output spending to it.


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Caught when trying to release (#1420), clippy failed randomly although it worked on master, this happened because rust 1.78 had just been release and we use clippy stable. IMHO we should pin the clippy version in CI and bump it manually at each new rust release.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
