### PR TITLE
fix(persist): add default feature to enable bdk_chain/std

### DIFF
--- a/crates/persist/Cargo.toml
+++ b/crates/persist/Cargo.toml
@@ -16,4 +16,7 @@ rust-version = "1.63"
 anyhow = { version = "1", default-features = false }
 bdk_chain = { path = "../chain", version = "0.13.0", default-features = false }
 
+[features]
+default = ["bdk_chain/std"]
+
 


### PR DESCRIPTION
### Description

This PR adds a `default` feature to `bdk_persist` so it can be build on its own.  Once #1422 is done we can remove the `default`again.

### Notes to the reviewers

I need to be able to build `bdk_persist` on its own so I can publish it to crates.io. 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
