### PR TITLE
Bump bdk version to 1.0.0-alpha.11

### DIFF
--- a/crates/bdk/Cargo.toml
+++ b/crates/bdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bdk"
 homepage = "https://bitcoindevkit.org"
-version = "1.0.0-alpha.10"
+version = "1.0.0-alpha.11"
 repository = "https://github.com/bitcoindevkit/bdk"
 documentation = "https://docs.rs/bdk"
 description = "A modern, lightweight, descriptor-based wallet library"
@@ -19,8 +19,8 @@ miniscript = { version = "11.0.0", features = ["serde"], default-features = fals
 bitcoin = { version = "0.31.0", features = ["serde", "base64", "rand-std"], default-features = false }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
-bdk_chain = { path = "../chain", version = "0.13.0", features = ["miniscript", "serde"], default-features = false }
-bdk_persist = { path = "../persist", version = "0.1.0" }
+bdk_chain = { path = "../chain", version = "0.14.0", features = ["miniscript", "serde"], default-features = false }
+bdk_persist = { path = "../persist", version = "0.2.0" }
 
 # Optional dependencies
 bip39 = { version = "2.0", optional = true }

--- a/crates/bitcoind_rpc/Cargo.toml
+++ b/crates/bitcoind_rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_bitcoind_rpc"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"
@@ -16,7 +16,7 @@ readme = "README.md"
 # For no-std, remember to enable the bitcoin/no-std feature
 bitcoin = { version = "0.31", default-features = false }
 bitcoincore-rpc = { version = "0.18" }
-bdk_chain = { path = "../chain", version = "0.13", default-features = false }
+bdk_chain = { path = "../chain", version = "0.14", default-features = false }
 
 [dev-dependencies]
 bdk_testenv = { path = "../testenv", default_features = false }

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_chain"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"

--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_electrum"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -12,7 +12,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bdk_chain = { path = "../chain", version = "0.13.0" }
+bdk_chain = { path = "../chain", version = "0.14.0" }
 electrum-client = { version = "0.19" }
 #rustls = { version = "=0.21.1", optional = true, features = ["dangerous_configuration"] }
 

--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_esplora"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -12,7 +12,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bdk_chain = { path = "../chain", version = "0.13.0", default-features = false }
+bdk_chain = { path = "../chain", version = "0.14.0", default-features = false }
 esplora-client = { version = "0.7.0", default-features = false }
 async-trait = { version = "0.1.66", optional = true }
 futures = { version = "0.3.26", optional = true }

--- a/crates/file_store/Cargo.toml
+++ b/crates/file_store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_file_store"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -12,8 +12,8 @@ readme = "README.md"
 
 [dependencies]
 anyhow = { version = "1", default-features = false }
-bdk_chain = { path = "../chain", version = "0.13.0", features = [ "serde", "miniscript" ] }
-bdk_persist = { path = "../persist", version = "0.1.0"}
+bdk_chain = { path = "../chain", version = "0.14.0", features = [ "serde", "miniscript" ] }
+bdk_persist = { path = "../persist", version = "0.2.0"}
 bincode = { version = "1" }
 serde = { version = "1", features = ["derive"] }
 

--- a/crates/persist/Cargo.toml
+++ b/crates/persist/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bdk_persist"
 homepage = "https://bitcoindevkit.org"
-version = "0.1.0"
+version = "0.2.0"
 repository = "https://github.com/bitcoindevkit/bdk"
 documentation = "https://docs.rs/bdk_persist"
 description = "Types that define data persistence of a BDK wallet"
@@ -14,7 +14,7 @@ rust-version = "1.63"
 
 [dependencies]
 anyhow = { version = "1", default-features = false }
-bdk_chain = { path = "../chain", version = "0.13.0", default-features = false }
+bdk_chain = { path = "../chain", version = "0.14.0", default-features = false }
 
 [features]
 default = ["bdk_chain/std"]

--- a/crates/testenv/Cargo.toml
+++ b/crates/testenv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_testenv"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"
@@ -13,7 +13,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bdk_chain = { path = "../chain", version = "0.13", default-features = false }
+bdk_chain = { path = "../chain", version = "0.14", default-features = false }
 electrsd = { version= "0.27.1", features = ["bitcoind_25_0", "esplora_a33e97e1", "legacy"] }
 
 [features]


### PR DESCRIPTION
### Description

fixes #1435 

bdk_chain to 0.14.0
bdk_bitcoind_rpc to 0.10.0
bdk_electrum to 0.13.0
bdk_esplora to 0.13.0
bdk_file_store to 0.11.0
bdk_testenv to 0.4.0
bdk_persist to 0.2.0

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing