### PR TITLE
Remove duplicated InsufficientFunds error member

### DIFF
--- a/crates/wallet/src/wallet/error.rs
+++ b/crates/wallet/src/wallet/error.rs
@@ -94,13 +94,6 @@ pub enum CreateTxError {
     ChangePolicyDescriptor,
     /// There was an error with coin selection
     CoinSelection(coin_selection::Error),
-    /// Wallet's UTXO set is not enough to cover recipient's requested plus fee
-    InsufficientFunds {
-        /// Sats needed for some transaction
-        needed: u64,
-        /// Sats available for spending
-        available: u64,
-    },
     /// Cannot build a tx without recipients
     NoRecipients,
     /// Partially signed bitcoin transaction error
@@ -184,13 +177,6 @@ impl fmt::Display for CreateTxError {
                 )
             }
             CreateTxError::CoinSelection(e) => e.fmt(f),
-            CreateTxError::InsufficientFunds { needed, available } => {
-                write!(
-                    f,
-                    "Insufficient funds: {} sat available of {} sat needed",
-                    available, needed
-                )
-            }
             CreateTxError::NoRecipients => {
                 write!(f, "Cannot build tx without recipients")
             }

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -73,6 +73,8 @@ use crate::types::*;
 use crate::wallet::coin_selection::Excess::{Change, NoChange};
 use crate::wallet::error::{BuildFeeBumpError, CreateTxError, MiniscriptPsbtError};
 
+use self::coin_selection::Error;
+
 const COINBASE_MATURITY: u32 = 100;
 
 /// A Bitcoin wallet
@@ -1595,10 +1597,10 @@ impl Wallet {
                     change_fee,
                 } = excess
                 {
-                    return Err(CreateTxError::InsufficientFunds {
+                    return Err(CreateTxError::CoinSelection(Error::InsufficientFunds {
                         needed: *dust_threshold,
                         available: remaining_amount.saturating_sub(*change_fee),
-                    });
+                    }));
                 }
             } else {
                 return Err(CreateTxError::NoRecipients);


### PR DESCRIPTION
closes #1440 

### Description

- Replace `CreateTxError::InsufficientFunds` use by `coin_selection::Error::InsufficientFunds`
- Remove `InsufficientFunds` member from `CreateTxError` enum
- Rename `coin_selection::Error` to `coin_selection::CoinSelectionError`

### Notes to the reviewers

- We could also keep both members but rename one of them to avoid confusion

### Checklists

#### All Submissions:

* [X] I've signed all my commits
* [X] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [X] I ran `cargo fmt` and `cargo clippy` before committing
