### PR TITLE
fix: wallet examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Fully working examples of how to use these components are in `/example-crates`:
 - [`wallet_esplora_blocking`](./example-crates/wallet_esplora_blocking): Uses the `Wallet` to sync and spend using the Esplora blocking interface.
 - [`wallet_esplora_async`](./example-crates/wallet_esplora_async): Uses the `Wallet` to sync and spend using the Esplora asynchronous interface.
 - [`wallet_electrum`](./example-crates/wallet_electrum): Uses the `Wallet` to sync and spend using Electrum.
+- [`wallet_rpc`](./example-crates/wallet_rpc): Uses the `Wallet` to sync and spend using Bitcoin RPC.
 
 [`BDK 1.0 project page`]: https://github.com/orgs/bitcoindevkit/projects/14
 [`rust-miniscript`]: https://github.com/rust-bitcoin/rust-miniscript

--- a/example-crates/wallet_electrum/Cargo.toml
+++ b/example-crates/wallet_electrum/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "wallet_electrum_example"
+name = "wallet_electrum"
 version = "0.2.0"
 edition = "2021"
 
 [dependencies]
-bdk_wallet = { path = "../../crates/wallet", features = ["file_store"] }
+bdk_wallet = { path = "../../crates/wallet", features = ["rusqlite"] }
 bdk_electrum = { path = "../../crates/electrum" }
 anyhow = "1"

--- a/example-crates/wallet_rpc/Cargo.toml
+++ b/example-crates/wallet_rpc/Cargo.toml
@@ -6,9 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bdk_wallet = { path = "../../crates/wallet", features = ["file_store"] }
+bdk_wallet = { path = "../../crates/wallet" }
 bdk_bitcoind_rpc = { path = "../../crates/bitcoind_rpc" }
-
 anyhow = "1"
 clap = { version = "3.2.25", features = ["derive", "env"] }
 ctrlc = "2.0.1"

--- a/example-crates/wallet_rpc/README.md
+++ b/example-crates/wallet_rpc/README.md
@@ -7,21 +7,18 @@ wallet_rpc 0.1.0
 Bitcoind RPC example using `bdk_wallet::Wallet`
 
 USAGE:
-    wallet_rpc [OPTIONS] <DESCRIPTOR> [CHANGE_DESCRIPTOR]
+    wallet_rpc [OPTIONS] <DESCRIPTOR> <CHANGE_DESCRIPTOR>
 
 ARGS:
     <DESCRIPTOR>           Wallet descriptor [env: DESCRIPTOR=]
     <CHANGE_DESCRIPTOR>    Wallet change descriptor [env: CHANGE_DESCRIPTOR=]
 
 OPTIONS:
-        --db-path <DB_PATH>
-            Where to store wallet data [env: BDK_DB_PATH=] [default: .bdk_wallet_rpc_example.db]
-
     -h, --help
             Print help information
 
         --network <NETWORK>
-            Bitcoin network to connect to [env: BITCOIN_NETWORK=] [default: testnet]
+            Bitcoin network to connect to [env: BITCOIN_NETWORK=] [default: signet]
 
         --rpc-cookie <RPC_COOKIE>
             RPC auth cookie file [env: RPC_COOKIE=]
@@ -33,10 +30,10 @@ OPTIONS:
             RPC auth username [env: RPC_USER=]
 
         --start-height <START_HEIGHT>
-            Earliest block height to start sync from [env: START_HEIGHT=] [default: 481824]
+            Earliest block height to start sync from [env: START_HEIGHT=] [default: 100000]
 
         --url <URL>
-            RPC URL [env: RPC_URL=] [default: 127.0.0.1:8332]
+            RPC URL [env: RPC_URL=] [default: 127.0.0.1:38332]
 
     -V, --version
             Print version information


### PR DESCRIPTION
### Description

Fix wallet examples.

Closes #1434

### Notes to the reviewers

- Print balances only in BTC
- Uses Signet instead of Testnet
- Fix `wallet_esplora_async` printing the `KeychainKind` twice, and forgets to print `spk0`
- Change wallet examples to use mempool.space (Electrum) or BDK's signet (Esplora) to fix rate limiting issues, along with more conservative `PARALLEL_REQUESTS`
- Standardize code for `wallet_esplora_*`
- Uses the new BDK rustsqlite feature (in memory) instead of BDK's file store.

### Changelog notice

- fix BDK wallet example crates

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
