### PR TITLE
fix(electrum): Fix `fetch_prev_txout`

### DIFF
--- a/crates/electrum/src/electrum_ext.rs
+++ b/crates/electrum/src/electrum_ext.rs
@@ -523,10 +523,10 @@ fn fetch_prev_txout<C: ElectrumApi>(
     for tx in full_txs {
         for vin in &tx.input {
             let outpoint = vin.previous_output;
+            let vout = outpoint.vout;
             let prev_tx = fetch_tx(client, tx_cache, outpoint.txid)?;
-            for txout in prev_tx.output.clone() {
-                let _ = graph_update.insert_txout(outpoint, txout);
-            }
+            let txout = prev_tx.output[vout as usize].clone();
+            let _ = graph_update.insert_txout(outpoint, txout);
         }
     }
     Ok(())


### PR DESCRIPTION
Previously we inserted every `TxOut` of a previous tx at the same outpoint, which is incorrect because an outpoint only points to a single `TxOut`. Now just get the `TxOut` corresponding to the txin prevout and insert it with its outpoint.

### Notes to the reviewers

The bug in question was demonstrated in a discord comment https://discord.com/channels/753336465005608961/1239693193159639073/1239704153400414298 but I don't think we've opened an issue yet. Essentially, because of a mismatch between the outpoint and txout stored in TxGraph, we weren't summing the inputs correctly which caused `calculate_fee` to fail with `NegativeFee` error.

fixes #1419 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [ ] I've added tests to reproduce the issue which are now passing
