### PR TITLE
refactor(wallet): rename get_balance() to balance()

### DIFF
--- a/crates/wallet/README.md
+++ b/crates/wallet/README.md
@@ -101,7 +101,7 @@ fn main() {
 
 <!--     wallet.sync(&blockchain, SyncOptions::default())?; -->
 
-<!--     println!("Descriptor balance: {} SAT", wallet.get_balance()?); -->
+<!--     println!("Descriptor balance: {} SAT", wallet.balance()?); -->
 
 <!--     Ok(()) -->
 <!-- } -->

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -1216,7 +1216,7 @@ impl Wallet {
 
     /// Return the balance, separated into available, trusted-pending, untrusted-pending and immature
     /// values.
-    pub fn get_balance(&self) -> Balance {
+    pub fn balance(&self) -> Balance {
         self.indexed_graph.graph().balance(
             &self.chain,
             self.chain.tip().block_id(),

--- a/crates/wallet/tests/psbt.rs
+++ b/crates/wallet/tests/psbt.rs
@@ -171,7 +171,7 @@ fn test_psbt_multiple_internalkey_signers() {
     let keypair = Keypair::from_secret_key(&secp, &prv.inner);
 
     let (mut wallet, _) = get_funded_wallet(&desc);
-    let to_spend = wallet.get_balance().total();
+    let to_spend = wallet.balance().total();
     let send_to = wallet.peek_address(KeychainKind::External, 0);
     let mut builder = wallet.build_tx();
     builder.drain_to(send_to.script_pubkey()).drain_wallet();

--- a/crates/wallet/tests/wallet.rs
+++ b/crates/wallet/tests/wallet.rs
@@ -292,7 +292,7 @@ fn test_get_funded_wallet_balance() {
     // The funded wallet contains a tx with a 76_000 sats input and two outputs, one spending 25_000
     // to a foreign address and one returning 50_000 back to the wallet as change. The remaining 1000
     // sats are the transaction fee.
-    assert_eq!(wallet.get_balance().confirmed, Amount::from_sat(50_000));
+    assert_eq!(wallet.balance().confirmed, Amount::from_sat(50_000));
 }
 
 #[test]
@@ -3711,7 +3711,7 @@ fn test_spend_coinbase() {
     let not_yet_mature_time = confirmation_height + COINBASE_MATURITY - 1;
     let maturity_time = confirmation_height + COINBASE_MATURITY;
 
-    let balance = wallet.get_balance();
+    let balance = wallet.balance();
     assert_eq!(
         balance,
         Balance {
@@ -3762,7 +3762,7 @@ fn test_spend_coinbase() {
             hash: BlockHash::all_zeros(),
         })
         .unwrap();
-    let balance = wallet.get_balance();
+    let balance = wallet.balance();
     assert_eq!(
         balance,
         Balance {

--- a/example-crates/wallet_electrum/src/main.rs
+++ b/example-crates/wallet_electrum/src/main.rs
@@ -33,7 +33,7 @@ fn main() -> Result<(), anyhow::Error> {
     let address = wallet.next_unused_address(KeychainKind::External)?;
     println!("Generated Address: {}", address);
 
-    let balance = wallet.get_balance();
+    let balance = wallet.balance();
     println!("Wallet balance before syncing: {} sats", balance.total());
 
     print!("Syncing...");
@@ -65,7 +65,7 @@ fn main() -> Result<(), anyhow::Error> {
     wallet.apply_update(update)?;
     wallet.commit()?;
 
-    let balance = wallet.get_balance();
+    let balance = wallet.balance();
     println!("Wallet balance after syncing: {} sats", balance.total());
 
     if balance.total() < SEND_AMOUNT {

--- a/example-crates/wallet_esplora_async/src/main.rs
+++ b/example-crates/wallet_esplora_async/src/main.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<(), anyhow::Error> {
     let address = wallet.next_unused_address(KeychainKind::External)?;
     println!("Generated Address: {}", address);
 
-    let balance = wallet.get_balance();
+    let balance = wallet.balance();
     println!("Wallet balance before syncing: {} sats", balance.total());
 
     print!("Syncing...");
@@ -78,7 +78,7 @@ async fn main() -> Result<(), anyhow::Error> {
     wallet.commit()?;
     println!();
 
-    let balance = wallet.get_balance();
+    let balance = wallet.balance();
     println!("Wallet balance after syncing: {} sats", balance.total());
 
     if balance.total() < SEND_AMOUNT {

--- a/example-crates/wallet_esplora_blocking/src/main.rs
+++ b/example-crates/wallet_esplora_blocking/src/main.rs
@@ -29,7 +29,7 @@ fn main() -> Result<(), anyhow::Error> {
     let address = wallet.next_unused_address(KeychainKind::External)?;
     println!("Generated Address: {}", address);
 
-    let balance = wallet.get_balance();
+    let balance = wallet.balance();
     println!("Wallet balance before syncing: {} sats", balance.total());
 
     print!("Syncing...");
@@ -55,7 +55,7 @@ fn main() -> Result<(), anyhow::Error> {
     wallet.commit()?;
     println!();
 
-    let balance = wallet.get_balance();
+    let balance = wallet.balance();
     println!("Wallet balance after syncing: {} sats", balance.total());
 
     if balance.total() < SEND_AMOUNT {

--- a/example-crates/wallet_rpc/src/main.rs
+++ b/example-crates/wallet_rpc/src/main.rs
@@ -100,7 +100,7 @@ fn main() -> anyhow::Result<()> {
         start_load_wallet.elapsed().as_secs_f32()
     );
 
-    let balance = wallet.get_balance();
+    let balance = wallet.balance();
     println!("Wallet balance before syncing: {} sats", balance.total());
 
     let wallet_tip = wallet.latest_checkpoint();
@@ -163,7 +163,7 @@ fn main() -> anyhow::Result<()> {
         }
     }
     let wallet_tip_end = wallet.latest_checkpoint();
-    let balance = wallet.get_balance();
+    let balance = wallet.balance();
     println!(
         "Synced {} blocks in {}s",
         blocks_received,


### PR DESCRIPTION
### Description

fixes #1221

### Notes to the reviewers

See discussion in #1221.

### Changelog notice

Changed

- Wallet::get_balance() renamed to Wallet::balance()

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing