### PR TITLE
fix: typo on `SignedAmount` instead of `Amount`

### DIFF
--- a/crates/electrum/tests/test_electrum.rs
+++ b/crates/electrum/tests/test_electrum.rs
@@ -102,7 +102,7 @@ fn scan_detects_confirmed_tx() -> anyhow::Result<()> {
             .expect("Fee must exist")
             .abs()
             .to_unsigned()
-            .expect("valid `SignedAmount`");
+            .expect("valid `Amount`");
 
         // Check that the calculated fee matches the fee from the transaction data.
         assert_eq!(fee, tx_fee);


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

It fixes the typo on the `expect()` message introduced on #1426, noticed at https://github.com/bitcoindevkit/bdk/pull/1426#discussion_r1626761825

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

