### PR TITLE
No descriptor ids in spk txout index

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,2 +1,1 @@
 msrv="1.63.0"
-type-complexity-threshold = 275

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,2 @@
 msrv="1.63.0"
+type-complexity-threshold = 275

--- a/crates/chain/src/keychain.rs
+++ b/crates/chain/src/keychain.rs
@@ -12,7 +12,7 @@
 
 #[cfg(feature = "miniscript")]
 mod txout_index;
-use bitcoin::Amount;
+use bitcoin::{Amount, ScriptBuf};
 #[cfg(feature = "miniscript")]
 pub use txout_index::*;
 
@@ -48,6 +48,11 @@ impl Balance {
         self.confirmed + self.trusted_pending + self.untrusted_pending + self.immature
     }
 }
+
+/// A tuple of keychain index and corresponding [`ScriptBuf`].
+pub type Indexed<T> = (u32, T);
+/// A tuple of keychain, index and the [`ScriptBuf`] derived at that location.
+pub type KeychainIndexed<K, T> = ((K, u32), T);
 
 impl core::fmt::Display for Balance {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {

--- a/crates/chain/src/keychain.rs
+++ b/crates/chain/src/keychain.rs
@@ -49,9 +49,9 @@ impl Balance {
     }
 }
 
-/// A tuple of keychain index and corresponding [`ScriptBuf`].
+/// A tuple of keychain index and `T` representing the indexed value.
 pub type Indexed<T> = (u32, T);
-/// A tuple of keychain, index and the [`ScriptBuf`] derived at that location.
+/// A tuple of keychain `K`, derivation index (`u32`) and a `T` associated with them.
 pub type KeychainIndexed<K, T> = ((K, u32), T);
 
 impl core::fmt::Display for Balance {

--- a/crates/chain/src/keychain/txout_index.rs
+++ b/crates/chain/src/keychain/txout_index.rs
@@ -3,10 +3,10 @@ use crate::{
     indexed_tx_graph::Indexer,
     miniscript::{Descriptor, DescriptorPublicKey},
     spk_iter::BIP32_MAX_INDEX,
-    DescriptorExt, DescriptorId, SpkIterator, SpkTxOutIndex,
+    DescriptorExt, DescriptorId, IndexSpk, SpkIterator, SpkTxOutIndex,
 };
 use alloc::{borrow::ToOwned, vec::Vec};
-use bitcoin::{Amount, OutPoint, Script, ScriptBuf, SignedAmount, Transaction, TxOut, Txid};
+use bitcoin::{Amount, OutPoint, Script, SignedAmount, Transaction, TxOut, Txid};
 use core::{
     fmt::Debug,
     ops::{Bound, RangeBounds},
@@ -739,9 +739,9 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
         &mut self,
         keychain: &K,
         target_index: u32,
-    ) -> Option<(Vec<(u32, ScriptBuf)>, ChangeSet<K>)> {
+    ) -> Option<(Vec<IndexSpk>, ChangeSet<K>)> {
         let mut changeset = ChangeSet::default();
-        let mut spks: Vec<(u32, ScriptBuf)> = vec![];
+        let mut spks: Vec<IndexSpk> = vec![];
         while let Some((i, new)) = self.next_index(keychain) {
             if !new || i > target_index {
                 break;

--- a/crates/chain/src/keychain/txout_index.rs
+++ b/crates/chain/src/keychain/txout_index.rs
@@ -27,7 +27,11 @@ pub const DEFAULT_LOOKAHEAD: u32 = 25;
 ///
 /// There is a strict 1-to-1 relationship between descriptors and keychains. Each keychain has one
 /// and only one descriptor and each descriptor has one and only one keychain. The
-/// [`insert_descriptor`] method will return an error if you try and violate this invariant.
+/// [`insert_descriptor`] method will return an error if you try and violate this invariant. This
+/// rule is a proxy for a stronger rule: no two descriptors should produce the same script pubkey.
+/// Having two descriptors produce the same script pubkey should cause whichever keychain derives the
+/// script pubkey first to be the effective owner of it but you should not rely on this behaviour.
+/// ⚠ It is up you, the developer, not to violate this invariant.
 ///
 /// # Revealed script pubkeys
 ///

--- a/crates/chain/src/keychain/txout_index.rs
+++ b/crates/chain/src/keychain/txout_index.rs
@@ -154,8 +154,9 @@ impl<K: Clone + Ord + Debug> Indexer for KeychainTxOutIndex<K> {
 
     fn index_tx(&mut self, tx: &bitcoin::Transaction) -> Self::ChangeSet {
         let mut changeset = ChangeSet::<K>::default();
+        let txid = tx.compute_txid();
         for (op, txout) in tx.output.iter().enumerate() {
-            changeset.append(self.index_txout(OutPoint::new(tx.compute_txid(), op as u32), txout));
+            changeset.append(self.index_txout(OutPoint::new(txid, op as u32), txout));
         }
         changeset
     }

--- a/crates/chain/src/keychain/txout_index.rs
+++ b/crates/chain/src/keychain/txout_index.rs
@@ -29,9 +29,9 @@ pub const DEFAULT_LOOKAHEAD: u32 = 25;
 /// and only one descriptor and each descriptor has one and only one keychain. The
 /// [`insert_descriptor`] method will return an error if you try and violate this invariant. This
 /// rule is a proxy for a stronger rule: no two descriptors should produce the same script pubkey.
-/// Having two descriptors produce the same script pubkey should cause whichever keychain derives the
-/// script pubkey first to be the effective owner of it but you should not rely on this behaviour.
-/// ⚠ It is up you, the developer, not to violate this invariant.
+/// Having two descriptors produce the same script pubkey should cause whichever keychain derives
+/// the script pubkey first to be the effective owner of it but you should not rely on this
+/// behaviour. ⚠ It is up you, the developer, not to violate this invariant.
 ///
 /// # Revealed script pubkeys
 ///
@@ -341,7 +341,7 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
 }
 
 impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
-    /// Return the map of the keychain to descriptors.
+    /// Return all keychains and their corresponding descriptors.
     pub fn keychains(
         &self,
     ) -> impl DoubleEndedIterator<Item = (&K, &Descriptor<DescriptorPublicKey>)> + ExactSizeIterator + '_

--- a/crates/chain/src/keychain/txout_index.rs
+++ b/crates/chain/src/keychain/txout_index.rs
@@ -123,12 +123,12 @@ pub struct KeychainTxOutIndex<K> {
     /// keychain -> (descriptor id) map
     keychains_to_descriptor_ids: BTreeMap<K, DescriptorId>,
     /// descriptor id -> keychain map
-    descriptor_ids_to_keychains: BTreeMap<DescriptorId, K>,
+    descriptor_ids_to_keychains: HashMap<DescriptorId, K>,
     /// descriptor_id -> descriptor map
     /// This is a "monotone" map, meaning that its size keeps growing, i.e., we never delete
     /// descriptors from it. This is useful for revealing spks for descriptors that don't have
     /// keychains associated.
-    descriptor_ids_to_descriptors: BTreeMap<DescriptorId, Descriptor<DescriptorPublicKey>>,
+    descriptor_ids_to_descriptors: HashMap<DescriptorId, Descriptor<DescriptorPublicKey>>,
     /// last revealed indices for each descriptor.
     last_revealed: HashMap<DescriptorId, u32>,
     /// lookahead setting
@@ -201,8 +201,8 @@ impl<K> KeychainTxOutIndex<K> {
     pub fn new(lookahead: u32) -> Self {
         Self {
             inner: SpkTxOutIndex::default(),
-            keychains_to_descriptor_ids: BTreeMap::new(),
-            descriptor_ids_to_descriptors: BTreeMap::new(),
+            keychains_to_descriptor_ids: Default::default(),
+            descriptor_ids_to_descriptors: Default::default(),
             descriptor_ids_to_keychains: Default::default(),
             last_revealed: Default::default(),
             lookahead,

--- a/crates/chain/src/lib.rs
+++ b/crates/chain/src/lib.rs
@@ -28,6 +28,7 @@ pub use chain_data::*;
 pub mod indexed_tx_graph;
 pub use indexed_tx_graph::IndexedTxGraph;
 pub mod keychain;
+pub use keychain::{Indexed, KeychainIndexed};
 pub mod local_chain;
 mod tx_data_traits;
 pub mod tx_graph;

--- a/crates/chain/src/spk_client.rs
+++ b/crates/chain/src/spk_client.rs
@@ -1,7 +1,8 @@
 //! Helper types for spk-based blockchain clients.
 
 use crate::{
-    collections::BTreeMap, local_chain::CheckPoint, ConfirmationTimeHeightAnchor, IndexSpk, TxGraph,
+    collections::BTreeMap, keychain::Indexed, local_chain::CheckPoint,
+    ConfirmationTimeHeightAnchor, TxGraph,
 };
 use alloc::{boxed::Box, vec::Vec};
 use bitcoin::{OutPoint, Script, ScriptBuf, Txid};
@@ -195,7 +196,7 @@ pub struct FullScanRequest<K> {
     /// [`LocalChain::tip`]: crate::local_chain::LocalChain::tip
     pub chain_tip: CheckPoint,
     /// Iterators of script pubkeys indexed by the keychain index.
-    pub spks_by_keychain: BTreeMap<K, Box<dyn Iterator<Item = IndexSpk> + Send>>,
+    pub spks_by_keychain: BTreeMap<K, Box<dyn Iterator<Item = Indexed<ScriptBuf>> + Send>>,
 }
 
 impl<K: Ord + Clone> FullScanRequest<K> {
@@ -238,7 +239,7 @@ impl<K: Ord + Clone> FullScanRequest<K> {
     pub fn set_spks_for_keychain(
         mut self,
         keychain: K,
-        spks: impl IntoIterator<IntoIter = impl Iterator<Item = IndexSpk> + Send + 'static>,
+        spks: impl IntoIterator<IntoIter = impl Iterator<Item = Indexed<ScriptBuf>> + Send + 'static>,
     ) -> Self {
         self.spks_by_keychain
             .insert(keychain, Box::new(spks.into_iter()));
@@ -252,7 +253,7 @@ impl<K: Ord + Clone> FullScanRequest<K> {
     pub fn chain_spks_for_keychain(
         mut self,
         keychain: K,
-        spks: impl IntoIterator<IntoIter = impl Iterator<Item = IndexSpk> + Send + 'static>,
+        spks: impl IntoIterator<IntoIter = impl Iterator<Item = Indexed<ScriptBuf>> + Send + 'static>,
     ) -> Self {
         match self.spks_by_keychain.remove(&keychain) {
             // clippy here suggests to remove `into_iter` from `spks.into_iter()`, but doing so

--- a/crates/chain/src/spk_client.rs
+++ b/crates/chain/src/spk_client.rs
@@ -166,7 +166,7 @@ impl SyncRequest {
         self.chain_spks(
             index
                 .revealed_spks(spk_range)
-                .map(|(_, _, spk)| spk.to_owned())
+                .map(|(_, spk)| spk.to_owned())
                 .collect::<Vec<_>>(),
         )
     }

--- a/crates/chain/src/spk_client.rs
+++ b/crates/chain/src/spk_client.rs
@@ -1,7 +1,7 @@
 //! Helper types for spk-based blockchain clients.
 
 use crate::{
-    collections::BTreeMap, local_chain::CheckPoint, ConfirmationTimeHeightAnchor, TxGraph,
+    collections::BTreeMap, local_chain::CheckPoint, ConfirmationTimeHeightAnchor, IndexSpk, TxGraph,
 };
 use alloc::{boxed::Box, vec::Vec};
 use bitcoin::{OutPoint, Script, ScriptBuf, Txid};
@@ -195,7 +195,7 @@ pub struct FullScanRequest<K> {
     /// [`LocalChain::tip`]: crate::local_chain::LocalChain::tip
     pub chain_tip: CheckPoint,
     /// Iterators of script pubkeys indexed by the keychain index.
-    pub spks_by_keychain: BTreeMap<K, Box<dyn Iterator<Item = (u32, ScriptBuf)> + Send>>,
+    pub spks_by_keychain: BTreeMap<K, Box<dyn Iterator<Item = IndexSpk> + Send>>,
 }
 
 impl<K: Ord + Clone> FullScanRequest<K> {
@@ -238,7 +238,7 @@ impl<K: Ord + Clone> FullScanRequest<K> {
     pub fn set_spks_for_keychain(
         mut self,
         keychain: K,
-        spks: impl IntoIterator<IntoIter = impl Iterator<Item = (u32, ScriptBuf)> + Send + 'static>,
+        spks: impl IntoIterator<IntoIter = impl Iterator<Item = IndexSpk> + Send + 'static>,
     ) -> Self {
         self.spks_by_keychain
             .insert(keychain, Box::new(spks.into_iter()));
@@ -252,7 +252,7 @@ impl<K: Ord + Clone> FullScanRequest<K> {
     pub fn chain_spks_for_keychain(
         mut self,
         keychain: K,
-        spks: impl IntoIterator<IntoIter = impl Iterator<Item = (u32, ScriptBuf)> + Send + 'static>,
+        spks: impl IntoIterator<IntoIter = impl Iterator<Item = IndexSpk> + Send + 'static>,
     ) -> Self {
         match self.spks_by_keychain.remove(&keychain) {
             // clippy here suggests to remove `into_iter` from `spks.into_iter()`, but doing so

--- a/crates/chain/src/spk_iter.rs
+++ b/crates/chain/src/spk_iter.rs
@@ -7,6 +7,9 @@ use core::{borrow::Borrow, ops::Bound, ops::RangeBounds};
 /// Maximum [BIP32](https://bips.xyz/32) derivation index.
 pub const BIP32_MAX_INDEX: u32 = (1 << 31) - 1;
 
+/// A tuple of keychain index and corresponding [`ScriptBuf`].
+pub type IndexSpk = (u32, ScriptBuf);
+
 /// An iterator for derived script pubkeys.
 ///
 /// [`SpkIterator`] is an implementation of the [`Iterator`] trait which possesses its own `next()`
@@ -97,7 +100,7 @@ impl<D> Iterator for SpkIterator<D>
 where
     D: Borrow<Descriptor<DescriptorPublicKey>>,
 {
-    type Item = (u32, ScriptBuf);
+    type Item = IndexSpk;
 
     fn next(&mut self) -> Option<Self::Item> {
         // For non-wildcard descriptors, we expect the first element to be Some((0, spk)), then None after.

--- a/crates/chain/src/spk_iter.rs
+++ b/crates/chain/src/spk_iter.rs
@@ -1,14 +1,12 @@
 use crate::{
     bitcoin::{secp256k1::Secp256k1, ScriptBuf},
+    keychain::Indexed,
     miniscript::{Descriptor, DescriptorPublicKey},
 };
 use core::{borrow::Borrow, ops::Bound, ops::RangeBounds};
 
 /// Maximum [BIP32](https://bips.xyz/32) derivation index.
 pub const BIP32_MAX_INDEX: u32 = (1 << 31) - 1;
-
-/// A tuple of keychain index and corresponding [`ScriptBuf`].
-pub type IndexSpk = (u32, ScriptBuf);
 
 /// An iterator for derived script pubkeys.
 ///
@@ -100,7 +98,7 @@ impl<D> Iterator for SpkIterator<D>
 where
     D: Borrow<Descriptor<DescriptorPublicKey>>,
 {
-    type Item = IndexSpk;
+    type Item = Indexed<ScriptBuf>;
 
     fn next(&mut self) -> Option<Self::Item> {
         // For non-wildcard descriptors, we expect the first element to be Some((0, spk)), then None after.

--- a/crates/chain/src/spk_iter.rs
+++ b/crates/chain/src/spk_iter.rs
@@ -158,8 +158,12 @@ mod test {
         let (external_descriptor,_) = Descriptor::<DescriptorPublicKey>::parse_descriptor(&secp, "tr([73c5da0a/86'/0'/0']xprv9xgqHN7yz9MwCkxsBPN5qetuNdQSUttZNKw1dcYTV4mkaAFiBVGQziHs3NRSWMkCzvgjEe3n9xV8oYywvM8at9yRqyaZVz6TYYhX98VjsUk/0/*)").unwrap();
         let (internal_descriptor,_) = Descriptor::<DescriptorPublicKey>::parse_descriptor(&secp, "tr([73c5da0a/86'/0'/0']xprv9xgqHN7yz9MwCkxsBPN5qetuNdQSUttZNKw1dcYTV4mkaAFiBVGQziHs3NRSWMkCzvgjEe3n9xV8oYywvM8at9yRqyaZVz6TYYhX98VjsUk/1/*)").unwrap();
 
-        let _ = txout_index.insert_descriptor(TestKeychain::External, external_descriptor.clone());
-        let _ = txout_index.insert_descriptor(TestKeychain::Internal, internal_descriptor.clone());
+        let _ = txout_index
+            .insert_descriptor(TestKeychain::External, external_descriptor.clone())
+            .unwrap();
+        let _ = txout_index
+            .insert_descriptor(TestKeychain::Internal, internal_descriptor.clone())
+            .unwrap();
 
         (txout_index, external_descriptor, internal_descriptor)
     }

--- a/crates/chain/src/spk_txout_index.rs
+++ b/crates/chain/src/spk_txout_index.rs
@@ -52,7 +52,7 @@ impl<I> Default for SpkTxOutIndex<I> {
     }
 }
 
-impl<I: Clone + Ord> Indexer for SpkTxOutIndex<I> {
+impl<I: Clone + Ord + core::fmt::Debug> Indexer for SpkTxOutIndex<I> {
     type ChangeSet = ();
 
     fn index_txout(&mut self, outpoint: OutPoint, txout: &TxOut) -> Self::ChangeSet {
@@ -76,7 +76,7 @@ impl<I: Clone + Ord> Indexer for SpkTxOutIndex<I> {
     }
 }
 
-impl<I: Clone + Ord> SpkTxOutIndex<I> {
+impl<I: Clone + Ord + core::fmt::Debug> SpkTxOutIndex<I> {
     /// Scans a transaction's outputs for matching script pubkeys.
     ///
     /// Typically, this is used in two situations:

--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -34,7 +34,10 @@ fn insert_relevant_txs() {
     let mut graph = IndexedTxGraph::<ConfirmationHeightAnchor, KeychainTxOutIndex<()>>::new(
         KeychainTxOutIndex::new(10),
     );
-    let _ = graph.index.insert_descriptor((), descriptor.clone());
+    let _ = graph
+        .index
+        .insert_descriptor((), descriptor.clone())
+        .unwrap();
 
     let tx_a = Transaction {
         output: vec![

--- a/crates/chain/tests/test_keychain_txout_index.rs
+++ b/crates/chain/tests/test_keychain_txout_index.rs
@@ -34,8 +34,12 @@ fn init_txout_index(
 ) -> bdk_chain::keychain::KeychainTxOutIndex<TestKeychain> {
     let mut txout_index = bdk_chain::keychain::KeychainTxOutIndex::<TestKeychain>::new(lookahead);
 
-    let _ = txout_index.insert_descriptor(TestKeychain::External, external_descriptor);
-    let _ = txout_index.insert_descriptor(TestKeychain::Internal, internal_descriptor);
+    let _ = txout_index
+        .insert_descriptor(TestKeychain::External, external_descriptor)
+        .unwrap();
+    let _ = txout_index
+        .insert_descriptor(TestKeychain::Internal, internal_descriptor)
+        .unwrap();
 
     txout_index
 }
@@ -458,7 +462,9 @@ fn test_non_wildcard_derivations() {
         .unwrap()
         .script_pubkey();
 
-    let _ = txout_index.insert_descriptor(TestKeychain::External, no_wildcard_descriptor.clone());
+    let _ = txout_index
+        .insert_descriptor(TestKeychain::External, no_wildcard_descriptor.clone())
+        .unwrap();
 
     // given:
     // - `txout_index` with no stored scripts
@@ -702,7 +708,9 @@ fn applying_changesets_one_by_one_vs_aggregate_must_have_same_result() {
 fn assigning_same_descriptor_to_multiple_keychains_should_error() {
     let desc = parse_descriptor(DESCRIPTORS[0]);
     let mut indexer = KeychainTxOutIndex::<TestKeychain>::new(0);
-    let _ = indexer.insert_descriptor(TestKeychain::Internal, desc.clone());
+    let _ = indexer
+        .insert_descriptor(TestKeychain::Internal, desc.clone())
+        .unwrap();
     assert!(indexer
         .insert_descriptor(TestKeychain::External, desc)
         .is_err())
@@ -726,7 +734,7 @@ fn when_querying_over_a_range_of_keychains_the_utxos_should_show_up() {
 
     for (i, descriptor) in DESCRIPTORS.iter().enumerate() {
         let descriptor = parse_descriptor(descriptor);
-        let _ = indexer.insert_descriptor(i, descriptor.clone());
+        let _ = indexer.insert_descriptor(i, descriptor.clone()).unwrap();
         if i != 4 {
             // skip one in the middle to see if uncovers any bugs
             indexer.reveal_next_spk(&i);

--- a/crates/chain/tests/test_keychain_txout_index.rs
+++ b/crates/chain/tests/test_keychain_txout_index.rs
@@ -408,10 +408,10 @@ fn test_wildcard_derivations() {
     // - next_unused() == ((0, <spk>), keychain::ChangeSet:is_empty())
     assert_eq!(txout_index.next_index(&TestKeychain::External).unwrap(), (0, true));
     let (spk, changeset) = txout_index.reveal_next_spk(&TestKeychain::External).unwrap();
-    assert_eq!(spk, (0_u32, external_spk_0.as_script()));
+    assert_eq!(spk, (0_u32, external_spk_0.clone()));
     assert_eq!(&changeset.last_revealed, &[(external_descriptor.descriptor_id(), 0)].into());
     let (spk, changeset) = txout_index.next_unused_spk(&TestKeychain::External).unwrap();
-    assert_eq!(spk, (0_u32, external_spk_0.as_script()));
+    assert_eq!(spk, (0_u32, external_spk_0.clone()));
     assert_eq!(&changeset.last_revealed, &[].into());
 
     // - derived till 25
@@ -431,12 +431,12 @@ fn test_wildcard_derivations() {
     assert_eq!(txout_index.next_index(&TestKeychain::External).unwrap(), (26, true));
 
     let (spk, changeset) = txout_index.reveal_next_spk(&TestKeychain::External).unwrap();
-    assert_eq!(spk, (26, external_spk_26.as_script()));
+    assert_eq!(spk, (26, external_spk_26));
 
     assert_eq!(&changeset.last_revealed, &[(external_descriptor.descriptor_id(), 26)].into());
 
     let (spk, changeset) = txout_index.next_unused_spk(&TestKeychain::External).unwrap();
-    assert_eq!(spk, (16, external_spk_16.as_script()));
+    assert_eq!(spk, (16, external_spk_16));
     assert_eq!(&changeset.last_revealed, &[].into());
 
     // - Use all the derived till 26.
@@ -446,7 +446,7 @@ fn test_wildcard_derivations() {
     });
 
     let (spk, changeset) = txout_index.next_unused_spk(&TestKeychain::External).unwrap();
-    assert_eq!(spk, (27, external_spk_27.as_script()));
+    assert_eq!(spk, (27, external_spk_27));
     assert_eq!(&changeset.last_revealed, &[(external_descriptor.descriptor_id(), 27)].into());
 }
 
@@ -479,7 +479,7 @@ fn test_non_wildcard_derivations() {
     let (spk, changeset) = txout_index
         .reveal_next_spk(&TestKeychain::External)
         .unwrap();
-    assert_eq!(spk, (0, external_spk.as_script()));
+    assert_eq!(spk, (0, external_spk.clone()));
     assert_eq!(
         &changeset.last_revealed,
         &[(no_wildcard_descriptor.descriptor_id(), 0)].into()
@@ -488,7 +488,7 @@ fn test_non_wildcard_derivations() {
     let (spk, changeset) = txout_index
         .next_unused_spk(&TestKeychain::External)
         .unwrap();
-    assert_eq!(spk, (0, external_spk.as_script()));
+    assert_eq!(spk, (0, external_spk.clone()));
     assert_eq!(&changeset.last_revealed, &[].into());
 
     // given:
@@ -506,13 +506,13 @@ fn test_non_wildcard_derivations() {
     let (spk, changeset) = txout_index
         .reveal_next_spk(&TestKeychain::External)
         .unwrap();
-    assert_eq!(spk, (0, external_spk.as_script()));
+    assert_eq!(spk, (0, external_spk.clone()));
     assert_eq!(&changeset.last_revealed, &[].into());
 
     let (spk, changeset) = txout_index
         .next_unused_spk(&TestKeychain::External)
         .unwrap();
-    assert_eq!(spk, (0, external_spk.as_script()));
+    assert_eq!(spk, (0, external_spk.clone()));
     assert_eq!(&changeset.last_revealed, &[].into());
     let (revealed_spks, revealed_changeset) = txout_index
         .reveal_to_target(&TestKeychain::External, 200)

--- a/crates/chain/tests/test_keychain_txout_index.rs
+++ b/crates/chain/tests/test_keychain_txout_index.rs
@@ -98,7 +98,7 @@ fn append_changesets_check_last_revealed() {
 }
 
 #[test]
-fn test_apply_changeset_with_different_descriptors_to_same_keychain() {
+fn when_apply_contradictory_changesets_they_are_ignored() {
     let external_descriptor = parse_descriptor(DESCRIPTORS[0]);
     let internal_descriptor = parse_descriptor(DESCRIPTORS[1]);
     let mut txout_index =
@@ -120,7 +120,7 @@ fn test_apply_changeset_with_different_descriptors_to_same_keychain() {
     assert_eq!(
         txout_index.keychains().collect::<Vec<_>>(),
         vec![
-            (&TestKeychain::External, &internal_descriptor),
+            (&TestKeychain::External, &external_descriptor),
             (&TestKeychain::Internal, &internal_descriptor)
         ]
     );
@@ -134,8 +134,8 @@ fn test_apply_changeset_with_different_descriptors_to_same_keychain() {
     assert_eq!(
         txout_index.keychains().collect::<Vec<_>>(),
         vec![
-            (&TestKeychain::External, &internal_descriptor),
-            (&TestKeychain::Internal, &external_descriptor)
+            (&TestKeychain::External, &external_descriptor),
+            (&TestKeychain::Internal, &internal_descriptor)
         ]
     );
 }
@@ -156,7 +156,7 @@ fn test_set_all_derivation_indices() {
     ]
     .into();
     assert_eq!(
-        txout_index.reveal_to_target_multi(&derive_to).1,
+        txout_index.reveal_to_target_multi(&derive_to),
         ChangeSet {
             keychains_added: BTreeMap::new(),
             last_revealed: last_revealed.clone()
@@ -164,7 +164,7 @@ fn test_set_all_derivation_indices() {
     );
     assert_eq!(txout_index.last_revealed_indices(), derive_to);
     assert_eq!(
-        txout_index.reveal_to_target_multi(&derive_to).1,
+        txout_index.reveal_to_target_multi(&derive_to),
         keychain::ChangeSet::default(),
         "no changes if we set to the same thing"
     );
@@ -190,7 +190,7 @@ fn test_lookahead() {
             .reveal_to_target(&TestKeychain::External, index)
             .unwrap();
         assert_eq!(
-            revealed_spks.collect::<Vec<_>>(),
+            revealed_spks,
             vec![(index, spk_at_index(&external_descriptor, index))],
         );
         assert_eq!(
@@ -241,7 +241,7 @@ fn test_lookahead() {
         .reveal_to_target(&TestKeychain::Internal, 24)
         .unwrap();
     assert_eq!(
-        revealed_spks.collect::<Vec<_>>(),
+        revealed_spks,
         (0..=24)
             .map(|index| (index, spk_at_index(&internal_descriptor, index)))
             .collect::<Vec<_>>(),
@@ -511,7 +511,7 @@ fn test_non_wildcard_derivations() {
     let (revealed_spks, revealed_changeset) = txout_index
         .reveal_to_target(&TestKeychain::External, 200)
         .unwrap();
-    assert_eq!(revealed_spks.count(), 0);
+    assert_eq!(revealed_spks.len(), 0);
     assert!(revealed_changeset.is_empty());
 
     // we check that spks_of_keychain returns a SpkIterator with just one element
@@ -591,19 +591,17 @@ fn lookahead_to_target() {
 
         let keychain_test_cases = [
             (
-                external_descriptor.descriptor_id(),
                 TestKeychain::External,
                 t.external_last_revealed,
                 t.external_target,
             ),
             (
-                internal_descriptor.descriptor_id(),
                 TestKeychain::Internal,
                 t.internal_last_revealed,
                 t.internal_target,
             ),
         ];
-        for (descriptor_id, keychain, last_revealed, target) in keychain_test_cases {
+        for (keychain, last_revealed, target) in keychain_test_cases {
             if let Some(target) = target {
                 let original_last_stored_index = match last_revealed {
                     Some(last_revealed) => Some(last_revealed + t.lookahead),
@@ -619,59 +617,15 @@ fn lookahead_to_target() {
                 let keys = index
                     .inner()
                     .all_spks()
-                    .range((descriptor_id, 0)..=(descriptor_id, u32::MAX))
-                    .map(|(k, _)| *k)
+                    .range((keychain.clone(), 0)..=(keychain.clone(), u32::MAX))
+                    .map(|(k, _)| k.clone())
                     .collect::<Vec<_>>();
-                let exp_keys = core::iter::repeat(descriptor_id)
+                let exp_keys = core::iter::repeat(keychain)
                     .zip(0_u32..=exp_last_stored_index)
                     .collect::<Vec<_>>();
                 assert_eq!(keys, exp_keys);
             }
         }
-    }
-}
-
-/// `::index_txout` should still index txouts with spks derived from descriptors without keychains.
-/// This includes properly refilling the lookahead for said descriptors.
-#[test]
-fn index_txout_after_changing_descriptor_under_keychain() {
-    let secp = bdk_chain::bitcoin::secp256k1::Secp256k1::signing_only();
-    let (desc_a, _) = Descriptor::<DescriptorPublicKey>::parse_descriptor(&secp, DESCRIPTORS[0])
-        .expect("descriptor 0 must be valid");
-    let (desc_b, _) = Descriptor::<DescriptorPublicKey>::parse_descriptor(&secp, DESCRIPTORS[1])
-        .expect("descriptor 1 must be valid");
-    let desc_id_a = desc_a.descriptor_id();
-
-    let mut txout_index = bdk_chain::keychain::KeychainTxOutIndex::<()>::new(10);
-
-    // Introduce `desc_a` under keychain `()` and replace the descriptor.
-    let _ = txout_index.insert_descriptor((), desc_a.clone());
-    let _ = txout_index.insert_descriptor((), desc_b.clone());
-
-    // Loop through spks in intervals of `lookahead` to create outputs with. We should always be
-    // able to index these outputs if `lookahead` is respected.
-    let spk_indices = [9, 19, 29, 39];
-    for i in spk_indices {
-        let spk_at_index = desc_a
-            .at_derivation_index(i)
-            .expect("must derive")
-            .script_pubkey();
-        let index_changeset = txout_index.index_txout(
-            // Use spk derivation index as vout as we just want an unique outpoint.
-            OutPoint::new(h!("mock_tx"), i as _),
-            &TxOut {
-                value: Amount::from_sat(10_000),
-                script_pubkey: spk_at_index,
-            },
-        );
-        assert_eq!(
-            index_changeset,
-            bdk_chain::keychain::ChangeSet {
-                keychains_added: BTreeMap::default(),
-                last_revealed: [(desc_id_a, i)].into(),
-            },
-            "must always increase last active if impl respects lookahead"
-        );
     }
 }
 
@@ -683,19 +637,20 @@ fn insert_descriptor_no_change() {
     let mut txout_index = KeychainTxOutIndex::<()>::default();
     assert_eq!(
         txout_index.insert_descriptor((), desc.clone()),
-        keychain::ChangeSet {
+        Ok(keychain::ChangeSet {
             keychains_added: [((), desc.clone())].into(),
             last_revealed: Default::default()
-        },
+        }),
     );
     assert_eq!(
         txout_index.insert_descriptor((), desc.clone()),
-        keychain::ChangeSet::default(),
+        Ok(keychain::ChangeSet::default()),
         "inserting the same descriptor for keychain should return an empty changeset",
     );
 }
 
 #[test]
+#[cfg(not(debug_assertions))]
 fn applying_changesets_one_by_one_vs_aggregate_must_have_same_result() {
     let desc = parse_descriptor(DESCRIPTORS[0]);
     let changesets: &[ChangeSet<TestKeychain>] = &[
@@ -743,39 +698,25 @@ fn applying_changesets_one_by_one_vs_aggregate_must_have_same_result() {
     );
 }
 
-// When the same descriptor is associated with various keychains,
-// index methods only return the highest keychain by Ord
 #[test]
-fn test_only_highest_ord_keychain_is_returned() {
+fn assigning_same_descriptor_to_multiple_keychains_should_error() {
     let desc = parse_descriptor(DESCRIPTORS[0]);
-
     let mut indexer = KeychainTxOutIndex::<TestKeychain>::new(0);
     let _ = indexer.insert_descriptor(TestKeychain::Internal, desc.clone());
-    let _ = indexer.insert_descriptor(TestKeychain::External, desc);
+    assert!(indexer
+        .insert_descriptor(TestKeychain::External, desc)
+        .is_err())
+}
 
-    // reveal_next_spk will work with either keychain
-    let spk0: ScriptBuf = indexer
-        .reveal_next_spk(&TestKeychain::External)
-        .unwrap()
-        .0
-         .1
-        .into();
-    let spk1: ScriptBuf = indexer
-        .reveal_next_spk(&TestKeychain::Internal)
-        .unwrap()
-        .0
-         .1
-        .into();
-
-    // index_of_spk will always return External
-    assert_eq!(
-        indexer.index_of_spk(&spk0),
-        Some((TestKeychain::External, 0))
-    );
-    assert_eq!(
-        indexer.index_of_spk(&spk1),
-        Some((TestKeychain::External, 1))
-    );
+#[test]
+fn reassigning_keychain_to_a_new_descriptor_should_error() {
+    let desc1 = parse_descriptor(DESCRIPTORS[0]);
+    let desc2 = parse_descriptor(DESCRIPTORS[1]);
+    let mut indexer = KeychainTxOutIndex::<TestKeychain>::new(0);
+    let _ = indexer.insert_descriptor(TestKeychain::Internal, desc1);
+    assert!(indexer
+        .insert_descriptor(TestKeychain::Internal, desc2)
+        .is_err());
 }
 
 #[test]
@@ -786,27 +727,29 @@ fn when_querying_over_a_range_of_keychains_the_utxos_should_show_up() {
     for (i, descriptor) in DESCRIPTORS.iter().enumerate() {
         let descriptor = parse_descriptor(descriptor);
         let _ = indexer.insert_descriptor(i, descriptor.clone());
-        indexer.reveal_next_spk(&i);
+        if i != 4 {
+            // skip one in the middle to see if uncovers any bugs
+            indexer.reveal_next_spk(&i);
+        }
         tx.output.push(TxOut {
             script_pubkey: descriptor.at_derivation_index(0).unwrap().script_pubkey(),
             value: Amount::from_sat(10_000),
         });
     }
 
-    let _ = indexer.index_tx(&tx);
-    assert_eq!(indexer.outpoints().count(), DESCRIPTORS.len());
+    let n_spks = DESCRIPTORS.len() - /*we skipped one*/ 1;
 
-    assert_eq!(
-        indexer.revealed_spks(0..DESCRIPTORS.len()).count(),
-        DESCRIPTORS.len()
-    );
+    let _ = indexer.index_tx(&tx);
+    assert_eq!(indexer.outpoints().len(), n_spks);
+
+    assert_eq!(indexer.revealed_spks(0..DESCRIPTORS.len()).count(), n_spks);
     assert_eq!(indexer.revealed_spks(1..4).count(), 4 - 1);
     assert_eq!(
         indexer.net_value(&tx, 0..DESCRIPTORS.len()).to_sat(),
-        (10_000 * DESCRIPTORS.len()) as i64
+        (10_000 * n_spks) as i64
     );
     assert_eq!(
-        indexer.net_value(&tx, 3..5).to_sat(),
-        (10_000 * (5 - 3)) as i64
+        indexer.net_value(&tx, 3..6).to_sat(),
+        (10_000 * (6 - 3 - /*the skipped one*/ 1)) as i64
     );
 }

--- a/crates/esplora/src/async_ext.rs
+++ b/crates/esplora/src/async_ext.rs
@@ -8,7 +8,7 @@ use bdk_chain::{
     local_chain::CheckPoint,
     BlockId, ConfirmationTimeHeightAnchor, TxGraph,
 };
-use bdk_chain::{Anchor, IndexSpk};
+use bdk_chain::{Anchor, Indexed};
 use esplora_client::{Amount, TxStatus};
 use futures::{stream::FuturesOrdered, TryStreamExt};
 
@@ -236,7 +236,7 @@ async fn full_scan_for_index_and_graph<K: Ord + Clone + Send>(
     client: &esplora_client::AsyncClient,
     keychain_spks: BTreeMap<
         K,
-        impl IntoIterator<IntoIter = impl Iterator<Item = IndexSpk> + Send> + Send,
+        impl IntoIterator<IntoIter = impl Iterator<Item = Indexed<ScriptBuf>> + Send> + Send,
     >,
     stop_gap: usize,
     parallel_requests: usize,

--- a/crates/esplora/src/async_ext.rs
+++ b/crates/esplora/src/async_ext.rs
@@ -2,13 +2,13 @@ use std::collections::BTreeSet;
 
 use async_trait::async_trait;
 use bdk_chain::spk_client::{FullScanRequest, FullScanResult, SyncRequest, SyncResult};
-use bdk_chain::Anchor;
 use bdk_chain::{
     bitcoin::{BlockHash, OutPoint, ScriptBuf, TxOut, Txid},
     collections::BTreeMap,
     local_chain::CheckPoint,
     BlockId, ConfirmationTimeHeightAnchor, TxGraph,
 };
+use bdk_chain::{Anchor, IndexSpk};
 use esplora_client::{Amount, TxStatus};
 use futures::{stream::FuturesOrdered, TryStreamExt};
 
@@ -236,7 +236,7 @@ async fn full_scan_for_index_and_graph<K: Ord + Clone + Send>(
     client: &esplora_client::AsyncClient,
     keychain_spks: BTreeMap<
         K,
-        impl IntoIterator<IntoIter = impl Iterator<Item = (u32, ScriptBuf)> + Send> + Send,
+        impl IntoIterator<IntoIter = impl Iterator<Item = IndexSpk> + Send> + Send,
     >,
     stop_gap: usize,
     parallel_requests: usize,

--- a/crates/esplora/src/blocking_ext.rs
+++ b/crates/esplora/src/blocking_ext.rs
@@ -9,7 +9,7 @@ use bdk_chain::{
     local_chain::CheckPoint,
     BlockId, ConfirmationTimeHeightAnchor, TxGraph,
 };
-use bdk_chain::{Anchor, IndexSpk};
+use bdk_chain::{Anchor, Indexed};
 use esplora_client::TxStatus;
 
 use crate::anchor_from_status;
@@ -217,7 +217,7 @@ fn chain_update<A: Anchor>(
 /// [`KeychainTxOutIndex`](bdk_chain::keychain::KeychainTxOutIndex).
 fn full_scan_for_index_and_graph_blocking<K: Ord + Clone>(
     client: &esplora_client::BlockingClient,
-    keychain_spks: BTreeMap<K, impl IntoIterator<Item = IndexSpk>>,
+    keychain_spks: BTreeMap<K, impl IntoIterator<Item = Indexed<ScriptBuf>>>,
     stop_gap: usize,
     parallel_requests: usize,
 ) -> Result<(TxGraph<ConfirmationTimeHeightAnchor>, BTreeMap<K, u32>), Error> {

--- a/crates/esplora/src/blocking_ext.rs
+++ b/crates/esplora/src/blocking_ext.rs
@@ -4,12 +4,12 @@ use std::usize;
 
 use bdk_chain::collections::BTreeMap;
 use bdk_chain::spk_client::{FullScanRequest, FullScanResult, SyncRequest, SyncResult};
-use bdk_chain::Anchor;
 use bdk_chain::{
     bitcoin::{Amount, BlockHash, OutPoint, ScriptBuf, TxOut, Txid},
     local_chain::CheckPoint,
     BlockId, ConfirmationTimeHeightAnchor, TxGraph,
 };
+use bdk_chain::{Anchor, IndexSpk};
 use esplora_client::TxStatus;
 
 use crate::anchor_from_status;
@@ -217,7 +217,7 @@ fn chain_update<A: Anchor>(
 /// [`KeychainTxOutIndex`](bdk_chain::keychain::KeychainTxOutIndex).
 fn full_scan_for_index_and_graph_blocking<K: Ord + Clone>(
     client: &esplora_client::BlockingClient,
-    keychain_spks: BTreeMap<K, impl IntoIterator<Item = (u32, ScriptBuf)>>,
+    keychain_spks: BTreeMap<K, impl IntoIterator<Item = IndexSpk>>,
     stop_gap: usize,
     parallel_requests: usize,
 ) -> Result<(TxGraph<ConfirmationTimeHeightAnchor>, BTreeMap<K, u32>), Error> {

--- a/crates/wallet/src/descriptor/error.rs
+++ b/crates/wallet/src/descriptor/error.rs
@@ -23,7 +23,6 @@ pub enum Error {
     HardenedDerivationXpub,
     /// The descriptor contains multipath keys
     MultiPath,
-
     /// Error thrown while working with [`keys`](crate::keys)
     Key(crate::keys::KeyError),
     /// Error while extracting and manipulating policies

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -29,7 +29,7 @@ use bdk_chain::{
     spk_client::{FullScanRequest, FullScanResult, SyncRequest, SyncResult},
     tx_graph::{CanonicalTx, TxGraph},
     Append, BlockId, ChainPosition, ConfirmationTime, ConfirmationTimeHeightAnchor, FullTxOut,
-    IndexedTxGraph,
+    IndexSpk, IndexedTxGraph,
 };
 use bdk_persist::{Persist, PersistBackend};
 use bitcoin::secp256k1::{All, Secp256k1};
@@ -910,7 +910,7 @@ impl Wallet {
     /// script pubkeys the wallet is storing internally).
     pub fn all_unbounded_spk_iters(
         &self,
-    ) -> BTreeMap<KeychainKind, impl Iterator<Item = (u32, ScriptBuf)> + Clone> {
+    ) -> BTreeMap<KeychainKind, impl Iterator<Item = IndexSpk> + Clone> {
         self.indexed_graph.index.all_unbounded_spk_iters()
     }
 
@@ -922,7 +922,7 @@ impl Wallet {
     pub fn unbounded_spk_iter(
         &self,
         keychain: KeychainKind,
-    ) -> impl Iterator<Item = (u32, ScriptBuf)> + Clone {
+    ) -> impl Iterator<Item = IndexSpk> + Clone {
         self.indexed_graph
             .index
             .unbounded_spk_iter(&keychain)

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -772,7 +772,7 @@ impl Wallet {
         keychain: KeychainKind,
         index: u32,
     ) -> anyhow::Result<impl Iterator<Item = AddressInfo> + '_> {
-        let (spk_iter, index_changeset) = self
+        let (spks, index_changeset) = self
             .indexed_graph
             .index
             .reveal_to_target(&keychain, index)
@@ -781,7 +781,7 @@ impl Wallet {
         self.persist
             .stage_and_commit(indexed_tx_graph::ChangeSet::from(index_changeset).into())?;
 
-        Ok(spk_iter.map(move |(index, spk)| AddressInfo {
+        Ok(spks.into_iter().map(move |(index, spk)| AddressInfo {
             index,
             address: Address::from_script(&spk, self.network).expect("must have address form"),
             keychain,
@@ -861,7 +861,7 @@ impl Wallet {
     ///
     /// Will only return `Some(_)` if the wallet has given out the spk.
     pub fn derivation_of_spk(&self, spk: &Script) -> Option<(KeychainKind, u32)> {
-        self.indexed_graph.index.index_of_spk(spk)
+        self.indexed_graph.index.index_of_spk(spk).cloned()
     }
 
     /// Return the list of unspent outputs of this wallet
@@ -871,7 +871,7 @@ impl Wallet {
             .filter_chain_unspents(
                 &self.chain,
                 self.chain.tip().block_id(),
-                self.indexed_graph.index.outpoints(),
+                self.indexed_graph.index.outpoints().iter().cloned(),
             )
             .map(|((k, i), full_txo)| new_local_utxo(k, i, full_txo))
     }
@@ -885,7 +885,7 @@ impl Wallet {
             .filter_chain_txouts(
                 &self.chain,
                 self.chain.tip().block_id(),
-                self.indexed_graph.index.outpoints(),
+                self.indexed_graph.index.outpoints().iter().cloned(),
             )
             .map(|((k, i), full_txo)| new_local_utxo(k, i, full_txo))
     }
@@ -932,7 +932,7 @@ impl Wallet {
     /// Returns the utxo owned by this wallet corresponding to `outpoint` if it exists in the
     /// wallet's database.
     pub fn get_utxo(&self, op: OutPoint) -> Option<LocalOutput> {
-        let (keychain, index, _) = self.indexed_graph.index.txout(op)?;
+        let (&(keychain, index), _) = self.indexed_graph.index.txout(op)?;
         self.indexed_graph
             .graph()
             .filter_chain_unspents(
@@ -1207,7 +1207,7 @@ impl Wallet {
         self.indexed_graph.graph().balance(
             &self.chain,
             self.chain.tip().block_id(),
-            self.indexed_graph.index.outpoints(),
+            self.indexed_graph.index.outpoints().iter().cloned(),
             |&(k, _), _| k == KeychainKind::Internal,
         )
     }
@@ -1699,7 +1699,7 @@ impl Wallet {
                     .into();
 
                 let weighted_utxo = match txout_index.index_of_spk(&txout.script_pubkey) {
-                    Some((keychain, derivation_index)) => {
+                    Some(&(keychain, derivation_index)) => {
                         let satisfaction_weight = self
                             .get_descriptor_for_keychain(keychain)
                             .max_weight_to_satisfy()
@@ -1744,7 +1744,7 @@ impl Wallet {
             for (index, txout) in tx.output.iter().enumerate() {
                 let change_keychain = KeychainKind::Internal;
                 match txout_index.index_of_spk(&txout.script_pubkey) {
-                    Some((keychain, _)) if keychain == change_keychain => {
+                    Some((keychain, _)) if *keychain == change_keychain => {
                         change_index = Some(index)
                     }
                     _ => {}
@@ -2015,13 +2015,13 @@ impl Wallet {
             if let Some((keychain, index)) = txout_index.index_of_spk(&txout.script_pubkey) {
                 // NOTE: unmark_used will **not** make something unused if it has actually been used
                 // by a tx in the tracker. It only removes the superficial marking.
-                txout_index.unmark_used(keychain, index);
+                txout_index.unmark_used(*keychain, *index);
             }
         }
     }
 
     fn get_descriptor_for_txout(&self, txout: &TxOut) -> Option<DerivedDescriptor> {
-        let (keychain, child) = self
+        let &(keychain, child) = self
             .indexed_graph
             .index
             .index_of_spk(&txout.script_pubkey)?;
@@ -2237,7 +2237,7 @@ impl Wallet {
     ) -> Result<psbt::Input, CreateTxError> {
         // Try to find the prev_script in our db to figure out if this is internal or external,
         // and the derivation index
-        let (keychain, child) = self
+        let &(keychain, child) = self
             .indexed_graph
             .index
             .index_of_spk(&utxo.txout.script_pubkey)
@@ -2285,7 +2285,7 @@ impl Wallet {
 
         // Try to figure out the keychain and derivation for every input and output
         for (is_input, index, out) in utxos.into_iter() {
-            if let Some((keychain, child)) =
+            if let Some(&(keychain, child)) =
                 self.indexed_graph.index.index_of_spk(&out.script_pubkey)
             {
                 let desc = self.get_descriptor_for_keychain(keychain);
@@ -2331,7 +2331,7 @@ impl Wallet {
             None => ChangeSet::default(),
         };
 
-        let (_, index_changeset) = self
+        let index_changeset = self
             .indexed_graph
             .index
             .reveal_to_target_multi(&update.last_active_indices);
@@ -2536,17 +2536,27 @@ fn create_signers<E: IntoWalletDescriptor>(
 ) -> Result<(Arc<SignersContainer>, Arc<SignersContainer>), DescriptorError> {
     let descriptor = into_wallet_descriptor_checked(descriptor, secp, network)?;
     let change_descriptor = into_wallet_descriptor_checked(change_descriptor, secp, network)?;
-    if descriptor.0 == change_descriptor.0 {
-        return Err(DescriptorError::ExternalAndInternalAreTheSame);
-    }
-
     let (descriptor, keymap) = descriptor;
     let signers = Arc::new(SignersContainer::build(keymap, &descriptor, secp));
-    let _ = index.insert_descriptor(KeychainKind::External, descriptor);
+    let _ = index
+        .insert_descriptor(KeychainKind::External, descriptor)
+        .expect("this is the first descriptor we're inserting");
 
     let (descriptor, keymap) = change_descriptor;
     let change_signers = Arc::new(SignersContainer::build(keymap, &descriptor, secp));
-    let _ = index.insert_descriptor(KeychainKind::Internal, descriptor);
+    let _ = index
+        .insert_descriptor(KeychainKind::Internal, descriptor)
+        .map_err(|e| {
+            use bdk_chain::keychain::InsertDescriptorError;
+            match e {
+                InsertDescriptorError::DescriptorAlreadyAssigned { .. } => {
+                    crate::descriptor::error::Error::ExternalAndInternalAreTheSame
+                }
+                InsertDescriptorError::KeychainAlreadyAssigned { .. } => {
+                    unreachable!("this is the first time we're assigning internal")
+                }
+            }
+        })?;
 
     Ok((signers, change_signers))
 }

--- a/example-crates/example_bitcoind_rpc_polling/src/main.rs
+++ b/example-crates/example_bitcoind_rpc_polling/src/main.rs
@@ -212,7 +212,7 @@ fn main() -> anyhow::Result<()> {
                         graph.graph().balance(
                             &*chain,
                             synced_to.block_id(),
-                            graph.index.outpoints(),
+                            graph.index.outpoints().iter().cloned(),
                             |(k, _), _| k == &Keychain::Internal,
                         )
                     };
@@ -336,7 +336,7 @@ fn main() -> anyhow::Result<()> {
                         graph.graph().balance(
                             &*chain,
                             synced_to.block_id(),
-                            graph.index.outpoints(),
+                            graph.index.outpoints().iter().cloned(),
                             |(k, _), _| k == &Keychain::Internal,
                         )
                     };

--- a/example-crates/example_cli/src/lib.rs
+++ b/example-crates/example_cli/src/lib.rs
@@ -265,9 +265,6 @@ where
         .expect("Must exist");
     changeset.append(change_changeset);
 
-    // Clone to drop the immutable reference.
-    let change_script = change_script.into();
-
     let change_plan = bdk_tmp_plan::plan_satisfaction(
         &graph
             .index
@@ -481,8 +478,8 @@ where
                         local_chain::ChangeSet::default(),
                         indexed_tx_graph::ChangeSet::from(index_changeset),
                     )))?;
-                    let addr =
-                        Address::from_script(spk, network).context("failed to derive address")?;
+                    let addr = Address::from_script(spk.as_script(), network)
+                        .context("failed to derive address")?;
                     println!("[address @ {}] {}", spk_i, addr);
                     Ok(())
                 }

--- a/example-crates/example_cli/src/lib.rs
+++ b/example-crates/example_cli/src/lib.rs
@@ -427,7 +427,7 @@ pub fn planned_utxos<A: Anchor, O: ChainOracle, K: Clone + bdk_tmp_plan::CanDeri
     let outpoints = graph.index.outpoints();
     graph
         .graph()
-        .try_filter_chain_unspents(chain, chain_tip, outpoints)
+        .try_filter_chain_unspents(chain, chain_tip, outpoints.iter().cloned())
         .filter_map(|r| -> Option<Result<PlannedUtxo<K, A>, _>> {
             let (k, i, full_txo) = match r {
                 Err(err) => return Some(Err(err)),
@@ -527,7 +527,7 @@ where
             let balance = graph.graph().try_balance(
                 chain,
                 chain.get_chain_tip()?,
-                graph.index.outpoints(),
+                graph.index.outpoints().iter().cloned(),
                 |(k, _), _| k == &Keychain::Internal,
             )?;
 
@@ -568,7 +568,7 @@ where
                 } => {
                     let txouts = graph
                         .graph()
-                        .try_filter_chain_txouts(chain, chain_tip, outpoints)
+                        .try_filter_chain_txouts(chain, chain_tip, outpoints.iter().cloned())
                         .filter(|r| match r {
                             Ok((_, full_txo)) => match (spent, unspent) {
                                 (true, false) => full_txo.spent_by.is_some(),

--- a/example-crates/example_cli/src/lib.rs
+++ b/example-crates/example_cli/src/lib.rs
@@ -709,7 +709,7 @@ where
     // them in the index here. However, the keymap is not stored in the database.
     let (descriptor, mut keymap) =
         Descriptor::<DescriptorPublicKey>::parse_descriptor(&secp, &args.descriptor)?;
-    let _ = index.insert_descriptor(Keychain::External, descriptor);
+    let _ = index.insert_descriptor(Keychain::External, descriptor)?;
 
     if let Some((internal_descriptor, internal_keymap)) = args
         .change_descriptor
@@ -718,7 +718,7 @@ where
         .transpose()?
     {
         keymap.extend(internal_keymap);
-        let _ = index.insert_descriptor(Keychain::Internal, internal_descriptor);
+        let _ = index.insert_descriptor(Keychain::Internal, internal_descriptor)?;
     }
 
     let mut db_backend = match Store::<C>::open_or_create_new(db_magic, &args.db_path) {

--- a/example-crates/example_electrum/src/main.rs
+++ b/example-crates/example_electrum/src/main.rs
@@ -228,7 +228,7 @@ fn main() -> anyhow::Result<()> {
                 let all_spks = graph
                     .index
                     .revealed_spks(..)
-                    .map(|(index, spk)| (index.to_owned(), spk.to_owned()))
+                    .map(|(index, spk)| (index, spk.to_owned()))
                     .collect::<Vec<_>>();
                 request = request.chain_spks(all_spks.into_iter().map(|((k, spk_i), spk)| {
                     eprint!("Scanning {}: {}", k, spk_i);
@@ -239,7 +239,7 @@ fn main() -> anyhow::Result<()> {
                 let unused_spks = graph
                     .index
                     .unused_spks()
-                    .map(|(index, spk)| (index.to_owned(), spk.to_owned()))
+                    .map(|(index, spk)| (index, spk.to_owned()))
                     .collect::<Vec<_>>();
                 request =
                     request.chain_spks(unused_spks.into_iter().map(move |((k, spk_i), spk)| {

--- a/example-crates/example_esplora/src/main.rs
+++ b/example-crates/example_esplora/src/main.rs
@@ -245,7 +245,7 @@ fn main() -> anyhow::Result<()> {
                     let all_spks = graph
                         .index
                         .revealed_spks(..)
-                        .map(|((k, i), spk)| (k.to_owned(), *i, spk.to_owned()))
+                        .map(|((k, i), spk)| (k, i, spk.to_owned()))
                         .collect::<Vec<_>>();
                     request = request.chain_spks(all_spks.into_iter().map(|(k, i, spk)| {
                         eprint!("scanning {}:{}", k, i);
@@ -258,7 +258,7 @@ fn main() -> anyhow::Result<()> {
                     let unused_spks = graph
                         .index
                         .unused_spks()
-                        .map(|(index, spk)| (index.to_owned(), spk.to_owned()))
+                        .map(|(index, spk)| (index, spk.to_owned()))
                         .collect::<Vec<_>>();
                     request =
                         request.chain_spks(unused_spks.into_iter().map(move |((k, i), spk)| {


### PR DESCRIPTION
Fixes #1459

This reverts part of the changes in #1203. There the `SpkTxOutIndex<(K,u32)>` was changed to `SpkTxOutIndex<(DescriptorId, u32>)`. This led to a complicated translation logic in  `KeychainTxOutIndex` (where the API is based on `K`) to transform calls to it to calls to the underlying `SpkTxOutIndex` (which now indexes by `DescriptorId`). The translation layer was broken when it came to translating range queries from the `KeychainTxOutIndex`. My solution was just to revert this part of the change and remove the need for a translation layer (almost) altogether. A thin translation layer remains to ensure that un-revealed spks are filtered out before being returned from the `KeychainTxOutIndex` methods.

I feel like this PR could be extended to include a bunch of ergonomics improvements that are easier to implement now. But I think that's the point of https://github.com/bitcoindevkit/bdk/pull/1451 so I held off and should probably go and scope creep that one instead.


### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing


#### Bugfixes:

* [x] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
