### PR TITLE
ci: pin url dependency version to build with rust 1.63

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -34,6 +34,7 @@ jobs:
           cargo update -p time --precise "0.3.20"
           cargo update -p home --precise "0.5.5"
           cargo update -p proptest --precise "1.2.0"
+          cargo update -p url --precise "2.5.0"
       - name: Build
         run: cargo build ${{ matrix.features }}
       - name: Test

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ cargo update -p zstd-sys --precise "2.0.8+zstd.1.5.5"
 cargo update -p time --precise "0.3.20"
 cargo update -p home --precise "0.5.5"
 cargo update -p proptest --precise "1.2.0"
+cargo update -p url --precise "2.5.0"
 ```
 
 ## License


### PR DESCRIPTION
### Description

Required because upstream dependency `url` changed their MSRV to 1.67 in a patch release.

### Notes to the reviewers

See related discussion here: servo/rust-url#937

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
