### PR TITLE
chore(esplora): bump client version to 0.9.0

### DIFF
--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_esplora"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 bdk_chain = { path = "../chain", version = "0.16.0", default-features = false }
-esplora-client = { version = "0.8.0", default-features = false }
+esplora-client = { version = "0.9.0", git = "https://github.com/evanlinjin/rust-esplora-client", branch = "v0_9_0", default-features = false }
 async-trait = { version = "0.1.66", optional = true }
 futures = { version = "0.3.26", optional = true }
 


### PR DESCRIPTION
### Description

The new `esplora_client::BlockingClient` exposes the `url` and allows making raw requests. Also, both clients now have a method to fetch from `/tx/:txid` endpoint.

This is waiting on https://github.com/bitcoindevkit/rust-esplora-client/pull/88 to be merged.

### Changelog notice

* Update `esplora-client` to `v0.9.0`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing