### PR TITLE
Allow opting out of getting `LocalChain` updates with `FullScanRequest`/`SyncRequest` structures

### DIFF
--- a/crates/chain/src/spk_client.rs
+++ b/crates/chain/src/spk_client.rs
@@ -110,14 +110,7 @@ impl<K: Clone + Ord + core::fmt::Debug + Send + Sync> SyncRequestBuilder<(K, u32
         indexer: &crate::indexer::keychain_txout::KeychainTxOutIndex<K>,
         spk_range: impl core::ops::RangeBounds<K>,
     ) -> Self {
-        use crate::alloc::borrow::ToOwned;
-        use crate::alloc::vec::Vec;
-        self.spks_with_labels(
-            indexer
-                .revealed_spks(spk_range)
-                .map(|(i, spk)| (i, spk.to_owned()))
-                .collect::<Vec<_>>(),
-        )
+        self.spks_with_labels(indexer.revealed_spks(spk_range))
     }
 
     /// Add [`Script`]s that are revealed by the `indexer` but currently unused.
@@ -125,14 +118,7 @@ impl<K: Clone + Ord + core::fmt::Debug + Send + Sync> SyncRequestBuilder<(K, u32
         self,
         indexer: &crate::indexer::keychain_txout::KeychainTxOutIndex<K>,
     ) -> Self {
-        use crate::alloc::borrow::ToOwned;
-        use crate::alloc::vec::Vec;
-        self.spks_with_labels(
-            indexer
-                .unused_spks()
-                .map(|(i, spk)| (i, spk.to_owned()))
-                .collect::<Vec<_>>(),
-        )
+        self.spks_with_labels(indexer.unused_spks())
     }
 }
 

--- a/crates/chain/src/spk_client.rs
+++ b/crates/chain/src/spk_client.rs
@@ -557,8 +557,8 @@ impl<'r, I> Iterator for SyncIter<'r, I, ScriptBuf> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let consumed = self.request.spks_consumed;
-        (consumed, Some(consumed))
+        let remaining = self.request.spks.len();
+        (remaining, Some(remaining))
     }
 }
 
@@ -570,8 +570,8 @@ impl<'r, I> Iterator for SyncIter<'r, I, Txid> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let consumed = self.request.txids_consumed;
-        (consumed, Some(consumed))
+        let remaining = self.request.txids.len();
+        (remaining, Some(remaining))
     }
 }
 
@@ -583,7 +583,7 @@ impl<'r, I> Iterator for SyncIter<'r, I, OutPoint> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let consumed = self.request.outpoints_consumed;
-        (consumed, Some(consumed))
+        let remaining = self.request.outpoints.len();
+        (remaining, Some(remaining))
     }
 }

--- a/crates/chain/src/spk_client.rs
+++ b/crates/chain/src/spk_client.rs
@@ -1,186 +1,407 @@
 //! Helper types for spk-based blockchain clients.
-
 use crate::{
-    collections::BTreeMap, local_chain::CheckPoint, ConfirmationBlockTime, Indexed, TxGraph,
+    alloc::{boxed::Box, collections::VecDeque, vec::Vec},
+    collections::BTreeMap,
+    local_chain::CheckPoint,
+    ConfirmationBlockTime, Indexed, TxGraph,
 };
-use alloc::boxed::Box;
 use bitcoin::{OutPoint, Script, ScriptBuf, Txid};
-use core::marker::PhantomData;
+
+type InspectSync<I> = dyn FnMut(SyncItem<I>, SyncProgress) + Send + 'static;
+
+type InspectFullScan<K> = dyn FnMut(K, u32, &Script) + Send + 'static;
+
+/// An item reported to the [`inspect`](SyncRequestBuilder::inspect) closure of [`SyncRequest`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum SyncItem<'i, I> {
+    /// Script pubkey sync item.
+    Spk(I, &'i Script),
+    /// Txid sync item.
+    Txid(Txid),
+    /// Outpoint sync item.
+    OutPoint(OutPoint),
+}
+
+impl<'i, I: core::fmt::Debug + core::any::Any> core::fmt::Display for SyncItem<'i, I> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            SyncItem::Spk(i, spk) => {
+                if (i as &dyn core::any::Any).is::<()>() {
+                    write!(f, "script '{}'", spk)
+                } else {
+                    write!(f, "script {:?} '{}'", i, spk)
+                }
+            }
+            SyncItem::Txid(txid) => write!(f, "txid '{}'", txid),
+            SyncItem::OutPoint(op) => write!(f, "outpoint '{}'", op),
+        }
+    }
+}
+
+/// The progress of [`SyncRequest`].
+#[derive(Debug, Clone)]
+pub struct SyncProgress {
+    /// Script pubkeys consumed by the request.
+    pub spks_consumed: usize,
+    /// Script pubkeys remaining in the request.
+    pub spks_remaining: usize,
+    /// Txids consumed by the request.
+    pub txids_consumed: usize,
+    /// Txids remaining in the request.
+    pub txids_remaining: usize,
+    /// Outpoints consumed by the request.
+    pub outpoints_consumed: usize,
+    /// Outpoints remaining in the request.
+    pub outpoints_remaining: usize,
+}
+
+impl SyncProgress {
+    /// Total items, consumed and remaining, of the request.
+    pub fn total(&self) -> usize {
+        self.total_spks() + self.total_txids() + self.total_outpoints()
+    }
+
+    /// Total script pubkeys, consumed and remaining, of the request.
+    pub fn total_spks(&self) -> usize {
+        self.spks_consumed + self.spks_remaining
+    }
+
+    /// Total txids, consumed and remaining, of the request.
+    pub fn total_txids(&self) -> usize {
+        self.txids_consumed + self.txids_remaining
+    }
+
+    /// Total outpoints, consumed and remaining, of the request.
+    pub fn total_outpoints(&self) -> usize {
+        self.outpoints_consumed + self.outpoints_remaining
+    }
+
+    /// Total consumed items of the request.
+    pub fn consumed(&self) -> usize {
+        self.spks_consumed + self.txids_consumed + self.outpoints_consumed
+    }
+
+    /// Total remaining items of the request.
+    pub fn remaining(&self) -> usize {
+        self.spks_remaining + self.txids_remaining + self.outpoints_remaining
+    }
+}
+
+/// Builds a [`SyncRequest`].
+#[must_use]
+pub struct SyncRequestBuilder<SpkLabel = ()> {
+    inner: SyncRequest<SpkLabel>,
+}
+
+impl<SpkLabel> Default for SyncRequestBuilder<SpkLabel> {
+    fn default() -> Self {
+        Self {
+            inner: Default::default(),
+        }
+    }
+}
+
+#[cfg(feature = "miniscript")]
+impl<K: Clone + Ord + core::fmt::Debug + Send + Sync> SyncRequestBuilder<(K, u32)> {
+    /// Add [`Script`]s that are revealed by the `indexer` of the given `spk_range` that will be
+    /// synced against.
+    pub fn revealed_spks_from_indexer(
+        self,
+        indexer: &crate::indexer::keychain_txout::KeychainTxOutIndex<K>,
+        spk_range: impl core::ops::RangeBounds<K>,
+    ) -> Self {
+        use crate::alloc::borrow::ToOwned;
+        use crate::alloc::vec::Vec;
+        self.spks_with_labels(
+            indexer
+                .revealed_spks(spk_range)
+                .map(|(i, spk)| (i, spk.to_owned()))
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    /// Add [`Script`]s that are revealed by the `indexer` but currently unused.
+    pub fn unused_spks_from_indexer(
+        self,
+        indexer: &crate::indexer::keychain_txout::KeychainTxOutIndex<K>,
+    ) -> Self {
+        use crate::alloc::borrow::ToOwned;
+        use crate::alloc::vec::Vec;
+        self.spks_with_labels(
+            indexer
+                .unused_spks()
+                .map(|(i, spk)| (i, spk.to_owned()))
+                .collect::<Vec<_>>(),
+        )
+    }
+}
+
+impl SyncRequestBuilder<()> {
+    /// Add [`Script`]s that will be synced against.
+    pub fn spks(self, spks: impl IntoIterator<Item = ScriptBuf>) -> Self {
+        self.spks_with_labels(spks.into_iter().map(|spk| ((), spk)))
+    }
+}
+
+impl<SpkLabel> SyncRequestBuilder<SpkLabel> {
+    /// Set the initial chain tip for the sync request.
+    ///
+    /// This is used to update [`LocalChain`](crate::local_chain::LocalChain).
+    pub fn chain_tip(mut self, cp: CheckPoint) -> Self {
+        self.inner.chain_tip = Some(cp);
+        self
+    }
+
+    /// Add [`Script`]s coupled with an associated label that will be synced against.
+    pub fn spks_with_labels(
+        mut self,
+        spks: impl IntoIterator<Item = (SpkLabel, ScriptBuf)>,
+    ) -> Self {
+        self.inner.spks.extend(spks);
+        self
+    }
+
+    /// Add [`Txid`]s that will be synced against.
+    pub fn txids(mut self, txids: impl IntoIterator<Item = Txid>) -> Self {
+        self.inner.txids.extend(txids);
+        self
+    }
+
+    /// Add [`OutPoint`]s that will be synced against.
+    pub fn outpoints(mut self, outpoints: impl IntoIterator<Item = OutPoint>) -> Self {
+        self.inner.outpoints.extend(outpoints);
+        self
+    }
+
+    /// Set the closure that will inspect every sync item visited.
+    pub fn inspect<F>(mut self, inspect: F) -> Self
+    where
+        F: FnMut(SyncItem<SpkLabel>, SyncProgress) + Send + 'static,
+    {
+        self.inner.inspect = Box::new(inspect);
+        self
+    }
+
+    /// Build the [`SyncRequest`].
+    pub fn build(self) -> SyncRequest<SpkLabel> {
+        self.inner
+    }
+}
 
 /// Data required to perform a spk-based blockchain client sync.
 ///
 /// A client sync fetches relevant chain data for a known list of scripts, transaction ids and
-/// outpoints. The sync process also updates the chain from the given [`CheckPoint`].
-pub struct SyncRequest {
-    /// A checkpoint for the current chain [`LocalChain::tip`].
-    /// The sync process will return a new chain update that extends this tip.
-    ///
-    /// [`LocalChain::tip`]: crate::local_chain::LocalChain::tip
-    pub chain_tip: CheckPoint,
-    /// Transactions that spend from or to these indexed script pubkeys.
-    pub spks: Box<dyn ExactSizeIterator<Item = ScriptBuf> + Send>,
-    /// Transactions with these txids.
-    pub txids: Box<dyn ExactSizeIterator<Item = Txid> + Send>,
-    /// Transactions with these outpoints or spent from these outpoints.
-    pub outpoints: Box<dyn ExactSizeIterator<Item = OutPoint> + Send>,
+/// outpoints. The sync process also updates the chain from the given
+/// [`chain_tip`](SyncRequestBuilder::chain_tip) (if provided).
+///
+/// ```rust
+/// # use bdk_chain::{bitcoin::{hashes::Hash, ScriptBuf}, local_chain::LocalChain};
+/// # let (local_chain, _) = LocalChain::from_genesis_hash(Hash::all_zeros());
+/// # let scripts = [ScriptBuf::default(), ScriptBuf::default()];
+/// # use bdk_chain::spk_client::SyncRequest;
+/// // Construct a sync request.
+/// let sync_request = SyncRequest::builder()
+///     // Provide chain tip of the local wallet.
+///     .chain_tip(local_chain.tip())
+///     // Provide list of scripts to scan for transactions against.
+///     .spks(scripts)
+///     // This is called for every synced item.
+///     .inspect(|item, progress| println!("{} (remaining: {})", item, progress.remaining()))
+///     // Finish constructing the sync request.
+///     .build();
+/// ```
+#[must_use]
+pub struct SyncRequest<I = ()> {
+    chain_tip: Option<CheckPoint>,
+    spks: VecDeque<(I, ScriptBuf)>,
+    spks_consumed: usize,
+    txids: VecDeque<Txid>,
+    txids_consumed: usize,
+    outpoints: VecDeque<OutPoint>,
+    outpoints_consumed: usize,
+    inspect: Box<InspectSync<I>>,
 }
 
-impl SyncRequest {
-    /// Construct a new [`SyncRequest`] from a given `cp` tip.
-    pub fn from_chain_tip(cp: CheckPoint) -> Self {
+impl<I> Default for SyncRequest<I> {
+    fn default() -> Self {
         Self {
-            chain_tip: cp,
-            spks: Box::new(core::iter::empty()),
-            txids: Box::new(core::iter::empty()),
-            outpoints: Box::new(core::iter::empty()),
+            chain_tip: None,
+            spks: VecDeque::new(),
+            spks_consumed: 0,
+            txids: VecDeque::new(),
+            txids_consumed: 0,
+            outpoints: VecDeque::new(),
+            outpoints_consumed: 0,
+            inspect: Box::new(|_, _| {}),
+        }
+    }
+}
+
+impl<I> From<SyncRequestBuilder<I>> for SyncRequest<I> {
+    fn from(builder: SyncRequestBuilder<I>) -> Self {
+        builder.inner
+    }
+}
+
+impl<I> SyncRequest<I> {
+    /// Start building a [`SyncRequest`].
+    pub fn builder() -> SyncRequestBuilder<I> {
+        SyncRequestBuilder {
+            inner: Default::default(),
         }
     }
 
-    /// Set the [`Script`]s that will be synced against.
-    ///
-    /// This consumes the [`SyncRequest`] and returns the updated one.
-    #[must_use]
-    pub fn set_spks(
-        mut self,
-        spks: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = ScriptBuf> + Send + 'static>,
-    ) -> Self {
-        self.spks = Box::new(spks.into_iter());
-        self
+    /// Get the [`SyncProgress`] of this request.
+    pub fn progress(&self) -> SyncProgress {
+        SyncProgress {
+            spks_consumed: self.spks_consumed,
+            spks_remaining: self.spks.len(),
+            txids_consumed: self.txids_consumed,
+            txids_remaining: self.txids.len(),
+            outpoints_consumed: self.outpoints_consumed,
+            outpoints_remaining: self.outpoints.len(),
+        }
     }
 
-    /// Set the [`Txid`]s that will be synced against.
-    ///
-    /// This consumes the [`SyncRequest`] and returns the updated one.
-    #[must_use]
-    pub fn set_txids(
-        mut self,
-        txids: impl IntoIterator<IntoIter = impl ExactSizeIterator<Item = Txid> + Send + 'static>,
-    ) -> Self {
-        self.txids = Box::new(txids.into_iter());
-        self
+    /// Get the chain tip [`CheckPoint`] of this request (if any).
+    pub fn chain_tip(&self) -> Option<CheckPoint> {
+        self.chain_tip.clone()
     }
 
-    /// Set the [`OutPoint`]s that will be synced against.
+    /// Advances the sync request and returns the next [`ScriptBuf`].
     ///
-    /// This consumes the [`SyncRequest`] and returns the updated one.
-    #[must_use]
-    pub fn set_outpoints(
-        mut self,
-        outpoints: impl IntoIterator<
-            IntoIter = impl ExactSizeIterator<Item = OutPoint> + Send + 'static,
-        >,
-    ) -> Self {
-        self.outpoints = Box::new(outpoints.into_iter());
-        self
+    /// Returns [`None`] when there are no more scripts remaining in the request.
+    pub fn next_spk(&mut self) -> Option<ScriptBuf> {
+        let (i, spk) = self.spks.pop_front()?;
+        self.spks_consumed += 1;
+        self._call_inspect(SyncItem::Spk(i, spk.as_script()));
+        Some(spk)
     }
 
-    /// Chain on additional [`Script`]s that will be synced against.
+    /// Advances the sync request and returns the next [`Txid`].
     ///
-    /// This consumes the [`SyncRequest`] and returns the updated one.
-    #[must_use]
-    pub fn chain_spks(
-        mut self,
-        spks: impl IntoIterator<
-            IntoIter = impl ExactSizeIterator<Item = ScriptBuf> + Send + 'static,
-            Item = ScriptBuf,
-        >,
-    ) -> Self {
-        self.spks = Box::new(ExactSizeChain::new(self.spks, spks.into_iter()));
-        self
+    /// Returns [`None`] when there are no more txids remaining in the request.
+    pub fn next_txid(&mut self) -> Option<Txid> {
+        let txid = self.txids.pop_front()?;
+        self.txids_consumed += 1;
+        self._call_inspect(SyncItem::Txid(txid));
+        Some(txid)
     }
 
-    /// Chain on additional [`Txid`]s that will be synced against.
+    /// Advances the sync request and returns the next [`OutPoint`].
     ///
-    /// This consumes the [`SyncRequest`] and returns the updated one.
-    #[must_use]
-    pub fn chain_txids(
-        mut self,
-        txids: impl IntoIterator<
-            IntoIter = impl ExactSizeIterator<Item = Txid> + Send + 'static,
-            Item = Txid,
-        >,
-    ) -> Self {
-        self.txids = Box::new(ExactSizeChain::new(self.txids, txids.into_iter()));
-        self
+    /// Returns [`None`] when there are no more outpoints in the request.
+    pub fn next_outpoint(&mut self) -> Option<OutPoint> {
+        let outpoint = self.outpoints.pop_front()?;
+        self.outpoints_consumed += 1;
+        self._call_inspect(SyncItem::OutPoint(outpoint));
+        Some(outpoint)
     }
 
-    /// Chain on additional [`OutPoint`]s that will be synced against.
-    ///
-    /// This consumes the [`SyncRequest`] and returns the updated one.
-    #[must_use]
-    pub fn chain_outpoints(
-        mut self,
-        outpoints: impl IntoIterator<
-            IntoIter = impl ExactSizeIterator<Item = OutPoint> + Send + 'static,
-            Item = OutPoint,
-        >,
-    ) -> Self {
-        self.outpoints = Box::new(ExactSizeChain::new(self.outpoints, outpoints.into_iter()));
-        self
+    /// Iterate over [`ScriptBuf`]s contained in this request.
+    pub fn iter_spks(&mut self) -> impl ExactSizeIterator<Item = ScriptBuf> + '_ {
+        SyncIter::<I, ScriptBuf>::new(self)
     }
 
-    /// Add a closure that will be called for [`Script`]s previously added to this request.
-    ///
-    /// This consumes the [`SyncRequest`] and returns the updated one.
-    #[must_use]
-    pub fn inspect_spks(
-        mut self,
-        mut inspect: impl FnMut(&Script) + Send + Sync + 'static,
-    ) -> Self {
-        self.spks = Box::new(self.spks.inspect(move |spk| inspect(spk)));
-        self
+    /// Iterate over [`Txid`]s contained in this request.
+    pub fn iter_txids(&mut self) -> impl ExactSizeIterator<Item = Txid> + '_ {
+        SyncIter::<I, Txid>::new(self)
     }
 
-    /// Add a closure that will be called for [`Txid`]s previously added to this request.
-    ///
-    /// This consumes the [`SyncRequest`] and returns the updated one.
-    #[must_use]
-    pub fn inspect_txids(mut self, mut inspect: impl FnMut(&Txid) + Send + Sync + 'static) -> Self {
-        self.txids = Box::new(self.txids.inspect(move |txid| inspect(txid)));
-        self
+    /// Iterate over [`OutPoint`]s contained in this request.
+    pub fn iter_outpoints(&mut self) -> impl ExactSizeIterator<Item = OutPoint> + '_ {
+        SyncIter::<I, OutPoint>::new(self)
     }
 
-    /// Add a closure that will be called for [`OutPoint`]s previously added to this request.
-    ///
-    /// This consumes the [`SyncRequest`] and returns the updated one.
-    #[must_use]
-    pub fn inspect_outpoints(
-        mut self,
-        mut inspect: impl FnMut(&OutPoint) + Send + Sync + 'static,
-    ) -> Self {
-        self.outpoints = Box::new(self.outpoints.inspect(move |op| inspect(op)));
-        self
-    }
-
-    /// Populate the request with revealed script pubkeys from `index` with the given `spk_range`.
-    ///
-    /// This consumes the [`SyncRequest`] and returns the updated one.
-    #[cfg(feature = "miniscript")]
-    #[must_use]
-    pub fn populate_with_revealed_spks<K: Clone + Ord + core::fmt::Debug + Send + Sync>(
-        self,
-        index: &crate::indexer::keychain_txout::KeychainTxOutIndex<K>,
-        spk_range: impl core::ops::RangeBounds<K>,
-    ) -> Self {
-        use alloc::borrow::ToOwned;
-        use alloc::vec::Vec;
-        self.chain_spks(
-            index
-                .revealed_spks(spk_range)
-                .map(|(_, spk)| spk.to_owned())
-                .collect::<Vec<_>>(),
-        )
+    fn _call_inspect(&mut self, item: SyncItem<I>) {
+        let progress = self.progress();
+        (*self.inspect)(item, progress);
     }
 }
 
 /// Data returned from a spk-based blockchain client sync.
 ///
 /// See also [`SyncRequest`].
+#[must_use]
+#[derive(Debug)]
 pub struct SyncResult<A = ConfirmationBlockTime> {
     /// The update to apply to the receiving [`TxGraph`].
     pub graph_update: TxGraph<A>,
     /// The update to apply to the receiving [`LocalChain`](crate::local_chain::LocalChain).
-    pub chain_update: CheckPoint,
+    pub chain_update: Option<CheckPoint>,
+}
+
+impl<A> Default for SyncResult<A> {
+    fn default() -> Self {
+        Self {
+            graph_update: Default::default(),
+            chain_update: Default::default(),
+        }
+    }
+}
+
+/// Builds a [`FullScanRequest`].
+#[must_use]
+pub struct FullScanRequestBuilder<K> {
+    inner: FullScanRequest<K>,
+}
+
+impl<K> Default for FullScanRequestBuilder<K> {
+    fn default() -> Self {
+        Self {
+            inner: Default::default(),
+        }
+    }
+}
+
+#[cfg(feature = "miniscript")]
+impl<K: Ord + Clone + core::fmt::Debug> FullScanRequestBuilder<K> {
+    /// Add spk iterators for each keychain tracked in `indexer`.
+    pub fn spks_from_indexer(
+        mut self,
+        indexer: &crate::indexer::keychain_txout::KeychainTxOutIndex<K>,
+    ) -> Self {
+        for (keychain, spks) in indexer.all_unbounded_spk_iters() {
+            self = self.spks_for_keychain(keychain, spks);
+        }
+        self
+    }
+}
+
+impl<K: Ord> FullScanRequestBuilder<K> {
+    /// Set the initial chain tip for the full scan request.
+    ///
+    /// This is used to update [`LocalChain`](crate::local_chain::LocalChain).
+    pub fn chain_tip(mut self, tip: CheckPoint) -> Self {
+        self.inner.chain_tip = Some(tip);
+        self
+    }
+
+    /// Set the spk iterator for a given `keychain`.
+    pub fn spks_for_keychain(
+        mut self,
+        keychain: K,
+        spks: impl IntoIterator<IntoIter = impl Iterator<Item = Indexed<ScriptBuf>> + Send + 'static>,
+    ) -> Self {
+        self.inner
+            .spks_by_keychain
+            .insert(keychain, Box::new(spks.into_iter()));
+        self
+    }
+
+    /// Set the closure that will inspect every sync item visited.
+    pub fn inspect<F>(mut self, inspect: F) -> Self
+    where
+        F: FnMut(K, u32, &Script) + Send + 'static,
+    {
+        self.inner.inspect = Box::new(inspect);
+        self
+    }
+
+    /// Build the [`FullScanRequest`].
+    pub fn build(self) -> FullScanRequest<K> {
+        self.inner
+    }
 }
 
 /// Data required to perform a spk-based blockchain client full scan.
@@ -188,201 +409,158 @@ pub struct SyncResult<A = ConfirmationBlockTime> {
 /// A client full scan iterates through all the scripts for the given keychains, fetching relevant
 /// data until some stop gap number of scripts is found that have no data. This operation is
 /// generally only used when importing or restoring previously used keychains in which the list of
-/// used scripts is not known. The full scan process also updates the chain from the given [`CheckPoint`].
+/// used scripts is not known. The full scan process also updates the chain from the given
+/// [`chain_tip`](FullScanRequestBuilder::chain_tip) (if provided).
+#[must_use]
 pub struct FullScanRequest<K> {
-    /// A checkpoint for the current [`LocalChain::tip`].
-    /// The full scan process will return a new chain update that extends this tip.
-    ///
-    /// [`LocalChain::tip`]: crate::local_chain::LocalChain::tip
-    pub chain_tip: CheckPoint,
-    /// Iterators of script pubkeys indexed by the keychain index.
-    pub spks_by_keychain: BTreeMap<K, Box<dyn Iterator<Item = Indexed<ScriptBuf>> + Send>>,
+    chain_tip: Option<CheckPoint>,
+    spks_by_keychain: BTreeMap<K, Box<dyn Iterator<Item = Indexed<ScriptBuf>> + Send>>,
+    inspect: Box<InspectFullScan<K>>,
+}
+
+impl<K> From<FullScanRequestBuilder<K>> for FullScanRequest<K> {
+    fn from(builder: FullScanRequestBuilder<K>) -> Self {
+        builder.inner
+    }
+}
+
+impl<K> Default for FullScanRequest<K> {
+    fn default() -> Self {
+        Self {
+            chain_tip: None,
+            spks_by_keychain: Default::default(),
+            inspect: Box::new(|_, _, _| {}),
+        }
+    }
 }
 
 impl<K: Ord + Clone> FullScanRequest<K> {
-    /// Construct a new [`FullScanRequest`] from a given `chain_tip`.
-    #[must_use]
-    pub fn from_chain_tip(chain_tip: CheckPoint) -> Self {
-        Self {
-            chain_tip,
-            spks_by_keychain: BTreeMap::new(),
+    /// Start building a [`FullScanRequest`].
+    pub fn builder() -> FullScanRequestBuilder<K> {
+        FullScanRequestBuilder {
+            inner: Self::default(),
         }
     }
 
-    /// Construct a new [`FullScanRequest`] from a given `chain_tip` and `index`.
-    ///
-    /// Unbounded script pubkey iterators for each keychain (`K`) are extracted using
-    /// [`KeychainTxOutIndex::all_unbounded_spk_iters`] and is used to populate the
-    /// [`FullScanRequest`].
-    ///
-    /// [`KeychainTxOutIndex::all_unbounded_spk_iters`]: crate::indexer::keychain_txout::KeychainTxOutIndex::all_unbounded_spk_iters
-    #[cfg(feature = "miniscript")]
-    #[must_use]
-    pub fn from_keychain_txout_index(
-        chain_tip: CheckPoint,
-        index: &crate::indexer::keychain_txout::KeychainTxOutIndex<K>,
-    ) -> Self
-    where
-        K: core::fmt::Debug,
-    {
-        let mut req = Self::from_chain_tip(chain_tip);
-        for (keychain, spks) in index.all_unbounded_spk_iters() {
-            req = req.set_spks_for_keychain(keychain, spks);
+    /// Get the chain tip [`CheckPoint`] of this request (if any).
+    pub fn chain_tip(&self) -> Option<CheckPoint> {
+        self.chain_tip.clone()
+    }
+
+    /// List all keychains contained in this request.
+    pub fn keychains(&self) -> Vec<K> {
+        self.spks_by_keychain.keys().cloned().collect()
+    }
+
+    /// Advances the full scan request and returns the next indexed [`ScriptBuf`] of the given
+    /// `keychain`.
+    pub fn next_spk(&mut self, keychain: K) -> Option<Indexed<ScriptBuf>> {
+        self.iter_spks(keychain).next()
+    }
+
+    /// Iterate over indexed [`ScriptBuf`]s contained in this request of the given `keychain`.
+    pub fn iter_spks(&mut self, keychain: K) -> impl Iterator<Item = Indexed<ScriptBuf>> + '_ {
+        let spks = self.spks_by_keychain.get_mut(&keychain);
+        let inspect = &mut self.inspect;
+        KeychainSpkIter {
+            keychain,
+            spks,
+            inspect,
         }
-        req
-    }
-
-    /// Set the [`Script`]s for a given `keychain`.
-    ///
-    /// This consumes the [`FullScanRequest`] and returns the updated one.
-    #[must_use]
-    pub fn set_spks_for_keychain(
-        mut self,
-        keychain: K,
-        spks: impl IntoIterator<IntoIter = impl Iterator<Item = Indexed<ScriptBuf>> + Send + 'static>,
-    ) -> Self {
-        self.spks_by_keychain
-            .insert(keychain, Box::new(spks.into_iter()));
-        self
-    }
-
-    /// Chain on additional [`Script`]s that will be synced against.
-    ///
-    /// This consumes the [`FullScanRequest`] and returns the updated one.
-    #[must_use]
-    pub fn chain_spks_for_keychain(
-        mut self,
-        keychain: K,
-        spks: impl IntoIterator<IntoIter = impl Iterator<Item = Indexed<ScriptBuf>> + Send + 'static>,
-    ) -> Self {
-        match self.spks_by_keychain.remove(&keychain) {
-            // clippy here suggests to remove `into_iter` from `spks.into_iter()`, but doing so
-            // results in a compilation error
-            #[allow(clippy::useless_conversion)]
-            Some(keychain_spks) => self
-                .spks_by_keychain
-                .insert(keychain, Box::new(keychain_spks.chain(spks.into_iter()))),
-            None => self
-                .spks_by_keychain
-                .insert(keychain, Box::new(spks.into_iter())),
-        };
-        self
-    }
-
-    /// Add a closure that will be called for every [`Script`] previously added to any keychain in
-    /// this request.
-    ///
-    /// This consumes the [`SyncRequest`] and returns the updated one.
-    #[must_use]
-    pub fn inspect_spks_for_all_keychains(
-        mut self,
-        inspect: impl FnMut(K, u32, &Script) + Send + Sync + Clone + 'static,
-    ) -> Self
-    where
-        K: Send + 'static,
-    {
-        for (keychain, spks) in core::mem::take(&mut self.spks_by_keychain) {
-            let mut inspect = inspect.clone();
-            self.spks_by_keychain.insert(
-                keychain.clone(),
-                Box::new(spks.inspect(move |(i, spk)| inspect(keychain.clone(), *i, spk))),
-            );
-        }
-        self
-    }
-
-    /// Add a closure that will be called for every [`Script`] previously added to a given
-    /// `keychain` in this request.
-    ///
-    /// This consumes the [`SyncRequest`] and returns the updated one.
-    #[must_use]
-    pub fn inspect_spks_for_keychain(
-        mut self,
-        keychain: K,
-        mut inspect: impl FnMut(u32, &Script) + Send + Sync + 'static,
-    ) -> Self
-    where
-        K: Send + 'static,
-    {
-        if let Some(spks) = self.spks_by_keychain.remove(&keychain) {
-            self.spks_by_keychain.insert(
-                keychain,
-                Box::new(spks.inspect(move |(i, spk)| inspect(*i, spk))),
-            );
-        }
-        self
     }
 }
 
 /// Data returned from a spk-based blockchain client full scan.
 ///
 /// See also [`FullScanRequest`].
+#[must_use]
+#[derive(Debug)]
 pub struct FullScanResult<K, A = ConfirmationBlockTime> {
     /// The update to apply to the receiving [`LocalChain`](crate::local_chain::LocalChain).
     pub graph_update: TxGraph<A>,
     /// The update to apply to the receiving [`TxGraph`].
-    pub chain_update: CheckPoint,
+    pub chain_update: Option<CheckPoint>,
     /// Last active indices for the corresponding keychains (`K`).
     pub last_active_indices: BTreeMap<K, u32>,
 }
 
-/// A version of [`core::iter::Chain`] which can combine two [`ExactSizeIterator`]s to form a new
-/// [`ExactSizeIterator`].
-///
-/// The danger of this is explained in [the `ExactSizeIterator` docs]
-/// (https://doc.rust-lang.org/core/iter/trait.ExactSizeIterator.html#when-shouldnt-an-adapter-be-exactsizeiterator).
-/// This does not apply here since it would be impossible to scan an item count that overflows
-/// `usize` anyway.
-struct ExactSizeChain<A, B, I> {
-    a: Option<A>,
-    b: Option<B>,
-    i: PhantomData<I>,
-}
-
-impl<A, B, I> ExactSizeChain<A, B, I> {
-    fn new(a: A, b: B) -> Self {
-        ExactSizeChain {
-            a: Some(a),
-            b: Some(b),
-            i: PhantomData,
+impl<K, A> Default for FullScanResult<K, A> {
+    fn default() -> Self {
+        Self {
+            graph_update: Default::default(),
+            chain_update: Default::default(),
+            last_active_indices: Default::default(),
         }
     }
 }
 
-impl<A, B, I> Iterator for ExactSizeChain<A, B, I>
-where
-    A: Iterator<Item = I>,
-    B: Iterator<Item = I>,
-{
-    type Item = I;
+struct KeychainSpkIter<'r, K> {
+    keychain: K,
+    spks: Option<&'r mut Box<dyn Iterator<Item = Indexed<ScriptBuf>> + Send>>,
+    inspect: &'r mut Box<InspectFullScan<K>>,
+}
+
+impl<'r, K: Ord + Clone> Iterator for KeychainSpkIter<'r, K> {
+    type Item = Indexed<ScriptBuf>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(a) = &mut self.a {
-            let item = a.next();
-            if item.is_some() {
-                return item;
-            }
-            self.a = None;
-        }
-        if let Some(b) = &mut self.b {
-            let item = b.next();
-            if item.is_some() {
-                return item;
-            }
-            self.b = None;
-        }
-        None
+        let (i, spk) = self.spks.as_mut()?.next()?;
+        (*self.inspect)(self.keychain.clone(), i, &spk);
+        Some((i, spk))
     }
 }
 
-impl<A, B, I> ExactSizeIterator for ExactSizeChain<A, B, I>
-where
-    A: ExactSizeIterator<Item = I>,
-    B: ExactSizeIterator<Item = I>,
-{
-    fn len(&self) -> usize {
-        let a_len = self.a.as_ref().map(|a| a.len()).unwrap_or(0);
-        let b_len = self.b.as_ref().map(|a| a.len()).unwrap_or(0);
-        a_len + b_len
+struct SyncIter<'r, I, Item> {
+    request: &'r mut SyncRequest<I>,
+    marker: core::marker::PhantomData<Item>,
+}
+
+impl<'r, I, Item> SyncIter<'r, I, Item> {
+    fn new(request: &'r mut SyncRequest<I>) -> Self {
+        Self {
+            request,
+            marker: core::marker::PhantomData,
+        }
+    }
+}
+
+impl<'r, I, Item> ExactSizeIterator for SyncIter<'r, I, Item> where SyncIter<'r, I, Item>: Iterator {}
+
+impl<'r, I> Iterator for SyncIter<'r, I, ScriptBuf> {
+    type Item = ScriptBuf;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.request.next_spk()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let consumed = self.request.spks_consumed;
+        (consumed, Some(consumed))
+    }
+}
+
+impl<'r, I> Iterator for SyncIter<'r, I, Txid> {
+    type Item = Txid;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.request.next_txid()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let consumed = self.request.txids_consumed;
+        (consumed, Some(consumed))
+    }
+}
+
+impl<'r, I> Iterator for SyncIter<'r, I, OutPoint> {
+    type Item = OutPoint;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.request.next_outpoint()
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let consumed = self.request.outpoints_consumed;
+        (consumed, Some(consumed))
     }
 }

--- a/crates/electrum/src/bdk_electrum_client.rs
+++ b/crates/electrum/src/bdk_electrum_client.rs
@@ -205,19 +205,16 @@ impl<E: ElectrumApi> BdkElectrumClient<E> {
             None => None,
         };
 
-        let full_scan_request = FullScanRequest::builder()
-            .spks_for_keychain(
-                (),
-                request
-                    .iter_spks()
-                    .enumerate()
-                    .map(|(i, spk)| (i as u32, spk))
-                    .collect::<Vec<_>>(),
-            )
-            .build();
-        let mut graph_update = self
-            .full_scan(full_scan_request, usize::MAX, batch_size, false)?
-            .graph_update;
+        let mut graph_update = TxGraph::<ConfirmationBlockTime>::default();
+        self.populate_with_spks(
+            &mut graph_update,
+            request
+                .iter_spks()
+                .enumerate()
+                .map(|(i, spk)| (i as u32, spk)),
+            usize::MAX,
+            batch_size,
+        )?;
         self.populate_with_txids(&mut graph_update, request.iter_txids())?;
         self.populate_with_outpoints(&mut graph_update, request.iter_outpoints())?;
 

--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 bdk_chain = { path = "../chain", version = "0.17.0", default-features = false }
-esplora-client = { version = "0.8.0", default-features = false }
+esplora-client = { version = "0.9.0", default-features = false }
 async-trait = { version = "0.1.66", optional = true }
 futures = { version = "0.3.26", optional = true }
 

--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -16,8 +16,6 @@ bdk_chain = { path = "../chain", version = "0.17.0", default-features = false }
 esplora-client = { version = "0.9.0", default-features = false }
 async-trait = { version = "0.1.66", optional = true }
 futures = { version = "0.3.26", optional = true }
-
-bitcoin = { version = "0.32.0", optional = true, default-features = false }
 miniscript = { version = "12.0.0", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/crates/esplora/README.md
+++ b/crates/esplora/README.md
@@ -27,8 +27,8 @@ To use the extension traits:
 ```rust
 // for blocking
 use bdk_esplora::EsploraExt;
-// // for async
-// use bdk_esplora::EsploraAsyncExt;
+// for async
+use bdk_esplora::EsploraAsyncExt;
 ```
 
 For full examples, refer to [`example-crates/wallet_esplora_blocking`](https://github.com/bitcoindevkit/bdk/tree/master/example-crates/wallet_esplora_blocking) and [`example-crates/wallet_esplora_async`](https://github.com/bitcoindevkit/bdk/tree/master/example-crates/wallet_esplora_async).

--- a/crates/esplora/README.md
+++ b/crates/esplora/README.md
@@ -1,11 +1,12 @@
 # BDK Esplora
 
-BDK Esplora extends [`esplora-client`] to update [`bdk_chain`] structures
-from an Esplora server.
+BDK Esplora extends [`esplora-client`] (with extension traits: [`EsploraExt`] and
+[`EsploraAsyncExt`]) to update [`bdk_chain`] structures from an Esplora server.
+
+The extension traits are primarily intended to satisfy [`SyncRequest`]s with [`sync`] and
+[`FullScanRequest`]s with [`full_scan`].
 
 ## Usage
-
-There are two versions of the extension trait (blocking and async).
 
 For blocking-only:
 ```toml
@@ -26,7 +27,7 @@ To use the extension traits:
 ```rust
 // for blocking
 use bdk_esplora::EsploraExt;
-// for async
+// // for async
 // use bdk_esplora::EsploraAsyncExt;
 ```
 
@@ -34,3 +35,9 @@ For full examples, refer to [`example-crates/wallet_esplora_blocking`](https://g
 
 [`esplora-client`]: https://docs.rs/esplora-client/
 [`bdk_chain`]: https://docs.rs/bdk-chain/
+[`EsploraExt`]: crate::EsploraExt
+[`EsploraAsyncExt`]: crate::EsploraAsyncExt
+[`SyncRequest`]: bdk_chain::spk_client::SyncRequest
+[`FullScanRequest`]: bdk_chain::spk_client::FullScanRequest
+[`sync`]: crate::EsploraExt::sync
+[`full_scan`]: crate::EsploraExt::full_scan

--- a/crates/esplora/src/blocking_ext.rs
+++ b/crates/esplora/src/blocking_ext.rs
@@ -9,7 +9,7 @@ use bdk_chain::{
     BlockId, ConfirmationBlockTime, TxGraph,
 };
 use bdk_chain::{Anchor, Indexed};
-use esplora_client::TxStatus;
+use esplora_client::{OutputStatus, Tx, TxStatus};
 
 use crate::anchor_from_status;
 
@@ -18,32 +18,17 @@ pub type Error = Box<esplora_client::Error>;
 
 /// Trait to extend the functionality of [`esplora_client::BlockingClient`].
 ///
-/// Refer to [crate-level documentation] for more.
-///
-/// [crate-level documentation]: crate
+/// Refer to [crate-level documentation](crate) for more.
 pub trait EsploraExt {
     /// Scan keychain scripts for transactions against Esplora, returning an update that can be
     /// applied to the receiving structures.
     ///
-    /// - `request`: struct with data required to perform a spk-based blockchain client full scan,
-    ///              see [`FullScanRequest`]
+    /// `request` provides the data required to perform a script-pubkey-based full scan
+    /// (see [`FullScanRequest`]). The full scan for each keychain (`K`) stops after a gap of
+    /// `stop_gap` script pubkeys with no associated transactions. `parallel_requests` specifies
+    /// the maximum number of HTTP requests to make in parallel.
     ///
-    /// The full scan for each keychain stops after a gap of `stop_gap` script pubkeys with no
-    /// associated transactions. `parallel_requests` specifies the max number of HTTP requests to
-    /// make in parallel.
-    ///
-    /// ## Note
-    ///
-    /// `stop_gap` is defined as "the maximum number of consecutive unused addresses".
-    /// For example, with a `stop_gap` of  3, `full_scan` will keep scanning
-    /// until it encounters 3 consecutive script pubkeys with no associated transactions.
-    ///
-    /// This follows the same approach as other Bitcoin-related software,
-    /// such as [Electrum](https://electrum.readthedocs.io/en/latest/faq.html#what-is-the-gap-limit),
-    /// [BTCPay Server](https://docs.btcpayserver.org/FAQ/Wallet/#the-gap-limit-problem),
-    /// and [Sparrow](https://www.sparrowwallet.com/docs/faq.html#ive-restored-my-wallet-but-some-of-my-funds-are-missing).
-    ///
-    /// A `stop_gap` of 0 will be treated as a `stop_gap` of 1.
+    /// Refer to [crate-level docs](crate) for more.
     fn full_scan<K: Ord + Clone>(
         &self,
         request: FullScanRequest<K>,
@@ -51,17 +36,78 @@ pub trait EsploraExt {
         parallel_requests: usize,
     ) -> Result<FullScanResult<K>, Error>;
 
-    /// Sync a set of scripts with the blockchain (via an Esplora client) for the data
-    /// specified and return a [`TxGraph`].
+    /// Sync a set of scripts, txids, and/or outpoints against Esplora.
     ///
-    /// - `request`: struct with data required to perform a spk-based blockchain client sync, see
-    ///              [`SyncRequest`]
+    /// `request` provides the data required to perform a script-pubkey-based sync (see
+    /// [`SyncRequest`]). `parallel_requests` specifies the maximum number of HTTP requests to make
+    /// in parallel.
     ///
-    /// If the scripts to sync are unknown, such as when restoring or importing a keychain that
-    /// may include scripts that have been used, use [`full_scan`] with the keychain.
-    ///
-    /// [`full_scan`]: EsploraExt::full_scan
+    /// Refer to [crate-level docs](crate) for more.
     fn sync(&self, request: SyncRequest, parallel_requests: usize) -> Result<SyncResult, Error>;
+
+    /// Fetch transactions and associated [`ConfirmationBlockTime`]s by scanning
+    /// `keychain_spks` against Esplora.
+    ///
+    /// `keychain_spks` is an *unbounded* indexed-[`ScriptBuf`] iterator that represents scripts
+    /// derived from a keychain. The scanning logic stops after a `stop_gap` number of consecutive
+    /// scripts with no transaction history is reached. `parallel_requests` specifies the maximum
+    /// number of HTTP requests to make in parallel.
+    ///
+    /// A [`TxGraph`] (containing the fetched transactions and anchors) and the last active keychain
+    /// index (if any) is returned. The last active keychain index is the keychain's last script
+    /// pubkey that contains a non-empty transaction history.
+    ///
+    /// Refer to [crate-level docs](crate) for more.
+    fn fetch_txs_with_keychain_spks<I: Iterator<Item = Indexed<ScriptBuf>>>(
+        &self,
+        keychain_spks: I,
+        stop_gap: usize,
+        parallel_requests: usize,
+    ) -> Result<(TxGraph<ConfirmationBlockTime>, Option<u32>), Error>;
+
+    /// Fetch transactions and associated [`ConfirmationBlockTime`]s by scanning `spks`
+    /// against Esplora.
+    ///
+    /// Unlike with [`EsploraExt::fetch_txs_with_keychain_spks`], `spks` must be *bounded* as all
+    /// contained scripts will be scanned. `parallel_requests` specifies the maximum number of HTTP
+    /// requests to make in parallel.
+    ///
+    /// Refer to [crate-level docs](crate) for more.
+    fn fetch_txs_with_spks<I: IntoIterator<Item = ScriptBuf>>(
+        &self,
+        spks: I,
+        parallel_requests: usize,
+    ) -> Result<TxGraph<ConfirmationBlockTime>, Error>
+    where
+        I::IntoIter: ExactSizeIterator;
+
+    /// Fetch transactions and associated [`ConfirmationBlockTime`]s by scanning `txids`
+    /// against Esplora.
+    ///
+    /// `parallel_requests` specifies the maximum number of HTTP requests to make in parallel.
+    ///
+    /// Refer to [crate-level docs](crate) for more.
+    fn fetch_txs_with_txids<I: IntoIterator<Item = Txid>>(
+        &self,
+        txids: I,
+        parallel_requests: usize,
+    ) -> Result<TxGraph<ConfirmationBlockTime>, Error>
+    where
+        I::IntoIter: ExactSizeIterator;
+
+    /// Fetch transactions and [`ConfirmationBlockTime`]s that contain and spend the provided
+    /// `outpoints`.
+    ///
+    /// `parallel_requests` specifies the maximum number of HTTP requests to make in parallel.
+    ///
+    /// Refer to [crate-level docs](crate) for more.
+    fn fetch_txs_with_outpoints<I: IntoIterator<Item = OutPoint>>(
+        &self,
+        outpoints: I,
+        parallel_requests: usize,
+    ) -> Result<TxGraph<ConfirmationBlockTime>, Error>
+    where
+        I::IntoIter: ExactSizeIterator;
 }
 
 impl EsploraExt for esplora_client::BlockingClient {
@@ -72,12 +118,16 @@ impl EsploraExt for esplora_client::BlockingClient {
         parallel_requests: usize,
     ) -> Result<FullScanResult<K>, Error> {
         let latest_blocks = fetch_latest_blocks(self)?;
-        let (graph_update, last_active_indices) = full_scan_for_index_and_graph_blocking(
-            self,
-            request.spks_by_keychain,
-            stop_gap,
-            parallel_requests,
-        )?;
+        let mut graph_update = TxGraph::default();
+        let mut last_active_indices = BTreeMap::<K, u32>::new();
+        for (keychain, keychain_spks) in request.spks_by_keychain {
+            let (tx_graph, last_active_index) =
+                self.fetch_txs_with_keychain_spks(keychain_spks, stop_gap, parallel_requests)?;
+            let _ = graph_update.apply_update(tx_graph);
+            if let Some(last_active_index) = last_active_index {
+                last_active_indices.insert(keychain, last_active_index);
+            }
+        }
         let chain_update = chain_update(
             self,
             &latest_blocks,
@@ -93,13 +143,13 @@ impl EsploraExt for esplora_client::BlockingClient {
 
     fn sync(&self, request: SyncRequest, parallel_requests: usize) -> Result<SyncResult, Error> {
         let latest_blocks = fetch_latest_blocks(self)?;
-        let graph_update = sync_for_index_and_graph_blocking(
-            self,
-            request.spks,
-            request.txids,
-            request.outpoints,
-            parallel_requests,
-        )?;
+        let mut graph_update = TxGraph::default();
+        let _ =
+            graph_update.apply_update(self.fetch_txs_with_spks(request.spks, parallel_requests)?);
+        let _ =
+            graph_update.apply_update(self.fetch_txs_with_txids(request.txids, parallel_requests)?);
+        let _ = graph_update
+            .apply_update(self.fetch_txs_with_outpoints(request.outpoints, parallel_requests)?);
         let chain_update = chain_update(
             self,
             &latest_blocks,
@@ -110,6 +160,229 @@ impl EsploraExt for esplora_client::BlockingClient {
             chain_update,
             graph_update,
         })
+    }
+
+    fn fetch_txs_with_keychain_spks<I: Iterator<Item = Indexed<ScriptBuf>>>(
+        &self,
+        mut keychain_spks: I,
+        stop_gap: usize,
+        parallel_requests: usize,
+    ) -> Result<(TxGraph<ConfirmationBlockTime>, Option<u32>), Error> {
+        type TxsOfSpkIndex = (u32, Vec<esplora_client::Tx>);
+
+        let mut tx_graph = TxGraph::default();
+        let mut last_index = Option::<u32>::None;
+        let mut last_active_index = Option::<u32>::None;
+
+        loop {
+            let handles = keychain_spks
+                .by_ref()
+                .take(parallel_requests)
+                .map(|(spk_index, spk)| {
+                    std::thread::spawn({
+                        let client = self.clone();
+                        move || -> Result<TxsOfSpkIndex, Error> {
+                            let mut last_seen = None;
+                            let mut spk_txs = Vec::new();
+                            loop {
+                                let txs = client.scripthash_txs(&spk, last_seen)?;
+                                let tx_count = txs.len();
+                                last_seen = txs.last().map(|tx| tx.txid);
+                                spk_txs.extend(txs);
+                                if tx_count < 25 {
+                                    break Ok((spk_index, spk_txs));
+                                }
+                            }
+                        }
+                    })
+                })
+                .collect::<Vec<JoinHandle<Result<TxsOfSpkIndex, Error>>>>();
+
+            if handles.is_empty() {
+                break;
+            }
+
+            for handle in handles {
+                let (index, txs) = handle.join().expect("thread must not panic")?;
+                last_index = Some(index);
+                if !txs.is_empty() {
+                    last_active_index = Some(index);
+                }
+                for tx in txs {
+                    let _ = tx_graph.insert_tx(tx.to_tx());
+                    if let Some(anchor) = anchor_from_status(&tx.status) {
+                        let _ = tx_graph.insert_anchor(tx.txid, anchor);
+                    }
+
+                    let previous_outputs = tx.vin.iter().filter_map(|vin| {
+                        let prevout = vin.prevout.as_ref()?;
+                        Some((
+                            OutPoint {
+                                txid: vin.txid,
+                                vout: vin.vout,
+                            },
+                            TxOut {
+                                script_pubkey: prevout.scriptpubkey.clone(),
+                                value: Amount::from_sat(prevout.value),
+                            },
+                        ))
+                    });
+
+                    for (outpoint, txout) in previous_outputs {
+                        let _ = tx_graph.insert_txout(outpoint, txout);
+                    }
+                }
+            }
+
+            let last_index = last_index.expect("Must be set since handles wasn't empty.");
+            let gap_limit_reached = if let Some(i) = last_active_index {
+                last_index >= i.saturating_add(stop_gap as u32)
+            } else {
+                last_index + 1 >= stop_gap as u32
+            };
+            if gap_limit_reached {
+                break;
+            }
+        }
+
+        Ok((tx_graph, last_active_index))
+    }
+
+    fn fetch_txs_with_spks<I: IntoIterator<Item = ScriptBuf>>(
+        &self,
+        spks: I,
+        parallel_requests: usize,
+    ) -> Result<TxGraph<ConfirmationBlockTime>, Error>
+    where
+        I::IntoIter: ExactSizeIterator,
+    {
+        self.fetch_txs_with_keychain_spks(
+            spks.into_iter().enumerate().map(|(i, spk)| (i as u32, spk)),
+            usize::MAX,
+            parallel_requests,
+        )
+        .map(|(tx_graph, _)| tx_graph)
+    }
+
+    fn fetch_txs_with_txids<I: IntoIterator<Item = Txid>>(
+        &self,
+        txids: I,
+        parallel_requests: usize,
+    ) -> Result<TxGraph<ConfirmationBlockTime>, Error>
+    where
+        I::IntoIter: ExactSizeIterator,
+    {
+        enum EsploraResp {
+            TxStatus(TxStatus),
+            Tx(Option<Tx>),
+        }
+
+        let mut tx_graph = TxGraph::default();
+        let mut txids = txids.into_iter();
+        loop {
+            let handles = txids
+                .by_ref()
+                .take(parallel_requests)
+                .map(|txid| {
+                    let client = self.clone();
+                    let tx_already_exists = tx_graph.get_tx(txid).is_some();
+                    std::thread::spawn(move || {
+                        if tx_already_exists {
+                            client
+                                .get_tx_status(&txid)
+                                .map_err(Box::new)
+                                .map(|s| (txid, EsploraResp::TxStatus(s)))
+                        } else {
+                            client
+                                .get_tx_info(&txid)
+                                .map_err(Box::new)
+                                .map(|t| (txid, EsploraResp::Tx(t)))
+                        }
+                    })
+                })
+                .collect::<Vec<JoinHandle<Result<(Txid, EsploraResp), Error>>>>();
+
+            if handles.is_empty() {
+                break;
+            }
+
+            for handle in handles {
+                let (txid, resp) = handle.join().expect("thread must not panic")?;
+                match resp {
+                    EsploraResp::TxStatus(status) => {
+                        if let Some(anchor) = anchor_from_status(&status) {
+                            let _ = tx_graph.insert_anchor(txid, anchor);
+                        }
+                    }
+                    EsploraResp::Tx(Some(tx_info)) => {
+                        let _ = tx_graph.insert_tx(tx_info.to_tx());
+                        if let Some(anchor) = anchor_from_status(&tx_info.status) {
+                            let _ = tx_graph.insert_anchor(txid, anchor);
+                        }
+                    }
+                    _ => continue,
+                }
+            }
+        }
+        Ok(tx_graph)
+    }
+
+    fn fetch_txs_with_outpoints<I: IntoIterator<Item = OutPoint>>(
+        &self,
+        outpoints: I,
+        parallel_requests: usize,
+    ) -> Result<TxGraph<ConfirmationBlockTime>, Error>
+    where
+        I::IntoIter: ExactSizeIterator,
+    {
+        let outpoints = outpoints.into_iter().collect::<Vec<_>>();
+
+        // make sure txs exists in graph and tx statuses are updated
+        // TODO: We should maintain a tx cache (like we do with Electrum).
+        let mut tx_graph =
+            self.fetch_txs_with_txids(outpoints.iter().map(|op| op.txid), parallel_requests)?;
+
+        // get outpoint spend-statuses
+        let mut outpoints = outpoints.into_iter();
+        let mut missing_txs = Vec::<Txid>::with_capacity(outpoints.len());
+        loop {
+            let handles = outpoints
+                .by_ref()
+                .take(parallel_requests)
+                .map(|op| {
+                    let client = self.clone();
+                    std::thread::spawn(move || {
+                        client
+                            .get_output_status(&op.txid, op.vout as _)
+                            .map_err(Box::new)
+                    })
+                })
+                .collect::<Vec<JoinHandle<Result<Option<OutputStatus>, Error>>>>();
+
+            if handles.is_empty() {
+                break;
+            }
+
+            for handle in handles {
+                if let Some(op_status) = handle.join().expect("thread must not panic")? {
+                    let spend_txid = match op_status.txid {
+                        Some(txid) => txid,
+                        None => continue,
+                    };
+                    if tx_graph.get_tx(spend_txid).is_none() {
+                        missing_txs.push(spend_txid);
+                    }
+                    if let Some(spend_status) = op_status.status {
+                        if let Some(spend_anchor) = anchor_from_status(&spend_status) {
+                            let _ = tx_graph.insert_anchor(spend_txid, spend_anchor);
+                        }
+                    }
+                }
+            }
+        }
+
+        let _ = tx_graph.apply_update(self.fetch_txs_with_txids(missing_txs, parallel_requests)?);
+        Ok(tx_graph)
     }
 }
 
@@ -210,187 +483,6 @@ fn chain_update<A: Anchor>(
     }
 
     Ok(tip)
-}
-
-/// This performs a full scan to get an update for the [`TxGraph`] and
-/// [`KeychainTxOutIndex`](bdk_chain::indexer::keychain_txout::KeychainTxOutIndex).
-fn full_scan_for_index_and_graph_blocking<K: Ord + Clone>(
-    client: &esplora_client::BlockingClient,
-    keychain_spks: BTreeMap<K, impl IntoIterator<Item = Indexed<ScriptBuf>>>,
-    stop_gap: usize,
-    parallel_requests: usize,
-) -> Result<(TxGraph<ConfirmationBlockTime>, BTreeMap<K, u32>), Error> {
-    type TxsOfSpkIndex = (u32, Vec<esplora_client::Tx>);
-    let parallel_requests = Ord::max(parallel_requests, 1);
-    let mut tx_graph = TxGraph::<ConfirmationBlockTime>::default();
-    let mut last_active_indices = BTreeMap::<K, u32>::new();
-
-    for (keychain, spks) in keychain_spks {
-        let mut spks = spks.into_iter();
-        let mut last_index = Option::<u32>::None;
-        let mut last_active_index = Option::<u32>::None;
-
-        loop {
-            let handles = spks
-                .by_ref()
-                .take(parallel_requests)
-                .map(|(spk_index, spk)| {
-                    std::thread::spawn({
-                        let client = client.clone();
-                        move || -> Result<TxsOfSpkIndex, Error> {
-                            let mut last_seen = None;
-                            let mut spk_txs = Vec::new();
-                            loop {
-                                let txs = client.scripthash_txs(&spk, last_seen)?;
-                                let tx_count = txs.len();
-                                last_seen = txs.last().map(|tx| tx.txid);
-                                spk_txs.extend(txs);
-                                if tx_count < 25 {
-                                    break Ok((spk_index, spk_txs));
-                                }
-                            }
-                        }
-                    })
-                })
-                .collect::<Vec<JoinHandle<Result<TxsOfSpkIndex, Error>>>>();
-
-            if handles.is_empty() {
-                break;
-            }
-
-            for handle in handles {
-                let (index, txs) = handle.join().expect("thread must not panic")?;
-                last_index = Some(index);
-                if !txs.is_empty() {
-                    last_active_index = Some(index);
-                }
-                for tx in txs {
-                    let _ = tx_graph.insert_tx(tx.to_tx());
-                    if let Some(anchor) = anchor_from_status(&tx.status) {
-                        let _ = tx_graph.insert_anchor(tx.txid, anchor);
-                    }
-
-                    let previous_outputs = tx.vin.iter().filter_map(|vin| {
-                        let prevout = vin.prevout.as_ref()?;
-                        Some((
-                            OutPoint {
-                                txid: vin.txid,
-                                vout: vin.vout,
-                            },
-                            TxOut {
-                                script_pubkey: prevout.scriptpubkey.clone(),
-                                value: Amount::from_sat(prevout.value),
-                            },
-                        ))
-                    });
-
-                    for (outpoint, txout) in previous_outputs {
-                        let _ = tx_graph.insert_txout(outpoint, txout);
-                    }
-                }
-            }
-
-            let last_index = last_index.expect("Must be set since handles wasn't empty.");
-            let gap_limit_reached = if let Some(i) = last_active_index {
-                last_index >= i.saturating_add(stop_gap as u32)
-            } else {
-                last_index + 1 >= stop_gap as u32
-            };
-            if gap_limit_reached {
-                break;
-            }
-        }
-
-        if let Some(last_active_index) = last_active_index {
-            last_active_indices.insert(keychain, last_active_index);
-        }
-    }
-
-    Ok((tx_graph, last_active_indices))
-}
-
-fn sync_for_index_and_graph_blocking(
-    client: &esplora_client::BlockingClient,
-    misc_spks: impl IntoIterator<Item = ScriptBuf>,
-    txids: impl IntoIterator<Item = Txid>,
-    outpoints: impl IntoIterator<Item = OutPoint>,
-    parallel_requests: usize,
-) -> Result<TxGraph<ConfirmationBlockTime>, Error> {
-    let (mut tx_graph, _) = full_scan_for_index_and_graph_blocking(
-        client,
-        {
-            let mut keychains = BTreeMap::new();
-            keychains.insert(
-                (),
-                misc_spks
-                    .into_iter()
-                    .enumerate()
-                    .map(|(i, spk)| (i as u32, spk)),
-            );
-            keychains
-        },
-        usize::MAX,
-        parallel_requests,
-    )?;
-
-    let mut txids = txids.into_iter();
-    loop {
-        let handles = txids
-            .by_ref()
-            .take(parallel_requests)
-            .filter(|&txid| tx_graph.get_tx(txid).is_none())
-            .map(|txid| {
-                std::thread::spawn({
-                    let client = client.clone();
-                    move || {
-                        client
-                            .get_tx_status(&txid)
-                            .map_err(Box::new)
-                            .map(|s| (txid, s))
-                    }
-                })
-            })
-            .collect::<Vec<JoinHandle<Result<(Txid, TxStatus), Error>>>>();
-
-        if handles.is_empty() {
-            break;
-        }
-
-        for handle in handles {
-            let (txid, status) = handle.join().expect("thread must not panic")?;
-            if let Some(anchor) = anchor_from_status(&status) {
-                let _ = tx_graph.insert_anchor(txid, anchor);
-            }
-        }
-    }
-
-    for op in outpoints {
-        if tx_graph.get_tx(op.txid).is_none() {
-            if let Some(tx) = client.get_tx(&op.txid)? {
-                let _ = tx_graph.insert_tx(tx);
-            }
-            let status = client.get_tx_status(&op.txid)?;
-            if let Some(anchor) = anchor_from_status(&status) {
-                let _ = tx_graph.insert_anchor(op.txid, anchor);
-            }
-        }
-
-        if let Some(op_status) = client.get_output_status(&op.txid, op.vout as _)? {
-            if let Some(txid) = op_status.txid {
-                if tx_graph.get_tx(txid).is_none() {
-                    if let Some(tx) = client.get_tx(&txid)? {
-                        let _ = tx_graph.insert_tx(tx);
-                    }
-                    let status = client.get_tx_status(&txid)?;
-                    if let Some(anchor) = anchor_from_status(&status) {
-                        let _ = tx_graph.insert_anchor(txid, anchor);
-                    }
-                }
-            }
-        }
-    }
-
-    Ok(tx_graph)
 }
 
 #[cfg(test)]

--- a/crates/esplora/src/blocking_ext.rs
+++ b/crates/esplora/src/blocking_ext.rs
@@ -4,14 +4,14 @@ use std::thread::JoinHandle;
 use bdk_chain::collections::BTreeMap;
 use bdk_chain::spk_client::{FullScanRequest, FullScanResult, SyncRequest, SyncResult};
 use bdk_chain::{
-    bitcoin::{Amount, BlockHash, OutPoint, ScriptBuf, TxOut, Txid},
+    bitcoin::{BlockHash, OutPoint, ScriptBuf, Txid},
     local_chain::CheckPoint,
     BlockId, ConfirmationBlockTime, TxGraph,
 };
 use bdk_chain::{Anchor, Indexed};
 use esplora_client::{OutputStatus, Tx, TxStatus};
 
-use crate::anchor_from_status;
+use crate::{insert_anchor_from_status, insert_prevouts};
 
 /// [`esplora_client::Error`]
 pub type Error = Box<esplora_client::Error>;
@@ -210,27 +210,8 @@ impl EsploraExt for esplora_client::BlockingClient {
                 }
                 for tx in txs {
                     let _ = tx_graph.insert_tx(tx.to_tx());
-                    if let Some(anchor) = anchor_from_status(&tx.status) {
-                        let _ = tx_graph.insert_anchor(tx.txid, anchor);
-                    }
-
-                    let previous_outputs = tx.vin.iter().filter_map(|vin| {
-                        let prevout = vin.prevout.as_ref()?;
-                        Some((
-                            OutPoint {
-                                txid: vin.txid,
-                                vout: vin.vout,
-                            },
-                            TxOut {
-                                script_pubkey: prevout.scriptpubkey.clone(),
-                                value: Amount::from_sat(prevout.value),
-                            },
-                        ))
-                    });
-
-                    for (outpoint, txout) in previous_outputs {
-                        let _ = tx_graph.insert_txout(outpoint, txout);
-                    }
+                    insert_anchor_from_status(&mut tx_graph, tx.txid, tx.status);
+                    insert_prevouts(&mut tx_graph, tx.vin);
                 }
             }
 
@@ -310,15 +291,12 @@ impl EsploraExt for esplora_client::BlockingClient {
                 let (txid, resp) = handle.join().expect("thread must not panic")?;
                 match resp {
                     EsploraResp::TxStatus(status) => {
-                        if let Some(anchor) = anchor_from_status(&status) {
-                            let _ = tx_graph.insert_anchor(txid, anchor);
-                        }
+                        insert_anchor_from_status(&mut tx_graph, txid, status);
                     }
                     EsploraResp::Tx(Some(tx_info)) => {
                         let _ = tx_graph.insert_tx(tx_info.to_tx());
-                        if let Some(anchor) = anchor_from_status(&tx_info.status) {
-                            let _ = tx_graph.insert_anchor(txid, anchor);
-                        }
+                        insert_anchor_from_status(&mut tx_graph, txid, tx_info.status);
+                        insert_prevouts(&mut tx_graph, tx_info.vin);
                     }
                     _ => continue,
                 }
@@ -373,9 +351,7 @@ impl EsploraExt for esplora_client::BlockingClient {
                         missing_txs.push(spend_txid);
                     }
                     if let Some(spend_status) = op_status.status {
-                        if let Some(spend_anchor) = anchor_from_status(&spend_status) {
-                            let _ = tx_graph.insert_anchor(spend_txid, spend_anchor);
-                        }
+                        insert_anchor_from_status(&mut tx_graph, spend_txid, spend_status);
                     }
                 }
             }

--- a/crates/esplora/src/lib.rs
+++ b/crates/esplora/src/lib.rs
@@ -17,7 +17,7 @@
 //! # Async
 //!
 //! Just like how [`EsploraExt`] extends the functionality of an
-//! [`esplora_client::BlockingClient`], [`EsploraExt`] is the async version which extends
+//! [`esplora_client::BlockingClient`], [`EsploraAsyncExt`] is the async version which extends
 //! [`esplora_client::AsyncClient`].
 //!
 //! [`TxGraph`]: bdk_chain::tx_graph::TxGraph

--- a/crates/esplora/src/lib.rs
+++ b/crates/esplora/src/lib.rs
@@ -1,21 +1,4 @@
 #![doc = include_str!("../README.md")]
-
-//! # Primary Methods
-//!
-//! The two primary methods are [`EsploraExt::sync`] and [`EsploraExt::full_scan`].
-//!
-//! [`EsploraExt::sync`] is used to sync against a subset of wallet data. For example, transaction
-//! histories of revealed and unused script from the external (public) keychain and/or statuses of
-//! wallet-owned UTXOs and spending transactions from them. The policy of what to sync against can
-//! be customized.
-//!
-//! [`EsploraExt::full_scan`] is designed to be used when importing or restoring a keychain where
-//! the range of possibly used scripts is not known. In this case it is necessary to scan all
-//! keychain scripts until a number (the `stop_gap`) of unused scripts is discovered.
-//!
-//! For a sync or full scan, the user receives relevant blockchain data and output updates for
-//! [`bdk_chain`] .
-//!
 //! # Low-Level Methods
 //!
 //! [`EsploraExt::sync`] and [`EsploraExt::full_scan`] returns updates which are *complete* and can

--- a/crates/esplora/src/lib.rs
+++ b/crates/esplora/src/lib.rs
@@ -1,19 +1,59 @@
 #![doc = include_str!("../README.md")]
 
-//! This crate is used for updating structures of [`bdk_chain`] with data from an Esplora server.
+//! # Primary Methods
 //!
-//! The two primary methods are [`EsploraExt::sync`] and [`EsploraExt::full_scan`]. In most cases
-//! [`EsploraExt::sync`] is used to sync the transaction histories of scripts that the application
-//! cares about, for example the scripts for all the receive addresses of a Wallet's keychain that it
-//! has shown a user. [`EsploraExt::full_scan`] is meant to be used when importing or restoring a
-//! keychain where the range of possibly used scripts is not known. In this case it is necessary to
-//! scan all keychain scripts until a number (the "stop gap") of unused scripts is discovered. For a
-//! sync or full scan the user receives relevant blockchain data and output updates for [`bdk_chain`]
-//! via a new [`TxGraph`] to be appended to any existing [`TxGraph`] data.
+//! The two primary methods are [`EsploraExt::sync`] and [`EsploraExt::full_scan`].
 //!
-//! Refer to [`example_esplora`] for a complete example.
+//! [`EsploraExt::sync`] is used to sync against a subset of wallet data. For example, transaction
+//! histories of revealed and unused script from the external (public) keychain and/or statuses of
+//! wallet-owned UTXOs and spending transactions from them. The policy of what to sync against can
+//! be customized.
+//!
+//! [`EsploraExt::full_scan`] is designed to be used when importing or restoring a keychain where
+//! the range of possibly used scripts is not known. In this case it is necessary to scan all
+//! keychain scripts until a number (the `stop_gap`) of unused scripts is discovered.
+//!
+//! For a sync or full scan, the user receives relevant blockchain data and output updates for
+//! [`bdk_chain`] .
+//!
+//! # Low-Level Methods
+//!
+//! [`EsploraExt::sync`] and [`EsploraExt::full_scan`] returns updates which are *complete* and can
+//! be used directly to determine confirmation statuses of each transaction. This is because a
+//! [`LocalChain`] update is contained in the returned update structures. However, sometimes the
+//! caller wishes to use a custom [`ChainOracle`] implementation (something other than
+//! [`LocalChain`]). The following methods ONLY returns an update [`TxGraph`]:
+//!
+//! * [`EsploraExt::fetch_txs_with_keychain_spks`]
+//! * [`EsploraExt::fetch_txs_with_spks`]
+//! * [`EsploraExt::fetch_txs_with_txids`]
+//! * [`EsploraExt::fetch_txs_with_outpoints`]
+//!
+//! # Stop Gap
+//!
+//! Methods [`EsploraExt::full_scan`] and [`EsploraExt::fetch_txs_with_keychain_spks`] takes in a
+//! `stop_gap` input which is defined as the maximum number of consecutive unused script pubkeys to
+//! scan transactions for before stopping.
+//!
+//! For example, with a `stop_gap` of 3, `full_scan` will keep scanning until it encounters 3
+//! consecutive script pubkeys with no associated transactions.
+//!
+//! This follows the same approach as other Bitcoin-related software,
+//! such as [Electrum](https://electrum.readthedocs.io/en/latest/faq.html#what-is-the-gap-limit),
+//! [BTCPay Server](https://docs.btcpayserver.org/FAQ/Wallet/#the-gap-limit-problem),
+//! and [Sparrow](https://www.sparrowwallet.com/docs/faq.html#ive-restored-my-wallet-but-some-of-my-funds-are-missing).
+//!
+//! A `stop_gap` of 0 will be treated as a `stop_gap` of 1.
+//!
+//! # Async
+//!
+//! Just like how [`EsploraExt`] extends the functionality of an
+//! [`esplora_client::BlockingClient`], [`EsploraExt`] is the async version which extends
+//! [`esplora_client::AsyncClient`].
 //!
 //! [`TxGraph`]: bdk_chain::tx_graph::TxGraph
+//! [`LocalChain`]: bdk_chain::local_chain::LocalChain
+//! [`ChainOracle`]: bdk_chain::ChainOracle
 //! [`example_esplora`]: https://github.com/bitcoindevkit/bdk/tree/master/example-crates/example_esplora
 
 use bdk_chain::{BlockId, ConfirmationBlockTime};

--- a/crates/esplora/src/lib.rs
+++ b/crates/esplora/src/lib.rs
@@ -1,22 +1,8 @@
 #![doc = include_str!("../README.md")]
-//! # Low-Level Methods
-//!
-//! [`EsploraExt::sync`] and [`EsploraExt::full_scan`] returns updates which are *complete* and can
-//! be used directly to determine confirmation statuses of each transaction. This is because a
-//! [`LocalChain`] update is contained in the returned update structures. However, sometimes the
-//! caller wishes to use a custom [`ChainOracle`] implementation (something other than
-//! [`LocalChain`]). The following methods ONLY returns an update [`TxGraph`]:
-//!
-//! * [`EsploraExt::fetch_txs_with_keychain_spks`]
-//! * [`EsploraExt::fetch_txs_with_spks`]
-//! * [`EsploraExt::fetch_txs_with_txids`]
-//! * [`EsploraExt::fetch_txs_with_outpoints`]
-//!
 //! # Stop Gap
 //!
-//! Methods [`EsploraExt::full_scan`] and [`EsploraExt::fetch_txs_with_keychain_spks`] takes in a
-//! `stop_gap` input which is defined as the maximum number of consecutive unused script pubkeys to
-//! scan transactions for before stopping.
+//! [`EsploraExt::full_scan`] takes in a `stop_gap` input which is defined as the maximum number of
+//! consecutive unused script pubkeys to scan transactions for before stopping.
 //!
 //! For example, with a `stop_gap` of 3, `full_scan` will keep scanning until it encounters 3
 //! consecutive script pubkeys with no associated transactions.

--- a/crates/esplora/tests/async_ext.rs
+++ b/crates/esplora/tests/async_ext.rs
@@ -55,7 +55,9 @@ pub async fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
     let cp_tip = env.make_checkpoint_tip();
 
     let sync_update = {
-        let request = SyncRequest::from_chain_tip(cp_tip.clone()).set_spks(misc_spks);
+        let request = SyncRequest::builder()
+            .chain_tip(cp_tip.clone())
+            .spks(misc_spks);
         client.sync(request, 1).await?
     };
 
@@ -160,15 +162,17 @@ pub async fn test_async_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     // A scan with a gap limit of 3 won't find the transaction, but a scan with a gap limit of 4
     // will.
     let full_scan_update = {
-        let request =
-            FullScanRequest::from_chain_tip(cp_tip.clone()).set_spks_for_keychain(0, spks.clone());
+        let request = FullScanRequest::builder()
+            .chain_tip(cp_tip.clone())
+            .spks_for_keychain(0, spks.clone());
         client.full_scan(request, 3, 1).await?
     };
     assert!(full_scan_update.graph_update.full_txs().next().is_none());
     assert!(full_scan_update.last_active_indices.is_empty());
     let full_scan_update = {
-        let request =
-            FullScanRequest::from_chain_tip(cp_tip.clone()).set_spks_for_keychain(0, spks.clone());
+        let request = FullScanRequest::builder()
+            .chain_tip(cp_tip.clone())
+            .spks_for_keychain(0, spks.clone());
         client.full_scan(request, 4, 1).await?
     };
     assert_eq!(
@@ -201,8 +205,9 @@ pub async fn test_async_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     // A scan with gap limit 5 won't find the second transaction, but a scan with gap limit 6 will.
     // The last active indice won't be updated in the first case but will in the second one.
     let full_scan_update = {
-        let request =
-            FullScanRequest::from_chain_tip(cp_tip.clone()).set_spks_for_keychain(0, spks.clone());
+        let request = FullScanRequest::builder()
+            .chain_tip(cp_tip.clone())
+            .spks_for_keychain(0, spks.clone());
         client.full_scan(request, 5, 1).await?
     };
     let txs: HashSet<_> = full_scan_update
@@ -214,8 +219,9 @@ pub async fn test_async_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     assert!(txs.contains(&txid_4th_addr));
     assert_eq!(full_scan_update.last_active_indices[&0], 3);
     let full_scan_update = {
-        let request =
-            FullScanRequest::from_chain_tip(cp_tip.clone()).set_spks_for_keychain(0, spks.clone());
+        let request = FullScanRequest::builder()
+            .chain_tip(cp_tip.clone())
+            .spks_for_keychain(0, spks.clone());
         client.full_scan(request, 6, 1).await?
     };
     let txs: HashSet<_> = full_scan_update

--- a/crates/esplora/tests/blocking_ext.rs
+++ b/crates/esplora/tests/blocking_ext.rs
@@ -55,7 +55,9 @@ pub fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
     let cp_tip = env.make_checkpoint_tip();
 
     let sync_update = {
-        let request = SyncRequest::from_chain_tip(cp_tip.clone()).set_spks(misc_spks);
+        let request = SyncRequest::builder()
+            .chain_tip(cp_tip.clone())
+            .spks(misc_spks);
         client.sync(request, 1)?
     };
 
@@ -161,15 +163,17 @@ pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     // A scan with a stop_gap of 3 won't find the transaction, but a scan with a gap limit of 4
     // will.
     let full_scan_update = {
-        let request =
-            FullScanRequest::from_chain_tip(cp_tip.clone()).set_spks_for_keychain(0, spks.clone());
+        let request = FullScanRequest::builder()
+            .chain_tip(cp_tip.clone())
+            .spks_for_keychain(0, spks.clone());
         client.full_scan(request, 3, 1)?
     };
     assert!(full_scan_update.graph_update.full_txs().next().is_none());
     assert!(full_scan_update.last_active_indices.is_empty());
     let full_scan_update = {
-        let request =
-            FullScanRequest::from_chain_tip(cp_tip.clone()).set_spks_for_keychain(0, spks.clone());
+        let request = FullScanRequest::builder()
+            .chain_tip(cp_tip.clone())
+            .spks_for_keychain(0, spks.clone());
         client.full_scan(request, 4, 1)?
     };
     assert_eq!(
@@ -202,8 +206,9 @@ pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     // A scan with gap limit 5 won't find the second transaction, but a scan with gap limit 6 will.
     // The last active indice won't be updated in the first case but will in the second one.
     let full_scan_update = {
-        let request =
-            FullScanRequest::from_chain_tip(cp_tip.clone()).set_spks_for_keychain(0, spks.clone());
+        let request = FullScanRequest::builder()
+            .chain_tip(cp_tip.clone())
+            .spks_for_keychain(0, spks.clone());
         client.full_scan(request, 5, 1)?
     };
     let txs: HashSet<_> = full_scan_update
@@ -215,8 +220,9 @@ pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     assert!(txs.contains(&txid_4th_addr));
     assert_eq!(full_scan_update.last_active_indices[&0], 3);
     let full_scan_update = {
-        let request =
-            FullScanRequest::from_chain_tip(cp_tip.clone()).set_spks_for_keychain(0, spks.clone());
+        let request = FullScanRequest::builder()
+            .chain_tip(cp_tip.clone())
+            .spks_for_keychain(0, spks.clone());
         client.full_scan(request, 6, 1)?
     };
     let txs: HashSet<_> = full_scan_update

--- a/example-crates/example_electrum/src/main.rs
+++ b/example-crates/example_electrum/src/main.rs
@@ -209,10 +209,10 @@ fn main() -> anyhow::Result<()> {
                     });
 
             if all_spks {
-                request = request.spks_with_labels(graph.index.revealed_spks(..));
+                request = request.spks_with_indexes(graph.index.revealed_spks(..));
             }
             if unused_spks {
-                request = request.spks_with_labels(graph.index.unused_spks());
+                request = request.spks_with_indexes(graph.index.unused_spks());
             }
             if utxos {
                 let init_outpoints = graph.index.outpoints();

--- a/example-crates/example_electrum/src/main.rs
+++ b/example-crates/example_electrum/src/main.rs
@@ -209,22 +209,11 @@ fn main() -> anyhow::Result<()> {
                     });
 
             if all_spks {
-                request = request.spks_with_labels(
-                    graph
-                        .index
-                        .revealed_spks(..)
-                        .map(|(index, spk)| (index, spk.to_owned())),
-                );
+                request = request.spks_with_labels(graph.index.revealed_spks(..));
             }
             if unused_spks {
-                request = request.spks_with_labels(
-                    graph
-                        .index
-                        .unused_spks()
-                        .map(|(index, spk)| (index, spk.to_owned())),
-                );
+                request = request.spks_with_labels(graph.index.unused_spks());
             }
-
             if utxos {
                 let init_outpoints = graph.index.outpoints();
                 request = request.outpoints(
@@ -238,7 +227,6 @@ fn main() -> anyhow::Result<()> {
                         .map(|(_, utxo)| utxo.outpoint),
                 );
             };
-
             if unconfirmed {
                 request = request.txids(
                     graph

--- a/example-crates/example_esplora/src/main.rs
+++ b/example-crates/example_esplora/src/main.rs
@@ -230,20 +230,10 @@ fn main() -> anyhow::Result<()> {
                 let chain = chain.lock().unwrap();
 
                 if *all_spks {
-                    request = request.spks_with_labels(
-                        graph
-                            .index
-                            .revealed_spks(..)
-                            .map(|(i, spk)| (i, spk.to_owned())),
-                    );
+                    request = request.spks_with_labels(graph.index.revealed_spks(..));
                 }
                 if unused_spks {
-                    request = request.spks_with_labels(
-                        graph
-                            .index
-                            .unused_spks()
-                            .map(|(index, spk)| (index, spk.to_owned())),
-                    );
+                    request = request.spks_with_labels(graph.index.unused_spks());
                 }
                 if utxos {
                     // We want to search for whether the UTXO is spent, and spent by which

--- a/example-crates/example_esplora/src/main.rs
+++ b/example-crates/example_esplora/src/main.rs
@@ -230,10 +230,10 @@ fn main() -> anyhow::Result<()> {
                 let chain = chain.lock().unwrap();
 
                 if *all_spks {
-                    request = request.spks_with_labels(graph.index.revealed_spks(..));
+                    request = request.spks_with_indexes(graph.index.revealed_spks(..));
                 }
                 if unused_spks {
-                    request = request.spks_with_labels(graph.index.unused_spks());
+                    request = request.spks_with_indexes(graph.index.unused_spks());
                 }
                 if utxos {
                     // We want to search for whether the UTXO is spent, and spent by which

--- a/example-crates/wallet_electrum/src/main.rs
+++ b/example-crates/wallet_electrum/src/main.rs
@@ -52,19 +52,18 @@ fn main() -> Result<(), anyhow::Error> {
     // already have.
     client.populate_tx_cache(wallet.tx_graph());
 
-    let request = wallet
-        .start_full_scan()
-        .inspect_spks_for_all_keychains({
-            let mut once = HashSet::<KeychainKind>::new();
-            move |k, spk_i, _| {
-                if once.insert(k) {
-                    print!("\nScanning keychain [{:?}]", k)
-                } else {
-                    print!(" {:<3}", spk_i)
-                }
+    let request = wallet.start_full_scan().inspect({
+        let mut stdout = std::io::stdout();
+        let mut once = HashSet::<KeychainKind>::new();
+        move |k, spk_i, _| {
+            if once.insert(k) {
+                print!("\nScanning keychain [{:?}]", k)
+            } else {
+                print!(" {:<3}", spk_i)
             }
-        })
-        .inspect_spks_for_all_keychains(|_, _, _| std::io::stdout().flush().expect("must flush"));
+            stdout.flush().expect("must flush");
+        }
+    });
 
     let mut update = client.full_scan(request, STOP_GAP, BATCH_SIZE, false)?;
 

--- a/example-crates/wallet_electrum/src/main.rs
+++ b/example-crates/wallet_electrum/src/main.rs
@@ -57,10 +57,9 @@ fn main() -> Result<(), anyhow::Error> {
         let mut once = HashSet::<KeychainKind>::new();
         move |k, spk_i, _| {
             if once.insert(k) {
-                print!("\nScanning keychain [{:?}]", k)
-            } else {
-                print!(" {:<3}", spk_i)
+                print!("\nScanning keychain [{:?}]", k);
             }
+            print!(" {:<3}", spk_i);
             stdout.flush().expect("must flush");
         }
     });

--- a/example-crates/wallet_esplora_async/src/main.rs
+++ b/example-crates/wallet_esplora_async/src/main.rs
@@ -45,14 +45,15 @@ async fn main() -> Result<(), anyhow::Error> {
     print!("Syncing...");
     let client = esplora_client::Builder::new(ESPLORA_URL).build_async()?;
 
-    let request = wallet.start_full_scan().inspect_spks_for_all_keychains({
+    let request = wallet.start_full_scan().inspect({
+        let mut stdout = std::io::stdout();
         let mut once = BTreeSet::<KeychainKind>::new();
         move |keychain, spk_i, _| {
             if once.insert(keychain) {
-                print!("\nScanning keychain [{:?}] ", keychain);
+                print!("\nScanning keychain [{:?}]", keychain);
             }
             print!(" {:<3}", spk_i);
-            std::io::stdout().flush().expect("must flush")
+            stdout.flush().expect("must flush")
         }
     });
 

--- a/example-crates/wallet_esplora_blocking/src/main.rs
+++ b/example-crates/wallet_esplora_blocking/src/main.rs
@@ -47,14 +47,15 @@ fn main() -> Result<(), anyhow::Error> {
     print!("Syncing...");
     let client = esplora_client::Builder::new(ESPLORA_URL).build_blocking();
 
-    let request = wallet.start_full_scan().inspect_spks_for_all_keychains({
+    let request = wallet.start_full_scan().inspect({
+        let mut stdout = std::io::stdout();
         let mut once = BTreeSet::<KeychainKind>::new();
         move |keychain, spk_i, _| {
             if once.insert(keychain) {
                 print!("\nScanning keychain [{:?}] ", keychain);
             }
             print!(" {:<3}", spk_i);
-            std::io::stdout().flush().expect("must flush")
+            stdout.flush().expect("must flush")
         }
     });
 


### PR DESCRIPTION
Closes #1528

### Description

Some users use `bdk_esplora` to update `bdk_chain` structures *without* a `LocalChain`. ~~This PR introduces "low-level" methods to `EsploraExt` and `EsploraAsyncExt` which populates a `TxGraph` update with associated data.~~

We change `FullScanRequest`/`SyncRequest` to take in the `chain_tip` parameter as an option. Spk-based chain sources (`bdk_electrum` and `bdk_esplora`) will not fetch a chain-update if `chain_tip` is `None`, allowing callers to opt-out of receiving updates for `LocalChain`.

We change `FullScanRequest`/`SyncRequest` to have better ergonomics when inspecting the progress of syncing (refer to #1528).

We change `FullScanRequest`/`SyncRequest` to be constructed with a builder pattern. This is a better API since we separate request-construction and request-consumption.

Additionally, much of the `bdk_esplora` logic has been made more efficient (less calls to Esplora) by utilizing the `/tx/:txid` endpoint (`get_tx_info` method). This method returns the tx and tx_status in one call. The logic for fetching updates for outpoints has been reworked to support parallelism.

Documentation has also been updated.

### Notes to reviewers

This PR has evolved somewhat. Initially, we were adding more methods on `EsploraExt`/`EsploraAsyncExt` to make syncing/scanning more modular. However, it turns out we can just make the `chain_tip` parameter of the request structures optional. Since we are changing the request structures, we might as well go further and improve the ergonomics of the whole structures (refer to #1528). This is where we are at with this PR.

Unfortunately, the changes are now breaking. I think this is an okay tradeoff for the API improvements (before we get to stable).

### Changelog notice

* Change request structures in `bdk_chain::spk_client` to be constructed via a builder pattern, make providing a `chain_tip` optional, and have better ergonomics for inspecting progress while syncing.
* Change `bdk_esplora` to be more efficient by reducing the number of calls via the `/tx/:txid` endpoint. The logic for fetching outpoint updates has been reworked to support parallelism.
* Change `bdk_esplora` to always add prev-txouts to the `TxGraph` update.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature

