### PR TITLE
Update wallet docs and examples to persist staged then take_staged

### DIFF
--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -670,8 +670,11 @@ impl Wallet {
     /// # let changeset = ChangeSet::default();
     /// # let mut wallet = Wallet::load_from_changeset(changeset).expect("load wallet");
     /// let next_address = wallet.reveal_next_address(KeychainKind::External);
-    /// if let Some(changeset) = wallet.take_staged() {
+    /// if let Some(changeset) = wallet.staged() {
+    ///     // write staged wallet changes to db
     ///     db.write(&changeset)?;
+    ///     // remove staged changes from wallet
+    ///     wallet.take_staged();
     /// }
     ///
     /// // Now it's safe to show the user their next address!

--- a/crates/wallet/tests/wallet.rs
+++ b/crates/wallet/tests/wallet.rs
@@ -97,8 +97,9 @@ fn load_recovers_wallet() -> anyhow::Result<()> {
 
             // persist new wallet changes
             let mut db = create_new(&file_path).expect("must create db");
-            if let Some(changeset) = wallet.take_staged() {
-                write(&mut db, &changeset)?;
+            if let Some(changeset) = wallet.staged() {
+                write(&mut db, changeset)?;
+                wallet.take_staged();
             }
             wallet.spk_index().clone()
         };
@@ -171,8 +172,9 @@ fn new_or_load() -> anyhow::Result<()> {
             let wallet = &mut Wallet::new_or_load(desc, change_desc, None, Network::Testnet)
                 .expect("must init wallet");
             let mut db = new_or_load(&file_path).expect("must create db");
-            if let Some(changeset) = wallet.take_staged() {
-                write(&mut db, &changeset)?;
+            if let Some(changeset) = wallet.staged() {
+                write(&mut db, changeset)?;
+                wallet.take_staged();
             }
             wallet.keychains().map(|(k, v)| (*k, v.clone())).collect()
         };

--- a/example-crates/wallet_electrum/src/main.rs
+++ b/example-crates/wallet_electrum/src/main.rs
@@ -32,8 +32,9 @@ fn main() -> Result<(), anyhow::Error> {
     )?;
 
     let address = wallet.next_unused_address(KeychainKind::External);
-    if let Some(changeset) = wallet.take_staged() {
-        db.append_changeset(&changeset)?;
+    if let Some(changeset) = wallet.staged() {
+        db.append_changeset(changeset)?;
+        wallet.take_staged();
     }
     println!("Generated Address: {}", address);
 
@@ -73,8 +74,9 @@ fn main() -> Result<(), anyhow::Error> {
     println!();
 
     wallet.apply_update(update)?;
-    if let Some(changeset) = wallet.take_staged() {
-        db.append_changeset(&changeset)?;
+    if let Some(changeset) = wallet.staged() {
+        db.append_changeset(changeset)?;
+        wallet.take_staged();
     }
 
     let balance = wallet.balance();

--- a/example-crates/wallet_esplora_async/src/main.rs
+++ b/example-crates/wallet_esplora_async/src/main.rs
@@ -29,8 +29,9 @@ async fn main() -> Result<(), anyhow::Error> {
     )?;
 
     let address = wallet.next_unused_address(KeychainKind::External);
-    if let Some(changeset) = wallet.take_staged() {
-        db.write(&changeset)?;
+    if let Some(changeset) = wallet.staged() {
+        db.write(changeset)?;
+        wallet.take_staged();
     }
     println!("Generated Address: {}", address);
 
@@ -79,8 +80,9 @@ async fn main() -> Result<(), anyhow::Error> {
     let _ = update.graph_update.update_last_seen_unconfirmed(now);
 
     wallet.apply_update(update)?;
-    if let Some(changeset) = wallet.take_staged() {
-        db.write(&changeset)?;
+    if let Some(changeset) = wallet.staged() {
+        db.write(changeset)?;
+        wallet.take_staged();
     }
     println!();
 

--- a/example-crates/wallet_esplora_blocking/src/main.rs
+++ b/example-crates/wallet_esplora_blocking/src/main.rs
@@ -28,8 +28,9 @@ fn main() -> Result<(), anyhow::Error> {
     )?;
 
     let address = wallet.next_unused_address(KeychainKind::External);
-    if let Some(changeset) = wallet.take_staged() {
-        db.append_changeset(&changeset)?;
+    if let Some(changeset) = wallet.staged() {
+        db.append_changeset(changeset)?;
+        wallet.take_staged();
     }
     println!("Generated Address: {}", address);
 
@@ -56,8 +57,9 @@ fn main() -> Result<(), anyhow::Error> {
     let _ = update.graph_update.update_last_seen_unconfirmed(now);
 
     wallet.apply_update(update)?;
-    if let Some(changeset) = wallet.take_staged() {
-        db.append_changeset(&changeset)?;
+    if let Some(changeset) = wallet.staged() {
+        db.append_changeset(changeset)?;
+        wallet.take_staged();
     }
     println!();
 

--- a/example-crates/wallet_rpc/src/main.rs
+++ b/example-crates/wallet_rpc/src/main.rs
@@ -146,8 +146,9 @@ fn main() -> anyhow::Result<()> {
                 let connected_to = block_emission.connected_to();
                 let start_apply_block = Instant::now();
                 wallet.apply_block_connected_to(&block_emission.block, height, connected_to)?;
-                if let Some(changeset) = wallet.take_staged() {
-                    db.append_changeset(&changeset)?;
+                if let Some(changeset) = wallet.staged() {
+                    db.append_changeset(changeset)?;
+                    wallet.take_staged();
                 }
                 let elapsed = start_apply_block.elapsed().as_secs_f32();
                 println!(
@@ -158,8 +159,9 @@ fn main() -> anyhow::Result<()> {
             Emission::Mempool(mempool_emission) => {
                 let start_apply_mempool = Instant::now();
                 wallet.apply_unconfirmed_txs(mempool_emission.iter().map(|(tx, time)| (tx, *time)));
-                if let Some(changeset) = wallet.take_staged() {
-                    db.append_changeset(&changeset)?;
+                if let Some(changeset) = wallet.staged() {
+                    db.append_changeset(changeset)?;
+                    wallet.take_staged();
                 }
                 println!(
                     "Applied unconfirmed transactions in {}s",


### PR DESCRIPTION
### Description

Update wallet tests, docs and examples to persist staged changesets then if that succeeds use take_staged to remove them from the Wallet. 

### Notes to the reviewers

This was triggered by a discussion with @thunderbiscuit during our last rust dev call as the safer/recommended way to persist wallet changes. Only wallet docs, tests, and examples are changed.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing