### PR TITLE
refactor(wallet): Remove usage of `blockdata::` from bitcoin paths

### DIFF
--- a/crates/wallet/src/types.rs
+++ b/crates/wallet/src/types.rs
@@ -13,7 +13,7 @@ use alloc::boxed::Box;
 use core::convert::AsRef;
 
 use bdk_chain::ConfirmationTime;
-use bitcoin::blockdata::transaction::{OutPoint, Sequence, TxOut};
+use bitcoin::transaction::{OutPoint, Sequence, TxOut};
 use bitcoin::{psbt, Weight};
 
 use serde::{Deserialize, Serialize};

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -2530,7 +2530,7 @@ fn create_signers<E: IntoWalletDescriptor>(
 #[doc(hidden)]
 macro_rules! floating_rate {
     ($rate:expr) => {{
-        use $crate::bitcoin::blockdata::constants::WITNESS_SCALE_FACTOR;
+        use $crate::bitcoin::constants::WITNESS_SCALE_FACTOR;
         // sat_kwu / 250.0 -> sat_vb
         $rate.to_sat_per_kwu() as f64 / ((1000 / WITNESS_SCALE_FACTOR) as f64)
     }};

--- a/crates/wallet/tests/wallet.rs
+++ b/crates/wallet/tests/wallet.rs
@@ -201,8 +201,7 @@ fn new_or_load() -> anyhow::Result<()> {
         // wrong genesis hash
         {
             let exp_blockhash = BlockHash::all_zeros();
-            let got_blockhash =
-                bitcoin::blockdata::constants::genesis_block(Network::Testnet).block_hash();
+            let got_blockhash = bitcoin::constants::genesis_block(Network::Testnet).block_hash();
 
             let db = &mut new_or_load(&file_path).expect("must open db");
             let changeset = read(db)?;

--- a/nursery/tmp_plan/src/lib.rs
+++ b/nursery/tmp_plan/src/lib.rs
@@ -18,11 +18,11 @@ use bdk_chain::{bitcoin, collections::*, miniscript};
 use bitcoin::{
     absolute,
     bip32::{DerivationPath, Fingerprint, KeySource},
-    blockdata::transaction::Sequence,
     ecdsa,
     hashes::{hash160, ripemd160, sha256},
     secp256k1::Secp256k1,
     taproot::{self, LeafVersion, TapLeafHash},
+    transaction::Sequence,
     ScriptBuf, TxIn, Witness, WitnessVersion,
 };
 use miniscript::{


### PR DESCRIPTION
### Description

In `rust-bitcoin` the `blockdata` module is a code organisation thing, it should never have been public. One day those guys would like to remove it, so as not to be a PITA for `bdk` when they do lets remove all usage of `blockdata::` now.

### Changelog notice

Internal change only, no externally visible changes.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

