### PR TITLE
Enable selecting use-rustls-ring feature on electrum client

### DIFF
--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -9,12 +9,14 @@ description = "Fetch data from electrum in the form BDK accepts"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 bdk_chain = { path = "../chain", version = "0.17.0" }
-electrum-client = { version = "0.20" }
-#rustls = { version = "=0.21.1", optional = true, features = ["dangerous_configuration"] }
+electrum-client = { version = "0.21", features = ["proxy"], default-features = false }
 
 [dev-dependencies]
 bdk_testenv = { path = "../testenv", default-features = false }
+
+[features]
+default = ["use-rustls"]
+use-rustls = ["electrum-client/use-rustls"]
+use-rustls-ring = ["electrum-client/use-rustls-ring"]


### PR DESCRIPTION
This PR is a companion to bitcoindevkit/rust-electrum-client#135. It enables choosing the `ring` dependency on rustls instead of the new default (as of 0.23.0) `aws-lc-rs`. The AWS dependency breaks the Android and Swift builds. I wrote a more detailed explanation on [#135](https://github.com/bitcoindevkit/rust-electrum-client/pull/135).

### Notes to the reviewers

Do not merge before:
- [x] [#135](https://github.com/bitcoindevkit/rust-electrum-client/pull/135) is merged
- [x] A new version of rust-electrum-client is released (will be 0.21.0) 
- [x] The dependency points to the new version of the client rather than my fork of it.

### Changelog notice

```md
Added
    - bdk_electrum now enables choosing either the `use-rustls` or `use-rustls-ring` feature
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
