### PR TITLE
Slight rethinking of `Wallet` constructors (breaking change)

### DIFF
--- a/crates/wallet/README.md
+++ b/crates/wallet/README.md
@@ -78,9 +78,9 @@ let mut db =
 // Create a wallet with initial wallet data read from the file store.
 let descriptor = "wpkh(tprv8ZgxMBicQKsPdcAqYBpzAFwU5yxBUo88ggoBqu1qPcHUfSbKK1sKMLmC7EAk438btHQrSdu3jGGQa6PA71nvH5nkDexhLteJqkM4dQmWF9g/84'/1'/0'/0/*)";
 let change_descriptor = "wpkh(tprv8ZgxMBicQKsPdcAqYBpzAFwU5yxBUo88ggoBqu1qPcHUfSbKK1sKMLmC7EAk438btHQrSdu3jGGQa6PA71nvH5nkDexhLteJqkM4dQmWF9g/84'/1'/0'/1/*)";
-let changeset = db.aggregate_changesets().expect("changeset loaded");
+let changeset = db.aggregate_changesets().expect("changeset loaded").expect("changeset");
 let mut wallet =
-    Wallet::new_or_load(descriptor, change_descriptor, changeset, Network::Testnet)
+    Wallet::load(descriptor, change_descriptor, changeset, Network::Testnet)
         .expect("create or load wallet");
 
 // Get a new address to receive bitcoin.

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -204,7 +204,7 @@ impl std::error::Error for NewError {}
 ///
 /// Method [`load_no_priv`] and [`load`] may return this error.
 ///
-/// [`load_no_priv`]: Wallet::load_from_changeset
+/// [`load_no_priv`]: Wallet::load_no_priv
 /// [`load`]: Wallet::load
 #[derive(Debug)]
 pub enum LoadError {
@@ -379,7 +379,7 @@ impl Wallet {
     /// let external_signer_container = SignersContainer::build(external_keymap, &external_descriptor, &secp);
     /// let internal_signer_container = SignersContainer::build(internal_keymap, &internal_descriptor, &secp);
     /// let changeset = db.read()?.expect("there must be an existing changeset");
-    /// let mut wallet = Wallet::load_from_changeset(changeset)?;
+    /// let mut wallet = Wallet::load_no_priv(changeset)?;
     ///
     /// external_signer_container.signers().into_iter()
     ///     .for_each(|s| wallet.add_signer(KeychainKind::External, SignerOrdering::default(), s.clone()));
@@ -391,7 +391,7 @@ impl Wallet {
     ///
     /// Alternatively, you can call [`Wallet::load`], which will add the private keys of the
     /// passed-in descriptors to the [`Wallet`].
-    pub fn load_from_changeset(changeset: ChangeSet) -> Result<Self, LoadError> {
+    pub fn load_no_priv(changeset: ChangeSet) -> Result<Self, LoadError> {
         let secp = Secp256k1::new();
         let network = changeset.network.ok_or(LoadError::MissingNetwork)?;
         let chain =
@@ -462,7 +462,7 @@ impl Wallet {
         network: Network,
     ) -> Result<Self, LoadError> {
         let genesis_hash = genesis_block(network).block_hash();
-        let mut wallet = Self::load_from_changeset(changeset).map_err(|e| match e {
+        let mut wallet = Self::load_no_priv(changeset).map_err(|e| match e {
             LoadError::Descriptor(e) => LoadError::Descriptor(e),
             LoadError::MissingNetwork => LoadError::LoadedNetworkDoesNotMatch {
                 expected: network,
@@ -604,7 +604,7 @@ impl Wallet {
     /// let conn = Connection::open_in_memory().expect("must open connection");
     /// let mut db = Store::new(conn).expect("must create store");
     /// # let changeset = ChangeSet::default();
-    /// # let mut wallet = Wallet::load_from_changeset(changeset).expect("load wallet");
+    /// # let mut wallet = Wallet::load_no_priv(changeset).expect("load wallet");
     /// let next_address = wallet.reveal_next_address(KeychainKind::External);
     /// if let Some(changeset) = wallet.take_staged() {
     ///     db.write(&changeset)?;

--- a/crates/wallet/tests/wallet.rs
+++ b/crates/wallet/tests/wallet.rs
@@ -100,7 +100,7 @@ const P2WPKH_FAKE_WITNESS_SIZE: usize = 106;
 const DB_MAGIC: &[u8] = &[0x21, 0x24, 0x48];
 
 #[test]
-fn load_recovers_wallet() -> anyhow::Result<()> {
+fn test_wallet_load_no_priv() -> anyhow::Result<()> {
     fn run<Db, New, Recover, Read, Write>(
         filename: &str,
         create_new: New,
@@ -139,7 +139,7 @@ fn load_recovers_wallet() -> anyhow::Result<()> {
             let db = &mut recover(&file_path).expect("must recover db");
             let changeset = read(db).expect("must recover wallet").expect("changeset");
 
-            let wallet = Wallet::load_from_changeset(changeset).expect("must recover wallet");
+            let wallet = Wallet::load_no_priv(changeset).expect("must recover wallet");
             assert_eq!(wallet.network(), Network::Testnet);
             assert_eq!(
                 wallet.spk_index().keychains().collect::<Vec<_>>(),
@@ -180,7 +180,7 @@ fn load_recovers_wallet() -> anyhow::Result<()> {
 }
 
 #[test]
-fn new_or_load() -> anyhow::Result<()> {
+fn test_wallet_load() -> anyhow::Result<()> {
     fn run<Db, NewOrRecover, Read, Write>(
         filename: &str,
         new_or_load: NewOrRecover,
@@ -196,10 +196,10 @@ fn new_or_load() -> anyhow::Result<()> {
         let file_path = temp_dir.path().join(filename);
         let (desc, change_desc) = get_test_wpkh_with_change_desc();
 
-        // init wallet when non-existent
+        // initialize wallet
         let wallet_keychains: BTreeMap<_, _> = {
-            let wallet = &mut Wallet::new_or_load(desc, change_desc, None, Network::Testnet)
-                .expect("must init wallet");
+            let wallet =
+                &mut Wallet::new(desc, change_desc, Network::Testnet).expect("must init wallet");
             let mut db = new_or_load(&file_path).expect("must create db");
             if let Some(changeset) = wallet.take_staged() {
                 write(&mut db, &changeset)?;
@@ -210,42 +210,18 @@ fn new_or_load() -> anyhow::Result<()> {
         // wrong network
         {
             let mut db = new_or_load(&file_path).expect("must create db");
-            let changeset = read(&mut db)?;
-            let err = Wallet::new_or_load(desc, change_desc, changeset, Network::Bitcoin)
+            let changeset = read(&mut db)
+                .expect("must recover wallet")
+                .expect("changeset");
+            let err = Wallet::load(desc, change_desc, changeset, Network::Bitcoin)
                 .expect_err("wrong network");
             assert!(
                 matches!(
                     err,
-                    bdk_wallet::wallet::NewOrLoadError::LoadedNetworkDoesNotMatch {
+                    bdk_wallet::wallet::LoadError::LoadedNetworkDoesNotMatch {
                         got: Some(Network::Testnet),
                         expected: Network::Bitcoin
                     }
-                ),
-                "err: {}",
-                err,
-            );
-        }
-
-        // wrong genesis hash
-        {
-            let exp_blockhash = BlockHash::all_zeros();
-            let got_blockhash = bitcoin::constants::genesis_block(Network::Testnet).block_hash();
-
-            let db = &mut new_or_load(&file_path).expect("must open db");
-            let changeset = read(db)?;
-            let err = Wallet::new_or_load_with_genesis_hash(
-                desc,
-                change_desc,
-                changeset,
-                Network::Testnet,
-                exp_blockhash,
-            )
-            .expect_err("wrong genesis hash");
-            assert!(
-                matches!(
-                    err,
-                    bdk_wallet::wallet::NewOrLoadError::LoadedGenesisDoesNotMatch { got, expected }
-                    if got == Some(got_blockhash) && expected == exp_blockhash
                 ),
                 "err: {}",
                 err,
@@ -261,14 +237,13 @@ fn new_or_load() -> anyhow::Result<()> {
                 .0;
 
             let db = &mut new_or_load(&file_path).expect("must open db");
-            let changeset = read(db)?;
-            let err =
-                Wallet::new_or_load(exp_descriptor, exp_change_desc, changeset, Network::Testnet)
-                    .expect_err("wrong external descriptor");
+            let changeset = read(db).expect("must recover wallet").expect("changeset");
+            let err = Wallet::load(exp_descriptor, exp_change_desc, changeset, Network::Testnet)
+                .expect_err("wrong external descriptor");
             assert!(
                 matches!(
                     err,
-                    bdk_wallet::wallet::NewOrLoadError::LoadedDescriptorDoesNotMatch { ref got, keychain }
+                    bdk_wallet::wallet::LoadError::LoadedDescriptorDoesNotMatch { ref got, keychain }
                     if got == &Some(got_descriptor) && keychain == KeychainKind::External
                 ),
                 "err: {}",
@@ -285,13 +260,13 @@ fn new_or_load() -> anyhow::Result<()> {
                 .0;
 
             let db = &mut new_or_load(&file_path).expect("must open db");
-            let changeset = read(db)?;
-            let err = Wallet::new_or_load(desc, exp_descriptor, changeset, Network::Testnet)
+            let changeset = read(db).expect("must recover wallet").expect("changeset");
+            let err = Wallet::load(desc, exp_descriptor, changeset, Network::Testnet)
                 .expect_err("wrong internal descriptor");
             assert!(
                 matches!(
                     err,
-                    bdk_wallet::wallet::NewOrLoadError::LoadedDescriptorDoesNotMatch { ref got, keychain }
+                    bdk_wallet::wallet::LoadError::LoadedDescriptorDoesNotMatch { ref got, keychain }
                     if got == &Some(got_descriptor) && keychain == KeychainKind::Internal
                 ),
                 "err: {}",
@@ -302,8 +277,8 @@ fn new_or_load() -> anyhow::Result<()> {
         // all parameters match
         {
             let db = &mut new_or_load(&file_path).expect("must open db");
-            let changeset = read(db)?;
-            let wallet = Wallet::new_or_load(desc, change_desc, changeset, Network::Testnet)
+            let changeset = read(db).expect("must recover wallet").expect("changeset");
+            let wallet = Wallet::load(desc, change_desc, changeset, Network::Testnet)
                 .expect("must recover wallet");
             assert_eq!(wallet.network(), Network::Testnet);
             assert!(wallet
@@ -326,6 +301,20 @@ fn new_or_load() -> anyhow::Result<()> {
         |db| Ok(bdk_sqlite::Store::read(db)?),
         |db, changeset| Ok(bdk_sqlite::Store::write(db, changeset)?),
     )?;
+
+    Ok(())
+}
+
+#[test]
+fn test_wallet_new() -> anyhow::Result<()> {
+    let (desc, change_desc) = get_test_wpkh_with_change_desc();
+
+    // initialize wallet
+    let _: BTreeMap<_, _> = {
+        let wallet =
+            &mut Wallet::new(desc, change_desc, Network::Testnet).expect("must init wallet");
+        wallet.keychains().map(|(k, v)| (*k, v.clone())).collect()
+    };
 
     Ok(())
 }

--- a/example-crates/wallet_electrum/src/main.rs
+++ b/example-crates/wallet_electrum/src/main.rs
@@ -24,12 +24,18 @@ fn main() -> Result<(), anyhow::Error> {
     let changeset = db
         .aggregate_changesets()
         .map_err(|e| anyhow!("load changes error: {}", e))?;
-    let mut wallet = Wallet::new_or_load(
-        external_descriptor,
-        internal_descriptor,
-        changeset,
-        Network::Testnet,
-    )?;
+    let mut wallet;
+
+    if let Some(changeset) = changeset {
+        wallet = Wallet::load(
+            external_descriptor,
+            internal_descriptor,
+            changeset,
+            Network::Testnet,
+        )?;
+    } else {
+        wallet = Wallet::new(external_descriptor, internal_descriptor, Network::Testnet)?;
+    }
 
     let address = wallet.next_unused_address(KeychainKind::External);
     if let Some(changeset) = wallet.take_staged() {

--- a/example-crates/wallet_esplora_async/src/main.rs
+++ b/example-crates/wallet_esplora_async/src/main.rs
@@ -19,14 +19,8 @@ async fn main() -> Result<(), anyhow::Error> {
     let mut db = Store::new(conn)?;
     let external_descriptor = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/0/*)";
     let internal_descriptor = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/1/*)";
-    let changeset = db.read()?;
 
-    let mut wallet = Wallet::new_or_load(
-        external_descriptor,
-        internal_descriptor,
-        changeset,
-        Network::Signet,
-    )?;
+    let mut wallet = Wallet::new(external_descriptor, internal_descriptor, Network::Signet)?;
 
     let address = wallet.next_unused_address(KeychainKind::External);
     if let Some(changeset) = wallet.take_staged() {

--- a/example-crates/wallet_esplora_blocking/src/main.rs
+++ b/example-crates/wallet_esplora_blocking/src/main.rs
@@ -20,12 +20,17 @@ fn main() -> Result<(), anyhow::Error> {
     let internal_descriptor = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/1/*)";
     let changeset = db.aggregate_changesets()?;
 
-    let mut wallet = Wallet::new_or_load(
-        external_descriptor,
-        internal_descriptor,
-        changeset,
-        Network::Testnet,
-    )?;
+    let mut wallet;
+    if let Some(changeset) = changeset {
+        wallet = Wallet::load(
+            external_descriptor,
+            internal_descriptor,
+            changeset,
+            Network::Testnet,
+        )?;
+    } else {
+        wallet = Wallet::new(external_descriptor, internal_descriptor, Network::Testnet)?;
+    }
 
     let address = wallet.next_unused_address(KeychainKind::External);
     if let Some(changeset) = wallet.take_staged() {

--- a/example-crates/wallet_rpc/src/main.rs
+++ b/example-crates/wallet_rpc/src/main.rs
@@ -91,13 +91,19 @@ fn main() -> anyhow::Result<()> {
         args.db_path,
     )?;
     let changeset = db.aggregate_changesets()?;
+    let mut wallet;
 
-    let mut wallet = Wallet::new_or_load(
-        &args.descriptor,
-        &args.change_descriptor,
-        changeset,
-        args.network,
-    )?;
+    if let Some(changeset) = changeset {
+        wallet = Wallet::load(
+            &args.descriptor,
+            &args.change_descriptor,
+            changeset,
+            Network::Testnet,
+        )?;
+    } else {
+        wallet = Wallet::new(&args.descriptor, &args.change_descriptor, Network::Testnet)?;
+    }
+
     println!(
         "Loaded wallet in {}s",
         start_load_wallet.elapsed().as_secs_f32()


### PR DESCRIPTION
## Why This PR
Our current "constructors" on the `Wallet` type are as follow:
```rust
1. Wallet::new()
2. Wallet::new_with_genesis_hash()
3. Wallet::load_from_changeset()
4. Wallet::new_or_load()
5. Wallet::new_or_load_with_genesis_hash()
```

This PR proposes a revised set of constructors offering clearer boundaries between them and their intended use:
```rust
1. Wallet::new()
2. Wallet::new_with_genesis_hash()
3. Wallet::load()
4. Wallet::load_from_changeset() -> renamed load_no_priv()
```

A few observations on our current set of constructors and what led me to propose this PR:
- `Wallet.new_or_load()`. So... do you want to create a new wallet or load an existing one? It feels like you should know. If you don't know whether you're about to create a new wallet or load one from persistence, to me your issue lies upstream of this line in your code (but maybe there is a use case I'm not thinking of? let me know).
- The `new_or_load_with_genesis_hash()` is sort of named backwards (you don't load with a specific genesis hash, you can only do that on a new wallet). The clearer name for it would be `new_with_genesis_hash_or_load()`.
- Loading a wallet is _always_ done with a changeset; there is no other way to do it. In this sense, `Wallet.load_from_changeset()` is not optimally named. In fact, the name is also missing the core feature of the constructor: your wallet will not have private keys. An extra commit on this PR renames this method to `load_no_priv()`; feel free to bikeshed on the name I don't know that it's a particular good one yet and we can also just take that commit out if people like the load_from_changeset name.

Note that this PR doesn't touch the inner logic of the constructors. I simply renamed the methods, removed the `Option` on the changeset when calling the load methods, and fixed up the tests to break apart the behaviour tested. It did require removing the `NewOrLoadError` and adding the required variants to the `LoadError`.

## Changelog notice

```md
Breaking
    - The Wallet.new_or_load() method was removed [#1500]
    - The Wallet.load_from_changeset() method was renamed Wallet.load_no_priv() [#1500]
 
Added
    - A new method Wallet.load() was added to construct wallets [#1500]

[#1500]: https://github.com/bitcoindevkit/bdk/pull/1500
```

## Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
