### PR TITLE
refactor(wallet)!: Simplify public_descriptor(), remove redundant function

### DIFF
--- a/crates/wallet/src/wallet/export.rs
+++ b/crates/wallet/src/wallet/export.rs
@@ -116,7 +116,7 @@ impl FullyNodedExport {
         include_blockheight: bool,
     ) -> Result<Self, &'static str> {
         let descriptor = wallet
-            .get_descriptor_for_keychain(KeychainKind::External)
+            .public_descriptor(KeychainKind::External)
             .to_string_with_secret(
                 &wallet
                     .get_signers(KeychainKind::External)
@@ -144,7 +144,7 @@ impl FullyNodedExport {
 
         let change_descriptor = {
             let descriptor = wallet
-                .get_descriptor_for_keychain(KeychainKind::Internal)
+                .public_descriptor(KeychainKind::Internal)
                 .to_string_with_secret(
                     &wallet
                         .get_signers(KeychainKind::Internal)

--- a/crates/wallet/src/wallet/tx_builder.rs
+++ b/crates/wallet/src/wallet/tx_builder.rs
@@ -296,7 +296,7 @@ impl<'a, Cs> TxBuilder<'a, Cs> {
                 .collect::<Result<Vec<_>, _>>()?;
 
             for utxo in utxos {
-                let descriptor = wallet.get_descriptor_for_keychain(utxo.keychain);
+                let descriptor = wallet.public_descriptor(utxo.keychain);
                 let satisfaction_weight = descriptor.max_weight_to_satisfy().unwrap();
                 self.params.utxos.push(WeightedUtxo {
                     satisfaction_weight,

--- a/crates/wallet/tests/wallet.rs
+++ b/crates/wallet/tests/wallet.rs
@@ -151,7 +151,7 @@ fn load_recovers_wallet() -> anyhow::Result<()> {
             );
             let secp = Secp256k1::new();
             assert_eq!(
-                *wallet.get_descriptor_for_keychain(KeychainKind::External),
+                *wallet.public_descriptor(KeychainKind::External),
                 desc.into_wallet_descriptor(&secp, wallet.network())
                     .unwrap()
                     .0
@@ -1402,7 +1402,7 @@ fn test_add_foreign_utxo() {
         .assume_checked();
     let utxo = wallet2.list_unspent().next().expect("must take!");
     let foreign_utxo_satisfaction = wallet2
-        .get_descriptor_for_keychain(KeychainKind::External)
+        .public_descriptor(KeychainKind::External)
         .max_weight_to_satisfy()
         .unwrap();
 
@@ -1478,7 +1478,7 @@ fn test_calculate_fee_with_missing_foreign_utxo() {
         .assume_checked();
     let utxo = wallet2.list_unspent().next().expect("must take!");
     let foreign_utxo_satisfaction = wallet2
-        .get_descriptor_for_keychain(KeychainKind::External)
+        .public_descriptor(KeychainKind::External)
         .max_weight_to_satisfy()
         .unwrap();
 
@@ -1503,7 +1503,7 @@ fn test_add_foreign_utxo_invalid_psbt_input() {
     let (mut wallet, _) = get_funded_wallet_wpkh();
     let outpoint = wallet.list_unspent().next().expect("must exist").outpoint;
     let foreign_utxo_satisfaction = wallet
-        .get_descriptor_for_keychain(KeychainKind::External)
+        .public_descriptor(KeychainKind::External)
         .max_weight_to_satisfy()
         .unwrap();
 
@@ -1524,7 +1524,7 @@ fn test_add_foreign_utxo_where_outpoint_doesnt_match_psbt_input() {
     let tx2 = wallet2.get_tx(txid2).unwrap().tx_node.tx.clone();
 
     let satisfaction_weight = wallet2
-        .get_descriptor_for_keychain(KeychainKind::External)
+        .public_descriptor(KeychainKind::External)
         .max_weight_to_satisfy()
         .unwrap();
 
@@ -1568,7 +1568,7 @@ fn test_add_foreign_utxo_only_witness_utxo() {
     let utxo2 = wallet2.list_unspent().next().unwrap();
 
     let satisfaction_weight = wallet2
-        .get_descriptor_for_keychain(KeychainKind::External)
+        .public_descriptor(KeychainKind::External)
         .max_weight_to_satisfy()
         .unwrap();
 
@@ -3400,7 +3400,7 @@ fn test_taproot_foreign_utxo() {
     let utxo = wallet2.list_unspent().next().unwrap();
     let psbt_input = wallet2.get_psbt_input(utxo.clone(), None, false).unwrap();
     let foreign_utxo_satisfaction = wallet2
-        .get_descriptor_for_keychain(KeychainKind::External)
+        .public_descriptor(KeychainKind::External)
         .max_weight_to_satisfy()
         .unwrap();
 


### PR DESCRIPTION
Fixes #1501 


### Description

Simplifies `public_descriptor` function by using `get_descriptor` and removes `get_descriptor_for_keychain`.

### Notes to the reviewers

Tested with `cargo test --all-features`.

### Changelog notice

- Simplifies `public_descriptor` function and removes `get_descriptor_for_keychain`

### Checklists

#### All Submissions:

* [X] I've signed all my commits
* [X] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [X] I ran `cargo fmt` and `cargo clippy` before committing
