### PR TITLE
refactor(chain)!: Update KeychainTxOutIndex methods to use owned K and ScriptBuf

### DIFF
--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -94,7 +94,7 @@ use crate::{
 use alloc::collections::vec_deque::VecDeque;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
-use bitcoin::{Amount, OutPoint, Script, SignedAmount, Transaction, TxOut, Txid};
+use bitcoin::{Amount, OutPoint, ScriptBuf, SignedAmount, Transaction, TxOut, Txid};
 use core::fmt::{self, Formatter};
 use core::{
     convert::Infallible,
@@ -1163,7 +1163,7 @@ impl<A: Anchor> TxGraph<A> {
         chain: &C,
         chain_tip: BlockId,
         outpoints: impl IntoIterator<Item = (OI, OutPoint)>,
-        mut trust_predicate: impl FnMut(&OI, &Script) -> bool,
+        mut trust_predicate: impl FnMut(&OI, ScriptBuf) -> bool,
     ) -> Result<Balance, C::Error> {
         let mut immature = Amount::ZERO;
         let mut trusted_pending = Amount::ZERO;
@@ -1182,7 +1182,7 @@ impl<A: Anchor> TxGraph<A> {
                     }
                 }
                 ChainPosition::Unconfirmed(_) => {
-                    if trust_predicate(&spk_i, &txout.txout.script_pubkey) {
+                    if trust_predicate(&spk_i, txout.txout.script_pubkey) {
                         trusted_pending += txout.txout.value;
                     } else {
                         untrusted_pending += txout.txout.value;
@@ -1209,7 +1209,7 @@ impl<A: Anchor> TxGraph<A> {
         chain: &C,
         chain_tip: BlockId,
         outpoints: impl IntoIterator<Item = (OI, OutPoint)>,
-        trust_predicate: impl FnMut(&OI, &Script) -> bool,
+        trust_predicate: impl FnMut(&OI, ScriptBuf) -> bool,
     ) -> Balance {
         self.try_balance(chain, chain_tip, outpoints, trust_predicate)
             .expect("oracle is infallible")

--- a/crates/chain/tests/common/tx_template.rs
+++ b/crates/chain/tests/common/tx_template.rs
@@ -119,7 +119,7 @@ pub fn init_graph<'a, A: Anchor + Clone + 'a>(
                     },
                     Some(index) => TxOut {
                         value: Amount::from_sat(output.value),
-                        script_pubkey: spk_index.spk_at_index(index).unwrap().to_owned(),
+                        script_pubkey: spk_index.spk_at_index(index).unwrap(),
                     },
                 })
                 .collect(),

--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -12,9 +12,7 @@ use bdk_chain::{
     local_chain::LocalChain,
     tx_graph, Balance, ChainPosition, ConfirmationBlockTime, DescriptorExt,
 };
-use bitcoin::{
-    secp256k1::Secp256k1, Amount, OutPoint, Script, ScriptBuf, Transaction, TxIn, TxOut,
-};
+use bitcoin::{secp256k1::Secp256k1, Amount, OutPoint, ScriptBuf, Transaction, TxIn, TxOut};
 use miniscript::Descriptor;
 
 /// Ensure [`IndexedTxGraph::insert_relevant_txs`] can successfully index transactions NOT presented
@@ -284,7 +282,7 @@ fn test_list_owned_txouts() {
                 &local_chain,
                 chain_tip,
                 graph.index.outpoints().iter().cloned(),
-                |_, spk: &Script| trusted_spks.contains(&spk.to_owned()),
+                |_, spk: ScriptBuf| trusted_spks.contains(&spk),
             );
 
             let confirmed_txouts_txid = txouts

--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -161,7 +161,7 @@ fn test_list_owned_txouts() {
         for _ in 0..10 {
             let ((_, script), _) = graph
                 .index
-                .reveal_next_spk(&"keychain_1".to_string())
+                .reveal_next_spk("keychain_1".to_string())
                 .unwrap();
             // TODO Assert indexes
             trusted_spks.push(script.to_owned());
@@ -171,7 +171,7 @@ fn test_list_owned_txouts() {
         for _ in 0..10 {
             let ((_, script), _) = graph
                 .index
-                .reveal_next_spk(&"keychain_2".to_string())
+                .reveal_next_spk("keychain_2".to_string())
                 .unwrap();
             untrusted_spks.push(script.to_owned());
         }

--- a/crates/chain/tests/test_keychain_txout_index.rs
+++ b/crates/chain/tests/test_keychain_txout_index.rs
@@ -142,7 +142,7 @@ fn test_lookahead() {
     // - stored scripts of external keychain should be of expected counts
     for index in (0..20).skip_while(|i| i % 2 == 1) {
         let (revealed_spks, revealed_changeset) = txout_index
-            .reveal_to_target(&TestKeychain::External, index)
+            .reveal_to_target(TestKeychain::External, index)
             .unwrap();
         assert_eq!(
             revealed_spks,
@@ -161,25 +161,25 @@ fn test_lookahead() {
         );
         assert_eq!(
             txout_index
-                .revealed_keychain_spks(&TestKeychain::External)
+                .revealed_keychain_spks(TestKeychain::External)
                 .count(),
             index as usize + 1,
         );
         assert_eq!(
             txout_index
-                .revealed_keychain_spks(&TestKeychain::Internal)
+                .revealed_keychain_spks(TestKeychain::Internal)
                 .count(),
             0,
         );
         assert_eq!(
             txout_index
-                .unused_keychain_spks(&TestKeychain::External)
+                .unused_keychain_spks(TestKeychain::External)
                 .count(),
             index as usize + 1,
         );
         assert_eq!(
             txout_index
-                .unused_keychain_spks(&TestKeychain::Internal)
+                .unused_keychain_spks(TestKeychain::Internal)
                 .count(),
             0,
         );
@@ -193,7 +193,7 @@ fn test_lookahead() {
     // expect:
     // - scripts cached in spk_txout_index should increase correctly, a.k.a. no scripts are skipped
     let (revealed_spks, revealed_changeset) = txout_index
-        .reveal_to_target(&TestKeychain::Internal, 24)
+        .reveal_to_target(TestKeychain::Internal, 24)
         .unwrap();
     assert_eq!(
         revealed_spks,
@@ -214,17 +214,17 @@ fn test_lookahead() {
     );
     assert_eq!(
         txout_index
-            .revealed_keychain_spks(&TestKeychain::Internal)
+            .revealed_keychain_spks(TestKeychain::Internal)
             .count(),
         25,
     );
 
     // ensure derivation indices are expected for each keychain
     let last_external_index = txout_index
-        .last_revealed_index(&TestKeychain::External)
+        .last_revealed_index(TestKeychain::External)
         .expect("already derived");
     let last_internal_index = txout_index
-        .last_revealed_index(&TestKeychain::Internal)
+        .last_revealed_index(TestKeychain::Internal)
         .expect("already derived");
     assert_eq!(last_external_index, 19);
     assert_eq!(last_internal_index, 24);
@@ -257,22 +257,22 @@ fn test_lookahead() {
         };
         assert_eq!(txout_index.index_tx(&tx), ChangeSet::default());
         assert_eq!(
-            txout_index.last_revealed_index(&TestKeychain::External),
+            txout_index.last_revealed_index(TestKeychain::External),
             Some(last_external_index)
         );
         assert_eq!(
-            txout_index.last_revealed_index(&TestKeychain::Internal),
+            txout_index.last_revealed_index(TestKeychain::Internal),
             Some(last_internal_index)
         );
         assert_eq!(
             txout_index
-                .revealed_keychain_spks(&TestKeychain::External)
+                .revealed_keychain_spks(TestKeychain::External)
                 .count(),
             last_external_index as usize + 1,
         );
         assert_eq!(
             txout_index
-                .revealed_keychain_spks(&TestKeychain::Internal)
+                .revealed_keychain_spks(TestKeychain::Internal)
                 .count(),
             last_internal_index as usize + 1,
         );
@@ -317,11 +317,11 @@ fn test_scan_with_lookahead() {
             &[(external_descriptor.descriptor_id(), spk_i)].into()
         );
         assert_eq!(
-            txout_index.last_revealed_index(&TestKeychain::External),
+            txout_index.last_revealed_index(TestKeychain::External),
             Some(spk_i)
         );
         assert_eq!(
-            txout_index.last_used_index(&TestKeychain::External),
+            txout_index.last_used_index(TestKeychain::External),
             Some(spk_i)
         );
     }
@@ -357,11 +357,11 @@ fn test_wildcard_derivations() {
     // - next_derivation_index() == (0, true)
     // - derive_new() == ((0, <spk>), keychain::ChangeSet)
     // - next_unused() == ((0, <spk>), keychain::ChangeSet:is_empty())
-    assert_eq!(txout_index.next_index(&TestKeychain::External).unwrap(), (0, true));
-    let (spk, changeset) = txout_index.reveal_next_spk(&TestKeychain::External).unwrap();
+    assert_eq!(txout_index.next_index(TestKeychain::External).unwrap(), (0, true));
+    let (spk, changeset) = txout_index.reveal_next_spk(TestKeychain::External).unwrap();
     assert_eq!(spk, (0_u32, external_spk_0.clone()));
     assert_eq!(&changeset.last_revealed, &[(external_descriptor.descriptor_id(), 0)].into());
-    let (spk, changeset) = txout_index.next_unused_spk(&TestKeychain::External).unwrap();
+    let (spk, changeset) = txout_index.next_unused_spk(TestKeychain::External).unwrap();
     assert_eq!(spk, (0_u32, external_spk_0.clone()));
     assert_eq!(&changeset.last_revealed, &[].into());
 
@@ -373,20 +373,20 @@ fn test_wildcard_derivations() {
     // - next_derivation_index() = (26, true)
     // - derive_new() = ((26, <spk>), keychain::ChangeSet)
     // - next_unused() == ((16, <spk>), keychain::ChangeSet::is_empty())
-    let _ = txout_index.reveal_to_target(&TestKeychain::External, 25);
+    let _ = txout_index.reveal_to_target(TestKeychain::External, 25);
 
     (0..=15)
         .chain([17, 20, 23])
         .for_each(|index| assert!(txout_index.mark_used(TestKeychain::External, index)));
 
-    assert_eq!(txout_index.next_index(&TestKeychain::External).unwrap(), (26, true));
+    assert_eq!(txout_index.next_index(TestKeychain::External).unwrap(), (26, true));
 
-    let (spk, changeset) = txout_index.reveal_next_spk(&TestKeychain::External).unwrap();
+    let (spk, changeset) = txout_index.reveal_next_spk(TestKeychain::External).unwrap();
     assert_eq!(spk, (26, external_spk_26));
 
     assert_eq!(&changeset.last_revealed, &[(external_descriptor.descriptor_id(), 26)].into());
 
-    let (spk, changeset) = txout_index.next_unused_spk(&TestKeychain::External).unwrap();
+    let (spk, changeset) = txout_index.next_unused_spk(TestKeychain::External).unwrap();
     assert_eq!(spk, (16, external_spk_16));
     assert_eq!(&changeset.last_revealed, &[].into());
 
@@ -396,7 +396,7 @@ fn test_wildcard_derivations() {
         txout_index.mark_used(TestKeychain::External, index);
     });
 
-    let (spk, changeset) = txout_index.next_unused_spk(&TestKeychain::External).unwrap();
+    let (spk, changeset) = txout_index.next_unused_spk(TestKeychain::External).unwrap();
     assert_eq!(spk, (27, external_spk_27));
     assert_eq!(&changeset.last_revealed, &[(external_descriptor.descriptor_id(), 27)].into());
 }
@@ -424,21 +424,17 @@ fn test_non_wildcard_derivations() {
     // - when we derive a new script, script @ index 0
     // - when we get the next unused script, script @ index 0
     assert_eq!(
-        txout_index.next_index(&TestKeychain::External).unwrap(),
+        txout_index.next_index(TestKeychain::External).unwrap(),
         (0, true)
     );
-    let (spk, changeset) = txout_index
-        .reveal_next_spk(&TestKeychain::External)
-        .unwrap();
+    let (spk, changeset) = txout_index.reveal_next_spk(TestKeychain::External).unwrap();
     assert_eq!(spk, (0, external_spk.clone()));
     assert_eq!(
         &changeset.last_revealed,
         &[(no_wildcard_descriptor.descriptor_id(), 0)].into()
     );
 
-    let (spk, changeset) = txout_index
-        .next_unused_spk(&TestKeychain::External)
-        .unwrap();
+    let (spk, changeset) = txout_index.next_unused_spk(TestKeychain::External).unwrap();
     assert_eq!(spk, (0, external_spk.clone()));
     assert_eq!(&changeset.last_revealed, &[].into());
 
@@ -449,24 +445,20 @@ fn test_non_wildcard_derivations() {
     // - derive new and next unused should return the old script
     // - store_up_to should not panic and return empty changeset
     assert_eq!(
-        txout_index.next_index(&TestKeychain::External).unwrap(),
+        txout_index.next_index(TestKeychain::External).unwrap(),
         (0, false)
     );
     txout_index.mark_used(TestKeychain::External, 0);
 
-    let (spk, changeset) = txout_index
-        .reveal_next_spk(&TestKeychain::External)
-        .unwrap();
+    let (spk, changeset) = txout_index.reveal_next_spk(TestKeychain::External).unwrap();
     assert_eq!(spk, (0, external_spk.clone()));
     assert_eq!(&changeset.last_revealed, &[].into());
 
-    let (spk, changeset) = txout_index
-        .next_unused_spk(&TestKeychain::External)
-        .unwrap();
+    let (spk, changeset) = txout_index.next_unused_spk(TestKeychain::External).unwrap();
     assert_eq!(spk, (0, external_spk.clone()));
     assert_eq!(&changeset.last_revealed, &[].into());
     let (revealed_spks, revealed_changeset) = txout_index
-        .reveal_to_target(&TestKeychain::External, 200)
+        .reveal_to_target(TestKeychain::External, 200)
         .unwrap();
     assert_eq!(revealed_spks.len(), 0);
     assert!(revealed_changeset.is_empty());
@@ -474,7 +466,7 @@ fn test_non_wildcard_derivations() {
     // we check that spks_of_keychain returns a SpkIterator with just one element
     assert_eq!(
         txout_index
-            .revealed_keychain_spks(&TestKeychain::External)
+            .revealed_keychain_spks(TestKeychain::External)
             .count(),
         1,
     );
@@ -540,10 +532,10 @@ fn lookahead_to_target() {
         );
 
         if let Some(last_revealed) = t.external_last_revealed {
-            let _ = index.reveal_to_target(&TestKeychain::External, last_revealed);
+            let _ = index.reveal_to_target(TestKeychain::External, last_revealed);
         }
         if let Some(last_revealed) = t.internal_last_revealed {
-            let _ = index.reveal_to_target(&TestKeychain::Internal, last_revealed);
+            let _ = index.reveal_to_target(TestKeychain::Internal, last_revealed);
         }
 
         let keychain_test_cases = [
@@ -570,7 +562,7 @@ fn lookahead_to_target() {
                     }
                     None => target,
                 };
-                index.lookahead_to_target(&keychain, target);
+                index.lookahead_to_target(keychain.clone(), target);
                 let keys = index
                     .inner()
                     .all_spks()
@@ -671,7 +663,7 @@ fn when_querying_over_a_range_of_keychains_the_utxos_should_show_up() {
         let _ = indexer.insert_descriptor(i, descriptor.clone()).unwrap();
         if i != 4 {
             // skip one in the middle to see if uncovers any bugs
-            indexer.reveal_next_spk(&i);
+            indexer.reveal_next_spk(i);
         }
         tx.output.push(TxOut {
             script_pubkey: descriptor.at_derivation_index(0).unwrap().script_pubkey(),

--- a/crates/chain/tests/test_tx_graph_conflicts.rs
+++ b/crates/chain/tests/test_tx_graph_conflicts.rs
@@ -6,7 +6,7 @@ mod common;
 use std::collections::{BTreeSet, HashSet};
 
 use bdk_chain::{Balance, BlockId};
-use bitcoin::{Amount, OutPoint, Script};
+use bitcoin::{Amount, OutPoint, ScriptBuf};
 use common::*;
 
 #[allow(dead_code)]
@@ -659,7 +659,7 @@ fn test_tx_conflict_handling() {
             &local_chain,
             chain_tip,
             spk_index.outpoints().iter().cloned(),
-            |_, spk: &Script| spk_index.index_of_spk(spk).is_some(),
+            |_, spk: ScriptBuf| spk_index.index_of_spk(spk).is_some(),
         );
         assert_eq!(
             balance, scenario.exp_balance,

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -542,7 +542,7 @@ impl Wallet {
     }
 
     /// Iterator over all keychains in this wallet
-    pub fn keychains(&self) -> impl Iterator<Item = (&KeychainKind, &ExtendedDescriptor)> {
+    pub fn keychains(&self) -> impl Iterator<Item = (KeychainKind, &ExtendedDescriptor)> {
         self.indexed_graph.index.keychains()
     }
 
@@ -558,7 +558,7 @@ impl Wallet {
         let mut spk_iter = self
             .indexed_graph
             .index
-            .unbounded_spk_iter(&keychain)
+            .unbounded_spk_iter(keychain)
             .expect("keychain must exist");
         if !spk_iter.descriptor().has_wildcard() {
             index = 0;
@@ -604,7 +604,7 @@ impl Wallet {
         let stage = &mut self.stage;
 
         let ((index, spk), index_changeset) = index
-            .reveal_next_spk(&keychain)
+            .reveal_next_spk(keychain)
             .expect("keychain must exist");
 
         stage.merge(index_changeset.into());
@@ -634,7 +634,7 @@ impl Wallet {
         let (spks, index_changeset) = self
             .indexed_graph
             .index
-            .reveal_to_target(&keychain, index)
+            .reveal_to_target(keychain, index)
             .expect("keychain must exist");
 
         self.stage.merge(index_changeset.into());
@@ -658,7 +658,7 @@ impl Wallet {
         let index = &mut self.indexed_graph.index;
 
         let ((index, spk), index_changeset) = index
-            .next_unused_spk(&keychain)
+            .next_unused_spk(keychain)
             .expect("keychain must exist");
 
         self.stage
@@ -702,7 +702,7 @@ impl Wallet {
     ) -> impl DoubleEndedIterator<Item = AddressInfo> + '_ {
         self.indexed_graph
             .index
-            .unused_keychain_spks(&keychain)
+            .unused_keychain_spks(keychain)
             .map(move |(index, spk)| AddressInfo {
                 index,
                 address: Address::from_script(spk, self.network).expect("must have address form"),
@@ -783,7 +783,7 @@ impl Wallet {
     ) -> impl Iterator<Item = Indexed<ScriptBuf>> + Clone {
         self.indexed_graph
             .index
-            .unbounded_spk_iter(&keychain)
+            .unbounded_spk_iter(keychain)
             .expect("keychain must exist")
     }
 
@@ -1354,7 +1354,7 @@ impl Wallet {
                 let ((index, spk), index_changeset) = self
                     .indexed_graph
                     .index
-                    .next_unused_spk(&change_keychain)
+                    .next_unused_spk(change_keychain)
                     .expect("keychain must exist");
                 self.indexed_graph.index.mark_used(change_keychain, index);
                 self.stage.merge(index_changeset.into());
@@ -1734,7 +1734,7 @@ impl Wallet {
     pub fn public_descriptor(&self, keychain: KeychainKind) -> &ExtendedDescriptor {
         self.indexed_graph
             .index
-            .get_descriptor(&keychain)
+            .get_descriptor(keychain)
             .expect("keychain must exist")
     }
 
@@ -1843,14 +1843,14 @@ impl Wallet {
     /// The derivation index of this wallet. It will return `None` if it has not derived any addresses.
     /// Otherwise, it will return the index of the highest address it has derived.
     pub fn derivation_index(&self, keychain: KeychainKind) -> Option<u32> {
-        self.indexed_graph.index.last_revealed_index(&keychain)
+        self.indexed_graph.index.last_revealed_index(keychain)
     }
 
     /// The index of the next address that you would get if you were to ask the wallet for a new address
     pub fn next_derivation_index(&self, keychain: KeychainKind) -> u32 {
         self.indexed_graph
             .index
-            .next_index(&keychain)
+            .next_index(keychain)
             .expect("keychain must exist")
             .0
     }

--- a/crates/wallet/tests/wallet.rs
+++ b/crates/wallet/tests/wallet.rs
@@ -4023,7 +4023,7 @@ fn test_tx_cancellation() {
         .unsigned_tx
         .output
         .iter()
-        .find_map(|txout| wallet.derivation_of_spk(&txout.script_pubkey))
+        .find_map(|txout| wallet.derivation_of_spk(txout.script_pubkey.clone()))
         .unwrap();
     assert_eq!(change_derivation_1, (KeychainKind::Internal, 0));
 
@@ -4033,7 +4033,7 @@ fn test_tx_cancellation() {
         .unsigned_tx
         .output
         .iter()
-        .find_map(|txout| wallet.derivation_of_spk(&txout.script_pubkey))
+        .find_map(|txout| wallet.derivation_of_spk(txout.script_pubkey.clone()))
         .unwrap();
     assert_eq!(change_derivation_2, (KeychainKind::Internal, 1));
 
@@ -4044,7 +4044,7 @@ fn test_tx_cancellation() {
         .unsigned_tx
         .output
         .iter()
-        .find_map(|txout| wallet.derivation_of_spk(&txout.script_pubkey))
+        .find_map(|txout| wallet.derivation_of_spk(txout.script_pubkey.clone()))
         .unwrap();
     assert_eq!(change_derivation_3, (KeychainKind::Internal, 0));
 
@@ -4053,7 +4053,7 @@ fn test_tx_cancellation() {
         .unsigned_tx
         .output
         .iter()
-        .find_map(|txout| wallet.derivation_of_spk(&txout.script_pubkey))
+        .find_map(|txout| wallet.derivation_of_spk(txout.script_pubkey.clone()))
         .unwrap();
     assert_eq!(change_derivation_3, (KeychainKind::Internal, 2));
 
@@ -4064,7 +4064,7 @@ fn test_tx_cancellation() {
         .unsigned_tx
         .output
         .iter()
-        .find_map(|txout| wallet.derivation_of_spk(&txout.script_pubkey))
+        .find_map(|txout| wallet.derivation_of_spk(txout.script_pubkey.clone()))
         .unwrap();
     assert_eq!(change_derivation_4, (KeychainKind::Internal, 2));
 }

--- a/example-crates/example_cli/src/lib.rs
+++ b/example-crates/example_cli/src/lib.rs
@@ -502,7 +502,7 @@ where
                         false => Keychain::External,
                     };
                     for (spk_i, spk) in index.revealed_keychain_spks(target_keychain) {
-                        let address = Address::from_script(spk, network)
+                        let address = Address::from_script(spk.as_script(), network)
                             .expect("should always be able to derive address");
                         println!(
                             "{:?} {} used:{}",

--- a/example-crates/example_cli/src/lib.rs
+++ b/example-crates/example_cli/src/lib.rs
@@ -252,7 +252,7 @@ where
     let internal_keychain = if graph
         .index
         .keychains()
-        .any(|(k, _)| *k == Keychain::Internal)
+        .any(|(k, _)| k == Keychain::Internal)
     {
         Keychain::Internal
     } else {
@@ -261,7 +261,7 @@ where
 
     let ((change_index, change_script), change_changeset) = graph
         .index
-        .next_unused_spk(&internal_keychain)
+        .next_unused_spk(internal_keychain)
         .expect("Must exist");
     changeset.merge(change_changeset);
 
@@ -269,7 +269,7 @@ where
         &graph
             .index
             .keychains()
-            .find(|(k, _)| *k == &internal_keychain)
+            .find(|(k, _)| *k == internal_keychain)
             .expect("must exist")
             .1
             .at_derivation_index(change_index)
@@ -288,7 +288,7 @@ where
         min_drain_value: graph
             .index
             .keychains()
-            .find(|(k, _)| *k == &internal_keychain)
+            .find(|(k, _)| *k == internal_keychain)
             .expect("must exist")
             .1
             .dust_value(),
@@ -433,7 +433,7 @@ pub fn planned_utxos<A: Anchor, O: ChainOracle, K: Clone + bdk_tmp_plan::CanDeri
             let desc = graph
                 .index
                 .keychains()
-                .find(|(keychain, _)| *keychain == &k)
+                .find(|(keychain, _)| *keychain == k)
                 .expect("keychain must exist")
                 .1
                 .at_derivation_index(i)
@@ -479,7 +479,7 @@ where
                     };
 
                     let ((spk_i, spk), index_changeset) =
-                        spk_chooser(index, &Keychain::External).expect("Must exist");
+                        spk_chooser(index, Keychain::External).expect("Must exist");
                     let db = &mut *db.lock().unwrap();
                     db.append_changeset(&C::from((
                         local_chain::ChangeSet::default(),
@@ -501,7 +501,7 @@ where
                         true => Keychain::Internal,
                         false => Keychain::External,
                     };
-                    for (spk_i, spk) in index.revealed_keychain_spks(&target_keychain) {
+                    for (spk_i, spk) in index.revealed_keychain_spks(target_keychain) {
                         let address = Address::from_script(spk, network)
                             .expect("should always be able to derive address");
                         println!(

--- a/example-crates/example_electrum/src/main.rs
+++ b/example-crates/example_electrum/src/main.rs
@@ -166,7 +166,7 @@ fn main() -> anyhow::Result<()> {
                         Keychain::External,
                         graph
                             .index
-                            .unbounded_spk_iter(&Keychain::External)
+                            .unbounded_spk_iter(Keychain::External)
                             .into_iter()
                             .flatten(),
                     )
@@ -174,7 +174,7 @@ fn main() -> anyhow::Result<()> {
                         Keychain::Internal,
                         graph
                             .index
-                            .unbounded_spk_iter(&Keychain::Internal)
+                            .unbounded_spk_iter(Keychain::Internal)
                             .into_iter()
                             .flatten(),
                     )


### PR DESCRIPTION
### Description

Make all method signatures of `KeychainTxOutIndex` take owned `K` and use `ScriptBuf` instead of its borrowed counterpart `&Script`. Fixes #1482 

### Notes to the reviewers

Steve also added a CI fix as well

### Changelog notice

- Make all method signatures of `KeychainTxOutIndex` take owned `K`
- Update `KeychainTxOutIndex` methods to use `ScriptBuf`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [x] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
