### PR TITLE
refactor(wallet)!: make internal descriptor optional in constructors

### DIFF
--- a/crates/hwi/src/lib.rs
+++ b/crates/hwi/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! # let mut wallet = Wallet::new(
 //! #     "",
-//! #     "",
+//! #     Some(""),
 //! #     Network::Testnet,
 //! # )?;
 //! #

--- a/crates/wallet/README.md
+++ b/crates/wallet/README.md
@@ -79,9 +79,11 @@ let mut db =
 let descriptor = "wpkh(tprv8ZgxMBicQKsPdcAqYBpzAFwU5yxBUo88ggoBqu1qPcHUfSbKK1sKMLmC7EAk438btHQrSdu3jGGQa6PA71nvH5nkDexhLteJqkM4dQmWF9g/84'/1'/0'/0/*)";
 let change_descriptor = "wpkh(tprv8ZgxMBicQKsPdcAqYBpzAFwU5yxBUo88ggoBqu1qPcHUfSbKK1sKMLmC7EAk438btHQrSdu3jGGQa6PA71nvH5nkDexhLteJqkM4dQmWF9g/84'/1'/0'/1/*)";
 let changeset = db.aggregate_changesets().expect("changeset loaded");
-let mut wallet =
-    Wallet::new_or_load(descriptor, change_descriptor, changeset, Network::Testnet)
-        .expect("create or load wallet");
+let mut wallet = if let Some(changeset) = changeset {
+    Wallet::load(changeset).expect("loaded wallet")
+} else {
+    Wallet::new(descriptor, change_descriptor, Network::Testnet).expect("created new wallet")
+};
 
 // Get a new address to receive bitcoin.
 let receive_address = wallet.reveal_next_address(KeychainKind::External);

--- a/crates/wallet/README.md
+++ b/crates/wallet/README.md
@@ -82,7 +82,7 @@ let changeset = db.aggregate_changesets().expect("changeset loaded");
 let mut wallet = if let Some(changeset) = changeset {
     Wallet::load(changeset).expect("loaded wallet")
 } else {
-    Wallet::new(descriptor, change_descriptor, Network::Testnet).expect("created new wallet")
+    Wallet::new(descriptor, Some(change_descriptor), Network::Testnet).expect("created new wallet")
 };
 
 // Get a new address to receive bitcoin.

--- a/crates/wallet/examples/compiler.rs
+++ b/crates/wallet/examples/compiler.rs
@@ -77,7 +77,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     );
 
     // Create a new wallet from descriptors
-    let mut wallet = Wallet::new(&descriptor, &internal_descriptor, Network::Regtest)?;
+    let mut wallet = Wallet::new(&descriptor, Some(&internal_descriptor), Network::Regtest)?;
 
     println!(
         "First derived address from the descriptor: \n{}",

--- a/crates/wallet/src/descriptor/template.rs
+++ b/crates/wallet/src/descriptor/template.rs
@@ -81,7 +81,11 @@ impl<T: DescriptorTemplate> IntoWalletDescriptor for T {
 ///     bitcoin::PrivateKey::from_wif("cTc4vURSzdx6QE6KVynWGomDbLaA75dNALMNyfjh3p8DRRar84Um")?;
 /// let key_internal =
 ///     bitcoin::PrivateKey::from_wif("cVpPVruEDdmutPzisEsYvtST1usBR3ntr8pXSyt6D2YYqXRyPcFW")?;
-/// let mut wallet = Wallet::new(P2Pkh(key_external), P2Pkh(key_internal), Network::Testnet)?;
+/// let mut wallet = Wallet::new(
+///     P2Pkh(key_external),
+///     Some(P2Pkh(key_internal)),
+///     Network::Testnet,
+/// )?;
 ///
 /// assert_eq!(
 ///     wallet
@@ -115,7 +119,7 @@ impl<K: IntoDescriptorKey<Legacy>> DescriptorTemplate for P2Pkh<K> {
 ///     bitcoin::PrivateKey::from_wif("cVpPVruEDdmutPzisEsYvtST1usBR3ntr8pXSyt6D2YYqXRyPcFW")?;
 /// let mut wallet = Wallet::new(
 ///     P2Wpkh_P2Sh(key_external),
-///     P2Wpkh_P2Sh(key_internal),
+///     Some(P2Wpkh_P2Sh(key_internal)),
 ///     Network::Testnet,
 /// )?;
 ///
@@ -150,7 +154,11 @@ impl<K: IntoDescriptorKey<Segwitv0>> DescriptorTemplate for P2Wpkh_P2Sh<K> {
 ///     bitcoin::PrivateKey::from_wif("cTc4vURSzdx6QE6KVynWGomDbLaA75dNALMNyfjh3p8DRRar84Um")?;
 /// let key_internal =
 ///     bitcoin::PrivateKey::from_wif("cVpPVruEDdmutPzisEsYvtST1usBR3ntr8pXSyt6D2YYqXRyPcFW")?;
-/// let mut wallet = Wallet::new(P2Wpkh(key_external), P2Wpkh(key_internal), Network::Testnet)?;
+/// let mut wallet = Wallet::new(
+///     P2Wpkh(key_external),
+///     Some(P2Wpkh(key_internal)),
+///     Network::Testnet,
+/// )?;
 ///
 /// assert_eq!(
 ///     wallet
@@ -182,7 +190,11 @@ impl<K: IntoDescriptorKey<Segwitv0>> DescriptorTemplate for P2Wpkh<K> {
 ///     bitcoin::PrivateKey::from_wif("cTc4vURSzdx6QE6KVynWGomDbLaA75dNALMNyfjh3p8DRRar84Um")?;
 /// let key_internal =
 ///     bitcoin::PrivateKey::from_wif("cVpPVruEDdmutPzisEsYvtST1usBR3ntr8pXSyt6D2YYqXRyPcFW")?;
-/// let mut wallet = Wallet::new(P2TR(key_external), P2TR(key_internal), Network::Testnet)?;
+/// let mut wallet = Wallet::new(
+///     P2TR(key_external),
+///     Some(P2TR(key_internal)),
+///     Network::Testnet,
+/// )?;
 ///
 /// assert_eq!(
 ///     wallet
@@ -217,7 +229,7 @@ impl<K: IntoDescriptorKey<Tap>> DescriptorTemplate for P2TR<K> {
 /// let key = bitcoin::bip32::Xpriv::from_str("tprv8ZgxMBicQKsPeZRHk4rTG6orPS2CRNFX3njhUXx5vj9qGog5ZMH4uGReDWN5kCkY3jmWEtWause41CDvBRXD1shKknAMKxT99o9qUTRVC6m")?;
 /// let mut wallet = Wallet::new(
 ///     Bip44(key.clone(), KeychainKind::External),
-///     Bip44(key, KeychainKind::Internal),
+///     Some(Bip44(key, KeychainKind::Internal)),
 ///     Network::Testnet,
 /// )?;
 ///
@@ -254,7 +266,7 @@ impl<K: DerivableKey<Legacy>> DescriptorTemplate for Bip44<K> {
 /// let fingerprint = bitcoin::bip32::Fingerprint::from_str("c55b303f")?;
 /// let mut wallet = Wallet::new(
 ///     Bip44Public(key.clone(), fingerprint, KeychainKind::External),
-///     Bip44Public(key, fingerprint, KeychainKind::Internal),
+///     Some(Bip44Public(key, fingerprint, KeychainKind::Internal)),
 ///     Network::Testnet,
 /// )?;
 ///
@@ -290,7 +302,7 @@ impl<K: DerivableKey<Legacy>> DescriptorTemplate for Bip44Public<K> {
 /// let key = bitcoin::bip32::Xpriv::from_str("tprv8ZgxMBicQKsPeZRHk4rTG6orPS2CRNFX3njhUXx5vj9qGog5ZMH4uGReDWN5kCkY3jmWEtWause41CDvBRXD1shKknAMKxT99o9qUTRVC6m")?;
 /// let mut wallet = Wallet::new(
 ///     Bip49(key.clone(), KeychainKind::External),
-///     Bip49(key, KeychainKind::Internal),
+///     Some(Bip49(key, KeychainKind::Internal)),
 ///     Network::Testnet,
 /// )?;
 ///
@@ -327,7 +339,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip49<K> {
 /// let fingerprint = bitcoin::bip32::Fingerprint::from_str("c55b303f")?;
 /// let mut wallet = Wallet::new(
 ///     Bip49Public(key.clone(), fingerprint, KeychainKind::External),
-///     Bip49Public(key, fingerprint, KeychainKind::Internal),
+///     Some(Bip49Public(key, fingerprint, KeychainKind::Internal)),
 ///     Network::Testnet,
 /// )?;
 ///
@@ -363,7 +375,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip49Public<K> {
 /// let key = bitcoin::bip32::Xpriv::from_str("tprv8ZgxMBicQKsPeZRHk4rTG6orPS2CRNFX3njhUXx5vj9qGog5ZMH4uGReDWN5kCkY3jmWEtWause41CDvBRXD1shKknAMKxT99o9qUTRVC6m")?;
 /// let mut wallet = Wallet::new(
 ///     Bip84(key.clone(), KeychainKind::External),
-///     Bip84(key, KeychainKind::Internal),
+///     Some(Bip84(key, KeychainKind::Internal)),
 ///     Network::Testnet,
 /// )?;
 ///
@@ -400,7 +412,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip84<K> {
 /// let fingerprint = bitcoin::bip32::Fingerprint::from_str("c55b303f")?;
 /// let mut wallet = Wallet::new(
 ///     Bip84Public(key.clone(), fingerprint, KeychainKind::External),
-///     Bip84Public(key, fingerprint, KeychainKind::Internal),
+///     Some(Bip84Public(key, fingerprint, KeychainKind::Internal)),
 ///     Network::Testnet,
 /// )?;
 ///
@@ -436,7 +448,7 @@ impl<K: DerivableKey<Segwitv0>> DescriptorTemplate for Bip84Public<K> {
 /// let key = bitcoin::bip32::Xpriv::from_str("tprv8ZgxMBicQKsPeZRHk4rTG6orPS2CRNFX3njhUXx5vj9qGog5ZMH4uGReDWN5kCkY3jmWEtWause41CDvBRXD1shKknAMKxT99o9qUTRVC6m")?;
 /// let mut wallet = Wallet::new(
 ///     Bip86(key.clone(), KeychainKind::External),
-///     Bip86(key, KeychainKind::Internal),
+///     Some(Bip86(key, KeychainKind::Internal)),
 ///     Network::Testnet,
 /// )?;
 ///
@@ -473,7 +485,7 @@ impl<K: DerivableKey<Tap>> DescriptorTemplate for Bip86<K> {
 /// let fingerprint = bitcoin::bip32::Fingerprint::from_str("c55b303f")?;
 /// let mut wallet = Wallet::new(
 ///     Bip86Public(key.clone(), fingerprint, KeychainKind::External),
-///     Bip86Public(key, fingerprint, KeychainKind::Internal),
+///     Some(Bip86Public(key, fingerprint, KeychainKind::Internal)),
 ///     Network::Testnet,
 /// )?;
 ///

--- a/crates/wallet/src/wallet/export.rs
+++ b/crates/wallet/src/wallet/export.rs
@@ -31,7 +31,7 @@
 //! let import = FullyNodedExport::from_str(import)?;
 //! let wallet = Wallet::new(
 //!     &import.descriptor(),
-//!     &import.change_descriptor().expect("change descriptor"),
+//!     Some(&import.change_descriptor().expect("change descriptor")),
 //!     Network::Testnet,
 //! )?;
 //! # Ok::<_, Box<dyn std::error::Error>>(())
@@ -44,7 +44,7 @@
 //! # use bdk_wallet::*;
 //! let wallet = Wallet::new(
 //!     "wpkh([c258d2e4/84h/1h/0h]tpubDD3ynpHgJQW8VvWRzQ5WFDCrs4jqVFGHB3vLC3r49XHJSqP8bHKdK4AriuUKLccK68zfzowx7YhmDN8SiSkgCDENUFx9qVw65YyqM78vyVe/0/*)",
-//!     "wpkh([c258d2e4/84h/1h/0h]tpubDD3ynpHgJQW8VvWRzQ5WFDCrs4jqVFGHB3vLC3r49XHJSqP8bHKdK4AriuUKLccK68zfzowx7YhmDN8SiSkgCDENUFx9qVw65YyqM78vyVe/1/*)",
+//!     Some("wpkh([c258d2e4/84h/1h/0h]tpubDD3ynpHgJQW8VvWRzQ5WFDCrs4jqVFGHB3vLC3r49XHJSqP8bHKdK4AriuUKLccK68zfzowx7YhmDN8SiSkgCDENUFx9qVw65YyqM78vyVe/1/*)"),
 //!     Network::Testnet,
 //! )?;
 //! let export = FullyNodedExport::export_wallet(&wallet, "exported wallet", true).unwrap();
@@ -224,7 +224,7 @@ mod test {
     fn get_test_wallet(descriptor: &str, change_descriptor: &str, network: Network) -> Wallet {
         use crate::wallet::Update;
         use bdk_chain::TxGraph;
-        let mut wallet = Wallet::new(descriptor, change_descriptor, network).unwrap();
+        let mut wallet = Wallet::new(descriptor, Some(change_descriptor), network).unwrap();
         let transaction = Transaction {
             input: vec![],
             output: vec![],

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -202,9 +202,10 @@ impl std::error::Error for NewError {}
 
 /// The error type when loading a [`Wallet`] from a [`ChangeSet`].
 ///
-/// Method [`load_from_changeset`] may return this error.
+/// Methods [`load`] and [`load_with_descriptors`] may return this error.
 ///
-/// [`load_from_changeset`]: Wallet::load_from_changeset
+/// [`load`]: Wallet::load
+/// [`load_with_descriptors`]: Wallet::load_with_descriptors
 #[derive(Debug)]
 pub enum LoadError {
     /// There was a problem with the passed-in descriptor(s).
@@ -215,6 +216,13 @@ pub enum LoadError {
     MissingGenesis,
     /// Data loaded from persistence is missing descriptor.
     MissingDescriptor(KeychainKind),
+    /// The loaded descriptor does not match what was provided.
+    LoadedDescriptorDoesNotMatch {
+        /// The descriptor loaded from persistence.
+        got: Option<ExtendedDescriptor>,
+        /// The keychain of the descriptor not matching
+        keychain: KeychainKind,
+    },
 }
 
 impl fmt::Display for LoadError {
@@ -226,57 +234,7 @@ impl fmt::Display for LoadError {
             LoadError::MissingDescriptor(k) => {
                 write!(f, "loaded data is missing descriptor for keychain {k:?}")
             }
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl std::error::Error for LoadError {}
-
-/// Error type for when we try load a [`Wallet`] from persistence and creating it if non-existent.
-///
-/// Methods [`new_or_load`] and [`new_or_load_with_genesis_hash`] may return this error.
-///
-/// [`new_or_load`]: Wallet::new_or_load
-/// [`new_or_load_with_genesis_hash`]: Wallet::new_or_load_with_genesis_hash
-#[derive(Debug)]
-pub enum NewOrLoadError {
-    /// There is a problem with the passed-in descriptor.
-    Descriptor(crate::descriptor::DescriptorError),
-    /// The loaded genesis hash does not match what was provided.
-    LoadedGenesisDoesNotMatch {
-        /// The expected genesis block hash.
-        expected: BlockHash,
-        /// The block hash loaded from persistence.
-        got: Option<BlockHash>,
-    },
-    /// The loaded network type does not match what was provided.
-    LoadedNetworkDoesNotMatch {
-        /// The expected network type.
-        expected: Network,
-        /// The network type loaded from persistence.
-        got: Option<Network>,
-    },
-    /// The loaded desccriptor does not match what was provided.
-    LoadedDescriptorDoesNotMatch {
-        /// The descriptor loaded from persistence.
-        got: Option<ExtendedDescriptor>,
-        /// The keychain of the descriptor not matching
-        keychain: KeychainKind,
-    },
-}
-
-impl fmt::Display for NewOrLoadError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            NewOrLoadError::Descriptor(e) => e.fmt(f),
-            NewOrLoadError::LoadedGenesisDoesNotMatch { expected, got } => {
-                write!(f, "loaded genesis hash is not {}, got {:?}", expected, got)
-            }
-            NewOrLoadError::LoadedNetworkDoesNotMatch { expected, got } => {
-                write!(f, "loaded network type is not {}, got {:?}", expected, got)
-            }
-            NewOrLoadError::LoadedDescriptorDoesNotMatch { got, keychain } => {
+            LoadError::LoadedDescriptorDoesNotMatch { got, keychain } => {
                 write!(
                     f,
                     "loaded descriptor is different from what was provided, got {:?} for keychain {:?}",
@@ -288,7 +246,7 @@ impl fmt::Display for NewOrLoadError {
 }
 
 #[cfg(feature = "std")]
-impl std::error::Error for NewOrLoadError {}
+impl std::error::Error for LoadError {}
 
 /// An error that may occur when applying a block to [`Wallet`].
 #[derive(Debug)]
@@ -325,6 +283,15 @@ impl std::error::Error for ApplyBlockError {}
 
 impl Wallet {
     /// Initialize an empty [`Wallet`].
+    ///
+    /// The `descriptor` is used to derive external (receive) addresses and the `change_descriptor`
+    /// to derive internal (change) addresses.
+    ///
+    /// If only public keys are included in the descriptors then the wallet will be able to create
+    /// spending transactions but not sign them. Use [`Wallet::add_signer`] to manually add signers.
+    ///
+    /// If private keys are included in the descriptors then signers for those keys will be added
+    /// automatically to the new [`Wallet`].
     pub fn new<E: IntoWalletDescriptor>(
         descriptor: E,
         change_descriptor: E,
@@ -401,7 +368,7 @@ impl Wallet {
     /// let external_signer_container = SignersContainer::build(external_keymap, &external_descriptor, &secp);
     /// let internal_signer_container = SignersContainer::build(internal_keymap, &internal_descriptor, &secp);
     /// let changeset = db.read()?.expect("there must be an existing changeset");
-    /// let mut wallet = Wallet::load_from_changeset(changeset)?;
+    /// let mut wallet = Wallet::load(changeset)?;
     ///
     /// external_signer_container.signers().into_iter()
     ///     .for_each(|s| wallet.add_signer(KeychainKind::External, SignerOrdering::default(), s.clone()));
@@ -411,32 +378,14 @@ impl Wallet {
     /// # }
     /// ```
     ///
-    /// Alternatively, you can call [`Wallet::new_or_load`], which will add the private keys of the
-    /// passed-in descriptors to the [`Wallet`].
-    pub fn load_from_changeset(changeset: ChangeSet) -> Result<Self, LoadError> {
+    /// Alternatively, you can call [`Wallet::load_with_descriptors`], which will add the private
+    /// keys (if any) of the passed-in descriptors to the [`Wallet`].
+    pub fn load(changeset: ChangeSet) -> Result<Self, LoadError> {
         let secp = Secp256k1::new();
         let network = changeset.network.ok_or(LoadError::MissingNetwork)?;
         let chain =
             LocalChain::from_changeset(changeset.chain).map_err(|_| LoadError::MissingGenesis)?;
-        let mut index = KeychainTxOutIndex::<KeychainKind>::default();
-        let descriptor = changeset
-            .indexed_tx_graph
-            .indexer
-            .keychains_added
-            .get(&KeychainKind::External)
-            .ok_or(LoadError::MissingDescriptor(KeychainKind::External))?
-            .clone();
-        let change_descriptor = changeset
-            .indexed_tx_graph
-            .indexer
-            .keychains_added
-            .get(&KeychainKind::Internal)
-            .ok_or(LoadError::MissingDescriptor(KeychainKind::Internal))?
-            .clone();
-
-        let (signers, change_signers) =
-            create_signers(&mut index, &secp, descriptor, change_descriptor, network)
-                .expect("Can't fail: we passed in valid descriptors, recovered from the changeset");
+        let index = KeychainTxOutIndex::<KeychainKind>::default();
 
         let mut indexed_graph = IndexedTxGraph::new(index);
         indexed_graph.apply_changeset(changeset.indexed_tx_graph);
@@ -444,8 +393,8 @@ impl Wallet {
         let stage = ChangeSet::default();
 
         Ok(Wallet {
-            signers,
-            change_signers,
+            signers: Arc::new(SignersContainer::new()),
+            change_signers: Arc::new(SignersContainer::new()),
             chain,
             indexed_graph,
             stage,
@@ -454,9 +403,13 @@ impl Wallet {
         })
     }
 
-    /// Either loads [`Wallet`] from the given [`ChangeSet`] or initializes it if one does not exist.
+    /// Loads [`Wallet`] from the previously persisted [`ChangeSet`] and descriptors.
     ///
-    /// This method will fail if the loaded [`ChangeSet`] has different parameters to those provided.
+    /// This method will fail if the given descriptors don't match those included in the
+    /// [`ChangeSet`].
+    ///
+    /// If the provided descriptors contain private keys the signers for those keys will be added
+    /// to the [`Wallet`].
     ///
     /// ```rust,no_run
     /// # use bdk_wallet::Wallet;
@@ -464,133 +417,74 @@ impl Wallet {
     /// # use bitcoin::Network::Testnet;
     /// let conn = Connection::open_in_memory().expect("must open connection");
     /// let mut db = Store::new(conn).expect("must create db");
-    /// let changeset = db.read()?;
+    /// let changeset = db.read()?.expect("changeset must exist");
     ///
     /// let external_descriptor = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/0/*)";
     /// let internal_descriptor = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/1/*)";
     ///
-    /// let mut wallet = Wallet::new_or_load(external_descriptor, internal_descriptor, changeset, Testnet)?;
+    /// let mut wallet = Wallet::load_with_descriptors(external_descriptor, internal_descriptor, changeset)?;
     /// # Ok::<(), anyhow::Error>(())
     /// ```
-    pub fn new_or_load<E: IntoWalletDescriptor>(
+    pub fn load_with_descriptors<E: IntoWalletDescriptor>(
         descriptor: E,
         change_descriptor: E,
-        changeset: Option<ChangeSet>,
-        network: Network,
-    ) -> Result<Self, NewOrLoadError> {
-        let genesis_hash = genesis_block(network).block_hash();
-        Self::new_or_load_with_genesis_hash(
-            descriptor,
-            change_descriptor,
-            changeset,
-            network,
-            genesis_hash,
-        )
-    }
+        changeset: ChangeSet,
+    ) -> Result<Self, LoadError> {
+        let mut wallet = Self::load(changeset)?;
 
-    /// Either loads [`Wallet`] from a [`ChangeSet`] or initializes it if one does not exist, using the
-    /// provided descriptor, change descriptor, network, and custom genesis hash.
-    ///
-    /// This method will fail if the loaded [`ChangeSet`] has different parameters to those provided.
-    /// This is like [`Wallet::new_or_load`] with an additional `genesis_hash` parameter. This is
-    /// useful for syncing from alternative networks.
-    pub fn new_or_load_with_genesis_hash<E: IntoWalletDescriptor>(
-        descriptor: E,
-        change_descriptor: E,
-        changeset: Option<ChangeSet>,
-        network: Network,
-        genesis_hash: BlockHash,
-    ) -> Result<Self, NewOrLoadError> {
-        if let Some(changeset) = changeset {
-            let mut wallet = Self::load_from_changeset(changeset).map_err(|e| match e {
-                LoadError::Descriptor(e) => NewOrLoadError::Descriptor(e),
-                LoadError::MissingNetwork => NewOrLoadError::LoadedNetworkDoesNotMatch {
-                    expected: network,
-                    got: None,
-                },
-                LoadError::MissingGenesis => NewOrLoadError::LoadedGenesisDoesNotMatch {
-                    expected: genesis_hash,
-                    got: None,
-                },
-                LoadError::MissingDescriptor(keychain) => {
-                    NewOrLoadError::LoadedDescriptorDoesNotMatch {
-                        got: None,
-                        keychain,
-                    }
-                }
-            })?;
-            if wallet.network != network {
-                return Err(NewOrLoadError::LoadedNetworkDoesNotMatch {
-                    expected: network,
-                    got: Some(wallet.network),
-                });
-            }
-            if wallet.chain.genesis_hash() != genesis_hash {
-                return Err(NewOrLoadError::LoadedGenesisDoesNotMatch {
-                    expected: genesis_hash,
-                    got: Some(wallet.chain.genesis_hash()),
-                });
-            }
-
-            let (expected_descriptor, expected_descriptor_keymap) = descriptor
-                .into_wallet_descriptor(&wallet.secp, network)
-                .map_err(NewOrLoadError::Descriptor)?;
-            let wallet_descriptor = wallet.public_descriptor(KeychainKind::External);
-            if wallet_descriptor != &expected_descriptor {
-                return Err(NewOrLoadError::LoadedDescriptorDoesNotMatch {
-                    got: Some(wallet_descriptor.clone()),
-                    keychain: KeychainKind::External,
-                });
-            }
-            // if expected descriptor has private keys add them as new signers
-            if !expected_descriptor_keymap.is_empty() {
-                let signer_container = SignersContainer::build(
-                    expected_descriptor_keymap,
-                    &expected_descriptor,
-                    &wallet.secp,
-                );
-                signer_container.signers().into_iter().for_each(|signer| {
-                    wallet.add_signer(
-                        KeychainKind::External,
-                        SignerOrdering::default(),
-                        signer.clone(),
-                    )
-                });
-            }
-
-            let (expected_change_descriptor, expected_change_descriptor_keymap) = change_descriptor
-                .into_wallet_descriptor(&wallet.secp, network)
-                .map_err(NewOrLoadError::Descriptor)?;
-            let wallet_change_descriptor = wallet.public_descriptor(KeychainKind::Internal);
-            if wallet_change_descriptor != &expected_change_descriptor {
-                return Err(NewOrLoadError::LoadedDescriptorDoesNotMatch {
-                    got: Some(wallet_change_descriptor.clone()),
-                    keychain: KeychainKind::Internal,
-                });
-            }
-            // if expected change descriptor has private keys add them as new signers
-            if !expected_change_descriptor_keymap.is_empty() {
-                let signer_container = SignersContainer::build(
-                    expected_change_descriptor_keymap,
-                    &expected_change_descriptor,
-                    &wallet.secp,
-                );
-                signer_container.signers().into_iter().for_each(|signer| {
-                    wallet.add_signer(
-                        KeychainKind::Internal,
-                        SignerOrdering::default(),
-                        signer.clone(),
-                    )
-                });
-            }
-
-            Ok(wallet)
-        } else {
-            Self::new_with_genesis_hash(descriptor, change_descriptor, network, genesis_hash)
-                .map_err(|e| match e {
-                    NewError::Descriptor(e) => NewOrLoadError::Descriptor(e),
-                })
+        let (expected_descriptor, expected_descriptor_keymap) = descriptor
+            .into_wallet_descriptor(&wallet.secp, wallet.network)
+            .map_err(LoadError::Descriptor)?;
+        let wallet_descriptor = wallet.public_descriptor(KeychainKind::External);
+        if wallet_descriptor != &expected_descriptor {
+            return Err(LoadError::LoadedDescriptorDoesNotMatch {
+                got: Some(wallet_descriptor.clone()),
+                keychain: KeychainKind::External,
+            });
         }
+        // if expected descriptor has private keys add them as new signers
+        if !expected_descriptor_keymap.is_empty() {
+            let signer_container = SignersContainer::build(
+                expected_descriptor_keymap,
+                &expected_descriptor,
+                &wallet.secp,
+            );
+            signer_container.signers().into_iter().for_each(|signer| {
+                wallet.add_signer(
+                    KeychainKind::External,
+                    SignerOrdering::default(),
+                    signer.clone(),
+                )
+            });
+        }
+
+        let (expected_change_descriptor, expected_change_descriptor_keymap) = change_descriptor
+            .into_wallet_descriptor(&wallet.secp, wallet.network)
+            .map_err(LoadError::Descriptor)?;
+        let wallet_change_descriptor = wallet.public_descriptor(KeychainKind::Internal);
+        if wallet_change_descriptor != &expected_change_descriptor {
+            return Err(LoadError::LoadedDescriptorDoesNotMatch {
+                got: Some(wallet_change_descriptor.clone()),
+                keychain: KeychainKind::Internal,
+            });
+        }
+        // if expected change descriptor has private keys add them as new signers
+        if !expected_change_descriptor_keymap.is_empty() {
+            let signer_container = SignersContainer::build(
+                expected_change_descriptor_keymap,
+                &expected_change_descriptor,
+                &wallet.secp,
+            );
+            signer_container.signers().into_iter().for_each(|signer| {
+                wallet.add_signer(
+                    KeychainKind::Internal,
+                    SignerOrdering::default(),
+                    signer.clone(),
+                )
+            });
+        }
+
+        Ok(wallet)
     }
 
     /// Get the Bitcoin network the wallet is using.
@@ -648,7 +542,7 @@ impl Wallet {
     /// let conn = Connection::open_in_memory().expect("must open connection");
     /// let mut db = Store::new(conn).expect("must create store");
     /// # let changeset = ChangeSet::default();
-    /// # let mut wallet = Wallet::load_from_changeset(changeset).expect("load wallet");
+    /// # let mut wallet = Wallet::load(changeset).expect("load wallet");
     /// let next_address = wallet.reveal_next_address(KeychainKind::External);
     /// if let Some(changeset) = wallet.take_staged() {
     ///     db.write(&changeset)?;

--- a/crates/wallet/src/wallet/signer.rs
+++ b/crates/wallet/src/wallet/signer.rs
@@ -69,7 +69,7 @@
 //!
 //! let descriptor = "wpkh(tpubD6NzVbkrYhZ4Xferm7Pz4VnjdcDPFyjVu5K4iZXQ4pVN8Cks4pHVowTBXBKRhX64pkRyJZJN5xAKj4UDNnLPb5p2sSKXhewoYx5GbTdUFWq/0/*)";
 //! let change_descriptor = "wpkh(tpubD6NzVbkrYhZ4Xferm7Pz4VnjdcDPFyjVu5K4iZXQ4pVN8Cks4pHVowTBXBKRhX64pkRyJZJN5xAKj4UDNnLPb5p2sSKXhewoYx5GbTdUFWq/1/*)";
-//! let mut wallet = Wallet::new(descriptor, change_descriptor, Network::Testnet)?;
+//! let mut wallet = Wallet::new(descriptor, Some(change_descriptor), Network::Testnet)?;
 //! wallet.add_signer(
 //!     KeychainKind::External,
 //!     SignerOrdering(200),

--- a/crates/wallet/tests/common.rs
+++ b/crates/wallet/tests/common.rs
@@ -15,7 +15,12 @@ use std::str::FromStr;
 /// The funded wallet contains a tx with a 76_000 sats input and two outputs, one spending 25_000
 /// to a foreign address and one returning 50_000 back to the wallet. The remaining 1000
 /// sats are the transaction fee.
-pub fn get_funded_wallet_with_change(descriptor: &str, change: &str) -> (Wallet, bitcoin::Txid) {
+///
+/// Note: no change descriptor is used internal (change) SPKs will be derived from the external descriptor.
+pub fn get_funded_wallet_with_change(
+    descriptor: &str,
+    change: Option<&str>,
+) -> (Wallet, bitcoin::Txid) {
     let mut wallet = Wallet::new(descriptor, change, Network::Regtest).unwrap();
     let receive_address = wallet.peek_address(KeychainKind::External, 0).address;
     let sendto_address = Address::from_str("bcrt1q3qtze4ys45tgdvguj66zrk4fu6hq3a3v9pfly5")
@@ -113,16 +118,13 @@ pub fn get_funded_wallet_with_change(descriptor: &str, change: &str) -> (Wallet,
 /// to a foreign address and one returning 50_000 back to the wallet. The remaining 1000
 /// sats are the transaction fee.
 ///
-/// Note: the change descriptor will have script type `p2wpkh`. If passing some other script type
-/// as argument, make sure you're ok with getting a wallet where the keychains have potentially
-/// different script types. Otherwise, use `get_funded_wallet_with_change`.
+/// Note: no change descriptor is used internal (change) SPKs will be derived from the external descriptor.
 pub fn get_funded_wallet(descriptor: &str) -> (Wallet, bitcoin::Txid) {
-    let change = get_test_wpkh_change();
-    get_funded_wallet_with_change(descriptor, change)
+    get_funded_wallet_with_change(descriptor, None)
 }
 
 pub fn get_funded_wallet_wpkh() -> (Wallet, bitcoin::Txid) {
-    get_funded_wallet_with_change(get_test_wpkh(), get_test_wpkh_change())
+    get_funded_wallet_with_change(get_test_wpkh(), None)
 }
 
 pub fn get_test_wpkh() -> &'static str {

--- a/crates/wallet/tests/psbt.rs
+++ b/crates/wallet/tests/psbt.rs
@@ -144,7 +144,7 @@ fn test_psbt_fee_rate_with_missing_txout() {
 
     let desc = "pkh(tprv8ZgxMBicQKsPd3EupYiPRhaMooHKUHJxNsTfYuScep13go8QFfHdtkG9nRkFGb7busX4isf6X9dURGCoKgitaApQ6MupRhZMcELAxTBRJgS/0)";
     let change_desc = "pkh(tprv8ZgxMBicQKsPd3EupYiPRhaMooHKUHJxNsTfYuScep13go8QFfHdtkG9nRkFGb7busX4isf6X9dURGCoKgitaApQ6MupRhZMcELAxTBRJgS/1)";
-    let (mut pkh_wallet, _) = get_funded_wallet_with_change(desc, change_desc);
+    let (mut pkh_wallet, _) = get_funded_wallet_with_change(desc, Some(change_desc));
     let addr = pkh_wallet.peek_address(KeychainKind::External, 0);
     let mut builder = pkh_wallet.build_tx();
     builder.drain_to(addr.script_pubkey()).drain_wallet();
@@ -173,7 +173,7 @@ fn test_psbt_multiple_internalkey_signers() {
     let keypair = Keypair::from_secret_key(&secp, &prv.inner);
 
     let change_desc = "tr(cVpPVruEDdmutPzisEsYvtST1usBR3ntr8pXSyt6D2YYqXRyPcFW)";
-    let (mut wallet, _) = get_funded_wallet_with_change(&desc, change_desc);
+    let (mut wallet, _) = get_funded_wallet_with_change(&desc, Some(change_desc));
     let to_spend = wallet.balance().total();
     let send_to = wallet.peek_address(KeychainKind::External, 0);
     let mut builder = wallet.build_tx();

--- a/example-crates/wallet_electrum/src/main.rs
+++ b/example-crates/wallet_electrum/src/main.rs
@@ -27,7 +27,11 @@ fn main() -> Result<(), anyhow::Error> {
     let mut wallet = if let Some(changeset) = changeset {
         Wallet::load_with_descriptors(external_descriptor, internal_descriptor, changeset)?
     } else {
-        Wallet::new(external_descriptor, internal_descriptor, Network::Testnet)?
+        Wallet::new(
+            external_descriptor,
+            Some(internal_descriptor),
+            Network::Testnet,
+        )?
     };
 
     let address = wallet.next_unused_address(KeychainKind::External);

--- a/example-crates/wallet_electrum/src/main.rs
+++ b/example-crates/wallet_electrum/src/main.rs
@@ -24,12 +24,11 @@ fn main() -> Result<(), anyhow::Error> {
     let changeset = db
         .aggregate_changesets()
         .map_err(|e| anyhow!("load changes error: {}", e))?;
-    let mut wallet = Wallet::new_or_load(
-        external_descriptor,
-        internal_descriptor,
-        changeset,
-        Network::Testnet,
-    )?;
+    let mut wallet = if let Some(changeset) = changeset {
+        Wallet::load_with_descriptors(external_descriptor, internal_descriptor, changeset)?
+    } else {
+        Wallet::new(external_descriptor, internal_descriptor, Network::Testnet)?
+    };
 
     let address = wallet.next_unused_address(KeychainKind::External);
     if let Some(changeset) = wallet.take_staged() {

--- a/example-crates/wallet_esplora_async/src/main.rs
+++ b/example-crates/wallet_esplora_async/src/main.rs
@@ -21,12 +21,11 @@ async fn main() -> Result<(), anyhow::Error> {
     let internal_descriptor = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/1/*)";
     let changeset = db.read()?;
 
-    let mut wallet = Wallet::new_or_load(
-        external_descriptor,
-        internal_descriptor,
-        changeset,
-        Network::Signet,
-    )?;
+    let mut wallet = if let Some(changeset) = changeset {
+        Wallet::load_with_descriptors(external_descriptor, internal_descriptor, changeset)?
+    } else {
+        Wallet::new(external_descriptor, internal_descriptor, Network::Testnet)?
+    };
 
     let address = wallet.next_unused_address(KeychainKind::External);
     if let Some(changeset) = wallet.take_staged() {

--- a/example-crates/wallet_esplora_async/src/main.rs
+++ b/example-crates/wallet_esplora_async/src/main.rs
@@ -24,7 +24,11 @@ async fn main() -> Result<(), anyhow::Error> {
     let mut wallet = if let Some(changeset) = changeset {
         Wallet::load_with_descriptors(external_descriptor, internal_descriptor, changeset)?
     } else {
-        Wallet::new(external_descriptor, internal_descriptor, Network::Testnet)?
+        Wallet::new(
+            external_descriptor,
+            Some(internal_descriptor),
+            Network::Testnet,
+        )?
     };
 
     let address = wallet.next_unused_address(KeychainKind::External);

--- a/example-crates/wallet_esplora_blocking/src/main.rs
+++ b/example-crates/wallet_esplora_blocking/src/main.rs
@@ -23,7 +23,11 @@ fn main() -> Result<(), anyhow::Error> {
     let mut wallet = if let Some(changeset) = changeset {
         Wallet::load_with_descriptors(external_descriptor, internal_descriptor, changeset)?
     } else {
-        Wallet::new(external_descriptor, internal_descriptor, Network::Testnet)?
+        Wallet::new(
+            external_descriptor,
+            Some(internal_descriptor),
+            Network::Testnet,
+        )?
     };
 
     let address = wallet.next_unused_address(KeychainKind::External);

--- a/example-crates/wallet_esplora_blocking/src/main.rs
+++ b/example-crates/wallet_esplora_blocking/src/main.rs
@@ -20,12 +20,11 @@ fn main() -> Result<(), anyhow::Error> {
     let internal_descriptor = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/1/*)";
     let changeset = db.aggregate_changesets()?;
 
-    let mut wallet = Wallet::new_or_load(
-        external_descriptor,
-        internal_descriptor,
-        changeset,
-        Network::Testnet,
-    )?;
+    let mut wallet = if let Some(changeset) = changeset {
+        Wallet::load_with_descriptors(external_descriptor, internal_descriptor, changeset)?
+    } else {
+        Wallet::new(external_descriptor, internal_descriptor, Network::Testnet)?
+    };
 
     let address = wallet.next_unused_address(KeychainKind::External);
     if let Some(changeset) = wallet.take_staged() {

--- a/example-crates/wallet_rpc/src/main.rs
+++ b/example-crates/wallet_rpc/src/main.rs
@@ -92,12 +92,12 @@ fn main() -> anyhow::Result<()> {
     )?;
     let changeset = db.aggregate_changesets()?;
 
-    let mut wallet = Wallet::new_or_load(
-        &args.descriptor,
-        &args.change_descriptor,
-        changeset,
-        args.network,
-    )?;
+    let mut wallet = if let Some(changeset) = changeset {
+        Wallet::load_with_descriptors(&args.descriptor, &args.change_descriptor, changeset)?
+    } else {
+        Wallet::new(&args.descriptor, &args.change_descriptor, Network::Testnet)?
+    };
+
     println!(
         "Loaded wallet in {}s",
         start_load_wallet.elapsed().as_secs_f32()

--- a/example-crates/wallet_rpc/src/main.rs
+++ b/example-crates/wallet_rpc/src/main.rs
@@ -95,7 +95,11 @@ fn main() -> anyhow::Result<()> {
     let mut wallet = if let Some(changeset) = changeset {
         Wallet::load_with_descriptors(&args.descriptor, &args.change_descriptor, changeset)?
     } else {
-        Wallet::new(&args.descriptor, &args.change_descriptor, Network::Testnet)?
+        Wallet::new(
+            &args.descriptor,
+            Some(&args.change_descriptor),
+            Network::Testnet,
+        )?
     };
 
     println!(


### PR DESCRIPTION
### Description

WIP! needs more testing to ensure everything works without a change descriptor.

If OK then can add new constructors for single descriptor wallets in a post 1.0 release.

Built on #1512 and should fix #1511.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
