### PR TITLE
refactor(chain)!: Remove `Anchor` trait and make anchors unique to (Txid, BlockId)

### DIFF
--- a/crates/chain/src/changeset.rs
+++ b/crates/chain/src/changeset.rs
@@ -34,7 +34,10 @@ impl<K, A> core::default::Default for CombinedChangeSet<K, A> {
 }
 
 #[cfg(feature = "miniscript")]
-impl<K: Ord, A: crate::Anchor> crate::Merge for CombinedChangeSet<K, A> {
+impl<K: Ord, A> crate::Merge for CombinedChangeSet<K, A>
+where
+    A: Ord + Clone,
+{
     fn merge(&mut self, other: Self) {
         crate::Merge::merge(&mut self.chain, other.chain);
         crate::Merge::merge(&mut self.indexed_tx_graph, other.indexed_tx_graph);

--- a/crates/chain/src/spk_client.rs
+++ b/crates/chain/src/spk_client.rs
@@ -1,8 +1,6 @@
 //! Helper types for spk-based blockchain clients.
 
-use crate::{
-    collections::BTreeMap, local_chain::CheckPoint, ConfirmationBlockTime, Indexed, TxGraph,
-};
+use crate::{collections::BTreeMap, local_chain::CheckPoint, BlockTime, Indexed, TxGraph};
 use alloc::boxed::Box;
 use bitcoin::{OutPoint, Script, ScriptBuf, Txid};
 use core::marker::PhantomData;
@@ -176,7 +174,7 @@ impl SyncRequest {
 /// Data returned from a spk-based blockchain client sync.
 ///
 /// See also [`SyncRequest`].
-pub struct SyncResult<A = ConfirmationBlockTime> {
+pub struct SyncResult<A = BlockTime> {
     /// The update to apply to the receiving [`TxGraph`].
     pub graph_update: TxGraph<A>,
     /// The update to apply to the receiving [`LocalChain`](crate::local_chain::LocalChain).
@@ -317,7 +315,7 @@ impl<K: Ord + Clone> FullScanRequest<K> {
 /// Data returned from a spk-based blockchain client full scan.
 ///
 /// See also [`FullScanRequest`].
-pub struct FullScanResult<K, A = ConfirmationBlockTime> {
+pub struct FullScanResult<K, A = BlockTime> {
     /// The update to apply to the receiving [`LocalChain`](crate::local_chain::LocalChain).
     pub graph_update: TxGraph<A>,
     /// The update to apply to the receiving [`TxGraph`].

--- a/crates/chain/tests/common/mod.rs
+++ b/crates/chain/tests/common/mod.rs
@@ -5,6 +5,22 @@ mod tx_template;
 pub use tx_template::*;
 
 #[allow(unused_macros)]
+macro_rules! anchor {
+    ($height:expr, $hash:literal) => {
+        (
+            (
+                bdk_chain::bitcoin::Txid::all_zeros(),
+                bdk_chain::BlockId {
+                    height: $height,
+                    hash: bitcoin::hashes::Hash::hash($hash.as_bytes()),
+                },
+            ),
+            (),
+        )
+    };
+}
+
+#[allow(unused_macros)]
 macro_rules! block_id {
     ($height:expr, $hash:literal) => {{
         bdk_chain::BlockId {

--- a/crates/chain/tests/common/tx_template.rs
+++ b/crates/chain/tests/common/tx_template.rs
@@ -16,12 +16,12 @@ use miniscript::Descriptor;
 /// avoid having to explicitly hash previous transactions to form previous outpoints of later
 /// transactions.
 #[derive(Clone, Copy, Default)]
-pub struct TxTemplate<'a, A> {
+pub struct TxTemplate<'a> {
     /// Uniquely identifies the transaction, before it can have a txid.
     pub tx_name: &'a str,
     pub inputs: &'a [TxInTemplate<'a>],
     pub outputs: &'a [TxOutTemplate],
-    pub anchors: &'a [A],
+    pub anchors: &'a [(Anchor, ())],
     pub last_seen: Option<u64>,
 }
 
@@ -51,12 +51,12 @@ impl TxOutTemplate {
 }
 
 #[allow(dead_code)]
-pub fn init_graph<'a, A: Anchor + Clone + 'a>(
-    tx_templates: impl IntoIterator<Item = &'a TxTemplate<'a, A>>,
-) -> (TxGraph<A>, SpkTxOutIndex<u32>, HashMap<&'a str, Txid>) {
+pub fn init_graph<'a>(
+    tx_templates: impl IntoIterator<Item = &'a TxTemplate<'a>>,
+) -> (TxGraph, SpkTxOutIndex<u32>, HashMap<&'a str, Txid>) {
     let (descriptor, _) =
         Descriptor::parse_descriptor(&Secp256k1::signing_only(), super::DESCRIPTORS[2]).unwrap();
-    let mut graph = TxGraph::<A>::default();
+    let mut graph = TxGraph::<()>::default();
     let mut spk_index = SpkTxOutIndex::default();
     (0..10).for_each(|index| {
         spk_index.insert_spk(
@@ -128,8 +128,8 @@ pub fn init_graph<'a, A: Anchor + Clone + 'a>(
         tx_ids.insert(tx_tmp.tx_name, tx.compute_txid());
         spk_index.scan(&tx);
         let _ = graph.insert_tx(tx.clone());
-        for anchor in tx_tmp.anchors.iter() {
-            let _ = graph.insert_anchor(tx.compute_txid(), anchor.clone());
+        for ((_, blockid), _) in tx_tmp.anchors.iter() {
+            let _ = graph.insert_anchor((tx.compute_txid(), *blockid), ());
         }
         let _ = graph.insert_seen_at(tx.compute_txid(), tx_tmp.last_seen.unwrap_or(0));
     }

--- a/crates/chain/tests/test_tx_graph_conflicts.rs
+++ b/crates/chain/tests/test_tx_graph_conflicts.rs
@@ -5,8 +5,8 @@ mod common;
 
 use std::collections::{BTreeSet, HashSet};
 
-use bdk_chain::{Balance, BlockId};
-use bitcoin::{Amount, OutPoint, Script};
+use bdk_chain::Balance;
+use bitcoin::{hashes::Hash, Amount, OutPoint, Script};
 use common::*;
 
 #[allow(dead_code)]
@@ -14,7 +14,7 @@ struct Scenario<'a> {
     /// Name of the test scenario
     name: &'a str,
     /// Transaction templates
-    tx_templates: &'a [TxTemplate<'a, BlockId>],
+    tx_templates: &'a [TxTemplate<'a>],
     /// Names of txs that must exist in the output of `list_canonical_txs`
     exp_chain_txs: HashSet<&'a str>,
     /// Outpoints that must exist in the output of `filter_chain_txouts`
@@ -57,7 +57,7 @@ fn test_tx_conflict_handling() {
                     tx_name: "confirmed_genesis",
                     inputs: &[TxInTemplate::Bogus],
                     outputs: &[TxOutTemplate::new(10000, Some(1))],
-                    anchors: &[block_id!(1, "B")],
+                    anchors: &[anchor!(1, "B")],
                     last_seen: None,
                 },
                 TxTemplate {
@@ -73,7 +73,7 @@ fn test_tx_conflict_handling() {
                     tx_name: "confirmed_conflict",
                     inputs: &[TxInTemplate::PrevTx("confirmed_genesis", 0)],
                     outputs: &[TxOutTemplate::new(20000, Some(3))],
-                    anchors: &[block_id!(4, "E")],
+                    anchors: &[anchor!(4, "E")],
                     ..Default::default()
                 },
             ],
@@ -93,7 +93,7 @@ fn test_tx_conflict_handling() {
                 TxTemplate {
                     tx_name: "tx1",
                     outputs: &[TxOutTemplate::new(40000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
+                    anchors: &[anchor!(1, "B")],
                     last_seen: None,
                     ..Default::default()
                 },
@@ -130,7 +130,7 @@ fn test_tx_conflict_handling() {
                     tx_name: "tx1",
                     inputs: &[TxInTemplate::Bogus],
                     outputs: &[TxOutTemplate::new(10000, Some(0)), TxOutTemplate::new(10000, Some(1))],
-                    anchors: &[block_id!(1, "B")],
+                    anchors: &[anchor!(1, "B")],
                     last_seen: None,
                 },
                 TxTemplate {
@@ -165,7 +165,7 @@ fn test_tx_conflict_handling() {
                     tx_name: "tx1",
                     inputs: &[TxInTemplate::Bogus],
                     outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
+                    anchors: &[anchor!(1, "B")],
                     last_seen: None,
                 },
                 TxTemplate {
@@ -207,7 +207,7 @@ fn test_tx_conflict_handling() {
                     tx_name: "tx1",
                     inputs: &[TxInTemplate::Bogus],
                     outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
+                    anchors: &[anchor!(1, "B")],
                     last_seen: None,
                 },
                 TxTemplate {
@@ -221,7 +221,7 @@ fn test_tx_conflict_handling() {
                     tx_name: "tx_orphaned_conflict",
                     inputs: &[TxInTemplate::PrevTx("tx1", 0)],
                     outputs: &[TxOutTemplate::new(30000, Some(2))],
-                    anchors: &[block_id!(4, "Orphaned Block")],
+                    anchors: &[anchor!(4, "Orphaned Block")],
                     last_seen: Some(300),
                 },
             ],
@@ -242,7 +242,7 @@ fn test_tx_conflict_handling() {
                     tx_name: "tx1",
                     inputs: &[TxInTemplate::Bogus],
                     outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
+                    anchors: &[anchor!(1, "B")],
                     last_seen: None,
                 },
                 TxTemplate {
@@ -256,7 +256,7 @@ fn test_tx_conflict_handling() {
                     tx_name: "tx_orphaned_conflict",
                     inputs: &[TxInTemplate::PrevTx("tx1", 0)],
                     outputs: &[TxOutTemplate::new(30000, Some(2))],
-                    anchors: &[block_id!(4, "Orphaned Block")],
+                    anchors: &[anchor!(4, "Orphaned Block")],
                     last_seen: Some(100),
                 },
             ],
@@ -277,7 +277,7 @@ fn test_tx_conflict_handling() {
                     tx_name: "tx1",
                     inputs: &[TxInTemplate::Bogus],
                     outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
+                    anchors: &[anchor!(1, "B")],
                     last_seen: None,
                 },
                 TxTemplate {
@@ -305,7 +305,7 @@ fn test_tx_conflict_handling() {
                     tx_name: "tx_confirmed_conflict",
                     inputs: &[TxInTemplate::PrevTx("tx1", 0)],
                     outputs: &[TxOutTemplate::new(50000, Some(4))],
-                    anchors: &[block_id!(1, "B")],
+                    anchors: &[anchor!(1, "B")],
                     ..Default::default()
                 },
             ],
@@ -371,7 +371,7 @@ fn test_tx_conflict_handling() {
                     tx_name: "A",
                     inputs: &[TxInTemplate::Bogus],
                     outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
+                    anchors: &[anchor!(1, "B")],
                     last_seen: None,
                 },
                 TxTemplate {
@@ -384,7 +384,7 @@ fn test_tx_conflict_handling() {
                     tx_name: "B'",
                     inputs: &[TxInTemplate::PrevTx("A", 0)],
                     outputs: &[TxOutTemplate::new(20000, Some(2))],
-                    anchors: &[block_id!(4, "E")],
+                    anchors: &[anchor!(4, "E")],
                     ..Default::default()
                 },
                 TxTemplate {
@@ -412,7 +412,7 @@ fn test_tx_conflict_handling() {
                     tx_name: "A",
                     inputs: &[TxInTemplate::Bogus],
                     outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
+                    anchors: &[anchor!(1, "B")],
                     last_seen: None,
                 },
                 TxTemplate {
@@ -425,7 +425,7 @@ fn test_tx_conflict_handling() {
                     tx_name: "B'",
                     inputs: &[TxInTemplate::PrevTx("A", 0)],
                     outputs: &[TxOutTemplate::new(20000, Some(2))],
-                    anchors: &[block_id!(4, "E")],
+                    anchors: &[anchor!(4, "E")],
                     ..Default::default()
                 },
                 TxTemplate {
@@ -457,7 +457,7 @@ fn test_tx_conflict_handling() {
                     tx_name: "A",
                     inputs: &[TxInTemplate::Bogus],
                     outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
+                    anchors: &[anchor!(1, "B")],
                     last_seen: None,
                 },
                 TxTemplate {
@@ -502,7 +502,7 @@ fn test_tx_conflict_handling() {
                     tx_name: "A",
                     inputs: &[TxInTemplate::Bogus],
                     outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
+                    anchors: &[anchor!(1, "B")],
                     last_seen: None,
                 },
                 TxTemplate {
@@ -516,7 +516,7 @@ fn test_tx_conflict_handling() {
                     tx_name: "B'",
                     inputs: &[TxInTemplate::PrevTx("A", 0)],
                     outputs: &[TxOutTemplate::new(50000, Some(4))],
-                    anchors: &[block_id!(1, "B")],
+                    anchors: &[anchor!(1, "B")],
                     ..Default::default()
                 },
                 TxTemplate {
@@ -547,7 +547,7 @@ fn test_tx_conflict_handling() {
                     tx_name: "A",
                     inputs: &[TxInTemplate::Bogus],
                     outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
+                    anchors: &[anchor!(1, "B")],
                     last_seen: None,
                 },
                 TxTemplate {
@@ -561,7 +561,7 @@ fn test_tx_conflict_handling() {
                     tx_name: "B'",
                     inputs: &[TxInTemplate::PrevTx("A", 0)],
                     outputs: &[TxOutTemplate::new(50000, Some(4))],
-                    anchors: &[block_id!(1, "B")],
+                    anchors: &[anchor!(1, "B")],
                     ..Default::default()
                 },
                 TxTemplate {

--- a/crates/esplora/src/lib.rs
+++ b/crates/esplora/src/lib.rs
@@ -16,7 +16,7 @@
 //! [`TxGraph`]: bdk_chain::tx_graph::TxGraph
 //! [`example_esplora`]: https://github.com/bitcoindevkit/bdk/tree/master/example-crates/example_esplora
 
-use bdk_chain::{BlockId, ConfirmationBlockTime};
+use bdk_chain::{bitcoin::Txid, Anchor, BlockId, BlockTime};
 use esplora_client::TxStatus;
 
 pub use esplora_client;
@@ -31,7 +31,7 @@ mod async_ext;
 #[cfg(feature = "async")]
 pub use async_ext::*;
 
-fn anchor_from_status(status: &TxStatus) -> Option<ConfirmationBlockTime> {
+fn anchor_from_status(txid: Txid, status: &TxStatus) -> Option<(Anchor, BlockTime)> {
     if let TxStatus {
         block_height: Some(height),
         block_hash: Some(hash),
@@ -39,10 +39,10 @@ fn anchor_from_status(status: &TxStatus) -> Option<ConfirmationBlockTime> {
         ..
     } = status.clone()
     {
-        Some(ConfirmationBlockTime {
-            block_id: BlockId { height, hash },
-            confirmation_time: time,
-        })
+        Some((
+            (txid, BlockId { height, hash }),
+            BlockTime::new(time as u32),
+        ))
     } else {
         None
     }

--- a/crates/sqlite/src/store.rs
+++ b/crates/sqlite/src/store.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, Mutex};
 use crate::Error;
 use bdk_chain::CombinedChangeSet;
 use bdk_chain::{
-    indexed_tx_graph, indexer::keychain_txout, local_chain, tx_graph, Anchor, DescriptorExt,
+    indexed_tx_graph, indexer::keychain_txout, local_chain, tx_graph, BlockId, DescriptorExt,
     DescriptorId, Merge,
 };
 
@@ -39,7 +39,6 @@ impl<K, A> Debug for Store<K, A> {
 impl<K, A> Store<K, A>
 where
     K: Ord + for<'de> Deserialize<'de> + Serialize + Send,
-    A: Anchor + for<'de> Deserialize<'de> + Serialize + Send,
 {
     /// Creates a new store from a [`Connection`].
     pub fn new(mut conn: Connection) -> Result<Self, rusqlite::Error> {
@@ -181,7 +180,6 @@ impl<K, A> Store<K, A> {
 impl<K, A> Store<K, A>
 where
     K: Ord + for<'de> Deserialize<'de> + Serialize + Send,
-    A: Anchor + Send,
 {
     /// Insert keychain with descriptor and last active index.
     ///
@@ -414,7 +412,7 @@ impl<K, A> Store<K, A> {
 impl<K, A> Store<K, A>
 where
     K: Ord + for<'de> Deserialize<'de> + Serialize + Send,
-    A: Anchor + for<'de> Deserialize<'de> + Serialize + Send,
+    A: Ord + Clone + for<'de> Deserialize<'de> + Serialize + Send,
 {
     /// Insert anchors.
     fn insert_anchors(
@@ -422,13 +420,13 @@ where
         tx_graph_changeset: &indexed_tx_graph::ChangeSet<A, keychain_txout::ChangeSet<K>>,
     ) -> Result<(), Error> {
         // serde_json::to_string
-        for anchor in tx_graph_changeset.graph.anchors.iter() {
+        for ((txid, blockid), anchor_meta) in tx_graph_changeset.graph.anchors.iter() {
             let insert_anchor_stmt = &mut db_transaction
                 .prepare_cached("INSERT INTO anchor_tx (block_hash, anchor, txid) VALUES (:block_hash, jsonb(:anchor), :txid)")
                 .expect("insert anchor statement");
-            let block_hash = anchor.0.anchor_block().hash.to_string();
-            let anchor_json = serde_json::to_string(&anchor.0).expect("anchor json");
-            let txid = anchor.1.to_string();
+            let block_hash = blockid.hash.to_string();
+            let anchor_json = serde_json::to_string(&(blockid, anchor_meta)).expect("anchor json");
+            let txid = txid.to_string();
             insert_anchor_stmt.execute(named_params! {":block_hash": block_hash, ":anchor": anchor_json, ":txid": txid })
                 .map_err(Error::Sqlite)?;
         }
@@ -438,7 +436,7 @@ where
     /// Select all anchors.
     fn select_anchors(
         db_transaction: &rusqlite::Transaction,
-    ) -> Result<BTreeSet<(A, Txid)>, Error> {
+    ) -> Result<BTreeMap<(Txid, BlockId), A>, Error> {
         // serde_json::from_str
         let mut select_anchor_stmt = db_transaction
             .prepare_cached("SELECT block_hash, json(anchor), txid FROM anchor_tx")
@@ -448,12 +446,13 @@ where
                 let hash = row.get_unwrap::<usize, String>(0);
                 let hash = BlockHash::from_str(hash.as_str()).expect("block hash");
                 let anchor = row.get_unwrap::<usize, String>(1);
-                let anchor: A = serde_json::from_str(anchor.as_str()).expect("anchor");
+                let (blockid, anchor_meta): (BlockId, A) =
+                    serde_json::from_str(anchor.as_str()).expect("anchor");
                 // double check anchor blob block hash matches
-                assert_eq!(hash, anchor.anchor_block().hash);
+                assert_eq!(hash, blockid.hash);
                 let txid = row.get_unwrap::<usize, String>(2);
                 let txid = Txid::from_str(&txid).expect("txid");
-                Ok((anchor, txid))
+                Ok(((txid, blockid), anchor_meta))
             })
             .map_err(Error::Sqlite)?;
         anchors
@@ -467,7 +466,7 @@ where
 impl<K, A> Store<K, A>
 where
     K: Ord + for<'de> Deserialize<'de> + Serialize + Send,
-    A: Anchor + for<'de> Deserialize<'de> + Serialize + Send,
+    A: Ord + Clone + for<'de> Deserialize<'de> + Serialize + Send,
 {
     /// Write the given `changeset` atomically.
     pub fn write(&mut self, changeset: &CombinedChangeSet<K, A>) -> Result<(), Error> {
@@ -547,7 +546,7 @@ mod test {
     use bdk_chain::bitcoin::{secp256k1, BlockHash, OutPoint};
     use bdk_chain::miniscript::Descriptor;
     use bdk_chain::CombinedChangeSet;
-    use bdk_chain::{indexed_tx_graph, tx_graph, BlockId, ConfirmationBlockTime, DescriptorExt};
+    use bdk_chain::{indexed_tx_graph, tx_graph, BlockId, BlockTime, DescriptorExt};
     use std::str::FromStr;
     use std::sync::Arc;
 
@@ -558,16 +557,13 @@ mod test {
     }
 
     #[test]
-    fn insert_and_load_aggregate_changesets_with_confirmation_block_time_anchor() {
+    fn insert_and_load_aggregate_changesets_with_block_time_anchor() {
         let (test_changesets, agg_test_changesets) =
-            create_test_changesets(&|height, time, hash| ConfirmationBlockTime {
-                confirmation_time: time,
-                block_id: (height, hash).into(),
-            });
+            create_test_changesets(&|_height, time, _hash| BlockTime::new(time as u32));
 
         let conn = Connection::open_in_memory().expect("in memory connection");
-        let mut store = Store::<Keychain, ConfirmationBlockTime>::new(conn)
-            .expect("create new memory db store");
+        let mut store =
+            Store::<Keychain, BlockTime>::new(conn).expect("create new memory db store");
 
         test_changesets.iter().for_each(|changeset| {
             store.write(changeset).expect("write changeset");
@@ -578,24 +574,7 @@ mod test {
         assert_eq!(agg_changeset, Some(agg_test_changesets));
     }
 
-    #[test]
-    fn insert_and_load_aggregate_changesets_with_blockid_anchor() {
-        let (test_changesets, agg_test_changesets) =
-            create_test_changesets(&|height, _time, hash| BlockId { height, hash });
-
-        let conn = Connection::open_in_memory().expect("in memory connection");
-        let mut store = Store::<Keychain, BlockId>::new(conn).expect("create new memory db store");
-
-        test_changesets.iter().for_each(|changeset| {
-            store.write(changeset).expect("write changeset");
-        });
-
-        let agg_changeset = store.read().expect("aggregated changeset");
-
-        assert_eq!(agg_changeset, Some(agg_test_changesets));
-    }
-
-    fn create_test_changesets<A: Anchor + Copy>(
+    fn create_test_changesets<A: Ord + Clone + Copy>(
         anchor_fn: &dyn Fn(u32, u64, BlockHash) -> A,
     ) -> (
         Vec<CombinedChangeSet<Keychain, A>>,
@@ -645,13 +624,35 @@ mod test {
         let outpoint1_0 = OutPoint::new(tx1.compute_txid(), 0);
         let txout1_0 = tx1.output.first().unwrap().clone();
 
-        let anchor1 = anchor_fn(1, 1296667328, block_hash_1);
-        let anchor2 = anchor_fn(2, 1296688946, block_hash_2);
+        let anchor_meta1 = anchor_fn(1, 1296667328, block_hash_1);
+        let anchor_meta2 = anchor_fn(2, 1296688946, block_hash_2);
 
         let tx_graph_changeset = tx_graph::ChangeSet::<A> {
             txs: [tx0.clone(), tx1.clone()].into(),
             txouts: [(outpoint0_0, txout0_0), (outpoint1_0, txout1_0)].into(),
-            anchors: [(anchor1, tx0.compute_txid()), (anchor1, tx1.compute_txid())].into(),
+            anchors: [
+                (
+                    (
+                        tx0.compute_txid(),
+                        BlockId {
+                            height: 1,
+                            hash: block_hash_1,
+                        },
+                    ),
+                    anchor_meta1,
+                ),
+                (
+                    (
+                        tx1.compute_txid(),
+                        BlockId {
+                            height: 1,
+                            hash: block_hash_1,
+                        },
+                    ),
+                    anchor_meta1,
+                ),
+            ]
+            .into(),
             last_seen: [
                 (tx0.compute_txid(), 1598918400),
                 (tx1.compute_txid(), 1598919121),
@@ -684,7 +685,7 @@ mod test {
         let tx_graph_changeset2 = tx_graph::ChangeSet::<A> {
             txs: [tx2.clone()].into(),
             txouts: BTreeMap::default(),
-            anchors: BTreeSet::default(),
+            anchors: BTreeMap::default(),
             last_seen: [(tx2.compute_txid(), 1708919121)].into(),
         };
 
@@ -704,7 +705,29 @@ mod test {
         let tx_graph_changeset3 = tx_graph::ChangeSet::<A> {
             txs: BTreeSet::default(),
             txouts: BTreeMap::default(),
-            anchors: [(anchor2, tx0.compute_txid()), (anchor2, tx1.compute_txid())].into(),
+            anchors: [
+                (
+                    (
+                        tx0.compute_txid(),
+                        BlockId {
+                            height: 2,
+                            hash: block_hash_2,
+                        },
+                    ),
+                    anchor_meta2,
+                ),
+                (
+                    (
+                        tx1.compute_txid(),
+                        BlockId {
+                            height: 2,
+                            hash: block_hash_2,
+                        },
+                    ),
+                    anchor_meta2,
+                ),
+            ]
+            .into(),
             last_seen: BTreeMap::default(),
         };
 

--- a/crates/wallet/src/wallet/export.rs
+++ b/crates/wallet/src/wallet/export.rs
@@ -128,7 +128,7 @@ impl FullyNodedExport {
         let blockheight = if include_blockheight {
             wallet.transactions().next().map_or(0, |canonical_tx| {
                 match canonical_tx.chain_position {
-                    bdk_chain::ChainPosition::Confirmed(a) => a.block_id.height,
+                    bdk_chain::ChainPosition::Confirmed((_, blockid), _) => blockid.height,
                     bdk_chain::ChainPosition::Unconfirmed(_) => 0,
                 }
             })
@@ -214,7 +214,7 @@ mod test {
     use core::str::FromStr;
 
     use crate::std::string::ToString;
-    use bdk_chain::{BlockId, ConfirmationBlockTime};
+    use bdk_chain::{BlockId, BlockTime};
     use bitcoin::hashes::Hash;
     use bitcoin::{transaction, BlockHash, Network, Transaction};
 
@@ -244,12 +244,9 @@ mod test {
             })
             .unwrap();
         wallet.insert_tx(transaction);
-        let anchor = ConfirmationBlockTime {
-            confirmation_time: 0,
-            block_id,
-        };
+        let (anchor, anchor_meta) = ((txid, block_id), BlockTime::new(0));
         let mut graph = TxGraph::default();
-        let _ = graph.insert_anchor(txid, anchor);
+        let _ = graph.insert_anchor(anchor, anchor_meta);
         wallet
             .apply_update(Update {
                 graph,

--- a/example-crates/example_bitcoind_rpc_polling/src/main.rs
+++ b/example-crates/example_bitcoind_rpc_polling/src/main.rs
@@ -16,7 +16,7 @@ use bdk_chain::{
     indexed_tx_graph,
     indexer::keychain_txout,
     local_chain::{self, LocalChain},
-    ConfirmationBlockTime, IndexedTxGraph, Merge,
+    BlockTime, IndexedTxGraph, Merge,
 };
 use example_cli::{
     anyhow,
@@ -38,7 +38,7 @@ const DB_COMMIT_DELAY: Duration = Duration::from_secs(60);
 
 type ChangeSet = (
     local_chain::ChangeSet,
-    indexed_tx_graph::ChangeSet<ConfirmationBlockTime, keychain_txout::ChangeSet<Keychain>>,
+    indexed_tx_graph::ChangeSet<BlockTime, keychain_txout::ChangeSet<Keychain>>,
 );
 
 #[derive(Debug)]

--- a/example-crates/example_cli/src/lib.rs
+++ b/example-crates/example_cli/src/lib.rs
@@ -20,7 +20,7 @@ use bdk_chain::{
         descriptor::{DescriptorSecretKey, KeyMap},
         Descriptor, DescriptorPublicKey,
     },
-    Anchor, ChainOracle, DescriptorExt, FullTxOut, Merge,
+    ChainOracle, DescriptorExt, FullTxOut, Merge,
 };
 pub use bdk_file_store;
 pub use clap;
@@ -196,7 +196,7 @@ pub struct CreateTxChange {
     pub index: u32,
 }
 
-pub fn create_tx<A: Anchor, O: ChainOracle>(
+pub fn create_tx<A, O: ChainOracle>(
     graph: &mut KeychainTxGraph<A>,
     chain: &O,
     keymap: &BTreeMap<DescriptorPublicKey, DescriptorSecretKey>,
@@ -206,6 +206,7 @@ pub fn create_tx<A: Anchor, O: ChainOracle>(
 ) -> anyhow::Result<(Transaction, Option<CreateTxChange>)>
 where
     O::Error: std::error::Error + Send + Sync + 'static,
+    A: Ord + Clone,
 {
     let mut changeset = keychain_txout::ChangeSet::default();
 
@@ -415,7 +416,7 @@ where
 // Alias the elements of `Result` of `planned_utxos`
 pub type PlannedUtxo<K, A> = (bdk_tmp_plan::Plan<K>, FullTxOut<A>);
 
-pub fn planned_utxos<A: Anchor, O: ChainOracle, K: Clone + bdk_tmp_plan::CanDerive>(
+pub fn planned_utxos<A: Ord + Clone, O: ChainOracle, K: Clone + bdk_tmp_plan::CanDerive>(
     graph: &KeychainTxGraph<A>,
     chain: &O,
     assets: &bdk_tmp_plan::Assets<K>,
@@ -444,7 +445,7 @@ pub fn planned_utxos<A: Anchor, O: ChainOracle, K: Clone + bdk_tmp_plan::CanDeri
         .collect()
 }
 
-pub fn handle_commands<CS: clap::Subcommand, S: clap::Args, A: Anchor, O: ChainOracle, C>(
+pub fn handle_commands<CS: clap::Subcommand, S: clap::Args, A, O: ChainOracle, C>(
     graph: &Mutex<KeychainTxGraph<A>>,
     db: &Mutex<Store<C>>,
     chain: &Mutex<O>,
@@ -454,6 +455,7 @@ pub fn handle_commands<CS: clap::Subcommand, S: clap::Args, A: Anchor, O: ChainO
     cmd: Commands<CS, S>,
 ) -> anyhow::Result<()>
 where
+    A: Ord + Clone + Debug,
     O::Error: std::error::Error + Send + Sync + 'static,
     C: Default
         + Merge

--- a/example-crates/example_electrum/src/main.rs
+++ b/example-crates/example_electrum/src/main.rs
@@ -10,7 +10,7 @@ use bdk_chain::{
     indexer::keychain_txout,
     local_chain::{self, LocalChain},
     spk_client::{FullScanRequest, SyncRequest},
-    ConfirmationBlockTime, Merge,
+    BlockTime, Merge,
 };
 use bdk_electrum::{
     electrum_client::{self, Client, ElectrumApi},
@@ -100,7 +100,7 @@ pub struct ScanOptions {
 
 type ChangeSet = (
     local_chain::ChangeSet,
-    indexed_tx_graph::ChangeSet<ConfirmationBlockTime, keychain_txout::ChangeSet<Keychain>>,
+    indexed_tx_graph::ChangeSet<BlockTime, keychain_txout::ChangeSet<Keychain>>,
 );
 
 fn main() -> anyhow::Result<()> {
@@ -337,8 +337,7 @@ fn main() -> anyhow::Result<()> {
 
         let chain_changeset = chain.apply_update(chain_update)?;
 
-        let mut indexed_tx_graph_changeset =
-            indexed_tx_graph::ChangeSet::<ConfirmationBlockTime, _>::default();
+        let mut indexed_tx_graph_changeset = indexed_tx_graph::ChangeSet::<BlockTime, _>::default();
         if let Some(keychain_update) = keychain_update {
             let keychain_changeset = graph.index.reveal_to_target_multi(&keychain_update);
             indexed_tx_graph_changeset.merge(keychain_changeset.into());

--- a/example-crates/example_esplora/src/main.rs
+++ b/example-crates/example_esplora/src/main.rs
@@ -10,7 +10,7 @@ use bdk_chain::{
     indexer::keychain_txout,
     local_chain::{self, LocalChain},
     spk_client::{FullScanRequest, SyncRequest},
-    ConfirmationBlockTime, Merge,
+    BlockTime, Merge,
 };
 
 use bdk_esplora::{esplora_client, EsploraExt};
@@ -26,7 +26,7 @@ const DB_PATH: &str = ".bdk_esplora_example.db";
 
 type ChangeSet = (
     local_chain::ChangeSet,
-    indexed_tx_graph::ChangeSet<ConfirmationBlockTime, keychain_txout::ChangeSet<Keychain>>,
+    indexed_tx_graph::ChangeSet<BlockTime, keychain_txout::ChangeSet<Keychain>>,
 );
 
 #[derive(Subcommand, Debug, Clone)]


### PR DESCRIPTION
Resolves bitcoindevkit/bdk_wallet#90.
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

The `Anchor` trait has been removed and anchors are now unique to (`Txid`, `BlockId`).

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->
Documentation have been mostly untouched and need to be written/updated.

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->
* `Anchor` trait has been removed.
* `Anchor` type and `BlockTime` struct have been added to `bdk_chain`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing