### PR TITLE
bdk_wallet: Don't reimplement descriptor checksum, use the one from rust-miniscript

### DIFF
--- a/crates/wallet/src/descriptor/checksum.rs
+++ b/crates/wallet/src/descriptor/checksum.rs
@@ -43,7 +43,7 @@ fn poly_mod(mut c: u64, val: u64) -> u64 {
 }
 
 /// Compute the checksum bytes of a descriptor, excludes any existing checksum in the descriptor string from the calculation
-pub fn calc_checksum_bytes(mut desc: &str) -> Result<[u8; 8], DescriptorError> {
+fn calc_checksum_bytes(mut desc: &str) -> Result<[u8; 8], DescriptorError> {
     let mut c = 1;
     let mut cls = 0;
     let mut clscount = 0;

--- a/crates/wallet/src/descriptor/mod.rs
+++ b/crates/wallet/src/descriptor/mod.rs
@@ -42,7 +42,6 @@ pub mod policy;
 pub mod template;
 
 pub use self::checksum::calc_checksum;
-use self::checksum::calc_checksum_bytes;
 pub use self::error::Error as DescriptorError;
 pub use self::policy::Policy;
 use self::template::DescriptorTemplateOut;
@@ -88,8 +87,8 @@ impl IntoWalletDescriptor for &str {
     ) -> Result<(ExtendedDescriptor, KeyMap), DescriptorError> {
         let descriptor = match self.split_once('#') {
             Some((desc, original_checksum)) => {
-                let checksum = calc_checksum_bytes(desc)?;
-                if original_checksum.as_bytes() != checksum {
+                let checksum = calc_checksum(desc)?;
+                if original_checksum != checksum {
                     return Err(DescriptorError::InvalidDescriptorChecksum);
                 }
                 desc

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -79,7 +79,7 @@ use utils::{check_nsequence_rbf, After, Older, SecpCtx};
 
 use crate::descriptor::policy::BuildSatisfaction;
 use crate::descriptor::{
-    self, calc_checksum, DerivedDescriptor, DescriptorMeta, ExtendedDescriptor, ExtractPolicy,
+    self, DerivedDescriptor, DescriptorMeta, ExtendedDescriptor, ExtractPolicy,
     IntoWalletDescriptor, Policy, XKeyUtils,
 };
 use crate::psbt::PsbtUtils;
@@ -2360,15 +2360,13 @@ where
         .into_wallet_descriptor(secp, network)?
         .0
         .to_string();
-    let mut wallet_name = calc_checksum(&descriptor[..descriptor.find('#').unwrap()])?;
+    let mut wallet_name = descriptor.split_once('#').unwrap().1.to_string();
     if let Some(change_descriptor) = change_descriptor {
         let change_descriptor = change_descriptor
             .into_wallet_descriptor(secp, network)?
             .0
             .to_string();
-        wallet_name.push_str(
-            calc_checksum(&change_descriptor[..change_descriptor.find('#').unwrap()])?.as_str(),
-        );
+        wallet_name.push_str(change_descriptor.split_once('#').unwrap().1);
     }
 
     Ok(wallet_name)


### PR DESCRIPTION
Skimming through the BDK code today i noticed the descriptor checksum algorithm is re-implemented instead of using the implementation from rust-miniscript. Re-implementing it here is more code to review and maintain, more room for mistakes and overall less eyes over the code than centralizing a single implementation over at `rust-miniscript`.

While doing this i noticed that one of the variants was completely unnecessary (`calc_checksum_bytes`), so i removed it. I realise it's breaking the API, so if we want to avoid that i can remove this part. I also added a commit to remove redundant calls to `calc_checsum`.

Overall this is just a quick PoC as i noticed it i figured i'd send a PR, my bad if i missed anything!