### PR TITLE
ci: pin tokio to 1.38.1 to support MSRV 1.63

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -36,6 +36,7 @@ jobs:
           cargo update -p proptest --precise "1.2.0"
           cargo update -p url --precise "2.5.0"
           cargo update -p cc --precise "1.0.105"
+          cargo update -p tokio --precise "1.38.1"
       - name: Build
         run: cargo build ${{ matrix.features }}
       - name: Test

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ cargo update -p home --precise "0.5.5"
 cargo update -p proptest --precise "1.2.0"
 cargo update -p url --precise "2.5.0"
 cargo update -p cc --precise "1.0.105"
+cargo update -p tokio --precise "1.38.1"
 ```
 
 ## License


### PR DESCRIPTION
### Description

The latest tokio minor version update from 1.38.1 to 1.39.1 changed it's MSRV from 1.63.0 to 1.70.0, breaking our CI MSRV 1.63 testing. This PR pins `tokio` back to 1.38.1 for our CI MSRV testing.

### Notes to the reviewers

https://github.com/tokio-rs/tokio/pull/6645

https://crates.io/crates/tokio/versions

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing