### PR TITLE
feat(wallet): BIP 329 import/export labels

### DIFF
--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -32,6 +32,7 @@ all-keys = ["keys-bip39"]
 keys-bip39 = ["bip39"]
 rusqlite = ["bdk_chain/rusqlite"]
 file_store = ["bdk_file_store"]
+labels = []
 
 [dev-dependencies]
 lazy_static = "1.4"

--- a/crates/wallet/src/types.rs
+++ b/crates/wallet/src/types.rs
@@ -10,6 +10,8 @@
 // licenses.
 
 use alloc::boxed::Box;
+#[cfg(feature = "labels")]
+use alloc::string::String;
 use core::convert::AsRef;
 
 use bdk_chain::ConfirmationTime;
@@ -63,6 +65,46 @@ pub struct LocalOutput {
     pub derivation_index: u32,
     /// The confirmation time for transaction containing this utxo
     pub confirmation_time: ConfirmationTime,
+    #[cfg(feature = "labels")]
+    /// The label for this UTXO according to
+    /// [BIP 329](https://github.com/bitcoin/bips/blob/master/bip-0329.mediawiki)
+    /// format
+    pub label: Option<Label>,
+}
+
+#[cfg(feature = "labels")]
+/// A label for a [`LocalOutput`], used to identify the purpose of the UTXO.
+///
+/// # Note
+///
+/// The labels follow the [BIP 329](https://github.com/bitcoin/bips/blob/master/bip-0329.mediawiki)
+/// export/import format.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive] // We might add more types in the future
+pub enum Label {
+    /// Input Outpoint: Transaction id and input index separated by a colon
+    Input(String),
+    /// Output Outpoint: Transaction id and input index separated by a colon
+    Output(String),
+}
+
+#[cfg(feature = "labels")]
+impl Label {
+    /// Gets the [`Label`]
+    pub fn label(&self) -> &str {
+        match self {
+            Label::Input(s) => s,
+            Label::Output(s) => s,
+        }
+    }
+
+    /// Edits the [`Label`]
+    pub fn edit(&mut self, new_label: String) {
+        match self {
+            Label::Input(s) => *s = new_label,
+            Label::Output(s) => *s = new_label,
+        }
+    }
 }
 
 /// A [`Utxo`] with its `satisfaction_weight`.


### PR DESCRIPTION
### Description

Adds BIP 329 label import export functionality
into the `bdk_wallet` crate.

This is feature-gated to the `"labels"` feature.

Closes bitcoindevkit/bdk_wallet#168.

### Notes to the reviewers

This is a WIP.
I am still missing tests, but I want to first discuss if this is the right approach.

### Changelog notice

- feat(bdk_wallet): BIP 329 label import/export support

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
