### PR TITLE
Introduce backwards/forwards compatibility for `bdk_file_store`.

### DIFF
--- a/crates/file_store/src/entry_iter.rs
+++ b/crates/file_store/src/entry_iter.rs
@@ -13,16 +13,16 @@ use crate::bincode_options;
 /// iterator will yield a `Result::Err(_)` instead and then `None` for the next call to `next`.
 ///
 /// [`next`]: Self::next
-pub struct EntryIter<'t, T> {
+pub struct EntryIter<'t, T1, T2 = T1> {
     /// Buffered reader around the file
     db_file: BufReader<&'t mut File>,
     finished: bool,
     /// The file position for the first read of `db_file`.
     start_pos: Option<u64>,
-    types: PhantomData<T>,
+    types: PhantomData<(T1, T2)>,
 }
 
-impl<'t, T> EntryIter<'t, T> {
+impl<'t, T1, T2> EntryIter<'t, T1, T2> {
     pub fn new(start_pos: u64, db_file: &'t mut File) -> Self {
         Self {
             db_file: BufReader::new(db_file),
@@ -33,11 +33,12 @@ impl<'t, T> EntryIter<'t, T> {
     }
 }
 
-impl<'t, T> Iterator for EntryIter<'t, T>
+impl<'t, T1, T2> Iterator for EntryIter<'t, T1, T2>
 where
-    T: serde::de::DeserializeOwned,
+    T1: serde::de::DeserializeOwned + Default + serde::Serialize,
+    T2: serde::de::DeserializeOwned + Into<T1>,
 {
-    type Item = Result<T, IterError>;
+    type Item = Result<T1, IterError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.finished {
@@ -48,10 +49,51 @@ where
                 self.db_file.seek(io::SeekFrom::Start(start))?;
             }
 
-            let pos_before_read = self.db_file.stream_position()?;
-            match bincode_options().deserialize_from(&mut self.db_file) {
-                Ok(changeset) => Ok(Some(changeset)),
-                Err(e) => {
+            let mut pos_before_read = self.db_file.stream_position()?;
+            bincode_options()
+                .deserialize_from::<_, u64>(&mut self.db_file)
+                .and_then(|size| {
+                    pos_before_read = self.db_file.stream_position()?;
+                    bincode_options()
+                        .with_limit(size)
+                        .deserialize_from::<_, T1>(&mut self.db_file)
+                })
+                .or_else(|e| {
+                    let serialized_max_variant = bincode_options().serialize(&T1::default())?;
+                    // allow trailing bytes because we are serializing the variant, not an u64, and
+                    // we want to extract the varint index prefixed
+                    let max_variant_index = bincode_options()
+                        .allow_trailing_bytes()
+                        .deserialize::<u64>(&serialized_max_variant)?;
+
+                    match &*e {
+                        bincode::ErrorKind::Custom(e) if e.contains("expected variant index") => {
+                            self.db_file.seek(io::SeekFrom::Start(pos_before_read))?;
+                            pos_before_read = self.db_file.stream_position()?;
+                            let actual_index =
+                                bincode_options().deserialize_from::<_, u64>(&mut self.db_file)?;
+                            if actual_index > max_variant_index {
+                                pos_before_read = self.db_file.stream_position()?;
+                                return bincode_options()
+                                    .deserialize_from::<_, T2>(&mut self.db_file)
+                                    .map(Into::into);
+                            }
+                        }
+                        bincode::ErrorKind::InvalidTagEncoding(index) => {
+                            if *index as u64 > max_variant_index {
+                                pos_before_read = self.db_file.stream_position()?;
+                                return bincode_options()
+                                    .deserialize_from::<_, T2>(&mut self.db_file)
+                                    .map(Into::into);
+                            }
+                        }
+                        _ => (),
+                    };
+
+                    Err(e)
+                })
+                .map(|changeset| Some(changeset))
+                .or_else(|e| {
                     self.finished = true;
                     let pos_after_read = self.db_file.stream_position()?;
                     // allow unexpected EOF if 0 bytes were read
@@ -64,14 +106,13 @@ where
                     }
                     self.db_file.seek(io::SeekFrom::Start(pos_before_read))?;
                     Err(IterError::Bincode(*e))
-                }
-            }
+                })
         })()
         .transpose()
     }
 }
 
-impl<'t, T> Drop for EntryIter<'t, T> {
+impl<'t, T1, T2> Drop for EntryIter<'t, T1, T2> {
     fn drop(&mut self) {
         // This syncs the underlying file's offset with the buffer's position. This way, we
         // maintain the correct position to start the next read/write.

--- a/crates/file_store/src/entry_iter.rs
+++ b/crates/file_store/src/entry_iter.rs
@@ -49,10 +49,13 @@ where
                 self.db_file.seek(io::SeekFrom::Start(start))?;
             }
 
+            let mut changeset_size: u64 = 0;
             let mut pos_before_read = self.db_file.stream_position()?;
             bincode_options()
                 .deserialize_from::<_, u64>(&mut self.db_file)
                 .and_then(|size| {
+                    // Save changeset size to use in case a partial read is needed
+                    changeset_size = size;
                     pos_before_read = self.db_file.stream_position()?;
                     bincode_options()
                         .with_limit(size)
@@ -76,17 +79,40 @@ where
                             // risen when actual_index > max_variant_index
                             if actual_index > max_variant_index {
                                 pos_before_read = self.db_file.stream_position()?;
-                                return bincode_options()
+                                let fallback_decoded_value = bincode_options()
                                     .deserialize_from::<_, T2>(&mut self.db_file)
                                     .map(Into::into);
+
+                                if let Ok(v) = &fallback_decoded_value {
+                                    let actual_read_size = bincode_options().serialized_size(v)?;
+                                    let remaining_bytes_to_read =
+                                        (changeset_size - actual_read_size) as i64;
+                                    // Ignore remaining bytes
+                                    self.db_file
+                                        .seek(io::SeekFrom::Current(remaining_bytes_to_read))?;
+                                }
+
+                                return fallback_decoded_value;
                             }
                         }
                         bincode::ErrorKind::InvalidTagEncoding(index) => {
                             if *index as u64 > max_variant_index {
                                 pos_before_read = self.db_file.stream_position()?;
-                                return bincode_options()
+
+                                let fallback_decoded_value = bincode_options()
                                     .deserialize_from::<_, T2>(&mut self.db_file)
                                     .map(Into::into);
+
+                                if let Ok(v) = &fallback_decoded_value {
+                                    let actual_read_size = bincode_options().serialized_size(v)?;
+                                    let remaining_bytes_to_read =
+                                        (changeset_size - actual_read_size) as i64;
+                                    // Ignore remaining bytes
+                                    self.db_file
+                                        .seek(io::SeekFrom::Current(remaining_bytes_to_read))?;
+                                }
+
+                                return fallback_decoded_value;
                             }
                         }
                         _ => (),

--- a/crates/file_store/src/entry_iter.rs
+++ b/crates/file_store/src/entry_iter.rs
@@ -72,6 +72,8 @@ where
                             pos_before_read = self.db_file.stream_position()?;
                             let actual_index =
                                 bincode_options().deserialize_from::<_, u64>(&mut self.db_file)?;
+                            // This will always happen as the `expected variant index` only will be
+                            // risen when actual_index > max_variant_index
                             if actual_index > max_variant_index {
                                 pos_before_read = self.db_file.stream_position()?;
                                 return bincode_options()


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Addresses issue #1499.

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

~The changes have been rebased over https://github.com/bitcoindevkit/bdk/pull/1495, because it will be merged sooner and there is a great number of conflicts that will arise later with master if not done.~

~I created this draft to gather feedback.
I'm not understanding properly the issue and cannot visualize how the end user will use this feature.~

I noticed that the `expected variant index` error will be risen only when the decoded version is newer than the one implemented in the code. There is no need to check the indices in that case, as the error is already signaling the encoded variant is higher than the existing in the enum.
If the decoded variant is in the range of the enum variants, but still decoding of the inner struct fails, it means the error is somewhere else.
Also, the decoded variant shouldn't be below the range, as that's not possible, at least using the default variant representation.

Another point to have in mind is I was expecting the above situation raised `InvalidTagEncoding`, but it didn't happen. I'm tracking the trigger of this error, which seems more fitted to describe the situation we want to handle, but couldn't find anything yet.

All this means I could refactor the decoding `entry_iter` code and make it shorter.

### FAQ:

<details>
<summary>What's the idea behind versioned changesets?</summary>

To enable backward and forward compatibility @LLFourn crafted _versioned changeset_ with the following properties:
1. Each new version contains the variants of the previous version and at least one extra variant. I.e.: $\forall\ i,\ j\ \in\ \{1, 2, \cdots, n\}\ V_i > V_j$ if $i > j$ and $V_i \supset V_j$

E.g.:
```rust
enum Versioned1 {
	V1(StructA),
	V2(StructB),
	V3(StructC)
}

// Next code version
enum Versioned2 {
	V1(StructA),
	V2(StructB),
	V3(StructC),
	V4(StructD),
	V5(StructE)
}
```

2. Each variant contains the fields of the previous variant in the same order and at least one extra field. I.e.: $\forall\ r \in\ \{1, 2, \cdots, k\}\ |\ c_r,\ c_{r+1}\ \in\ V_i,\ c_{r+1}\ \supset\ c_r$
E.g.:
```rust
enum Versioned1 {
	V1(StructA),
	V2(StructB),
	V3(StructB)
}

// Next code version
enum Versioned2 {
	V1(StructA),
	V2(StructB),
	V3(StructC),
	V4(StructD),
	V5(StructE)
}

struct StructA {
	field_a: u64
}

struct StructB {
	field_a: u64,
	field_b: u64
}

struct StructC {
	field_a: u64,
	field_b: u64,
	field_c: u64
}

struct StructD {
	field_a: u64,
	field_b: u64,
	field_c: u64,
	field_d: u64,
	field_e: u64,
	field_f: u64
}

struct StructE {
	field_a: u64,
	field_b: u64,
	field_c: u64,
	field_d: u64,
	field_e: u64,
	field_f: u64,
	field_g: u64
}
```
</details>

<details>
<summary>How versioned changesets solve backward compatibility?</summary>
Considering the previous definition of versioned changesets, backward compatibility means:

> Decode $V_j$ using $V_i$ when $i\ >\ j$

This is trivial, as $V_i$ already includes all the variants in $V_j$ so it is a matter of just letting bincode select the variant of $V_i$ based on the encoded variant index.
</details>

<details>
<summary>How versioned changesets solve forward compatibility?</summary>
Defining forward compatibility in terms of the versioned changeset definition:

> Decode changeset $c_w$ from $V_i$ using code only knowing about $V_j$ when $i\ >\ j$ and $c_w$ is not included in $V_j$ . 

Because of property 1 and 2 we know the max variant in $V_j$ , let's call it $c_r$ , fulfills property 2: $c_r \subset c_w$ . So we can try to decode $c_r$ from the encoded data ignoring the remaining fields from $c_w$.
</details>

<details>
<summary>How does the encoding format look like?</summary>
Using the following format:

```text
[L][V]
```

where `[L]` is the length of the encoded data, and `[V]` is the encoding of a variant of the enum representing the versioned changeset, so it is encoded always prefixed with the variant prefix, let's call it `i` followed by the actual data, let's call it `C`. Being the final encoding as the following:

```text
[L][(i)(C)]
```
</details>

<details>
<summary>Why we need to prepend a length to every encoded versioned changeset?</summary>
Typically the encoding length of a versioned changeset $V_i$ would be determined by its type definition, however, a newer version $V_j$ with $j > i$ will have new variants, and the encoding length of those variants cannot be determined if the code only knows about $V_i$.
</details>

<details>
<summary>How we realize we are decoding a higher encoded version than we actually have?</summary>
As bincode encodes each enum variant prefixed with its variant index, if the versioned changeset $V_i$ we are currently working with doesn't contain the variant index we can be sure the data is of a newer type. On the flip side, if the data is of a variant index that exists in $V_i$, we can be sure the data is corrupted.
</details>

<details>
<summary>How encoding works?</summary>

1. Transform the changeset into a versioned-changeset first.
2. Get serialized size of versioned changeset: `[L]`.
3. Encode `[L]` as `u64` and write to file.
4. Encode `[V]` and write to file. Remember bincode encodes it prefixed with the variant index: `[(i)(C)]`
</details>

<details>
<summary>How decoding works?</summary>

1. Decode `[L]`as `u64` from file.
2. Attempt to decode first `[L]` bytes as `[V]`.
	a. On success: Extract `C` from `[V]` (`[(i)(C)]`) and return it.
	b. On failure: Decode `[V]` first bytes as `u64` to extract the enum variant index. If it is too high, trim the variant index from the data, and attempt to decode `C` , the written changeset $c_r$ into the version in use $V_i$ max variant $c_r$, the reading changeset.
</details>

<details>
<summary>How do we determine if a variant is too high?</summary>

Code available to extract the number of variants in an enum is unsafe or it is in the nightly API, so we force versioned changeset to implement the `Default` trait expecting it to always return the max variant (latest changeset version) of the versioned changeset. Then we can encode it using bincode and decode the prefixed variant index as `u64` ignoring the remaining encoded bytes.

```rust
let serialized_max_variant = bincode_options().serialize(&T1::default())?;
// allow trailing bytes because we are serializing the variant, not an u64, and
// we want to extract the varint index prefixed
let max_variant_index = bincode_options()
    .allow_trailing_bytes()
    .deserialize::<u64>(&serialized_max_variant)?;
```
</details>

<details>
<summary>Is it necessary to check if the encoded variant index is higher than the max variant index of the versioned changeset in use?
</summary>

I think it's not. While testing the implementation the code panicked with a particular `bincode::ErrorKind::Custom` error announcing the decoded variant index wasn't expected as it exceeded the limits of the variant indexes available. So it seems just handling this error is enough to detect higher encoded versions.

I **haven't removed the check** because I want someone else to confirm this.

</details>

<details>
<summary>How to decode the higher version encoded changeset $c_w$ with the lower version decoding changeset $c_r$?</summary>


 As I said, the code decodes `[V]` first bytes as `u64` to extract the enum variant index and if it is too high, trims the variant index from the data, and attempts to decode `C` , the written changeset $c_r$ into the version in use $V_i$ max variant $c_r$, the reading changeset.
 As this step is decoding less data than the available in the buffer, we risk to left this data in the buffer losing "data alignment" and ending with a bincode `SizeLimit` error produced after falling short while decoding the last portion of the encoded data.
 To avoid this, we need to keep track of the encoded versioned changeset size `[L]` and after decoding $c_r$, substract the serialized size of $c_r$ (which includes the variant index) to the decoded `[L]`, and use this as an offset to move the reader position after that amount of bytes.

To summarize:
1. Keep track of the encoded size of the changeset
2. Get the size of the decoded $c_r$
3. Get the remaining data to read from the subtraction of 1 minus 2
4. Skip the obtained number in 3 of bytes (the extra fields from $c_w$)
5. Keep decoding the remaining data, coming back to 1 if needed

To illustrate this look at the following example:
$c_w$ (greater encoded changeset version)
$c_r$ (decoding changeset version with less fields)
$c_w$ = `[0][0][0][0]`
$c_r$ = `[x][x]`
`[S]` means the byte has been skipped

Ignore for the sake of the example the length prefix, and the variant index, and give me the license to use a delimiter that bincode doesn't have, the pipe `|`.

initial encoded buffer = `[0][0][0]|[0] | [0][0][0][0] | [0][0][0]|[0] | [0][0][0][0]`
first decode = `[X][X][S]|[S] | [0][0][0][0] | [0][0][0]|[0] | [0][0][0][0]`
second decode = `[X][X][S]|[S] | [X][X][S][S] | [0][0][0]|[0] | [0][0][0][0]`
third decode = `[X][X][S]|[S] | [X][X][S][S] | [X][X][S]|[S] | [0][0][0][0]`
fourth decode = `[X][X][S]|[S] | [X][X][S][S] | [X][X][S]|[S] | [X][X][S][S]`

</details>

<details>
<summary>Which problems this realignment of data may have?</summary>

If not used carefully a version $V_i$ and a higher $V_j$ may have the same variant indexes with different types, and the change above will decode it without returning any error. This is obviously something against the definition of versioned changeset, but without the realignment code this error was easily spotted.
</details>

<details>
<summary>All users should implement versioned changesets to work with the `file_store` crate?</summary>

No, the current code is completely compatible with a simple changeset without using any enum versioned changeset or variant index prefix.
</details>

<details>
<summary>Why there is an pattern matching arm handling `bincode::ErrorKind::InvalidTagEncoding`?</summary>

While implementing the changes and investigating the bincode I tumbled over this error that at first seemed the most suitable to handle in relation to a variant index off limits, but I never got it to reproduce.

**I think it is removable**, but I would like another eye there before doing it.
</details>

<details>
<summary>What tests have been added?</summary>

As the backward compatibility case is trivial, it just depends of bincode logic, the only added tests involves the forward compatibility hard case: when changeset $c_w$ has been encoded with a versioned changeset $V_j$ and its being decoded with a lesser versioned changeset $V_i$ with $i < j$ , and the maximum available variant is $c_r$.
For this test multiple changesets have been appended to replicate the alignment explained above (which may not rise if the changeset encoded was just one).
Also, `Option` type has been avoided because there was a misleading notion of how bincode encoded and decoded these fields that might introduce users to think any additional variants added to higher versions should be of this type.
</details>

<details>
<summary>What I would like to have feedback about?</summary>


To figure out parts of the code where I would like to have feedback on, check out:

- The only implemented test
- Question `Is it necessary to check if the encoded variant index is higher than the max variant index of the versioned changeset in use?` of this **FAQ**.
- Question  `Why there is an arm handling bincode::ErrorKind::InvalidTagEncoding?` of this **FAQ**.
- Question `Which problems this realignment of data may have?` of this **FAQ**.
</details>

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
