### PR TITLE
refactor(chain)! SyncRequest ergonomics improvements

### DIFF
--- a/crates/chain/src/local_chain.rs
+++ b/crates/chain/src/local_chain.rs
@@ -151,8 +151,7 @@ impl CheckPoint {
 
     /// Iterate checkpoints over a height range.
     ///
-    /// Note that we always iterate checkpoints in reverse height order (iteration starts at tip
-    /// height).
+    /// Note that we always iterate checkpoints in reverse height order (iteration starts with highest).
     pub fn range<R>(&self, range: R) -> impl Iterator<Item = CheckPoint>
     where
         R: RangeBounds<u32>,

--- a/crates/esplora/tests/async_ext.rs
+++ b/crates/esplora/tests/async_ext.rs
@@ -21,8 +21,8 @@ pub async fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
         Address::from_str("bcrt1qfjg5lv3dvc9az8patec8fjddrs4aqtauadnagr")?.assume_checked();
 
     let misc_spks = [
-        receive_address0.script_pubkey(),
-        receive_address1.script_pubkey(),
+        (0, receive_address0.script_pubkey()),
+        (1, receive_address1.script_pubkey()),
     ];
 
     let _block_hashes = env.mine_blocks(101, None)?;
@@ -55,7 +55,7 @@ pub async fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
     let cp_tip = env.make_checkpoint_tip();
 
     let sync_update = {
-        let request = SyncRequest::from_chain_tip(cp_tip.clone()).set_spks(misc_spks);
+        let request = SyncRequest::new(cp_tip.clone()).add_spks(misc_spks);
         client.sync(request, 1).await?
     };
 

--- a/crates/esplora/tests/blocking_ext.rs
+++ b/crates/esplora/tests/blocking_ext.rs
@@ -55,7 +55,7 @@ pub fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
     let cp_tip = env.make_checkpoint_tip();
 
     let sync_update = {
-        let request = SyncRequest::from_chain_tip(cp_tip.clone()).set_spks(misc_spks);
+        let request = SyncRequest::new(cp_tip.clone()).set_spks(misc_spks);
         client.sync(request, 1)?
     };
 

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -2320,7 +2320,7 @@ impl Wallet {
     /// [`SyncRequest`] collects all revealed script pubkeys from the wallet keychain needed to
     /// start a blockchain sync with a spk based blockchain client.
     pub fn start_sync_with_revealed_spks(&self) -> SyncRequest {
-        SyncRequest::from_chain_tip(self.chain.tip())
+        SyncRequest::new(self.chain.tip())
             .populate_with_revealed_spks(&self.indexed_graph.index, ..)
     }
 

--- a/example-crates/example_electrum/src/main.rs
+++ b/example-crates/example_electrum/src/main.rs
@@ -221,7 +221,7 @@ fn main() -> anyhow::Result<()> {
             }
 
             let chain_tip = chain.tip();
-            let mut request = SyncRequest::from_chain_tip(chain_tip.clone());
+            let mut request = SyncRequest::new(chain_tip.clone());
 
             if all_spks {
                 let all_spks = graph

--- a/example-crates/example_esplora/src/main.rs
+++ b/example-crates/example_esplora/src/main.rs
@@ -233,7 +233,7 @@ fn main() -> anyhow::Result<()> {
 
             let local_tip = chain.lock().expect("mutex must not be poisoned").tip();
             // Spks, outpoints and txids we want updates on will be accumulated here.
-            let mut request = SyncRequest::from_chain_tip(local_tip.clone());
+            let mut request = SyncRequest::new(local_tip.clone());
 
             // Get a short lock on the structures to get spks, utxos, and txs that we are interested
             // in.


### PR DESCRIPTION
This is an attempt to improve the ergonomics of sync request especially with regards to inspecting the progress of the sync.
Now there is a single `inspect` method which takes a closure which gets richer information than the previous ones. It takes:

```
(SyncItem<'a, I>, usize, usize)
```
where the `usize`s are the index of the current item and the number of items remaining respectively.
`SyncItem` is defined as:

```
/// An item reported to [`inspect`]
///
/// [`inspect`]: SyncRequest::inspect
pub enum SyncItem<'a, I> {
    /// Script pubkey sycn item
    Spk(I, &'a Script),
    /// Transaction id sync item
    Txid(Txid),
    /// Transaction outpoint sync item
    OutPoint(OutPoint),
}
```

Note carefully the type parameter `I` inside which is just to help log out the index (or whatever metadata you want) along with the spk.

This is not ready for review but I thought @evanlinjin might be interested in finishing this work.
