### PR TITLE
[wallet] Enable support for single descriptor wallets

### DIFF
--- a/crates/chain/src/lib.rs
+++ b/crates/chain/src/lib.rs
@@ -113,6 +113,13 @@ pub type KeychainIndexed<K, T> = ((K, u32), T);
 /// A wrapper that we use to impl remote traits for types in our crate or dependency crates.
 pub struct Impl<T>(pub T);
 
+impl<T> Impl<T> {
+    /// Returns the inner `T`.
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
 impl<T> From<T> for Impl<T> {
     fn from(value: T) -> Self {
         Self(value)

--- a/crates/wallet/README.md
+++ b/crates/wallet/README.md
@@ -79,8 +79,10 @@ let network = Network::Testnet;
 let descriptor = "wpkh(tprv8ZgxMBicQKsPdcAqYBpzAFwU5yxBUo88ggoBqu1qPcHUfSbKK1sKMLmC7EAk438btHQrSdu3jGGQa6PA71nvH5nkDexhLteJqkM4dQmWF9g/84'/1'/0'/0/*)";
 let change_descriptor = "wpkh(tprv8ZgxMBicQKsPdcAqYBpzAFwU5yxBUo88ggoBqu1qPcHUfSbKK1sKMLmC7EAk438btHQrSdu3jGGQa6PA71nvH5nkDexhLteJqkM4dQmWF9g/84'/1'/0'/1/*)";
 let wallet_opt = Wallet::load()
-    .descriptors(descriptor, change_descriptor)
     .network(network)
+    .descriptor(KeychainKind::External, Some(descriptor))
+    .descriptor(KeychainKind::Internal, Some(change_descriptor))
+    .extract_keys()
     .load_wallet(&mut db)
     .expect("wallet");
 let mut wallet = match wallet_opt {

--- a/crates/wallet/examples/compiler.rs
+++ b/crates/wallet/examples/compiler.rs
@@ -56,28 +56,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     println!("Compiled into Descriptor: \n{}", descriptor);
 
-    // Do the same for another (internal) keychain
-    let policy_str = "or(
-        10@thresh(2,
-            pk(029ffbe722b147f3035c87cb1c60b9a5947dd49c774cc31e94773478711a929ac0),pk(025f05815e3a1a8a83bfbb03ce016c9a2ee31066b98f567f6227df1d76ec4bd143),pk(025625f41e4a065efc06d5019cbbd56fe8c07595af1231e7cbc03fafb87ebb71ec)
-        ),1@and(
-            pk(03deae92101c790b12653231439f27b8897264125ecb2f46f48278603102573165),
-            older(12960)
-        )
-    )"
-    .replace(&[' ', '\n', '\t'][..], "");
-
-    println!("Compiling internal policy: \n{}", policy_str);
-
-    let policy = Concrete::<String>::from_str(&policy_str)?;
-    let internal_descriptor = Descriptor::new_wsh(policy.compile()?)?.to_string();
-    println!(
-        "Compiled into internal Descriptor: \n{}",
-        internal_descriptor
-    );
-
     // Create a new wallet from descriptors
-    let mut wallet = Wallet::create(descriptor, internal_descriptor)
+    let mut wallet = Wallet::create_single(descriptor)
         .network(Network::Regtest)
         .create_wallet_no_persist()?;
 

--- a/crates/wallet/src/wallet/changeset.rs
+++ b/crates/wallet/src/wallet/changeset.rs
@@ -103,16 +103,18 @@ impl ChangeSet {
         let row = wallet_statement
             .query_row([], |row| {
                 Ok((
-                    row.get::<_, Impl<Descriptor<DescriptorPublicKey>>>("descriptor")?,
-                    row.get::<_, Impl<Descriptor<DescriptorPublicKey>>>("change_descriptor")?,
-                    row.get::<_, Impl<bitcoin::Network>>("network")?,
+                    row.get::<_, Option<Impl<Descriptor<DescriptorPublicKey>>>>("descriptor")?,
+                    row.get::<_, Option<Impl<Descriptor<DescriptorPublicKey>>>>(
+                        "change_descriptor",
+                    )?,
+                    row.get::<_, Option<Impl<bitcoin::Network>>>("network")?,
                 ))
             })
             .optional()?;
-        if let Some((Impl(desc), Impl(change_desc), Impl(network))) = row {
-            changeset.descriptor = Some(desc);
-            changeset.change_descriptor = Some(change_desc);
-            changeset.network = Some(network);
+        if let Some((desc, change_desc, network)) = row {
+            changeset.descriptor = desc.map(Impl::into_inner);
+            changeset.change_descriptor = change_desc.map(Impl::into_inner);
+            changeset.network = network.map(Impl::into_inner);
         }
 
         changeset.local_chain = local_chain::ChangeSet::from_sqlite(db_tx)?;

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -443,10 +443,11 @@ impl Wallet {
 
     /// Build [`Wallet`] by loading from persistence or [`ChangeSet`].
     ///
-    /// Note that the descriptor secret keys are not persisted to the db. You can either add
-    /// signers after-the-fact with [`Wallet::add_signer`] or [`Wallet::set_keymap`]. Or you can
-    /// add keys when building the wallet using [`LoadParams::keymap`] and/or
-    /// [`LoadParams::descriptor`].
+    /// Note that the descriptor secret keys are not persisted to the db. You can add
+    /// signers after-the-fact with [`Wallet::add_signer`] or [`Wallet::set_keymap`]. You
+    /// can also add keys when building the wallet by using [`LoadParams::keymap`]. Finally
+    /// you can check the wallet's descriptors are what you expect with [`LoadParams::descriptor`]
+    /// which will try to populate signers if [`LoadParams::extract_keys`] is enabled.
     ///
     /// # Synopsis
     ///

--- a/crates/wallet/src/wallet/params.rs
+++ b/crates/wallet/src/wallet/params.rs
@@ -32,7 +32,7 @@ where
 pub struct CreateParams {
     pub(crate) descriptor: DescriptorToExtract,
     pub(crate) descriptor_keymap: KeyMap,
-    pub(crate) change_descriptor: DescriptorToExtract,
+    pub(crate) change_descriptor: Option<DescriptorToExtract>,
     pub(crate) change_descriptor_keymap: KeyMap,
     pub(crate) network: Network,
     pub(crate) genesis_hash: Option<BlockHash>,
@@ -40,14 +40,39 @@ pub struct CreateParams {
 }
 
 impl CreateParams {
-    /// Construct parameters with provided `descriptor`, `change_descriptor` and `network`.
+    /// Construct parameters with provided `descriptor`.
     ///
-    /// Default values: `genesis_hash` = `None`, `lookahead` = [`DEFAULT_LOOKAHEAD`]
+    /// Default values:
+    /// * `change_descriptor` = `None`
+    /// * `network` = [`Network::Bitcoin`]
+    /// * `genesis_hash` = `None`
+    /// * `lookahead` = [`DEFAULT_LOOKAHEAD`]
+    ///
+    /// Use this method only when building a wallet with a single descriptor. See
+    /// also [`Wallet::create_single`].
+    pub fn new_single<D: IntoWalletDescriptor + 'static>(descriptor: D) -> Self {
+        Self {
+            descriptor: make_descriptor_to_extract(descriptor),
+            descriptor_keymap: KeyMap::default(),
+            change_descriptor: None,
+            change_descriptor_keymap: KeyMap::default(),
+            network: Network::Bitcoin,
+            genesis_hash: None,
+            lookahead: DEFAULT_LOOKAHEAD,
+        }
+    }
+
+    /// Construct parameters with provided `descriptor` and `change_descriptor`.
+    ///
+    /// Default values:
+    /// * `network` = [`Network::Bitcoin`]
+    /// * `genesis_hash` = `None`
+    /// * `lookahead` = [`DEFAULT_LOOKAHEAD`]
     pub fn new<D: IntoWalletDescriptor + 'static>(descriptor: D, change_descriptor: D) -> Self {
         Self {
             descriptor: make_descriptor_to_extract(descriptor),
             descriptor_keymap: KeyMap::default(),
-            change_descriptor: make_descriptor_to_extract(change_descriptor),
+            change_descriptor: Some(make_descriptor_to_extract(change_descriptor)),
             change_descriptor_keymap: KeyMap::default(),
             network: Network::Bitcoin,
             genesis_hash: None,

--- a/crates/wallet/src/wallet/tx_builder.rs
+++ b/crates/wallet/src/wallet/tx_builder.rs
@@ -481,7 +481,8 @@ impl<'a, Cs> TxBuilder<'a, Cs> {
     /// Do not spend change outputs
     ///
     /// This effectively adds all the change outputs to the "unspendable" list. See
-    /// [`TxBuilder::unspendable`].
+    /// [`TxBuilder::unspendable`]. This method assumes the presence of an internal
+    /// keychain, otherwise it has no effect.
     pub fn do_not_spend_change(&mut self) -> &mut Self {
         self.params.change_policy = ChangeSpendPolicy::ChangeForbidden;
         self
@@ -490,14 +491,16 @@ impl<'a, Cs> TxBuilder<'a, Cs> {
     /// Only spend change outputs
     ///
     /// This effectively adds all the non-change outputs to the "unspendable" list. See
-    /// [`TxBuilder::unspendable`].
+    /// [`TxBuilder::unspendable`]. This method assumes the presence of an internal
+    /// keychain, otherwise it has no effect.
     pub fn only_spend_change(&mut self) -> &mut Self {
         self.params.change_policy = ChangeSpendPolicy::OnlyChange;
         self
     }
 
     /// Set a specific [`ChangeSpendPolicy`]. See [`TxBuilder::do_not_spend_change`] and
-    /// [`TxBuilder::only_spend_change`] for some shortcuts.
+    /// [`TxBuilder::only_spend_change`] for some shortcuts. This method assumes the presence
+    /// of an internal keychain, otherwise it has no effect.
     pub fn change_policy(&mut self, change_policy: ChangeSpendPolicy) -> &mut Self {
         self.params.change_policy = change_policy;
         self

--- a/example-crates/wallet_electrum/src/main.rs
+++ b/example-crates/wallet_electrum/src/main.rs
@@ -26,8 +26,10 @@ fn main() -> Result<(), anyhow::Error> {
     let mut db = Store::<bdk_wallet::ChangeSet>::open_or_create_new(DB_MAGIC.as_bytes(), db_path)?;
 
     let wallet_opt = Wallet::load()
-        .descriptors(EXTERNAL_DESC, INTERNAL_DESC)
         .network(NETWORK)
+        .descriptor(KeychainKind::External, Some(EXTERNAL_DESC))
+        .descriptor(KeychainKind::Internal, Some(INTERNAL_DESC))
+        .extract_keys()
         .load_wallet(&mut db)?;
     let mut wallet = match wallet_opt {
         Some(wallet) => wallet,

--- a/example-crates/wallet_esplora_async/src/main.rs
+++ b/example-crates/wallet_esplora_async/src/main.rs
@@ -23,8 +23,10 @@ async fn main() -> Result<(), anyhow::Error> {
     let mut conn = Connection::open(DB_PATH)?;
 
     let wallet_opt = Wallet::load()
-        .descriptors(EXTERNAL_DESC, INTERNAL_DESC)
         .network(NETWORK)
+        .descriptor(KeychainKind::External, Some(EXTERNAL_DESC))
+        .descriptor(KeychainKind::Internal, Some(INTERNAL_DESC))
+        .extract_keys()
         .load_wallet(&mut conn)?;
     let mut wallet = match wallet_opt {
         Some(wallet) => wallet,

--- a/example-crates/wallet_esplora_blocking/src/main.rs
+++ b/example-crates/wallet_esplora_blocking/src/main.rs
@@ -22,8 +22,10 @@ fn main() -> Result<(), anyhow::Error> {
     let mut db = Store::<bdk_wallet::ChangeSet>::open_or_create_new(DB_MAGIC.as_bytes(), DB_PATH)?;
 
     let wallet_opt = Wallet::load()
-        .descriptors(EXTERNAL_DESC, INTERNAL_DESC)
         .network(NETWORK)
+        .descriptor(KeychainKind::External, Some(EXTERNAL_DESC))
+        .descriptor(KeychainKind::Internal, Some(INTERNAL_DESC))
+        .extract_keys()
         .load_wallet(&mut db)?;
     let mut wallet = match wallet_opt {
         Some(wallet) => wallet,

--- a/example-crates/wallet_rpc/src/main.rs
+++ b/example-crates/wallet_rpc/src/main.rs
@@ -5,7 +5,7 @@ use bdk_bitcoind_rpc::{
 use bdk_wallet::{
     bitcoin::{Block, Network, Transaction},
     file_store::Store,
-    Wallet,
+    KeychainKind, Wallet,
 };
 use clap::{self, Parser};
 use std::{path::PathBuf, sync::mpsc::sync_channel, thread::spawn, time::Instant};
@@ -89,8 +89,10 @@ fn main() -> anyhow::Result<()> {
     let mut db =
         Store::<bdk_wallet::ChangeSet>::open_or_create_new(DB_MAGIC.as_bytes(), args.db_path)?;
     let wallet_opt = Wallet::load()
-        .descriptors(args.descriptor.clone(), args.change_descriptor.clone())
         .network(args.network)
+        .descriptor(KeychainKind::External, Some(args.descriptor.clone()))
+        .descriptor(KeychainKind::Internal, Some(args.change_descriptor.clone()))
+        .extract_keys()
         .load_wallet(&mut db)?;
     let mut wallet = match wallet_opt {
         Some(wallet) => wallet,


### PR DESCRIPTION
The change descriptor is made optional, making this an effective reversion of #1390 and enables creating wallets with a single descriptor.

fixes #1511 

### Notes to the reviewers

PR 1390 also removed an error case [`ChangePolicyDescriptor`](https://github.com/bitcoindevkit/bdk/blob/8eef350bd08057acc39b6fc50b1217db5e29b968/crates/wallet/src/wallet/mod.rs#L1529-L1533) and this can possibly be added back. In the case the wallet only has a single descriptor we allow any utxos to fund a tx that aren't specifically marked unspendable regardless of the change spend policy.

### Changelog notice

* Added method `Wallet::create_single` that expects a single `D: IntoWalletDescriptor` as input and enables building a wallet with no internal keychain.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] This pull request breaks the existing API
* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
