### PR TITLE
chore(electrum): update electrum-client version to 0.21

### DIFF
--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 
 [dependencies]
 bdk_chain = { path = "../chain", version = "0.17.0" }
-electrum-client = { version = "0.20" }
+electrum-client = { version = "0.21" }
 #rustls = { version = "=0.21.1", optional = true, features = ["dangerous_configuration"] }
 
 [dev-dependencies]


### PR DESCRIPTION
### Description

Update electrum-client dependency version to 0.21.

### Notes to the reviewers

This is required to complete bitcoindevkit/bdk-ffi#582.

### Changelog notice

- chore(electrum): update electrum-client version to 0.21

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
