### PR TITLE
POC: Multi-descriptor wallet

### DIFF
--- a/crates/wallet/src/wallet/changeset.rs
+++ b/crates/wallet/src/wallet/changeset.rs
@@ -1,19 +1,23 @@
 use bdk_chain::{
-    indexed_tx_graph, keychain_txout, local_chain, tx_graph, ConfirmationBlockTime, Merge,
+    collections::BTreeMap, indexed_tx_graph, keychain_txout, local_chain, tx_graph,
+    ConfirmationBlockTime, Merge,
 };
 use miniscript::{Descriptor, DescriptorPublicKey};
+use serde::{de::DeserializeOwned, Serialize};
 
 type IndexedTxGraphChangeSet =
     indexed_tx_graph::ChangeSet<ConfirmationBlockTime, keychain_txout::ChangeSet>;
 
 /// A changeset for [`Wallet`](crate::Wallet).
-#[derive(Default, Debug, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
+#[serde(bound(
+    deserialize = "K: Ord + serde::Deserialize<'de>",
+    serialize = "K: Ord + serde::Serialize"
+))]
 #[non_exhaustive]
-pub struct ChangeSet {
-    /// Descriptor for recipient addresses.
-    pub descriptor: Option<Descriptor<DescriptorPublicKey>>,
-    /// Descriptor for change addresses.
-    pub change_descriptor: Option<Descriptor<DescriptorPublicKey>>,
+pub struct ChangeSet<K> {
+    /// Descriptor for addresses.
+    pub descriptors: BTreeMap<K, Descriptor<DescriptorPublicKey>>,
     /// Stores the network type of the transaction data.
     pub network: Option<bitcoin::Network>,
     /// Changes to the [`LocalChain`](local_chain::LocalChain).
@@ -24,24 +28,37 @@ pub struct ChangeSet {
     pub indexer: keychain_txout::ChangeSet,
 }
 
-impl Merge for ChangeSet {
+impl<K> Default for ChangeSet<K> {
+    fn default() -> Self {
+        Self {
+            descriptors: Default::default(),
+            network: Default::default(),
+            local_chain: Default::default(),
+            tx_graph: Default::default(),
+            indexer: Default::default(),
+        }
+    }
+}
+
+impl<K: Ord> Merge for ChangeSet<K> {
     /// Merge another [`ChangeSet`] into itself.
     fn merge(&mut self, other: Self) {
-        if other.descriptor.is_some() {
-            debug_assert!(
-                self.descriptor.is_none() || self.descriptor == other.descriptor,
-                "descriptor must never change"
-            );
-            self.descriptor = other.descriptor;
+        for (k, descriptor) in other.descriptors {
+            use bdk_chain::collections::btree_map::Entry;
+            match self.descriptors.entry(k) {
+                Entry::Vacant(entry) => {
+                    entry.insert(descriptor);
+                }
+                Entry::Occupied(entry) => {
+                    debug_assert_eq!(
+                        entry.get(),
+                        &descriptor,
+                        "changeset must not replace existing descriptor under keychain"
+                    );
+                }
+            }
         }
-        if other.change_descriptor.is_some() {
-            debug_assert!(
-                self.change_descriptor.is_none()
-                    || self.change_descriptor == other.change_descriptor,
-                "change descriptor must never change"
-            );
-            self.change_descriptor = other.change_descriptor;
-        }
+
         if other.network.is_some() {
             debug_assert!(
                 self.network.is_none() || self.network == other.network,
@@ -56,8 +73,7 @@ impl Merge for ChangeSet {
     }
 
     fn is_empty(&self) -> bool {
-        self.descriptor.is_none()
-            && self.change_descriptor.is_none()
+        self.descriptors.is_empty()
             && self.network.is_none()
             && self.local_chain.is_empty()
             && self.tx_graph.is_empty()
@@ -66,11 +82,15 @@ impl Merge for ChangeSet {
 }
 
 #[cfg(feature = "rusqlite")]
-impl ChangeSet {
+impl<K: Serialize + DeserializeOwned + Ord> ChangeSet<K> {
     /// Schema name for wallet.
     pub const WALLET_SCHEMA_NAME: &'static str = "bdk_wallet";
     /// Name of table to store wallet descriptors and network.
     pub const WALLET_TABLE_NAME: &'static str = "bdk_wallet";
+    /// Name of table to store wallet network.
+    pub const NETWORK_TABLE_NAME: &'static str = "bdk_network";
+    /// Name of table to store descriptors and an associated label (used as the table key).
+    pub const DESCRIPTOR_TABLE_NAME: &'static str = "bdk_descriptor";
 
     /// Initialize sqlite tables for wallet schema & table.
     fn init_wallet_sqlite_tables(
@@ -82,38 +102,85 @@ impl ChangeSet {
                 descriptor TEXT, \
                 change_descriptor TEXT, \
                 network TEXT \
-                ) STRICT;",
+                ) STRICT",
             Self::WALLET_TABLE_NAME,
         )];
-        crate::rusqlite_impl::migrate_schema(db_tx, Self::WALLET_SCHEMA_NAME, &[schema_v0])
+        // TODO: We can't really migrate from V0 to V1 unless type 'K' provides some sort of
+        // mapping from 'KeychainKind'.
+        let schema_v1: &[&str] = &[
+            &format!(
+                "CREATE TABLE {} ( \
+                    id INTEGER PRIMARY KEY NOT NULL CHECK (id = 0), \
+                    network TEXT NOT NULL \
+                ) STRICT",
+                Self::NETWORK_TABLE_NAME,
+            ),
+            &format!(
+                "CREATE TABLE {} ( \
+                    label TEXT PRIMARY KEY NOT NULL, \
+                    descriptor TEXT NOT NULL
+                ) STRICT",
+                Self::DESCRIPTOR_TABLE_NAME,
+            ),
+        ];
+        crate::rusqlite_impl::migrate_schema(
+            db_tx,
+            Self::WALLET_SCHEMA_NAME,
+            &[schema_v0, schema_v1],
+        )
     }
 
     /// Recover a [`ChangeSet`] from sqlite database.
     pub fn from_sqlite(db_tx: &chain::rusqlite::Transaction) -> chain::rusqlite::Result<Self> {
         Self::init_wallet_sqlite_tables(db_tx)?;
         use chain::rusqlite::OptionalExtension;
+        use chain::rusqlite_impl::SerdeImpl;
         use chain::Impl;
 
         let mut changeset = Self::default();
 
-        let mut wallet_statement = db_tx.prepare(&format!(
-            "SELECT descriptor, change_descriptor, network FROM {}",
-            Self::WALLET_TABLE_NAME,
+        let mut statement = db_tx.prepare(&format!(
+            "SELECT label, descriptor FROM {}",
+            Self::DESCRIPTOR_TABLE_NAME
         ))?;
-        let row = wallet_statement
-            .query_row([], |row| {
-                Ok((
-                    row.get::<_, Impl<Descriptor<DescriptorPublicKey>>>("descriptor")?,
-                    row.get::<_, Impl<Descriptor<DescriptorPublicKey>>>("change_descriptor")?,
-                    row.get::<_, Impl<bitcoin::Network>>("network")?,
-                ))
-            })
+        let row_iter = statement.query_map([], |row| {
+            Ok((
+                row.get::<_, SerdeImpl<K>>("label")?,
+                row.get::<_, Impl<Descriptor<DescriptorPublicKey>>>("descriptor")?,
+            ))
+        })?;
+        for row in row_iter {
+            let (SerdeImpl(label), Impl(descriptor)) = row?;
+            changeset.descriptors.insert(label, descriptor);
+        }
+
+        let mut statement =
+            db_tx.prepare(&format!("SELECT network FROM {}", Self::NETWORK_TABLE_NAME))?;
+        let row = statement
+            .query_row([], |row| row.get::<_, Impl<bitcoin::Network>>("network"))
             .optional()?;
-        if let Some((Impl(desc), Impl(change_desc), Impl(network))) = row {
-            changeset.descriptor = Some(desc);
-            changeset.change_descriptor = Some(change_desc);
+        if let Some(Impl(network)) = row {
             changeset.network = Some(network);
         }
+
+        // let mut wallet_statement = db_tx.prepare(&format!(
+        //     "SELECT descriptor, change_descriptor, network FROM {}",
+        //     Self::WALLET_TABLE_NAME,
+        // ))?;
+        // let row = wallet_statement
+        //     .query_row([], |row| {
+        //         Ok((
+        //             row.get::<_, Impl<Descriptor<DescriptorPublicKey>>>("descriptor")?,
+        //             row.get::<_, Impl<Descriptor<DescriptorPublicKey>>>("change_descriptor")?,
+        //             row.get::<_, Impl<bitcoin::Network>>("network")?,
+        //         ))
+        //     })
+        //     .optional()?;
+        // if let Some((Impl(desc), Impl(change_desc), Impl(network))) = row {
+        //     changeset.descriptor = Some(desc);
+        //     changeset.change_descriptor = Some(change_desc);
+        //     changeset.network = Some(network);
+        // }
 
         changeset.local_chain = local_chain::ChangeSet::from_sqlite(db_tx)?;
         changeset.tx_graph = tx_graph::ChangeSet::<_>::from_sqlite(db_tx)?;
@@ -129,40 +196,62 @@ impl ChangeSet {
     ) -> chain::rusqlite::Result<()> {
         Self::init_wallet_sqlite_tables(db_tx)?;
         use chain::rusqlite::named_params;
+        use chain::rusqlite_impl::SerdeImpl;
         use chain::Impl;
 
-        let mut descriptor_statement = db_tx.prepare_cached(&format!(
-            "INSERT INTO {}(id, descriptor) VALUES(:id, :descriptor) ON CONFLICT(id) DO UPDATE SET descriptor=:descriptor",
-            Self::WALLET_TABLE_NAME,
+        let mut statement = db_tx.prepare_cached(&format!(
+            "INSERT INTO {}(label, descriptor) VALUES(:label, descriptor) ON CONFLICT(label) DO UPDATE SET descriptor=:descriptor",
+            Self::DESCRIPTOR_TABLE_NAME,
         ))?;
-        if let Some(descriptor) = &self.descriptor {
-            descriptor_statement.execute(named_params! {
-                ":id": 0,
+        for (label, descriptor) in &self.descriptors {
+            statement.execute(named_params! {
+                ":label": SerdeImpl(label),
                 ":descriptor": Impl(descriptor.clone()),
             })?;
         }
-
-        let mut change_descriptor_statement = db_tx.prepare_cached(&format!(
-            "INSERT INTO {}(id, change_descriptor) VALUES(:id, :change_descriptor) ON CONFLICT(id) DO UPDATE SET change_descriptor=:change_descriptor",
-            Self::WALLET_TABLE_NAME,
-        ))?;
-        if let Some(change_descriptor) = &self.change_descriptor {
-            change_descriptor_statement.execute(named_params! {
-                ":id": 0,
-                ":change_descriptor": Impl(change_descriptor.clone()),
-            })?;
-        }
-
-        let mut network_statement = db_tx.prepare_cached(&format!(
+        let mut statement = db_tx.prepare_cached(&format!(
             "INSERT INTO {}(id, network) VALUES(:id, :network) ON CONFLICT(id) DO UPDATE SET network=:network",
-            Self::WALLET_TABLE_NAME,
+            Self::NETWORK_TABLE_NAME,
         ))?;
         if let Some(network) = self.network {
-            network_statement.execute(named_params! {
+            statement.execute(named_params! {
                 ":id": 0,
                 ":network": Impl(network),
             })?;
         }
+
+        // let mut descriptor_statement = db_tx.prepare_cached(&format!(
+        //     "INSERT INTO {}(id, descriptor) VALUES(:id, :descriptor) ON CONFLICT(id) DO UPDATE SET descriptor=:descriptor",
+        //     Self::WALLET_TABLE_NAME,
+        // ))?;
+        // if let Some(descriptor) = &self.descriptor {
+        //     descriptor_statement.execute(named_params! {
+        //         ":id": 0,
+        //         ":descriptor": Impl(descriptor.clone()),
+        //     })?;
+        // }
+        //
+        // let mut change_descriptor_statement = db_tx.prepare_cached(&format!(
+        //     "INSERT INTO {}(id, change_descriptor) VALUES(:id, :change_descriptor) ON CONFLICT(id) DO UPDATE SET change_descriptor=:change_descriptor",
+        //     Self::WALLET_TABLE_NAME,
+        // ))?;
+        // if let Some(change_descriptor) = &self.change_descriptor {
+        //     change_descriptor_statement.execute(named_params! {
+        //         ":id": 0,
+        //         ":change_descriptor": Impl(change_descriptor.clone()),
+        //     })?;
+        // }
+        //
+        // let mut network_statement = db_tx.prepare_cached(&format!(
+        //     "INSERT INTO {}(id, network) VALUES(:id, :network) ON CONFLICT(id) DO UPDATE SET network=:network",
+        //     Self::WALLET_TABLE_NAME,
+        // ))?;
+        // if let Some(network) = self.network {
+        //     network_statement.execute(named_params! {
+        //         ":id": 0,
+        //         ":network": Impl(network),
+        //     })?;
+        // }
 
         self.local_chain.persist_to_sqlite(db_tx)?;
         self.tx_graph.persist_to_sqlite(db_tx)?;
@@ -171,7 +260,7 @@ impl ChangeSet {
     }
 }
 
-impl From<local_chain::ChangeSet> for ChangeSet {
+impl<K> From<local_chain::ChangeSet> for ChangeSet<K> {
     fn from(chain: local_chain::ChangeSet) -> Self {
         Self {
             local_chain: chain,
@@ -180,7 +269,7 @@ impl From<local_chain::ChangeSet> for ChangeSet {
     }
 }
 
-impl From<IndexedTxGraphChangeSet> for ChangeSet {
+impl<K> From<IndexedTxGraphChangeSet> for ChangeSet<K> {
     fn from(indexed_tx_graph: IndexedTxGraphChangeSet) -> Self {
         Self {
             tx_graph: indexed_tx_graph.tx_graph,
@@ -190,7 +279,7 @@ impl From<IndexedTxGraphChangeSet> for ChangeSet {
     }
 }
 
-impl From<tx_graph::ChangeSet<ConfirmationBlockTime>> for ChangeSet {
+impl<K> From<tx_graph::ChangeSet<ConfirmationBlockTime>> for ChangeSet<K> {
     fn from(tx_graph: tx_graph::ChangeSet<ConfirmationBlockTime>) -> Self {
         Self {
             tx_graph,
@@ -199,7 +288,7 @@ impl From<tx_graph::ChangeSet<ConfirmationBlockTime>> for ChangeSet {
     }
 }
 
-impl From<keychain_txout::ChangeSet> for ChangeSet {
+impl<K> From<keychain_txout::ChangeSet> for ChangeSet<K> {
     fn from(indexer: keychain_txout::ChangeSet) -> Self {
         Self {
             indexer,

--- a/crates/wallet/src/wallet/tx_builder.rs
+++ b/crates/wallet/src/wallet/tx_builder.rs
@@ -213,7 +213,7 @@ impl<'a, K: Clone, Cs: Clone> Clone for TxBuilder<'a, K, Cs> {
 }
 
 // Methods supported for any CoinSelectionAlgorithm.
-impl<'a, K: core::fmt::Debug + Default + Clone + Ord, Cs> TxBuilder<'a, K, Cs> {
+impl<'a, K: core::fmt::Debug + Clone + Ord, Cs> TxBuilder<'a, K, Cs> {
     /// Set a custom fee rate.
     ///
     /// This method sets the mining fee paid by the transaction as a rate on its size.
@@ -718,7 +718,7 @@ impl<'a, K: core::fmt::Debug + Default + Clone + Ord, Cs> TxBuilder<'a, K, Cs> {
     }
 }
 
-impl<'a, K: Debug + Default + Clone + Ord, Cs: CoinSelectionAlgorithm> TxBuilder<'a, K, Cs> {
+impl<'a, K: Debug + Clone + Ord, Cs: CoinSelectionAlgorithm> TxBuilder<'a, K, Cs> {
     /// Finish building the transaction.
     ///
     /// Uses the thread-local random number generator (rng).

--- a/example-crates/wallet_electrum/src/main.rs
+++ b/example-crates/wallet_electrum/src/main.rs
@@ -23,10 +23,11 @@ const ELECTRUM_URL: &str = "ssl://electrum.blockstream.info:60002";
 fn main() -> Result<(), anyhow::Error> {
     let db_path = "bdk-electrum-example.db";
 
-    let mut db = Store::<bdk_wallet::ChangeSet>::open_or_create_new(DB_MAGIC.as_bytes(), db_path)?;
+    let mut db = Store::<bdk_wallet::ChangeSet<KeychainKind>>::open_or_create_new(DB_MAGIC.as_bytes(), db_path)?;
 
-    let wallet_opt = Wallet::load()
-        .descriptors(EXTERNAL_DESC, INTERNAL_DESC)
+    let wallet_opt = Wallet::<KeychainKind>::load()
+        .descriptor(KeychainKind::External, EXTERNAL_DESC)
+        .descriptor(KeychainKind::Internal, INTERNAL_DESC)
         .network(NETWORK)
         .load_wallet(&mut db)?;
     let mut wallet = match wallet_opt {


### PR DESCRIPTION
Closes bitcoindevkit/bdk_wallet#84

### Description

Based on the discussion about single-keychain wallets on Tuesday, I couldn't stop myself from experimenting with an any-keychain-count wallet. This is done by introducing a type parameter to `Wallet<K>`.

This is obviously a breaking change, but this seems to be the only non-hacky solution for the problem. The only downside is that a whole bunch of wallet methods now return `Option` since we can have keychains without corresponding descriptors.

`TxBuilder` parameters have been refactored to make sense in this context.

`ChangeSet` has been refactored to allow for any keychain count.

### Notes to the reviewers

It's building with `cargo build -p bdk_wallet`. The tests do not compile.

To see something that has a bigger chance of being merged, check out bitcoindevkit/bdk#1533.

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
