### PR TITLE
Force `Persisted<T>` to mutate and persist atomically

### DIFF
--- a/crates/chain/src/spk_client.rs
+++ b/crates/chain/src/spk_client.rs
@@ -317,6 +317,7 @@ impl<K: Ord + Clone> FullScanRequest<K> {
 /// Data returned from a spk-based blockchain client full scan.
 ///
 /// See also [`FullScanRequest`].
+#[derive(Debug, Clone)]
 pub struct FullScanResult<K, A = ConfirmationBlockTime> {
     /// The update to apply to the receiving [`LocalChain`](crate::local_chain::LocalChain).
     pub graph_update: TxGraph<A>,

--- a/crates/wallet/README.md
+++ b/crates/wallet/README.md
@@ -91,10 +91,10 @@ let mut wallet = match wallet_opt {
         .expect("wallet"),
 };
 
-// Get a new address to receive bitcoin.
-let receive_address = wallet.reveal_next_address(KeychainKind::External);
-// Persist staged wallet data changes to the file store.
-wallet.persist(&mut db).expect("persist");
+// Get a new address to receive bitcoin and persist staged wallet data changes to the file store.
+let receive_address = wallet
+    .mutate(&mut db, |w| w.reveal_next_address(KeychainKind::External))
+    .expect("persist");
 println!("Your new receive address is: {}", receive_address.address);
 ```
 

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -581,9 +581,6 @@ impl Wallet {
     /// index defined in [BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki),
     /// then the last revealed address will be returned.
     ///
-    /// **WARNING**: To avoid address reuse you must persist the changes resulting from one or more
-    /// calls to this method before closing the wallet. For example:
-    ///
     /// ```rust,no_run
     /// # use bdk_wallet::{LoadParams, ChangeSet, KeychainKind};
     /// use bdk_chain::rusqlite::Connection;
@@ -592,10 +589,10 @@ impl Wallet {
     ///     .load_wallet(&mut conn)
     ///     .expect("database is okay")
     ///     .expect("database has data");
-    /// let next_address = wallet.reveal_next_address(KeychainKind::External);
-    /// wallet.persist(&mut conn).expect("write is okay");
+    /// let next_address = wallet
+    ///     .mutate(&mut conn, |w| w.reveal_next_address(KeychainKind::External))
+    ///     .expect("write is okay");
     ///
-    /// // Now it's safe to show the user their next address!
     /// println!("Next address: {}", next_address.address);
     /// # Ok::<(), anyhow::Error>(())
     /// ```

--- a/crates/wallet/tests/wallet.rs
+++ b/crates/wallet/tests/wallet.rs
@@ -126,10 +126,9 @@ fn wallet_is_persisted() -> anyhow::Result<()> {
             let mut wallet = Wallet::create(external_desc, internal_desc)
                 .network(Network::Testnet)
                 .create_wallet(&mut db)?;
-            wallet.reveal_next_address(KeychainKind::External);
-
-            // persist new wallet changes
-            assert!(wallet.persist(&mut db)?, "must write");
+            wallet
+                .mutate(&mut db, |w| w.reveal_next_address(KeychainKind::External))
+                .expect("must write changes");
             wallet.spk_index().clone()
         };
 

--- a/example-crates/wallet_electrum/src/main.rs
+++ b/example-crates/wallet_electrum/src/main.rs
@@ -1,3 +1,5 @@
+use bdk_wallet::chain::PersistWith;
+use bdk_wallet::chain::Staged;
 use bdk_wallet::file_store::Store;
 use bdk_wallet::Wallet;
 use std::io::Write;
@@ -19,6 +21,38 @@ const NETWORK: Network = Network::Testnet;
 const EXTERNAL_DESC: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/0/*)";
 const INTERNAL_DESC: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/1/*)";
 const ELECTRUM_URL: &str = "ssl://electrum.blockstream.info:60002";
+
+pub struct CustomDb;
+
+impl PersistWith<CustomDb> for Wallet {
+    type CreateParams = ();
+
+    type LoadParams = ();
+
+    type CreateError = ();
+
+    type LoadError = ();
+
+    type PersistError = ();
+
+    fn create(_db: &mut CustomDb, _params: Self::CreateParams) -> Result<Self, Self::CreateError> {
+        todo!()
+    }
+
+    fn load(
+        _db: &mut CustomDb,
+        _params: Self::LoadParams,
+    ) -> Result<Option<Self>, Self::LoadError> {
+        todo!()
+    }
+
+    fn persist(
+        _db: &mut CustomDb,
+        _changeset: &<Self as Staged>::ChangeSet,
+    ) -> Result<(), Self::PersistError> {
+        Ok(())
+    }
+}
 
 fn main() -> Result<(), anyhow::Error> {
     let db_path = "bdk-electrum-example.db";

--- a/example-crates/wallet_rpc/src/main.rs
+++ b/example-crates/wallet_rpc/src/main.rs
@@ -145,8 +145,9 @@ fn main() -> anyhow::Result<()> {
                 let hash = block_emission.block_hash();
                 let connected_to = block_emission.connected_to();
                 let start_apply_block = Instant::now();
-                wallet.apply_block_connected_to(&block_emission.block, height, connected_to)?;
-                wallet.persist(&mut db)?;
+                wallet.mutate(&mut db, |w| {
+                    w.apply_block_connected_to(&block_emission.block, height, connected_to)
+                })??;
                 let elapsed = start_apply_block.elapsed().as_secs_f32();
                 println!(
                     "Applied block {} at height {} in {}s",
@@ -155,8 +156,9 @@ fn main() -> anyhow::Result<()> {
             }
             Emission::Mempool(mempool_emission) => {
                 let start_apply_mempool = Instant::now();
-                wallet.apply_unconfirmed_txs(mempool_emission.iter().map(|(tx, time)| (tx, *time)));
-                wallet.persist(&mut db)?;
+                wallet.mutate(&mut db, |w| {
+                    w.apply_unconfirmed_txs(mempool_emission.iter().map(|(tx, time)| (tx, *time)))
+                })?;
                 println!(
                     "Applied unconfirmed transactions in {}s",
                     start_apply_mempool.elapsed().as_secs_f32()


### PR DESCRIPTION
### Description

@tnull asked why we have to do a separate `.persist` call when using `Persisted<Wallet>`. This is my solution to not having to do that.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
