### PR TITLE
Remove crate-renaming

### DIFF
--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -14,14 +14,14 @@ readme = "README.md"
 
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false }
-serde_crate = { package = "serde", version = "1", optional = true, features = ["derive", "rc"] }
+serde = { version = "1", optional = true, features = ["derive", "rc"] }
 
 # Use hashbrown as a feature flag to have HashSet and HashMap from it.
 hashbrown = { version = "0.9.1", optional = true, features = ["serde"] }
 miniscript = { version = "12.0.0", optional = true, default-features = false }
 
 # Feature dependencies
-rusqlite_crate = { package = "rusqlite", version = "0.31.0", features = ["bundled"], optional = true }
+rusqlite = { version = "0.31.0", features = ["bundled"], optional = true }
 serde_json = {version = "1", optional = true }
 
 [dev-dependencies]
@@ -31,5 +31,5 @@ proptest = "1.2.0"
 [features]
 default = ["std", "miniscript"]
 std = ["bitcoin/std", "miniscript?/std"]
-serde = ["serde_crate", "bitcoin/serde", "miniscript?/serde"]
-rusqlite = ["std", "rusqlite_crate", "serde", "serde_json"]
+serde = ["dep:serde", "bitcoin/serde", "miniscript?/serde"]
+rusqlite = ["std", "dep:rusqlite", "serde", "serde_json"]

--- a/crates/chain/src/balance.rs
+++ b/crates/chain/src/balance.rs
@@ -2,11 +2,7 @@ use bitcoin::Amount;
 
 /// Balance, differentiated into various categories.
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde_crate",)
-)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Balance {
     /// All coinbase outputs not yet matured
     pub immature: Amount,

--- a/crates/chain/src/chain_data.rs
+++ b/crates/chain/src/chain_data.rs
@@ -42,11 +42,7 @@ impl<A: Anchor> ChainPosition<A> {
 
 /// Block height and timestamp at which a transaction is confirmed.
 #[derive(Debug, Clone, PartialEq, Eq, Copy, PartialOrd, Ord, core::hash::Hash)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde_crate")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum ConfirmationTime {
     /// The transaction is confirmed
     Confirmed {
@@ -91,11 +87,7 @@ impl From<ChainPosition<ConfirmationBlockTime>> for ConfirmationTime {
 /// `BlockId` implements [`Anchor`]. When a transaction is anchored to `BlockId`, the confirmation
 /// block and anchor block are the same block.
 #[derive(Debug, Clone, PartialEq, Eq, Copy, PartialOrd, Ord, core::hash::Hash)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde_crate")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct BlockId {
     /// The height of the block.
     pub height: u32,
@@ -149,11 +141,7 @@ impl From<(&u32, &BlockHash)> for BlockId {
 ///
 /// Refer to [`Anchor`] for more details.
 #[derive(Debug, Default, Clone, PartialEq, Eq, Copy, PartialOrd, Ord, core::hash::Hash)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde_crate")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct ConfirmationBlockTime {
     /// The anchor block.
     pub block_id: BlockId,

--- a/crates/chain/src/indexed_tx_graph.rs
+++ b/crates/chain/src/indexed_tx_graph.rs
@@ -306,13 +306,10 @@ impl<A, I> AsRef<TxGraph<A>> for IndexedTxGraph<A, I> {
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(
-        crate = "serde_crate",
-        bound(
-            deserialize = "A: Ord + serde::Deserialize<'de>, IA: serde::Deserialize<'de>",
-            serialize = "A: Ord + serde::Serialize, IA: serde::Serialize"
-        )
-    )
+    serde(bound(
+        deserialize = "A: Ord + serde::Deserialize<'de>, IA: serde::Deserialize<'de>",
+        serialize = "A: Ord + serde::Serialize, IA: serde::Serialize"
+    ))
 )]
 #[must_use]
 pub struct ChangeSet<A, IA> {

--- a/crates/chain/src/indexer/keychain_txout.rs
+++ b/crates/chain/src/indexer/keychain_txout.rs
@@ -843,11 +843,7 @@ impl<K: core::fmt::Debug> std::error::Error for InsertDescriptorError<K> {}
 /// [`apply_changeset`]: crate::keychain_txout::KeychainTxOutIndex::apply_changeset
 /// [`merge`]: Self::merge
 #[derive(Clone, Debug, Default, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde_crate")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[must_use]
 pub struct ChangeSet {
     /// Contains for each descriptor_id the last revealed index of derivation

--- a/crates/chain/src/lib.rs
+++ b/crates/chain/src/lib.rs
@@ -63,9 +63,9 @@ pub mod spk_client;
 #[macro_use]
 extern crate alloc;
 #[cfg(feature = "rusqlite")]
-pub extern crate rusqlite_crate as rusqlite;
+pub extern crate rusqlite;
 #[cfg(feature = "serde")]
-pub extern crate serde_crate as serde;
+pub extern crate serde;
 
 #[cfg(feature = "std")]
 #[macro_use]

--- a/crates/chain/src/local_chain.rs
+++ b/crates/chain/src/local_chain.rs
@@ -631,11 +631,7 @@ impl LocalChain {
 
 /// The [`ChangeSet`] represents changes to [`LocalChain`].
 #[derive(Debug, Default, Clone, PartialEq)]
-#[cfg_attr(
-    feature = "serde",
-    derive(serde::Deserialize, serde::Serialize),
-    serde(crate = "serde_crate")
-)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct ChangeSet {
     /// Changes to the [`LocalChain`] blocks.
     ///

--- a/crates/chain/src/rusqlite_impl.rs
+++ b/crates/chain/src/rusqlite_impl.rs
@@ -157,7 +157,7 @@ impl ToSql for Impl<bitcoin::Amount> {
     }
 }
 
-impl<A: Anchor + serde_crate::de::DeserializeOwned> FromSql for Impl<A> {
+impl<A: Anchor + serde::de::DeserializeOwned> FromSql for Impl<A> {
     fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
         serde_json::from_str(value.as_str()?)
             .map(Impl)
@@ -165,7 +165,7 @@ impl<A: Anchor + serde_crate::de::DeserializeOwned> FromSql for Impl<A> {
     }
 }
 
-impl<A: Anchor + serde_crate::Serialize> ToSql for Impl<A> {
+impl<A: Anchor + serde::Serialize> ToSql for Impl<A> {
     fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
         serde_json::to_string(&self.0)
             .map(Into::into)

--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -1228,13 +1228,10 @@ impl<A: Anchor> TxGraph<A> {
 #[cfg_attr(
     feature = "serde",
     derive(serde::Deserialize, serde::Serialize),
-    serde(
-        crate = "serde_crate",
-        bound(
-            deserialize = "A: Ord + serde::Deserialize<'de>",
-            serialize = "A: Ord + serde::Serialize",
-        )
-    )
+    serde(bound(
+        deserialize = "A: Ord + serde::Deserialize<'de>",
+        serialize = "A: Ord + serde::Serialize",
+    ))
 )]
 #[must_use]
 pub struct ChangeSet<A = ()> {


### PR DESCRIPTION
### Description

[Rust 1.60 introduces *"namespaced features"*](https://blog.rust-lang.org/2022/04/07/Rust-1.60.0.html#new-syntax-for-cargo-features) so we can add a dependency without implicitly also defining a feature of the same name.

We can now get rid of crate-renaming and use "namespaced features" instead.

Thanks to @LLFourn for pointing this out.

### Changelog notice

* Remove crate-renaming in `bdk_chain` and use "namespaced features" instead.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
