### PR TITLE
fix(example_cli): add bitcoin and rand dependencies

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -130,3 +130,32 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features --all-targets -- -D warnings
+
+  build-examples:
+    name: Build Examples
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        example-dir:
+          - example_cli
+          - example_bitcoind_rpc_polling
+          - example_electrum
+          - example_esplora
+          - wallet_electrum
+          - wallet_esplora_async
+          - wallet_esplora_blocking
+          - wallet_rpc
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          profile: minimal
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2.2.1
+      - name: Build
+        working-directory: example-crates/${{ matrix.example-dir }}
+        run: cargo build

--- a/example-crates/example_cli/Cargo.toml
+++ b/example-crates/example_cli/Cargo.toml
@@ -9,8 +9,10 @@ edition = "2021"
 bdk_chain = { path = "../../crates/chain", features = ["serde", "miniscript"]}
 bdk_coin_select = "0.3.0"
 bdk_file_store = { path = "../../crates/file_store" }
+bitcoin = { version = "0.32.0", features = ["base64"], default-features = false }
 
 anyhow = "1"
 clap = { version = "3.2.23", features = ["derive", "env"] }
+rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"

--- a/example-crates/example_cli/src/lib.rs
+++ b/example-crates/example_cli/src/lib.rs
@@ -10,14 +10,9 @@ use std::sync::Mutex;
 use anyhow::bail;
 use anyhow::Context;
 use bdk_chain::bitcoin::{
-    absolute,
-    address::NetworkUnchecked,
-    bip32, consensus, constants,
-    hex::DisplayHex,
-    relative,
-    secp256k1::{rand::prelude::*, Secp256k1},
-    transaction, Address, Amount, Network, NetworkKind, PrivateKey, Psbt, PublicKey, Sequence,
-    Transaction, TxIn, TxOut,
+    absolute, address::NetworkUnchecked, bip32, consensus, constants, hex::DisplayHex, relative,
+    secp256k1::Secp256k1, transaction, Address, Amount, Network, NetworkKind, PrivateKey, Psbt,
+    PublicKey, Sequence, Transaction, TxIn, TxOut,
 };
 use bdk_chain::miniscript::{
     descriptor::{DescriptorSecretKey, SinglePubKey},
@@ -37,6 +32,7 @@ use bdk_coin_select::{
 };
 use bdk_file_store::Store;
 use clap::{Parser, Subcommand};
+use rand::prelude::*;
 
 pub use anyhow;
 pub use clap;
@@ -675,7 +671,7 @@ pub fn handle_commands<CS: clap::Subcommand, S: clap::Args>(
                 Ok(())
             }
             PsbtCmd::Sign { psbt, descriptor } => {
-                let mut psbt = Psbt::from_str(&psbt.unwrap_or_default())?;
+                let mut psbt = Psbt::from_str(psbt.unwrap_or_default().as_str())?;
 
                 let desc_str = match descriptor {
                     Some(s) => s,
@@ -717,7 +713,7 @@ pub fn handle_commands<CS: clap::Subcommand, S: clap::Args>(
                 chain_specific,
                 psbt,
             } => {
-                let mut psbt = Psbt::from_str(&psbt)?;
+                let mut psbt = Psbt::from_str(psbt.as_str())?;
                 psbt.finalize_mut(&Secp256k1::new())
                     .map_err(|errors| anyhow::anyhow!("failed to finalize PSBT {errors:?}"))?;
 


### PR DESCRIPTION
### Description

Fix building `example_cli` by adding the bitcoin and rand dependencies so it, and the crates that depend on it, can be built independently and not only from the workspace.

### Notes to the reviewers

I also added the  build-examples CI job to verify we can build examples individually.

### Changelog notice

None.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
