### PR TITLE
feat(chain): Introduce `tx_graph::Update` WIP

### DIFF
--- a/crates/chain/src/spk_client.rs
+++ b/crates/chain/src/spk_client.rs
@@ -3,7 +3,8 @@ use crate::{
     alloc::{boxed::Box, collections::VecDeque, vec::Vec},
     collections::BTreeMap,
     local_chain::CheckPoint,
-    ConfirmationBlockTime, Indexed, TxGraph,
+    tx_graph::Update,
+    ConfirmationBlockTime, Indexed,
 };
 use bitcoin::{OutPoint, Script, ScriptBuf, Txid};
 
@@ -345,8 +346,8 @@ impl<I> SyncRequest<I> {
 #[must_use]
 #[derive(Debug)]
 pub struct SyncResult<A = ConfirmationBlockTime> {
-    /// The update to apply to the receiving [`TxGraph`].
-    pub graph_update: TxGraph<A>,
+    /// The update to apply to the receiving [`Update`].
+    pub graph_update: Update<A>,
     /// The update to apply to the receiving [`LocalChain`](crate::local_chain::LocalChain).
     pub chain_update: Option<CheckPoint>,
 }
@@ -497,8 +498,8 @@ impl<K: Ord + Clone> FullScanRequest<K> {
 #[derive(Debug)]
 pub struct FullScanResult<K, A = ConfirmationBlockTime> {
     /// The update to apply to the receiving [`LocalChain`](crate::local_chain::LocalChain).
-    pub graph_update: TxGraph<A>,
-    /// The update to apply to the receiving [`TxGraph`].
+    pub graph_update: Update<A>,
+    /// The update to apply to the receiving [`Update`].
     pub chain_update: Option<CheckPoint>,
     /// Last active indices for the corresponding keychains (`K`).
     pub last_active_indices: BTreeMap<K, u32>,

--- a/crates/esplora/src/lib.rs
+++ b/crates/esplora/src/lib.rs
@@ -20,13 +20,13 @@
 //! [`esplora_client::BlockingClient`], [`EsploraAsyncExt`] is the async version which extends
 //! [`esplora_client::AsyncClient`].
 //!
-//! [`TxGraph`]: bdk_chain::tx_graph::TxGraph
+//! [`Update`]: bdk_chain::tx_graph::Update
 //! [`LocalChain`]: bdk_chain::local_chain::LocalChain
 //! [`ChainOracle`]: bdk_chain::ChainOracle
 //! [`example_esplora`]: https://github.com/bitcoindevkit/bdk/tree/master/example-crates/example_esplora
 
 use bdk_chain::bitcoin::{Amount, OutPoint, TxOut, Txid};
-use bdk_chain::{BlockId, ConfirmationBlockTime, TxGraph};
+use bdk_chain::{tx_graph::Update, BlockId, ConfirmationBlockTime};
 use esplora_client::TxStatus;
 
 pub use esplora_client;
@@ -42,7 +42,7 @@ mod async_ext;
 pub use async_ext::*;
 
 fn insert_anchor_from_status(
-    tx_graph: &mut TxGraph<ConfirmationBlockTime>,
+    update: &mut Update<ConfirmationBlockTime>,
     txid: Txid,
     status: TxStatus,
 ) {
@@ -57,21 +57,21 @@ fn insert_anchor_from_status(
             block_id: BlockId { height, hash },
             confirmation_time: time,
         };
-        let _ = tx_graph.insert_anchor(txid, anchor);
+        update.insert_anchor(txid, anchor);
     }
 }
 
 /// Inserts floating txouts into `tx_graph` using [`Vin`](esplora_client::api::Vin)s returned by
 /// Esplora.
 fn insert_prevouts(
-    tx_graph: &mut TxGraph<ConfirmationBlockTime>,
+    update: &mut Update<ConfirmationBlockTime>,
     esplora_inputs: impl IntoIterator<Item = esplora_client::api::Vin>,
 ) {
     let prevouts = esplora_inputs
         .into_iter()
         .filter_map(|vin| Some((vin.txid, vin.vout, vin.prevout?)));
     for (prev_txid, prev_vout, prev_txout) in prevouts {
-        let _ = tx_graph.insert_txout(
+        update.insert_txout(
             OutPoint::new(prev_txid, prev_vout),
             TxOut {
                 script_pubkey: prev_txout.scriptpubkey,

--- a/crates/esplora/tests/async_ext.rs
+++ b/crates/esplora/tests/async_ext.rs
@@ -77,7 +77,7 @@ pub async fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
         "update should not alter original checkpoint tip since we already started with all checkpoints",
     );
 
-    let graph_update = sync_update.graph_update;
+    let graph_update = sync_update.graph_update.into_tx_graph();
     // Check to see if we have the floating txouts available from our two created transactions'
     // previous outputs in order to calculate transaction fees.
     for tx in graph_update.full_txs() {
@@ -167,7 +167,12 @@ pub async fn test_async_update_tx_graph_stop_gap() -> anyhow::Result<()> {
             .spks_for_keychain(0, spks.clone());
         client.full_scan(request, 3, 1).await?
     };
-    assert!(full_scan_update.graph_update.full_txs().next().is_none());
+    assert!(full_scan_update
+        .graph_update
+        .into_tx_graph()
+        .full_txs()
+        .next()
+        .is_none());
     assert!(full_scan_update.last_active_indices.is_empty());
     let full_scan_update = {
         let request = FullScanRequest::builder()
@@ -178,6 +183,7 @@ pub async fn test_async_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     assert_eq!(
         full_scan_update
             .graph_update
+            .into_tx_graph()
             .full_txs()
             .next()
             .unwrap()
@@ -212,6 +218,7 @@ pub async fn test_async_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     };
     let txs: HashSet<_> = full_scan_update
         .graph_update
+        .into_tx_graph()
         .full_txs()
         .map(|tx| tx.txid)
         .collect();
@@ -226,6 +233,7 @@ pub async fn test_async_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     };
     let txs: HashSet<_> = full_scan_update
         .graph_update
+        .into_tx_graph()
         .full_txs()
         .map(|tx| tx.txid)
         .collect();

--- a/crates/esplora/tests/blocking_ext.rs
+++ b/crates/esplora/tests/blocking_ext.rs
@@ -77,7 +77,7 @@ pub fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
         "update should not alter original checkpoint tip since we already started with all checkpoints",
     );
 
-    let graph_update = sync_update.graph_update;
+    let graph_update = sync_update.graph_update.into_tx_graph();
     // Check to see if we have the floating txouts available from our two created transactions'
     // previous outputs in order to calculate transaction fees.
     for tx in graph_update.full_txs() {
@@ -168,7 +168,12 @@ pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
             .spks_for_keychain(0, spks.clone());
         client.full_scan(request, 3, 1)?
     };
-    assert!(full_scan_update.graph_update.full_txs().next().is_none());
+    assert!(full_scan_update
+        .graph_update
+        .into_tx_graph()
+        .full_txs()
+        .next()
+        .is_none());
     assert!(full_scan_update.last_active_indices.is_empty());
     let full_scan_update = {
         let request = FullScanRequest::builder()
@@ -179,6 +184,7 @@ pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     assert_eq!(
         full_scan_update
             .graph_update
+            .into_tx_graph()
             .full_txs()
             .next()
             .unwrap()
@@ -213,6 +219,7 @@ pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     };
     let txs: HashSet<_> = full_scan_update
         .graph_update
+        .into_tx_graph()
         .full_txs()
         .map(|tx| tx.txid)
         .collect();
@@ -227,6 +234,7 @@ pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     };
     let txs: HashSet<_> = full_scan_update
         .graph_update
+        .into_tx_graph()
         .full_txs()
         .map(|tx| tx.txid)
         .collect();

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -153,7 +153,7 @@ impl From<FullScanResult<KeychainKind>> for Update {
     fn from(value: FullScanResult<KeychainKind>) -> Self {
         Self {
             last_active_indices: value.last_active_indices,
-            graph: value.graph_update,
+            graph: value.graph_update.into_tx_graph(),
             chain: value.chain_update,
         }
     }
@@ -163,7 +163,7 @@ impl From<SyncResult> for Update {
     fn from(value: SyncResult) -> Self {
         Self {
             last_active_indices: BTreeMap::new(),
-            graph: value.graph_update,
+            graph: value.graph_update.into_tx_graph(),
             chain: value.chain_update,
         }
     }

--- a/example-crates/wallet_electrum/src/main.rs
+++ b/example-crates/wallet_electrum/src/main.rs
@@ -50,7 +50,7 @@ fn main() -> Result<(), anyhow::Error> {
 
     // Populate the electrum client's transaction cache so it doesn't redownload transaction we
     // already have.
-    client.populate_tx_cache(wallet.tx_graph());
+    client.populate_tx_cache(wallet.tx_graph().clone());
 
     let request = wallet.start_full_scan().inspect({
         let mut stdout = std::io::stdout();
@@ -65,9 +65,11 @@ fn main() -> Result<(), anyhow::Error> {
     });
 
     let mut update = client.full_scan(request, STOP_GAP, BATCH_SIZE, false)?;
+    let mut tx_graph = update.graph_update.into_tx_graph();
 
     let now = std::time::UNIX_EPOCH.elapsed().unwrap().as_secs();
-    let _ = update.graph_update.update_last_seen_unconfirmed(now);
+    let _ = tx_graph.update_last_seen_unconfirmed(now);
+    update.graph_update = tx_graph.into();
 
     println!();
 

--- a/example-crates/wallet_esplora_async/src/main.rs
+++ b/example-crates/wallet_esplora_async/src/main.rs
@@ -60,8 +60,10 @@ async fn main() -> Result<(), anyhow::Error> {
     let mut update = client
         .full_scan(request, STOP_GAP, PARALLEL_REQUESTS)
         .await?;
+    let mut tx_graph = update.graph_update.clone().into_tx_graph();
     let now = std::time::UNIX_EPOCH.elapsed().unwrap().as_secs();
-    let _ = update.graph_update.update_last_seen_unconfirmed(now);
+    let _ = tx_graph.update_last_seen_unconfirmed(now);
+    update.graph_update = tx_graph.into();
 
     wallet.apply_update(update)?;
     wallet.persist(&mut conn)?;

--- a/example-crates/wallet_esplora_blocking/src/main.rs
+++ b/example-crates/wallet_esplora_blocking/src/main.rs
@@ -60,8 +60,10 @@ fn main() -> Result<(), anyhow::Error> {
     });
 
     let mut update = client.full_scan(request, STOP_GAP, PARALLEL_REQUESTS)?;
+    let mut tx_graph = update.graph_update.clone().into_tx_graph();
     let now = std::time::UNIX_EPOCH.elapsed().unwrap().as_secs();
-    let _ = update.graph_update.update_last_seen_unconfirmed(now);
+    let _ = tx_graph.update_last_seen_unconfirmed(now);
+    update.graph_update = tx_graph.into();
 
     wallet.apply_update(update)?;
     if let Some(changeset) = wallet.take_staged() {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
Introduces the `tx_graph::Update` struct, which will be used to update a `TxGraph`. This will replace the old method of updating a `TxGraph` with a `TxGraph`.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->
With the current implementation, there is some goofiness in the `esplora`/`electrum` wallet examples and `test_electrum::sync_with_electrum()`, where an `Update` is converted into a `TxGraph` to execute `update_last_seen_unconfirmed()`, before reverting the `TxGraph` back into an `Update` again. Implementing #1550 would prevent the need for this.

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->
WIP

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing