### PR TITLE
feat(chain): export type alias for FutureResult

### DIFF
--- a/crates/wallet/src/wallet/persisted.rs
+++ b/crates/wallet/src/wallet/persisted.rs
@@ -52,7 +52,8 @@ pub trait WalletPersister {
     fn persist(persister: &mut Self, changeset: &ChangeSet) -> Result<(), Self::Error>;
 }
 
-type FutureResult<'a, T, E> = Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'a>>;
+/// A future that is allocated on the heap, so it may be used in a trait.
+pub type FutureResult<'a, T, E> = Pin<Box<dyn Future<Output = Result<T, E>> + Send + 'a>>;
 
 /// Async trait that persists [`PersistedWallet`].
 ///


### PR DESCRIPTION
### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

Similar to [`BoxedFuture`](https://docs.rs/futures/latest/futures/future/type.BoxFuture.html) it may be helpful for users to use this alias when implementing `PersistAsyncWith`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
