### PR TITLE
fix(wallet)!: make `LoadParams` implicitly satisfy `Send`

### DIFF
--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -343,7 +343,7 @@ impl Wallet {
     /// [`reveal_next_address`]: Self::reveal_next_address
     pub fn create_single<D>(descriptor: D) -> CreateParams
     where
-        D: IntoWalletDescriptor + Clone + 'static,
+        D: IntoWalletDescriptor + Send + Clone + 'static,
     {
         CreateParams::new_single(descriptor)
     }
@@ -378,7 +378,7 @@ impl Wallet {
     /// ```
     pub fn create<D>(descriptor: D, change_descriptor: D) -> CreateParams
     where
-        D: IntoWalletDescriptor + Clone + 'static,
+        D: IntoWalletDescriptor + Send + Clone + 'static,
     {
         CreateParams::new(descriptor, change_descriptor)
     }

--- a/crates/wallet/src/wallet/params.rs
+++ b/crates/wallet/src/wallet/params.rs
@@ -17,12 +17,13 @@ use super::{ChangeSet, LoadError, PersistedWallet};
 /// [object safety rules](https://doc.rust-lang.org/reference/items/traits.html#object-safety).
 type DescriptorToExtract = Box<
     dyn FnOnce(&SecpCtx, Network) -> Result<(ExtendedDescriptor, KeyMap), DescriptorError>
+        + Send
         + 'static,
 >;
 
 fn make_descriptor_to_extract<D>(descriptor: D) -> DescriptorToExtract
 where
-    D: IntoWalletDescriptor + 'static,
+    D: IntoWalletDescriptor + Send + 'static,
 {
     Box::new(|secp, network| descriptor.into_wallet_descriptor(secp, network))
 }
@@ -50,7 +51,7 @@ impl CreateParams {
     ///
     /// Use this method only when building a wallet with a single descriptor. See
     /// also [`Wallet::create_single`].
-    pub fn new_single<D: IntoWalletDescriptor + 'static>(descriptor: D) -> Self {
+    pub fn new_single<D: IntoWalletDescriptor + Send + 'static>(descriptor: D) -> Self {
         Self {
             descriptor: make_descriptor_to_extract(descriptor),
             descriptor_keymap: KeyMap::default(),
@@ -68,7 +69,10 @@ impl CreateParams {
     /// * `network` = [`Network::Bitcoin`]
     /// * `genesis_hash` = `None`
     /// * `lookahead` = [`DEFAULT_LOOKAHEAD`]
-    pub fn new<D: IntoWalletDescriptor + 'static>(descriptor: D, change_descriptor: D) -> Self {
+    pub fn new<D: IntoWalletDescriptor + Send + 'static>(
+        descriptor: D,
+        change_descriptor: D,
+    ) -> Self {
         Self {
             descriptor: make_descriptor_to_extract(descriptor),
             descriptor_keymap: KeyMap::default(),
@@ -184,7 +188,7 @@ impl LoadParams {
     /// for an expected descriptor containing secrets.
     pub fn descriptor<D>(mut self, keychain: KeychainKind, expected_descriptor: Option<D>) -> Self
     where
-        D: IntoWalletDescriptor + 'static,
+        D: IntoWalletDescriptor + Send + 'static,
     {
         let expected = expected_descriptor.map(|d| make_descriptor_to_extract(d));
         match keychain {


### PR DESCRIPTION
### Description

Make `LoadParams` implicitly satisfy `Send`. This will hopefully make `AsyncWalletPersister` easier to implement.

Refer to the [conversation on Discord](https://discord.com/channels/753336465005608961/753367451319926827/1273667818528964714).

cc. @matthiasdebernardini

### Notes to the reviewers

This is a breaking change, since we are tightening the bounds to some methods.

### Changelog notice

* Change `LoadParams` to implicitly satisfy `Send`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
