### PR TITLE
Add generic `Params` type parameter to persistence traits

### DIFF
--- a/crates/wallet/README.md
+++ b/crates/wallet/README.md
@@ -83,13 +83,13 @@ let wallet_opt = Wallet::load()
     .descriptor(KeychainKind::Internal, Some(change_descriptor))
     .extract_keys()
     .check_network(network)
-    .load_wallet(&mut db)
+    .load_wallet(&mut db, ())
     .expect("wallet");
 let mut wallet = match wallet_opt {
     Some(wallet) => wallet,
     None => Wallet::create(descriptor, change_descriptor)
         .network(network)
-        .create_wallet(&mut db)
+        .create_wallet(&mut db, ())
         .expect("wallet"),
 };
 

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -324,7 +324,7 @@ impl Wallet {
     /// let mut conn = Connection::open(file_path)?;
     /// let wallet = Wallet::create_single(EXTERNAL_DESC)
     ///     .network(Network::Testnet)
-    ///     .create_wallet(&mut conn)?;
+    ///     .create_wallet(&mut conn, ())?;
     /// # Ok::<_, anyhow::Error>(())
     /// ```
     /// [`change_policy`]: TxBuilder::change_policy
@@ -363,7 +363,7 @@ impl Wallet {
     /// let mut conn = Connection::open(file_path)?;
     /// let wallet = Wallet::create(EXTERNAL_DESC, INTERNAL_DESC)
     ///     .network(Network::Testnet)
-    ///     .create_wallet(&mut conn)?;
+    ///     .create_wallet(&mut conn, ())?;
     /// # Ok(())
     /// # }
     /// ```
@@ -476,7 +476,7 @@ impl Wallet {
     ///     .check_genesis_hash(genesis_hash)
     ///     // set a lookahead for our indexer
     ///     .lookahead(101)
-    ///     .load_wallet(&mut conn)?
+    ///     .load_wallet(&mut conn, ())?
     ///     .expect("must have data to load wallet");
     /// # Ok(())
     /// # }
@@ -672,7 +672,7 @@ impl Wallet {
     /// use bdk_chain::rusqlite::Connection;
     /// let mut conn = Connection::open_in_memory().expect("must open connection");
     /// let mut wallet = LoadParams::new()
-    ///     .load_wallet(&mut conn)
+    ///     .load_wallet(&mut conn, ())
     ///     .expect("database is okay")
     ///     .expect("database has data");
     /// let next_address = wallet.reveal_next_address(KeychainKind::External);

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -334,7 +334,7 @@ impl Wallet {
     /// [`reveal_next_address`]: Self::reveal_next_address
     pub fn create_single<D>(descriptor: D) -> CreateParams
     where
-        D: IntoWalletDescriptor + Clone + 'static,
+        D: IntoWalletDescriptor + Send + Clone + 'static,
     {
         CreateParams::new_single(descriptor)
     }
@@ -369,7 +369,7 @@ impl Wallet {
     /// ```
     pub fn create<D>(descriptor: D, change_descriptor: D) -> CreateParams
     where
-        D: IntoWalletDescriptor + Clone + 'static,
+        D: IntoWalletDescriptor + Send + Clone + 'static,
     {
         CreateParams::new(descriptor, change_descriptor)
     }

--- a/crates/wallet/src/wallet/params.rs
+++ b/crates/wallet/src/wallet/params.rs
@@ -117,22 +117,24 @@ impl CreateParams {
     pub fn create_wallet<P>(
         self,
         persister: &mut P,
+        persister_params: P::Params,
     ) -> Result<PersistedWallet<P>, CreateWithPersistError<P::Error>>
     where
         P: WalletPersister,
     {
-        PersistedWallet::create(persister, self)
+        PersistedWallet::create(persister, persister_params, self)
     }
 
     /// Create [`PersistedWallet`] with the given [`AsyncWalletPersister`].
     pub async fn create_wallet_async<P>(
         self,
         persister: &mut P,
+        persister_params: P::Params,
     ) -> Result<PersistedWallet<P>, CreateWithPersistError<P::Error>>
     where
         P: AsyncWalletPersister,
     {
-        PersistedWallet::create_async(persister, self).await
+        PersistedWallet::create_async(persister, persister_params, self).await
     }
 
     /// Create [`Wallet`] without persistence.
@@ -228,22 +230,24 @@ impl LoadParams {
     pub fn load_wallet<P>(
         self,
         persister: &mut P,
+        persister_params: P::Params,
     ) -> Result<Option<PersistedWallet<P>>, LoadWithPersistError<P::Error>>
     where
         P: WalletPersister,
     {
-        PersistedWallet::load(persister, self)
+        PersistedWallet::load(persister, persister_params, self)
     }
 
     /// Load [`PersistedWallet`] with the given [`AsyncWalletPersister`].
     pub async fn load_wallet_async<P>(
         self,
         persister: &mut P,
+        persister_params: P::Params,
     ) -> Result<Option<PersistedWallet<P>>, LoadWithPersistError<P::Error>>
     where
         P: AsyncWalletPersister,
     {
-        PersistedWallet::load_async(persister, self).await
+        PersistedWallet::load_async(persister, persister_params, self).await
     }
 
     /// Load [`Wallet`] without persistence.

--- a/example-crates/wallet_electrum/src/main.rs
+++ b/example-crates/wallet_electrum/src/main.rs
@@ -30,12 +30,12 @@ fn main() -> Result<(), anyhow::Error> {
         .descriptor(KeychainKind::Internal, Some(INTERNAL_DESC))
         .extract_keys()
         .check_network(NETWORK)
-        .load_wallet(&mut db)?;
+        .load_wallet(&mut db, ())?;
     let mut wallet = match wallet_opt {
         Some(wallet) => wallet,
         None => Wallet::create(EXTERNAL_DESC, INTERNAL_DESC)
             .network(NETWORK)
-            .create_wallet(&mut db)?,
+            .create_wallet(&mut db, ())?,
     };
 
     let address = wallet.next_unused_address(KeychainKind::External);

--- a/example-crates/wallet_esplora_async/src/main.rs
+++ b/example-crates/wallet_esplora_async/src/main.rs
@@ -27,12 +27,12 @@ async fn main() -> Result<(), anyhow::Error> {
         .descriptor(KeychainKind::Internal, Some(INTERNAL_DESC))
         .extract_keys()
         .check_network(NETWORK)
-        .load_wallet(&mut conn)?;
+        .load_wallet(&mut conn, ())?;
     let mut wallet = match wallet_opt {
         Some(wallet) => wallet,
         None => Wallet::create(EXTERNAL_DESC, INTERNAL_DESC)
             .network(NETWORK)
-            .create_wallet(&mut conn)?,
+            .create_wallet(&mut conn, ())?,
     };
 
     let address = wallet.next_unused_address(KeychainKind::External);

--- a/example-crates/wallet_esplora_blocking/src/main.rs
+++ b/example-crates/wallet_esplora_blocking/src/main.rs
@@ -26,12 +26,12 @@ fn main() -> Result<(), anyhow::Error> {
         .descriptor(KeychainKind::Internal, Some(INTERNAL_DESC))
         .extract_keys()
         .check_network(NETWORK)
-        .load_wallet(&mut db)?;
+        .load_wallet(&mut db, ())?;
     let mut wallet = match wallet_opt {
         Some(wallet) => wallet,
         None => Wallet::create(EXTERNAL_DESC, INTERNAL_DESC)
             .network(NETWORK)
-            .create_wallet(&mut db)?,
+            .create_wallet(&mut db, ())?,
     };
 
     let address = wallet.next_unused_address(KeychainKind::External);

--- a/example-crates/wallet_rpc/src/main.rs
+++ b/example-crates/wallet_rpc/src/main.rs
@@ -93,12 +93,12 @@ fn main() -> anyhow::Result<()> {
         .descriptor(KeychainKind::Internal, Some(args.change_descriptor.clone()))
         .extract_keys()
         .check_network(args.network)
-        .load_wallet(&mut db)?;
+        .load_wallet(&mut db, ())?;
     let mut wallet = match wallet_opt {
         Some(wallet) => wallet,
         None => Wallet::create(args.descriptor, args.change_descriptor)
             .network(args.network)
-            .create_wallet(&mut db)?,
+            .create_wallet(&mut db, ())?,
     };
     println!(
         "Loaded wallet in {}s",


### PR DESCRIPTION
### Description

This is a potential solution for the problem @matthiasdebernardini mentioned in https://github.com/bitcoindevkit/bdk/pull/1562#issuecomment-2298613820.

However, I'm wondering if it would be better for persistence implementations to internally provide custom configuration. I.e.

```rust
type NamedWalletConnection<'c> {
    wallet_name: String,
    conn: sqlx::Connection<'c>,
}

impl<'c> AsyncWalletPersister for NamedWalletConnection<'c> {
    // ... stuff ...
}
```

I'm worried that this PR will introduce unnecessary complexity.

### Notes to the reviewers

Refer to the conversation in #1562 (which this PR is based on).

### Changelog notice

* Changed `bdk_wallet` persistence traits to have a generic `Params` type parameter to allow persister implementations to include custom configurations. This is introduced via a common trait `WalletPersisterCommon`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
