### PR TITLE
feat(chain)!: Add `time_of_sync` to `SyncRequest` and `FullScanRequest` WIP

### DIFF
--- a/crates/chain/src/spk_client.rs
+++ b/crates/chain/src/spk_client.rs
@@ -193,6 +193,12 @@ impl<I> SyncRequestBuilder<I> {
         self
     }
 
+    /// Set the `time_of_sync` for unconfirmed transactions.
+    pub fn time_of_sync(mut self, time_of_sync: u64) -> Self {
+        self.inner.time_of_sync = Some(time_of_sync);
+        self
+    }
+
     /// Set the closure that will inspect every sync item visited.
     pub fn inspect<F>(mut self, inspect: F) -> Self
     where
@@ -239,6 +245,7 @@ pub struct SyncRequest<I = ()> {
     txids_consumed: usize,
     outpoints: VecDeque<OutPoint>,
     outpoints_consumed: usize,
+    time_of_sync: Option<u64>,
     inspect: Box<InspectSync<I>>,
 }
 
@@ -252,6 +259,7 @@ impl<I> Default for SyncRequest<I> {
             txids_consumed: 0,
             outpoints: VecDeque::new(),
             outpoints_consumed: 0,
+            time_of_sync: None,
             inspect: Box::new(|_, _| {}),
         }
     }
@@ -333,6 +341,11 @@ impl<I> SyncRequest<I> {
         SyncIter::<I, OutPoint>::new(self)
     }
 
+    /// Retrive the `time_of_sync`.
+    pub fn get_time_of_sync(&self) -> Option<u64> {
+        self.time_of_sync
+    }
+
     fn _call_inspect(&mut self, item: SyncItem<I>) {
         let progress = self.progress();
         (*self.inspect)(item, progress);
@@ -409,6 +422,12 @@ impl<K: Ord> FullScanRequestBuilder<K> {
         self
     }
 
+    /// Set the `time_of_sync` for unconfirmed transactions.
+    pub fn time_of_sync(mut self, time_of_sync: u64) -> Self {
+        self.inner.time_of_sync = Some(time_of_sync);
+        self
+    }
+
     /// Set the closure that will inspect every sync item visited.
     pub fn inspect<F>(mut self, inspect: F) -> Self
     where
@@ -435,6 +454,7 @@ impl<K: Ord> FullScanRequestBuilder<K> {
 pub struct FullScanRequest<K> {
     chain_tip: Option<CheckPoint>,
     spks_by_keychain: BTreeMap<K, Box<dyn Iterator<Item = Indexed<ScriptBuf>> + Send>>,
+    time_of_sync: Option<u64>,
     inspect: Box<InspectFullScan<K>>,
 }
 
@@ -449,6 +469,7 @@ impl<K> Default for FullScanRequest<K> {
         Self {
             chain_tip: None,
             spks_by_keychain: Default::default(),
+            time_of_sync: None,
             inspect: Box::new(|_, _, _| {}),
         }
     }
@@ -487,6 +508,11 @@ impl<K: Ord + Clone> FullScanRequest<K> {
             spks,
             inspect,
         }
+    }
+
+    /// Retrive the `time_of_sync`.
+    pub fn get_time_of_sync(&self) -> Option<u64> {
+        self.time_of_sync
     }
 }
 

--- a/crates/chain/tests/test_tx_graph.rs
+++ b/crates/chain/tests/test_tx_graph.rs
@@ -1089,42 +1089,6 @@ fn test_changeset_last_seen_merge() {
 }
 
 #[test]
-fn update_last_seen_unconfirmed() {
-    let mut graph = TxGraph::<()>::default();
-    let tx = new_tx(0);
-    let txid = tx.compute_txid();
-
-    // insert a new tx
-    // initially we have a last_seen of None and no anchors
-    let _ = graph.insert_tx(tx);
-    let tx = graph.full_txs().next().unwrap();
-    assert_eq!(tx.last_seen_unconfirmed, None);
-    assert!(tx.anchors.is_empty());
-
-    // higher timestamp should update last seen
-    let changeset = graph.update_last_seen_unconfirmed(2);
-    assert_eq!(changeset.last_seen.get(&txid).unwrap(), &2);
-
-    // lower timestamp has no effect
-    let changeset = graph.update_last_seen_unconfirmed(1);
-    assert!(changeset.last_seen.is_empty());
-
-    // once anchored, last seen is not updated
-    let _ = graph.insert_anchor(txid, ());
-    let changeset = graph.update_last_seen_unconfirmed(4);
-    assert!(changeset.is_empty());
-    assert_eq!(
-        graph
-            .full_txs()
-            .next()
-            .unwrap()
-            .last_seen_unconfirmed
-            .unwrap(),
-        2
-    );
-}
-
-#[test]
 fn transactions_inserted_into_tx_graph_are_not_canonical_until_they_have_an_anchor_in_best_chain() {
     let txs = vec![new_tx(0), new_tx(1)];
     let txids: Vec<Txid> = txs.iter().map(Transaction::compute_txid).collect();

--- a/crates/electrum/tests/test_electrum.rs
+++ b/crates/electrum/tests/test_electrum.rs
@@ -38,18 +38,14 @@ where
     Spks: IntoIterator<Item = ScriptBuf>,
     Spks::IntoIter: ExactSizeIterator + Send + 'static,
 {
-    let mut update = client.sync(
-        SyncRequest::builder().chain_tip(chain.tip()).spks(spks),
+    let update = client.sync(
+        SyncRequest::builder()
+            .chain_tip(chain.tip())
+            .spks(spks)
+            .time_of_sync(std::time::UNIX_EPOCH.elapsed().unwrap().as_secs()),
         BATCH_SIZE,
         true,
     )?;
-
-    // Update `last_seen` to be able to calculate balance for unconfirmed transactions.
-    let now = std::time::UNIX_EPOCH
-        .elapsed()
-        .expect("must get time")
-        .as_secs();
-    let _ = update.graph_update.update_last_seen_unconfirmed(now);
 
     if let Some(chain_update) = update.chain_update.clone() {
         let _ = chain
@@ -107,6 +103,7 @@ pub fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
     let sync_update = {
         let request = SyncRequest::builder()
             .chain_tip(cp_tip.clone())
+            .time_of_sync(std::time::UNIX_EPOCH.elapsed().unwrap().as_secs())
             .spks(misc_spks);
         client.sync(request, 1, true)?
     };
@@ -213,6 +210,7 @@ pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     let full_scan_update = {
         let request = FullScanRequest::builder()
             .chain_tip(cp_tip.clone())
+            .time_of_sync(std::time::UNIX_EPOCH.elapsed().unwrap().as_secs())
             .spks_for_keychain(0, spks.clone());
         client.full_scan(request, 3, 1, false)?
     };
@@ -221,6 +219,7 @@ pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     let full_scan_update = {
         let request = FullScanRequest::builder()
             .chain_tip(cp_tip.clone())
+            .time_of_sync(std::time::UNIX_EPOCH.elapsed().unwrap().as_secs())
             .spks_for_keychain(0, spks.clone());
         client.full_scan(request, 4, 1, false)?
     };
@@ -254,6 +253,7 @@ pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     let full_scan_update = {
         let request = FullScanRequest::builder()
             .chain_tip(cp_tip.clone())
+            .time_of_sync(std::time::UNIX_EPOCH.elapsed().unwrap().as_secs())
             .spks_for_keychain(0, spks.clone());
         client.full_scan(request, 5, 1, false)?
     };
@@ -268,6 +268,7 @@ pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     let full_scan_update = {
         let request = FullScanRequest::builder()
             .chain_tip(cp_tip.clone())
+            .time_of_sync(std::time::UNIX_EPOCH.elapsed().unwrap().as_secs())
             .spks_for_keychain(0, spks.clone());
         client.full_scan(request, 6, 1, false)?
     };

--- a/crates/esplora/src/lib.rs
+++ b/crates/esplora/src/lib.rs
@@ -41,11 +41,18 @@ mod async_ext;
 #[cfg(feature = "async")]
 pub use async_ext::*;
 
-fn insert_anchor_from_status(
+fn insert_anchor_or_seen_at_from_status(
     tx_graph: &mut TxGraph<ConfirmationBlockTime>,
     txid: Txid,
     status: TxStatus,
+    time_of_sync: Option<u64>,
 ) {
+    if !status.confirmed {
+        if let Some(seen_at) = time_of_sync {
+            let _ = tx_graph.insert_seen_at(txid, seen_at);
+        }
+    }
+
     if let TxStatus {
         block_height: Some(height),
         block_hash: Some(hash),

--- a/crates/esplora/tests/async_ext.rs
+++ b/crates/esplora/tests/async_ext.rs
@@ -57,6 +57,7 @@ pub async fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
     let sync_update = {
         let request = SyncRequest::builder()
             .chain_tip(cp_tip.clone())
+            .time_of_sync(std::time::UNIX_EPOCH.elapsed().unwrap().as_secs())
             .spks(misc_spks);
         client.sync(request, 1).await?
     };
@@ -164,6 +165,7 @@ pub async fn test_async_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     let full_scan_update = {
         let request = FullScanRequest::builder()
             .chain_tip(cp_tip.clone())
+            .time_of_sync(std::time::UNIX_EPOCH.elapsed().unwrap().as_secs())
             .spks_for_keychain(0, spks.clone());
         client.full_scan(request, 3, 1).await?
     };
@@ -172,6 +174,7 @@ pub async fn test_async_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     let full_scan_update = {
         let request = FullScanRequest::builder()
             .chain_tip(cp_tip.clone())
+            .time_of_sync(std::time::UNIX_EPOCH.elapsed().unwrap().as_secs())
             .spks_for_keychain(0, spks.clone());
         client.full_scan(request, 4, 1).await?
     };
@@ -207,6 +210,7 @@ pub async fn test_async_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     let full_scan_update = {
         let request = FullScanRequest::builder()
             .chain_tip(cp_tip.clone())
+            .time_of_sync(std::time::UNIX_EPOCH.elapsed().unwrap().as_secs())
             .spks_for_keychain(0, spks.clone());
         client.full_scan(request, 5, 1).await?
     };
@@ -221,6 +225,7 @@ pub async fn test_async_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     let full_scan_update = {
         let request = FullScanRequest::builder()
             .chain_tip(cp_tip.clone())
+            .time_of_sync(std::time::UNIX_EPOCH.elapsed().unwrap().as_secs())
             .spks_for_keychain(0, spks.clone());
         client.full_scan(request, 6, 1).await?
     };

--- a/crates/esplora/tests/blocking_ext.rs
+++ b/crates/esplora/tests/blocking_ext.rs
@@ -57,6 +57,7 @@ pub fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
     let sync_update = {
         let request = SyncRequest::builder()
             .chain_tip(cp_tip.clone())
+            .time_of_sync(std::time::UNIX_EPOCH.elapsed().unwrap().as_secs())
             .spks(misc_spks);
         client.sync(request, 1)?
     };
@@ -165,6 +166,7 @@ pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     let full_scan_update = {
         let request = FullScanRequest::builder()
             .chain_tip(cp_tip.clone())
+            .time_of_sync(std::time::UNIX_EPOCH.elapsed().unwrap().as_secs())
             .spks_for_keychain(0, spks.clone());
         client.full_scan(request, 3, 1)?
     };
@@ -173,6 +175,7 @@ pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     let full_scan_update = {
         let request = FullScanRequest::builder()
             .chain_tip(cp_tip.clone())
+            .time_of_sync(std::time::UNIX_EPOCH.elapsed().unwrap().as_secs())
             .spks_for_keychain(0, spks.clone());
         client.full_scan(request, 4, 1)?
     };
@@ -208,6 +211,7 @@ pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     let full_scan_update = {
         let request = FullScanRequest::builder()
             .chain_tip(cp_tip.clone())
+            .time_of_sync(std::time::UNIX_EPOCH.elapsed().unwrap().as_secs())
             .spks_for_keychain(0, spks.clone());
         client.full_scan(request, 5, 1)?
     };
@@ -222,6 +226,7 @@ pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     let full_scan_update = {
         let request = FullScanRequest::builder()
             .chain_tip(cp_tip.clone())
+            .time_of_sync(std::time::UNIX_EPOCH.elapsed().unwrap().as_secs())
             .spks_for_keychain(0, spks.clone());
         client.full_scan(request, 6, 1)?
     };

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -2446,10 +2446,10 @@ impl Wallet {
             .revealed_spks_from_indexer(&self.indexed_graph.index, ..)
     }
 
-    /// Create a [`FullScanRequest] for this wallet.
+    /// Create a [`FullScanRequest`] for this wallet.
     ///
     /// This is the first step when performing a spk-based wallet full scan, the returned
-    /// [`FullScanRequest] collects iterators for the wallet's keychain script pub keys needed to
+    /// [`FullScanRequest`] collects iterators for the wallet's keychain script pub keys needed to
     /// start a blockchain full scan with a spk based blockchain client.
     ///
     /// This operation is generally only used when importing or restoring a previously used wallet

--- a/example-crates/wallet_esplora_blocking/src/main.rs
+++ b/example-crates/wallet_esplora_blocking/src/main.rs
@@ -47,21 +47,22 @@ fn main() -> Result<(), anyhow::Error> {
     print!("Syncing...");
     let client = esplora_client::Builder::new(ESPLORA_URL).build_blocking();
 
-    let request = wallet.start_full_scan().inspect({
-        let mut stdout = std::io::stdout();
-        let mut once = BTreeSet::<KeychainKind>::new();
-        move |keychain, spk_i, _| {
-            if once.insert(keychain) {
-                print!("\nScanning keychain [{:?}] ", keychain);
+    let request = wallet
+        .start_full_scan()
+        .time_of_sync(std::time::UNIX_EPOCH.elapsed().unwrap().as_secs())
+        .inspect({
+            let mut stdout = std::io::stdout();
+            let mut once = BTreeSet::<KeychainKind>::new();
+            move |keychain, spk_i, _| {
+                if once.insert(keychain) {
+                    print!("\nScanning keychain [{:?}] ", keychain);
+                }
+                print!(" {:<3}", spk_i);
+                stdout.flush().expect("must flush")
             }
-            print!(" {:<3}", spk_i);
-            stdout.flush().expect("must flush")
-        }
-    });
+        });
 
-    let mut update = client.full_scan(request, STOP_GAP, PARALLEL_REQUESTS)?;
-    let now = std::time::UNIX_EPOCH.elapsed().unwrap().as_secs();
-    let _ = update.graph_update.update_last_seen_unconfirmed(now);
+    let update = client.full_scan(request, STOP_GAP, PARALLEL_REQUESTS)?;
 
     wallet.apply_update(update)?;
     if let Some(changeset) = wallet.take_staged() {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
Implements #1550.

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
Adds `time_of_sync` as a member of `SyncRequest` and `FullSyncRequest` so we can set the `last_seen` for unconfirmed transactions during the sync/scan process in `bdk_electrum`.

### Notes to the reviewers

This PR is a WIP because setting the `last_seen` for unconfirmed transactions during the sync/scan process is yet to be implemented for `bdk_esplora`. I pushed my WIP towards setting the `last_seen` for `bdk_esplora` but I'm unsure if it is correct, as I did not have enough time to confirm and write a test for it before my travel. Please feel free to drop that commit if the concept is incorrect.

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->
* Removed `update_last_seen_unconfirmed()` from `TxGraph`.
* Added `time_of_sync` as a member of `SyncRequest`.
* Added `time_of_sync` as a member of `FullScanRequest`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
