### PR TITLE
Introduce `tx_graph::Update` and simplify `TxGraph` update logic

### DIFF
--- a/crates/chain/src/indexed_tx_graph.rs
+++ b/crates/chain/src/indexed_tx_graph.rs
@@ -91,13 +91,10 @@ where
     /// Apply an `update` directly.
     ///
     /// `update` is a [`TxGraph<A>`] and the resultant changes is returned as [`ChangeSet`].
-    pub fn apply_update(&mut self, update: TxGraph<A>) -> ChangeSet<A, I::ChangeSet> {
-        let graph = self.graph.apply_update(update);
-        let indexer = self.index_tx_graph_changeset(&graph);
-        ChangeSet {
-            tx_graph: graph,
-            indexer,
-        }
+    pub fn apply_update(&mut self, update: tx_graph::Update<A>) -> ChangeSet<A, I::ChangeSet> {
+        let tx_graph = self.graph.apply_update(update);
+        let indexer = self.index_tx_graph_changeset(&tx_graph);
+        ChangeSet { tx_graph, indexer }
     }
 
     /// Insert a floating `txout` of given `outpoint`.

--- a/crates/chain/src/lib.rs
+++ b/crates/chain/src/lib.rs
@@ -17,6 +17,12 @@
 //!
 //! [Bitcoin Dev Kit]: https://bitcoindevkit.org/
 
+// only enables the `doc_cfg` feature when the `docsrs` configuration attribute is defined
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(
+    docsrs,
+    doc(html_logo_url = "https://github.com/bitcoindevkit/bdk/raw/master/static/bdk.png")
+)]
 #![no_std]
 #![warn(missing_docs)]
 

--- a/crates/chain/src/spk_client.rs
+++ b/crates/chain/src/spk_client.rs
@@ -3,7 +3,7 @@ use crate::{
     alloc::{boxed::Box, collections::VecDeque, vec::Vec},
     collections::BTreeMap,
     local_chain::CheckPoint,
-    ConfirmationBlockTime, Indexed, TxGraph,
+    ConfirmationBlockTime, Indexed,
 };
 use bitcoin::{OutPoint, Script, ScriptBuf, Txid};
 
@@ -345,8 +345,8 @@ impl<I> SyncRequest<I> {
 #[must_use]
 #[derive(Debug)]
 pub struct SyncResult<A = ConfirmationBlockTime> {
-    /// The update to apply to the receiving [`TxGraph`].
-    pub graph_update: TxGraph<A>,
+    /// The update to apply to the receiving [`TxGraph`](crate::tx_graph::TxGraph).
+    pub graph_update: crate::tx_graph::Update<A>,
     /// The update to apply to the receiving [`LocalChain`](crate::local_chain::LocalChain).
     pub chain_update: Option<CheckPoint>,
 }
@@ -497,8 +497,8 @@ impl<K: Ord + Clone> FullScanRequest<K> {
 #[derive(Debug)]
 pub struct FullScanResult<K, A = ConfirmationBlockTime> {
     /// The update to apply to the receiving [`LocalChain`](crate::local_chain::LocalChain).
-    pub graph_update: TxGraph<A>,
-    /// The update to apply to the receiving [`TxGraph`].
+    pub graph_update: crate::tx_graph::Update<A>,
+    /// The update to apply to the receiving [`TxGraph`](crate::tx_graph::TxGraph).
     pub chain_update: Option<CheckPoint>,
     /// Last active indices for the corresponding keychains (`K`).
     pub last_active_indices: BTreeMap<K, u32>,

--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -671,76 +671,13 @@ impl<A: Clone + Ord> TxGraph<A> {
 
     /// Inserts the given `seen_at` for `txid` into [`TxGraph`].
     ///
-    /// Note that [`TxGraph`] only keeps track of the latest `seen_at`. To batch
-    /// update all unconfirmed transactions with the latest `seen_at`, see
-    /// [`update_last_seen_unconfirmed`].
-    ///
-    /// [`update_last_seen_unconfirmed`]: Self::update_last_seen_unconfirmed
+    /// Note that [`TxGraph`] only keeps track of the latest `seen_at`.
     pub fn insert_seen_at(&mut self, txid: Txid, seen_at: u64) -> ChangeSet<A> {
         let mut changeset = ChangeSet::<A>::default();
         let last_seen = self.last_seen.entry(txid).or_default();
         if seen_at > *last_seen {
             *last_seen = seen_at;
             changeset.last_seen.insert(txid, seen_at);
-        }
-        changeset
-    }
-
-    /// Update the last seen time for all unconfirmed transactions.
-    ///
-    /// This method updates the last seen unconfirmed time for this [`TxGraph`] by inserting
-    /// the given `seen_at` for every transaction not yet anchored to a confirmed block,
-    /// and returns the [`ChangeSet`] after applying all updates to `self`.
-    ///
-    /// This is useful for keeping track of the latest time a transaction was seen
-    /// unconfirmed, which is important for evaluating transaction conflicts in the same
-    /// [`TxGraph`]. For details of how [`TxGraph`] resolves conflicts, see the docs for
-    /// [`try_get_chain_position`].
-    ///
-    /// A normal use of this method is to call it with the current system time. Although
-    /// block headers contain a timestamp, using the header time would be less effective
-    /// at tracking mempool transactions, because it can drift from actual clock time, plus
-    /// we may want to update a transaction's last seen time repeatedly between blocks.
-    ///
-    /// # Example
-    ///
-    /// ```rust
-    /// # use bdk_chain::example_utils::*;
-    /// # use std::time::UNIX_EPOCH;
-    /// # let tx = tx_from_hex(RAW_TX_1);
-    /// # let mut tx_graph = bdk_chain::TxGraph::<()>::new([tx]);
-    /// let now = std::time::SystemTime::now()
-    ///     .duration_since(UNIX_EPOCH)
-    ///     .expect("valid duration")
-    ///     .as_secs();
-    /// let changeset = tx_graph.update_last_seen_unconfirmed(now);
-    /// assert!(!changeset.last_seen.is_empty());
-    /// ```
-    ///
-    /// Note that [`TxGraph`] only keeps track of the latest `seen_at`, so the given time must
-    /// by strictly greater than what is currently stored for a transaction to have an effect.
-    /// To insert a last seen time for a single txid, see [`insert_seen_at`].
-    ///
-    /// [`insert_seen_at`]: Self::insert_seen_at
-    /// [`try_get_chain_position`]: Self::try_get_chain_position
-    pub fn update_last_seen_unconfirmed(&mut self, seen_at: u64) -> ChangeSet<A> {
-        let mut changeset = ChangeSet::default();
-        let unanchored_txs: Vec<Txid> = self
-            .txs
-            .iter()
-            .filter_map(
-                |(&txid, (_, anchors))| {
-                    if anchors.is_empty() {
-                        Some(txid)
-                    } else {
-                        None
-                    }
-                },
-            )
-            .collect();
-
-        for txid in unanchored_txs {
-            changeset.merge(self.insert_seen_at(txid, seen_at));
         }
         changeset
     }

--- a/crates/chain/tests/test_tx_graph.rs
+++ b/crates/chain/tests/test_tx_graph.rs
@@ -1014,42 +1014,6 @@ fn test_changeset_last_seen_merge() {
 }
 
 #[test]
-fn update_last_seen_unconfirmed() {
-    let mut graph = TxGraph::<()>::default();
-    let tx = new_tx(0);
-    let txid = tx.compute_txid();
-
-    // insert a new tx
-    // initially we have a last_seen of None and no anchors
-    let _ = graph.insert_tx(tx);
-    let tx = graph.full_txs().next().unwrap();
-    assert_eq!(tx.last_seen_unconfirmed, None);
-    assert!(tx.anchors.is_empty());
-
-    // higher timestamp should update last seen
-    let changeset = graph.update_last_seen_unconfirmed(2);
-    assert_eq!(changeset.last_seen.get(&txid).unwrap(), &2);
-
-    // lower timestamp has no effect
-    let changeset = graph.update_last_seen_unconfirmed(1);
-    assert!(changeset.last_seen.is_empty());
-
-    // once anchored, last seen is not updated
-    let _ = graph.insert_anchor(txid, ());
-    let changeset = graph.update_last_seen_unconfirmed(4);
-    assert!(changeset.is_empty());
-    assert_eq!(
-        graph
-            .full_txs()
-            .next()
-            .unwrap()
-            .last_seen_unconfirmed
-            .unwrap(),
-        2
-    );
-}
-
-#[test]
 fn transactions_inserted_into_tx_graph_are_not_canonical_until_they_have_an_anchor_in_best_chain() {
     let txs = vec![new_tx(0), new_tx(1)];
     let txids: Vec<Txid> = txs.iter().map(Transaction::compute_txid).collect();

--- a/crates/electrum/tests/test_electrum.rs
+++ b/crates/electrum/tests/test_electrum.rs
@@ -38,18 +38,11 @@ where
     Spks: IntoIterator<Item = ScriptBuf>,
     Spks::IntoIter: ExactSizeIterator + Send + 'static,
 {
-    let mut update = client.sync(
+    let update = client.sync(
         SyncRequest::builder().chain_tip(chain.tip()).spks(spks),
         BATCH_SIZE,
         true,
     )?;
-
-    // Update `last_seen` to be able to calculate balance for unconfirmed transactions.
-    let now = std::time::UNIX_EPOCH
-        .elapsed()
-        .expect("must get time")
-        .as_secs();
-    update.graph_update.update_last_seen_unconfirmed(now);
 
     if let Some(chain_update) = update.chain_update.clone() {
         let _ = chain

--- a/crates/esplora/tests/async_ext.rs
+++ b/crates/esplora/tests/async_ext.rs
@@ -1,4 +1,5 @@
 use bdk_chain::spk_client::{FullScanRequest, SyncRequest};
+use bdk_chain::{ConfirmationBlockTime, TxGraph};
 use bdk_esplora::EsploraAsyncExt;
 use esplora_client::{self, Builder};
 use std::collections::{BTreeSet, HashSet};
@@ -6,7 +7,7 @@ use std::str::FromStr;
 use std::thread::sleep;
 use std::time::Duration;
 
-use bdk_chain::bitcoin::{Address, Amount, Txid};
+use bdk_chain::bitcoin::{Address, Amount};
 use bdk_testenv::{anyhow, bitcoincore_rpc::RpcApi, TestEnv};
 
 #[tokio::test]
@@ -78,18 +79,23 @@ pub async fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
     );
 
     let graph_update = sync_update.graph_update;
+    let updated_graph = {
+        let mut graph = TxGraph::<ConfirmationBlockTime>::default();
+        let _ = graph.apply_update(graph_update.clone());
+        graph
+    };
     // Check to see if we have the floating txouts available from our two created transactions'
     // previous outputs in order to calculate transaction fees.
-    for tx in graph_update.full_txs() {
+    for tx in &graph_update.txs {
         // Retrieve the calculated fee from `TxGraph`, which will panic if we do not have the
         // floating txouts available from the transactions' previous outputs.
-        let fee = graph_update.calculate_fee(&tx.tx).expect("Fee must exist");
+        let fee = updated_graph.calculate_fee(tx).expect("Fee must exist");
 
         // Retrieve the fee in the transaction data from `bitcoind`.
         let tx_fee = env
             .bitcoind
             .client
-            .get_transaction(&tx.txid, None)
+            .get_transaction(&tx.compute_txid(), None)
             .expect("Tx must exist")
             .fee
             .expect("Fee must exist")
@@ -101,11 +107,15 @@ pub async fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
         assert_eq!(fee, tx_fee);
     }
 
-    let mut graph_update_txids: Vec<Txid> = graph_update.full_txs().map(|tx| tx.txid).collect();
-    graph_update_txids.sort();
-    let mut expected_txids = vec![txid1, txid2];
-    expected_txids.sort();
-    assert_eq!(graph_update_txids, expected_txids);
+    assert_eq!(
+        graph_update
+            .txs
+            .iter()
+            .map(|tx| tx.compute_txid())
+            .collect::<BTreeSet<_>>(),
+        [txid1, txid2].into(),
+        "update must include all expected transactions"
+    );
     Ok(())
 }
 
@@ -167,7 +177,7 @@ pub async fn test_async_update_tx_graph_stop_gap() -> anyhow::Result<()> {
             .spks_for_keychain(0, spks.clone());
         client.full_scan(request, 3, 1).await?
     };
-    assert!(full_scan_update.graph_update.full_txs().next().is_none());
+    assert!(full_scan_update.graph_update.txs.is_empty());
     assert!(full_scan_update.last_active_indices.is_empty());
     let full_scan_update = {
         let request = FullScanRequest::builder()
@@ -178,10 +188,10 @@ pub async fn test_async_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     assert_eq!(
         full_scan_update
             .graph_update
-            .full_txs()
-            .next()
+            .txs
+            .first()
             .unwrap()
-            .txid,
+            .compute_txid(),
         txid_4th_addr
     );
     assert_eq!(full_scan_update.last_active_indices[&0], 3);
@@ -212,8 +222,9 @@ pub async fn test_async_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     };
     let txs: HashSet<_> = full_scan_update
         .graph_update
-        .full_txs()
-        .map(|tx| tx.txid)
+        .txs
+        .iter()
+        .map(|tx| tx.compute_txid())
         .collect();
     assert_eq!(txs.len(), 1);
     assert!(txs.contains(&txid_4th_addr));
@@ -226,8 +237,9 @@ pub async fn test_async_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     };
     let txs: HashSet<_> = full_scan_update
         .graph_update
-        .full_txs()
-        .map(|tx| tx.txid)
+        .txs
+        .iter()
+        .map(|tx| tx.compute_txid())
         .collect();
     assert_eq!(txs.len(), 2);
     assert!(txs.contains(&txid_4th_addr) && txs.contains(&txid_last_addr));

--- a/crates/esplora/tests/blocking_ext.rs
+++ b/crates/esplora/tests/blocking_ext.rs
@@ -1,4 +1,5 @@
 use bdk_chain::spk_client::{FullScanRequest, SyncRequest};
+use bdk_chain::{ConfirmationBlockTime, TxGraph};
 use bdk_esplora::EsploraExt;
 use esplora_client::{self, Builder};
 use std::collections::{BTreeSet, HashSet};
@@ -6,7 +7,7 @@ use std::str::FromStr;
 use std::thread::sleep;
 use std::time::Duration;
 
-use bdk_chain::bitcoin::{Address, Amount, Txid};
+use bdk_chain::bitcoin::{Address, Amount};
 use bdk_testenv::{anyhow, bitcoincore_rpc::RpcApi, TestEnv};
 
 #[test]
@@ -78,18 +79,23 @@ pub fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
     );
 
     let graph_update = sync_update.graph_update;
+    let updated_graph = {
+        let mut graph = TxGraph::<ConfirmationBlockTime>::default();
+        let _ = graph.apply_update(graph_update.clone());
+        graph
+    };
     // Check to see if we have the floating txouts available from our two created transactions'
     // previous outputs in order to calculate transaction fees.
-    for tx in graph_update.full_txs() {
+    for tx in &graph_update.txs {
         // Retrieve the calculated fee from `TxGraph`, which will panic if we do not have the
         // floating txouts available from the transactions' previous outputs.
-        let fee = graph_update.calculate_fee(&tx.tx).expect("Fee must exist");
+        let fee = updated_graph.calculate_fee(tx).expect("Fee must exist");
 
         // Retrieve the fee in the transaction data from `bitcoind`.
         let tx_fee = env
             .bitcoind
             .client
-            .get_transaction(&tx.txid, None)
+            .get_transaction(&tx.compute_txid(), None)
             .expect("Tx must exist")
             .fee
             .expect("Fee must exist")
@@ -101,12 +107,15 @@ pub fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
         assert_eq!(fee, tx_fee);
     }
 
-    let mut graph_update_txids: Vec<Txid> = graph_update.full_txs().map(|tx| tx.txid).collect();
-    graph_update_txids.sort();
-    let mut expected_txids = vec![txid1, txid2];
-    expected_txids.sort();
-    assert_eq!(graph_update_txids, expected_txids);
-
+    assert_eq!(
+        graph_update
+            .txs
+            .iter()
+            .map(|tx| tx.compute_txid())
+            .collect::<BTreeSet<_>>(),
+        [txid1, txid2].into(),
+        "update must include all expected transactions"
+    );
     Ok(())
 }
 
@@ -168,7 +177,7 @@ pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
             .spks_for_keychain(0, spks.clone());
         client.full_scan(request, 3, 1)?
     };
-    assert!(full_scan_update.graph_update.full_txs().next().is_none());
+    assert!(full_scan_update.graph_update.txs.is_empty());
     assert!(full_scan_update.last_active_indices.is_empty());
     let full_scan_update = {
         let request = FullScanRequest::builder()
@@ -179,10 +188,10 @@ pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     assert_eq!(
         full_scan_update
             .graph_update
-            .full_txs()
-            .next()
+            .txs
+            .first()
             .unwrap()
-            .txid,
+            .compute_txid(),
         txid_4th_addr
     );
     assert_eq!(full_scan_update.last_active_indices[&0], 3);
@@ -213,8 +222,9 @@ pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     };
     let txs: HashSet<_> = full_scan_update
         .graph_update
-        .full_txs()
-        .map(|tx| tx.txid)
+        .txs
+        .iter()
+        .map(|tx| tx.compute_txid())
         .collect();
     assert_eq!(txs.len(), 1);
     assert!(txs.contains(&txid_4th_addr));
@@ -227,8 +237,9 @@ pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     };
     let txs: HashSet<_> = full_scan_update
         .graph_update
-        .full_txs()
-        .map(|tx| tx.txid)
+        .txs
+        .iter()
+        .map(|tx| tx.compute_txid())
         .collect();
     assert_eq!(txs.len(), 2);
     assert!(txs.contains(&txid_4th_addr) && txs.contains(&txid_last_addr));

--- a/crates/wallet/src/wallet/export.rs
+++ b/crates/wallet/src/wallet/export.rs
@@ -219,13 +219,13 @@ mod test {
     use bdk_chain::{BlockId, ConfirmationBlockTime};
     use bitcoin::hashes::Hash;
     use bitcoin::{transaction, BlockHash, Network, Transaction};
+    use chain::tx_graph;
 
     use super::*;
     use crate::Wallet;
 
     fn get_test_wallet(descriptor: &str, change_descriptor: &str, network: Network) -> Wallet {
         use crate::wallet::Update;
-        use bdk_chain::TxGraph;
         let mut wallet = Wallet::create(descriptor.to_string(), change_descriptor.to_string())
             .network(network)
             .create_wallet_no_persist()
@@ -253,11 +253,12 @@ mod test {
             confirmation_time: 0,
             block_id,
         };
-        let mut graph = TxGraph::default();
-        let _ = graph.insert_anchor(txid, anchor);
         wallet
             .apply_update(Update {
-                graph,
+                graph: tx_graph::Update {
+                    anchors: [(anchor, txid)].into_iter().collect(),
+                    ..Default::default()
+                },
                 ..Default::default()
             })
             .unwrap();

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -132,7 +132,7 @@ pub struct Update {
     pub last_active_indices: BTreeMap<KeychainKind, u32>,
 
     /// Update for the wallet's internal [`TxGraph`].
-    pub graph: TxGraph<ConfirmationBlockTime>,
+    pub graph: chain::tx_graph::Update<ConfirmationBlockTime>,
 
     /// Update for the wallet's internal [`LocalChain`].
     ///
@@ -2562,7 +2562,7 @@ macro_rules! floating_rate {
 macro_rules! doctest_wallet {
     () => {{
         use $crate::bitcoin::{BlockHash, Transaction, absolute, TxOut, Network, hashes::Hash};
-        use $crate::chain::{ConfirmationBlockTime, BlockId, TxGraph};
+        use $crate::chain::{ConfirmationBlockTime, BlockId, TxGraph, tx_graph};
         use $crate::{Update, KeychainKind, Wallet};
         let descriptor = "tr([73c5da0a/86'/0'/0']tprv8fMn4hSKPRC1oaCPqxDb1JWtgkpeiQvZhsr8W2xuy3GEMkzoArcAWTfJxYb6Wj8XNNDWEjfYKK4wGQXh3ZUXhDF2NcnsALpWTeSwarJt7Vc/0/*)";
         let change_descriptor = "tr([73c5da0a/86'/0'/0']tprv8fMn4hSKPRC1oaCPqxDb1JWtgkpeiQvZhsr8W2xuy3GEMkzoArcAWTfJxYb6Wj8XNNDWEjfYKK4wGQXh3ZUXhDF2NcnsALpWTeSwarJt7Vc/1/*)";
@@ -2590,9 +2590,13 @@ macro_rules! doctest_wallet {
             confirmation_time: 50_000,
             block_id,
         };
-        let mut graph = TxGraph::default();
-        let _ = graph.insert_anchor(txid, anchor);
-        let update = Update { graph, ..Default::default() };
+        let update = Update {
+            graph: tx_graph::Update {
+                anchors: [(anchor, txid)].into_iter().collect(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
         wallet.apply_update(update).unwrap();
         wallet
     }}

--- a/crates/wallet/tests/common.rs
+++ b/crates/wallet/tests/common.rs
@@ -1,5 +1,5 @@
 #![allow(unused)]
-use bdk_chain::{BlockId, ConfirmationBlockTime, ConfirmationTime, TxGraph};
+use bdk_chain::{tx_graph, BlockId, ConfirmationBlockTime, ConfirmationTime, TxGraph};
 use bdk_wallet::{CreateParams, KeychainKind, LocalOutput, Update, Wallet};
 use bitcoin::{
     hashes::Hash, transaction, Address, Amount, BlockHash, FeeRate, Network, OutPoint, Transaction,
@@ -218,11 +218,12 @@ pub fn insert_anchor_from_conf(wallet: &mut Wallet, txid: Txid, position: Confir
             })
             .expect("confirmation height cannot be greater than tip");
 
-        let mut graph = TxGraph::default();
-        let _ = graph.insert_anchor(txid, anchor);
         wallet
             .apply_update(Update {
-                graph,
+                graph: tx_graph::Update {
+                    anchors: [(anchor, txid)].into(),
+                    ..Default::default()
+                },
                 ..Default::default()
             })
             .unwrap();

--- a/crates/wallet/tests/wallet.rs
+++ b/crates/wallet/tests/wallet.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 
 use anyhow::Context;
 use assert_matches::assert_matches;
-use bdk_chain::COINBASE_MATURITY;
+use bdk_chain::{tx_graph, COINBASE_MATURITY};
 use bdk_chain::{BlockId, ConfirmationTime};
 use bdk_wallet::coin_selection::{self, LargestFirstCoinSelection};
 use bdk_wallet::descriptor::{calc_checksum, DescriptorError, IntoWalletDescriptor};
@@ -81,11 +81,12 @@ fn receive_output_in_latest_block(wallet: &mut Wallet, value: u64) -> OutPoint {
 
 fn insert_seen_at(wallet: &mut Wallet, txid: Txid, seen_at: u64) {
     use bdk_wallet::Update;
-    let mut graph = bdk_chain::TxGraph::default();
-    let _ = graph.insert_seen_at(txid, seen_at);
     wallet
         .apply_update(Update {
-            graph,
+            graph: tx_graph::Update {
+                seen_ats: [(txid, seen_at)].into_iter().collect(),
+                ..Default::default()
+            },
             ..Default::default()
         })
         .unwrap();

--- a/example-crates/example_electrum/src/main.rs
+++ b/example-crates/example_electrum/src/main.rs
@@ -129,7 +129,7 @@ fn main() -> anyhow::Result<()> {
     // Tell the electrum client about the txs we've already got locally so it doesn't re-download them
     client.populate_tx_cache(&*graph.lock().unwrap());
 
-    let (chain_update, mut graph_update, keychain_update) = match electrum_cmd.clone() {
+    let (chain_update, graph_update, keychain_update) = match electrum_cmd.clone() {
         ElectrumCommands::Scan {
             stop_gap,
             scan_options,
@@ -247,12 +247,6 @@ fn main() -> anyhow::Result<()> {
             (res.chain_update, res.graph_update, None)
         }
     };
-
-    let now = std::time::UNIX_EPOCH
-        .elapsed()
-        .expect("must get time")
-        .as_secs();
-    graph_update.update_last_seen_unconfirmed(now);
 
     let db_changeset = {
         let mut chain = chain.lock().unwrap();

--- a/example-crates/example_electrum/src/main.rs
+++ b/example-crates/example_electrum/src/main.rs
@@ -252,7 +252,7 @@ fn main() -> anyhow::Result<()> {
         .elapsed()
         .expect("must get time")
         .as_secs();
-    let _ = graph_update.update_last_seen_unconfirmed(now);
+    graph_update.update_last_seen_unconfirmed(now);
 
     let db_changeset = {
         let mut chain = chain.lock().unwrap();

--- a/example-crates/example_esplora/src/main.rs
+++ b/example-crates/example_esplora/src/main.rs
@@ -172,7 +172,7 @@ fn main() -> anyhow::Result<()> {
 
             // We want to keep track of the latest time a transaction was seen unconfirmed.
             let now = std::time::UNIX_EPOCH.elapsed().unwrap().as_secs();
-            let _ = update.graph_update.update_last_seen_unconfirmed(now);
+            update.graph_update.update_last_seen_unconfirmed(now);
 
             let mut graph = graph.lock().expect("mutex must not be poisoned");
             let mut chain = chain.lock().expect("mutex must not be poisoned");
@@ -269,7 +269,7 @@ fn main() -> anyhow::Result<()> {
 
             // Update last seen unconfirmed
             let now = std::time::UNIX_EPOCH.elapsed().unwrap().as_secs();
-            let _ = update.graph_update.update_last_seen_unconfirmed(now);
+            update.graph_update.update_last_seen_unconfirmed(now);
 
             (
                 chain

--- a/example-crates/example_esplora/src/main.rs
+++ b/example-crates/example_esplora/src/main.rs
@@ -166,13 +166,9 @@ fn main() -> anyhow::Result<()> {
             // is reached. It returns a `TxGraph` update (`graph_update`) and a structure that
             // represents the last active spk derivation indices of keychains
             // (`keychain_indices_update`).
-            let mut update = client
+            let update = client
                 .full_scan(request, *stop_gap, scan_options.parallel_requests)
                 .context("scanning for transactions")?;
-
-            // We want to keep track of the latest time a transaction was seen unconfirmed.
-            let now = std::time::UNIX_EPOCH.elapsed().unwrap().as_secs();
-            update.graph_update.update_last_seen_unconfirmed(now);
 
             let mut graph = graph.lock().expect("mutex must not be poisoned");
             let mut chain = chain.lock().expect("mutex must not be poisoned");
@@ -265,11 +261,7 @@ fn main() -> anyhow::Result<()> {
                 }
             }
 
-            let mut update = client.sync(request, scan_options.parallel_requests)?;
-
-            // Update last seen unconfirmed
-            let now = std::time::UNIX_EPOCH.elapsed().unwrap().as_secs();
-            update.graph_update.update_last_seen_unconfirmed(now);
+            let update = client.sync(request, scan_options.parallel_requests)?;
 
             (
                 chain

--- a/example-crates/wallet_electrum/src/main.rs
+++ b/example-crates/wallet_electrum/src/main.rs
@@ -64,10 +64,7 @@ fn main() -> Result<(), anyhow::Error> {
         }
     });
 
-    let mut update = client.full_scan(request, STOP_GAP, BATCH_SIZE, false)?;
-
-    let now = std::time::UNIX_EPOCH.elapsed().unwrap().as_secs();
-    update.graph_update.update_last_seen_unconfirmed(now);
+    let update = client.full_scan(request, STOP_GAP, BATCH_SIZE, false)?;
 
     println!();
 

--- a/example-crates/wallet_electrum/src/main.rs
+++ b/example-crates/wallet_electrum/src/main.rs
@@ -67,7 +67,7 @@ fn main() -> Result<(), anyhow::Error> {
     let mut update = client.full_scan(request, STOP_GAP, BATCH_SIZE, false)?;
 
     let now = std::time::UNIX_EPOCH.elapsed().unwrap().as_secs();
-    let _ = update.graph_update.update_last_seen_unconfirmed(now);
+    update.graph_update.update_last_seen_unconfirmed(now);
 
     println!();
 

--- a/example-crates/wallet_esplora_async/src/main.rs
+++ b/example-crates/wallet_esplora_async/src/main.rs
@@ -61,7 +61,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .full_scan(request, STOP_GAP, PARALLEL_REQUESTS)
         .await?;
     let now = std::time::UNIX_EPOCH.elapsed().unwrap().as_secs();
-    let _ = update.graph_update.update_last_seen_unconfirmed(now);
+    update.graph_update.update_last_seen_unconfirmed(now);
 
     wallet.apply_update(update)?;
     wallet.persist(&mut conn)?;

--- a/example-crates/wallet_esplora_async/src/main.rs
+++ b/example-crates/wallet_esplora_async/src/main.rs
@@ -57,11 +57,9 @@ async fn main() -> Result<(), anyhow::Error> {
         }
     });
 
-    let mut update = client
+    let update = client
         .full_scan(request, STOP_GAP, PARALLEL_REQUESTS)
         .await?;
-    let now = std::time::UNIX_EPOCH.elapsed().unwrap().as_secs();
-    update.graph_update.update_last_seen_unconfirmed(now);
 
     wallet.apply_update(update)?;
     wallet.persist(&mut conn)?;

--- a/example-crates/wallet_esplora_blocking/src/main.rs
+++ b/example-crates/wallet_esplora_blocking/src/main.rs
@@ -61,7 +61,7 @@ fn main() -> Result<(), anyhow::Error> {
 
     let mut update = client.full_scan(request, STOP_GAP, PARALLEL_REQUESTS)?;
     let now = std::time::UNIX_EPOCH.elapsed().unwrap().as_secs();
-    let _ = update.graph_update.update_last_seen_unconfirmed(now);
+    update.graph_update.update_last_seen_unconfirmed(now);
 
     wallet.apply_update(update)?;
     if let Some(changeset) = wallet.take_staged() {

--- a/example-crates/wallet_esplora_blocking/src/main.rs
+++ b/example-crates/wallet_esplora_blocking/src/main.rs
@@ -59,9 +59,7 @@ fn main() -> Result<(), anyhow::Error> {
         }
     });
 
-    let mut update = client.full_scan(request, STOP_GAP, PARALLEL_REQUESTS)?;
-    let now = std::time::UNIX_EPOCH.elapsed().unwrap().as_secs();
-    update.graph_update.update_last_seen_unconfirmed(now);
+    let update = client.full_scan(request, STOP_GAP, PARALLEL_REQUESTS)?;
 
     wallet.apply_update(update)?;
     if let Some(changeset) = wallet.take_staged() {


### PR DESCRIPTION
Part of #1543
Closes #1550

### Description

Instead of updating a `TxGraph` with another `TxGraph` in `.apply_update()`, we introduce `tx_graph::Update`. `tx_graph::Update` is a simple data object. This is the first step of #1543. This also makes it slightly less expensive to create an update.

Additionally, we simplify the update logic of `TxGraph` by containing most of the update logic in `.insert_{}`-esc methods. `.apply_update` and `.apply_changeset` will call `.insert_{}` methods internally and is greatly simplified. Thus, we also get rid of `.determine_changeset`.

We change `.apply_update` methods of `TxGraph`,`IndexedTxGraph` and `Wallet` to implicitly set `seen_at` to the current timestamp for unconfirmed update transactions. This makes these methods only available when the `"std"` cargo feature is enabled. For a non-std environment, we introduce `.apply_update_at` (as shown below).

```rust
pub fn apply_update_at(&mut self, update: Update<A>, seen_at: Option<u64>) -> ChangeSet<A> {
    todo!()
}
```

During this process, I've fixed some tests that didn't make much sense.

### Notes to the reviewers

There is a slight scope-creep, but they all address the update logic of `TxGraph` and structures that build on top.

### Changelog notice

* Changed update API (`.apply_update`) of `TxGraph` to take in a simple data object (`tx_graph::Update`).
* Changed `.apply_update` methods of `TxGraph`, `IndexedTxGraph` and `Wallet` to implicitly set the `seen_at` to the current timestamp for unconfirmed update transactions (this making them depend on the "std" cargo feature).
* Add `.apply_update_at` which is the no-std version of `.apply_update`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
