### PR TITLE
Bump bdk version to 1.0.0-beta.2

### DIFF
--- a/crates/bitcoind_rpc/Cargo.toml
+++ b/crates/bitcoind_rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_bitcoind_rpc"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"
@@ -19,7 +19,7 @@ bdk_core = { path = "../core", version = "0.1", default-features = false }
 
 [dev-dependencies]
 bdk_testenv = { path = "../testenv", default-features = false }
-bdk_chain = { path = "../chain", version = "0.17" }
+bdk_chain = { path = "../chain", version = "0.18" }
 
 [features]
 default = ["std"]

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_chain"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"
@@ -20,7 +20,7 @@ miniscript = { version = "12.0.0", optional = true, default-features = false }
 
 # Feature dependencies
 rusqlite = { version = "0.31.0", features = ["bundled"], optional = true }
-serde_json = {version = "1", optional = true }
+serde_json = { version = "1", optional = true }
 
 [dev-dependencies]
 rand = "0.8"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -21,4 +21,4 @@ std = ["bitcoin/std"]
 serde = ["dep:serde", "bitcoin/serde", "hashbrown?/serde"]
 
 [dev-dependencies]
-bdk_chain = { version = "0.17.0", path = "../chain" }
+bdk_chain = { version = "0.18.0", path = "../chain" }

--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_electrum"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -11,11 +11,11 @@ readme = "README.md"
 
 [dependencies]
 bdk_core = { path = "../core", version = "0.1" }
-electrum-client = { version = "0.21", features = ["proxy"], default-features = false }
+electrum-client = { version = "0.21", features = [ "proxy" ], default-features = false }
 
 [dev-dependencies]
 bdk_testenv = { path = "../testenv", default-features = false }
-bdk_chain = { path = "../chain", version = "0.17.0" }
+bdk_chain = { path = "../chain", version = "0.18.0" }
 
 [features]
 default = ["use-rustls"]

--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_esplora"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -19,7 +19,7 @@ futures = { version = "0.3.26", optional = true }
 miniscript = { version = "12.0.0", optional = true, default-features = false }
 
 [dev-dependencies]
-bdk_chain = { path = "../chain", version = "0.17.0" }
+bdk_chain = { path = "../chain", version = "0.18.0" }
 bdk_testenv = { path = "../testenv", default-features = false }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 

--- a/crates/file_store/Cargo.toml
+++ b/crates/file_store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_file_store"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -11,7 +11,7 @@ authors = ["Bitcoin Dev Kit Developers"]
 readme = "README.md"
 
 [dependencies]
-bdk_chain = { path = "../chain", version = "0.17.0", features = [ "serde", "miniscript" ] }
+bdk_chain = { path = "../chain", version = "0.18.0", features = [ "serde", "miniscript" ] }
 bincode = { version = "1" }
 serde = { version = "1", features = ["derive"] }
 

--- a/crates/hwi/Cargo.toml
+++ b/crates/hwi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_hwi"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -9,5 +9,5 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-bdk_wallet = { path = "../wallet", version = "1.0.0-beta.1" }
-hwi = { version = "0.9.0", features = [ "miniscript"] }
+bdk_wallet = { path = "../wallet", version = "1.0.0-beta.2" }
+hwi = { version = "0.9.0", features = [ "miniscript" ] }

--- a/crates/testenv/Cargo.toml
+++ b/crates/testenv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_testenv"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"
@@ -13,8 +13,8 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bdk_chain = { path = "../chain", version = "0.17", default-features = false }
-electrsd = { version = "0.28.0", features = ["bitcoind_25_0", "esplora_a33e97e1", "legacy"] }
+bdk_chain = { path = "../chain", version = "0.18", default-features = false }
+electrsd = { version = "0.28.0", features = [ "bitcoind_25_0", "esplora_a33e97e1", "legacy" ] }
 
 [features]
 default = ["std"]

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bdk_wallet"
 homepage = "https://bitcoindevkit.org"
-version = "1.0.0-beta.1"
+version = "1.0.0-beta.2"
 repository = "https://github.com/bitcoindevkit/bdk"
 documentation = "https://docs.rs/bdk"
 description = "A modern, lightweight, descriptor-based wallet library"
@@ -14,12 +14,12 @@ rust-version = "1.63"
 
 [dependencies]
 rand_core = { version = "0.6.0" }
-miniscript = { version = "12.0.0", features = ["serde"], default-features = false }
-bitcoin = { version = "0.32.0", features = ["serde", "base64"], default-features = false }
+miniscript = { version = "12.0.0", features = [ "serde" ], default-features = false }
+bitcoin = { version = "0.32.0", features = [ "serde", "base64" ], default-features = false }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
-bdk_chain = { path = "../chain", version = "0.17.0", features = ["miniscript", "serde"], default-features = false }
-bdk_file_store = { path = "../file_store", version = "0.14.0", optional = true }
+bdk_chain = { path = "../chain", version = "0.18.0", features = [ "miniscript", "serde" ], default-features = false }
+bdk_file_store = { path = "../file_store", version = "0.15.0", optional = true }
 
 # Optional dependencies
 bip39 = { version = "2.0", optional = true }


### PR DESCRIPTION
Bump versions for bdk 1.0.0-beta.2 release:

bdk version to 1.0.0-beta.2
bdk_chain to 0.18.0
bdk_bitcoind_rpc to 0.14.0
bdk_electrum to 0.17.0
bdk_esplora to 0.17.0
bdk_file_store to 0.15.0
bdk_testenv to 0.8.0
bdk_hwi to 0.5.0
