### PR TITLE
chore: add missing bdk_core README.md and remove specific bdk_chain dev version

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -21,4 +21,4 @@ std = ["bitcoin/std"]
 serde = ["dep:serde", "bitcoin/serde", "hashbrown?/serde"]
 
 [dev-dependencies]
-bdk_chain = { version = "0.18.0", path = "../chain" }
+bdk_chain = { path = "../chain" }

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -1,0 +1,3 @@
+# BDK Core
+
+This crate is a collection of core structures used by the bdk_chain, bdk_wallet, and bdk chain data source crates.


### PR DESCRIPTION
Add the missing README.md file for the bdk_core crate. This is required to publish to crates.io.

Also had to removed fixed bdk_chain version from bdk_core dev dependencies to prevent missing dependency when publishing bdk_core before publishing new version of bdk_chain. 

