### PR TITLE
ci: add `workspace` or single `package` to build-test

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -14,7 +14,7 @@ jobs:
       - name: "Read rust version"
         id: read_toolchain
         run: echo "rust_version=$(cat rust-version)" >> $GITHUB_OUTPUT
-  
+
   build-test:
     name: Build and test
     runs-on: ubuntu-latest
@@ -27,6 +27,17 @@ jobs:
         features:
           - --no-default-features
           - --all-features
+        workspace-or-package:
+          - --workspace
+          - -p bdk_wallet
+          - -p bdk_chain
+          - -p bdk_core
+          - -p bdk_file_store
+          - -p bdk_electrum
+          - -p bdk_esplora
+          - -p bdk_bitcoind_rpc
+          - -p bdk_hwi
+          - -p bdk_testenv
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -49,9 +60,9 @@ jobs:
           cargo update -p cc --precise "1.0.105"
           cargo update -p tokio --precise "1.38.1"
       - name: Build
-        run: cargo build ${{ matrix.features }}
+        run: cargo build ${{ matrix.workspace-or-package }} ${{ matrix.features }}
       - name: Test
-        run: cargo test ${{ matrix.features }}
+        run: cargo test ${{ matrix.workspace-or-package }} ${{ matrix.features }}
 
   check-no-std:
     name: Check no_std


### PR DESCRIPTION
fixes bitcoindevkit/bdk#1944
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

I was going through the Project board and gave it a try as I'm already working with CI on `rust-esplora-client`, and it looked simple.

I was wondering if it should really be another job, I felt that adding to the matrix strategy it's simpler and clearer, let me know what you think.

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

I'm happy with either a new job or this approach (if it's sound), please let me know of any flaws with this one.

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

- Adds `--workspace` and `-p <bdk-package>` to CI `build-test` job matrix strategy, to build and test the workspace and every single BDK package. 

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

<!--

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
-->