### PR TITLE
fix(wallet): only mark change address used if `create_tx` succeeds

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: coverage-report.html

--- a/.github/workflows/nightly_docs.yml
+++ b/.github/workflows/nightly_docs.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           RUSTDOCFLAGS: '--cfg docsrs -Dwarnings'
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: built-docs
           path: ./target/doc/*
@@ -44,7 +44,7 @@ jobs:
       - name: Remove old latest
         run: rm -rf ./docs/.vuepress/public/docs-rs/bdk/nightly/latest
       - name: Download built docs
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: built-docs
           path: ./docs/.vuepress/public/docs-rs/bdk/nightly/latest


### PR DESCRIPTION
If no drain script is specified in tx params then we get it from the change keychain by looking at the next unused address. Before this PR we marked the index used regardless of whether a change output is finally added. Then if creating a psbt failed, we never restored the unused status of the change address, so creating the next tx would have revealed an extra one.

We want to mark the change address used so that other callers won't attempt to use the same address between the time we create the tx and when it appears on chain. With this PR we only mark the change address used if we successfully create a psbt and the drain script is used in the change output.

fixes bitcoindevkit/bdk#1578 

### Notes to the reviewers

An early idea was to unmark the change address used if we fail to create a tx due to `InsufficientFunds`, but after looking into it I figure it doesn't totally make sense to mark the address used before we've determined that a change output is necessary. Further, `create_tx` can fail in other ways besides running coin selection, so I moved the `mark_used` logic to the end of the function.

### Changelog notice

Fixed an issue that caused an unused internal address to be skipped when creating transactions (#1578)

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing


#### Bugfixes:

* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
