### PR TITLE
ci: add token for cron-update-rust.yml

### DIFF
--- a/.github/workflows/cron-update-rust.yml
+++ b/.github/workflows/cron-update-rust.yml
@@ -10,6 +10,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Update rust-version to use latest stable
         run: |
           set -x
@@ -30,7 +35,7 @@ jobs:
         if: env.changes_made == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           author: Update Rustc Bot <bot@example.com>
           committer: Update Rustc Bot <bot@example.com>
           branch: create-pull-request/update-rust-version

--- a/.github/workflows/cron-update-rust.yml
+++ b/.github/workflows/cron-update-rust.yml
@@ -15,6 +15,11 @@ jobs:
         with:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.APP_PRIVATE_KEY }}
+      - uses: crazy-max/ghaction-import-gpg@v5
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
       - name: Update rust-version to use latest stable
         run: |
           set -x
@@ -36,8 +41,8 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ steps.generate-token.outputs.token }}
-          author: Update Rustc Bot <bot@example.com>
-          committer: Update Rustc Bot <bot@example.com>
+          author: Github Action <github@bitcoindevkit.org>
+          committer: Github Action <github@bitcoindevkit.org>
           branch: create-pull-request/update-rust-version
           title: |
             ci: automated update to rustc ${{ env.rust_version }}


### PR DESCRIPTION
### Description

Add organization app token and GPG signing key for cron-update-rust.yml.

### Notes to the reviewers

I went with the organization github app token option mentioned here:
https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs

I added gpg commit signing with below instructions. The instructions say to use PAT for signing but the plugin doesn't mention it's needed so I want to try it with only the github app token.
https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#gpg-commit-signature-verification

