### PR TITLE
refactor!: Implement generics for `CheckPoint`, `LocalChain`, and `spk_client` types

### DIFF
--- a/crates/bitcoind_rpc/examples/filter_iter.rs
+++ b/crates/bitcoind_rpc/examples/filter_iter.rs
@@ -7,7 +7,7 @@ use bdk_chain::bitcoin::{constants::genesis_block, secp256k1::Secp256k1, Network
 use bdk_chain::indexer::keychain_txout::KeychainTxOutIndex;
 use bdk_chain::local_chain::LocalChain;
 use bdk_chain::miniscript::Descriptor;
-use bdk_chain::{BlockId, ConfirmationBlockTime, IndexedTxGraph, SpkIterator};
+use bdk_chain::{ConfirmationBlockTime, IndexedTxGraph, SpkIterator};
 use bdk_testenv::anyhow;
 
 // This example shows how BDK chain and tx-graph structures are updated using compact
@@ -29,7 +29,7 @@ fn main() -> anyhow::Result<()> {
     let secp = Secp256k1::new();
     let (descriptor, _) = Descriptor::parse_descriptor(&secp, EXTERNAL)?;
     let (change_descriptor, _) = Descriptor::parse_descriptor(&secp, INTERNAL)?;
-    let (mut chain, _) = LocalChain::from_genesis_hash(genesis_block(NETWORK).block_hash());
+    let (mut chain, _) = LocalChain::from_genesis(genesis_block(NETWORK).block_hash());
 
     let mut graph = IndexedTxGraph::<ConfirmationBlockTime, KeychainTxOutIndex<&str>>::new({
         let mut index = KeychainTxOutIndex::default();
@@ -39,11 +39,7 @@ fn main() -> anyhow::Result<()> {
     });
 
     // Assume a minimum birthday height
-    let block = BlockId {
-        height: START_HEIGHT,
-        hash: START_HASH.parse()?,
-    };
-    let _ = chain.insert_block(block)?;
+    let _ = chain.insert_block(START_HEIGHT, START_HASH.parse()?)?;
 
     // Configure RPC client
     let url = std::env::var("RPC_URL").context("must set RPC_URL")?;

--- a/crates/bitcoind_rpc/src/bip158.rs
+++ b/crates/bitcoind_rpc/src/bip158.rs
@@ -7,7 +7,8 @@
 //! [1]: https://github.com/bitcoin/bips/blob/master/bip-0158.mediawiki
 
 use bdk_core::bitcoin;
-use bdk_core::{BlockId, CheckPoint};
+use bdk_core::CheckPoint;
+use bitcoin::BlockHash;
 use bitcoin::{bip158::BlockFilter, Block, ScriptBuf};
 use bitcoincore_rpc;
 use bitcoincore_rpc::{json::GetBlockHeaderResult, RpcApi};
@@ -34,7 +35,7 @@ pub struct FilterIter<'a> {
     /// SPK inventory
     spks: Vec<ScriptBuf>,
     /// checkpoint
-    cp: CheckPoint,
+    cp: CheckPoint<BlockHash>,
     /// Header info, contains the prev and next hashes for each header.
     header: Option<GetBlockHeaderResult>,
 }
@@ -125,10 +126,7 @@ impl Iterator for FilterIter<'_> {
             next_hash = next_header.hash;
             let next_height: u32 = next_header.height.try_into()?;
 
-            cp = cp.insert(BlockId {
-                height: next_height,
-                hash: next_hash,
-            });
+            cp = cp.insert(next_height, next_hash);
 
             let mut block = None;
             let filter =

--- a/crates/bitcoind_rpc/tests/test_filter_iter.rs
+++ b/crates/bitcoind_rpc/tests/test_filter_iter.rs
@@ -1,5 +1,5 @@
 use bdk_bitcoind_rpc::bip158::{Error, FilterIter};
-use bdk_core::{BlockId, CheckPoint};
+use bdk_core::CheckPoint;
 use bdk_testenv::{anyhow, bitcoind, TestEnv};
 use bitcoin::{Address, Amount, Network, ScriptBuf};
 use bitcoincore_rpc::RpcApi;
@@ -36,10 +36,7 @@ fn filter_iter_matches_blocks() -> anyhow::Result<()> {
     let _ = env.mine_blocks(1, None);
 
     let genesis_hash = env.genesis_hash()?;
-    let cp = CheckPoint::new(BlockId {
-        height: 0,
-        hash: genesis_hash,
-    });
+    let cp = CheckPoint::new(0, genesis_hash);
 
     let iter = FilterIter::new(&env.bitcoind.client, cp, [addr.script_pubkey()]);
 
@@ -62,11 +59,7 @@ fn filter_iter_error_wrong_network() -> anyhow::Result<()> {
     let _ = env.mine_blocks(10, None)?;
 
     // Try to initialize FilterIter with a CP on the wrong network
-    let block_id = BlockId {
-        height: 0,
-        hash: bitcoin::hashes::Hash::hash(b"wrong-hash"),
-    };
-    let cp = CheckPoint::new(block_id);
+    let cp = CheckPoint::new(0, bitcoin::hashes::Hash::hash(b"wrong-hash"));
     let mut iter = FilterIter::new(&env.bitcoind.client, cp, [ScriptBuf::new()]);
     assert!(matches!(iter.next(), Some(Err(Error::ReorgDepthExceeded))));
 
@@ -85,10 +78,7 @@ fn filter_iter_detects_reorgs() -> anyhow::Result<()> {
     }
 
     let genesis_hash = env.genesis_hash()?;
-    let cp = CheckPoint::new(BlockId {
-        height: 0,
-        hash: genesis_hash,
-    });
+    let cp = CheckPoint::new(0, genesis_hash);
 
     let spk = ScriptBuf::from_hex("0014446906a6560d8ad760db3156706e72e171f3a2aa")?;
     let mut iter = FilterIter::new(&env.bitcoind.client, cp, [spk]);

--- a/crates/chain/benches/canonicalization.rs
+++ b/crates/chain/benches/canonicalization.rs
@@ -76,8 +76,12 @@ fn add_ancestor_tx(graph: &mut KeychainTxGraph, block_id: BlockId, locktime: u32
 
 fn setup<F: Fn(&mut KeychainTxGraph, &LocalChain)>(f: F) -> (KeychainTxGraph, LocalChain) {
     const DESC: &str = "tr([ab28dc00/86h/1h/0h]tpubDCdDtzAMZZrkwKBxwNcGCqe4FRydeD9rfMisoi7qLdraG79YohRfPW4YgdKQhpgASdvh612xXNY5xYzoqnyCgPbkpK4LSVcH5Xv4cK7johH/0/*)";
-    let cp = CheckPoint::from_block_ids([genesis_block_id(), tip_block_id()])
-        .expect("blocks must be chronological");
+    let cp = CheckPoint::from_blocks(
+        [genesis_block_id(), tip_block_id()]
+            .into_iter()
+            .map(|block_id| (block_id.height, block_id.hash)),
+    )
+    .expect("blocks must be chronological");
     let chain = LocalChain::from_tip(cp).unwrap();
 
     let (desc, _) =

--- a/crates/chain/benches/indexer.rs
+++ b/crates/chain/benches/indexer.rs
@@ -50,7 +50,12 @@ fn setup<F: Fn(&mut KeychainTxGraph, &LocalChain)>(f: F) -> (KeychainTxGraph, Lo
         .unwrap()
         .0;
 
-    let cp = CheckPoint::from_block_ids([genesis_block_id(), tip_block_id()]).unwrap();
+    let cp = CheckPoint::from_blocks(
+        [genesis_block_id(), tip_block_id()]
+            .into_iter()
+            .map(|block_id| (block_id.height, block_id.hash)),
+    )
+    .unwrap();
     let chain = LocalChain::from_tip(cp).unwrap();
 
     let mut index = KeychainTxOutIndex::new(LOOKAHEAD, USE_SPK_CACHE);

--- a/crates/chain/src/tx_data_traits.rs
+++ b/crates/chain/src/tx_data_traits.rs
@@ -20,8 +20,9 @@ use crate::{BlockId, ConfirmationBlockTime};
 /// # use bdk_chain::ConfirmationBlockTime;
 /// # use bdk_chain::example_utils::*;
 /// # use bitcoin::hashes::Hash;
+/// # use bitcoin::BlockHash;
 /// // Initialize the local chain with two blocks.
-/// let chain = LocalChain::from_blocks(
+/// let chain = LocalChain::<BlockHash>::from_blocks(
 ///     [
 ///         (1, Hash::hash("first".as_bytes())),
 ///         (2, Hash::hash("second".as_bytes())),

--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -1325,11 +1325,11 @@ impl<A: Anchor> TxGraph<A> {
     /// # use bdk_chain::tx_graph::TxGraph;
     /// # use bdk_chain::{local_chain::LocalChain, CanonicalizationParams, ConfirmationBlockTime};
     /// # use bdk_testenv::{hash, utils::new_tx};
-    /// # use bitcoin::{Amount, OutPoint, ScriptBuf, Transaction, TxIn, TxOut};
+    /// # use bitcoin::{Amount, BlockHash, OutPoint, ScriptBuf, Transaction, TxIn, TxOut};
     ///
     /// # let spk = ScriptBuf::from_hex("0014c692ecf13534982a9a2834565cbd37add8027140").unwrap();
     /// # let chain =
-    /// #     LocalChain::from_blocks((0..=15).map(|i| (i as u32, hash!("h"))).collect()).unwrap();
+    /// #     LocalChain::<BlockHash>::from_blocks((0..=15).map(|i| (i as u32, hash!("h"))).collect()).unwrap();
     /// # let mut graph: TxGraph = TxGraph::default();
     /// # let coinbase_tx = Transaction {
     /// #     input: vec![TxIn {

--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -24,8 +24,8 @@ use bdk_testenv::{
     TestEnv,
 };
 use bitcoin::{
-    secp256k1::Secp256k1, Address, Amount, Network, OutPoint, ScriptBuf, Transaction, TxIn, TxOut,
-    Txid,
+    secp256k1::Secp256k1, Address, Amount, BlockHash, Network, OutPoint, ScriptBuf, Transaction,
+    TxIn, TxOut, Txid,
 };
 use miniscript::Descriptor;
 
@@ -323,9 +323,10 @@ fn insert_relevant_txs() {
 #[test]
 fn test_list_owned_txouts() {
     // Create Local chains
-    let local_chain =
-        LocalChain::from_blocks((0..150).map(|i| (i as u32, hash!("random"))).collect())
-            .expect("must have genesis hash");
+    let local_chain = LocalChain::<BlockHash>::from_blocks(
+        (0..150).map(|i| (i as u32, hash!("random"))).collect(),
+    )
+    .expect("must have genesis hash");
 
     // Initiate IndexedTxGraph
 
@@ -751,9 +752,14 @@ fn test_get_chain_position() {
     });
 
     // Anchors to test
-    let blocks = vec![block_id!(0, "g"), block_id!(1, "A"), block_id!(2, "B")];
+    let blocks = [block_id!(0, "g"), block_id!(1, "A"), block_id!(2, "B")];
 
-    let cp = CheckPoint::from_block_ids(blocks.clone()).unwrap();
+    let cp = CheckPoint::from_blocks(
+        blocks
+            .iter()
+            .map(|block_id| (block_id.height, block_id.hash)),
+    )
+    .unwrap();
     let chain = LocalChain::from_tip(cp).unwrap();
 
     // The test will insert a transaction into the indexed tx graph along with any anchors and

--- a/crates/chain/tests/test_tx_graph_conflicts.rs
+++ b/crates/chain/tests/test_tx_graph_conflicts.rs
@@ -3,9 +3,9 @@
 #[macro_use]
 mod common;
 
-use bdk_chain::{Balance, BlockId};
+use bdk_chain::{local_chain::LocalChain, Balance, BlockId};
 use bdk_testenv::{block_id, hash, local_chain};
-use bitcoin::{Amount, OutPoint, ScriptBuf};
+use bitcoin::{Amount, BlockHash, OutPoint, ScriptBuf};
 use common::*;
 use std::collections::{BTreeSet, HashSet};
 
@@ -32,7 +32,7 @@ struct Scenario<'a> {
 #[test]
 fn test_tx_conflict_handling() {
     // Create Local chains
-    let local_chain = local_chain!(
+    let local_chain: LocalChain<BlockHash> = local_chain!(
         (0, hash!("A")),
         (1, hash!("B")),
         (2, hash!("C")),

--- a/crates/core/src/spk_client.rs
+++ b/crates/core/src/spk_client.rs
@@ -164,8 +164,8 @@ impl<I, D> SyncRequestBuilder<I, D> {
     ///     .build();
     ///
     /// // Sync all revealed spks in the indexer. This time, spks may be derived from different
-    /// // keychains. Each spk will be indexed with `(&'static str, u32)` where `&'static str` is
-    /// // the keychain identifier and `u32` is the derivation index.
+    /// // keychains. Each spk will be indexed with `(&str, u32)` where `&str` is the keychain
+    /// // identifier and `u32` is the derivation index.
     /// let all_revealed_spks = indexer.revealed_spks(..);
     /// let _request: SyncRequest<(&str, u32), BlockHash> = SyncRequest::builder()
     ///     .spks_with_indexes(all_revealed_spks)

--- a/crates/core/tests/test_checkpoint.rs
+++ b/crates/core/tests/test_checkpoint.rs
@@ -1,5 +1,6 @@
-use bdk_core::{BlockId, CheckPoint};
+use bdk_core::CheckPoint;
 use bdk_testenv::{block_id, hash};
+use bitcoin::BlockHash;
 
 /// Inserting a block that already exists in the checkpoint chain must always succeed.
 #[test]
@@ -14,15 +15,22 @@ fn checkpoint_insert_existing() {
     // Index `i` allows us to test with chains of different length.
     // Index `j` allows us to test inserting different block heights.
     for i in 0..blocks.len() {
-        let cp_chain = CheckPoint::from_block_ids(blocks[..=i].iter().copied())
-            .expect("must construct valid chain");
+        let cp_chain = CheckPoint::from_blocks(
+            blocks[..=i]
+                .iter()
+                .copied()
+                .map(|block_id| (block_id.height, block_id.hash)),
+        )
+        .expect("must construct valid chain");
 
         for j in 0..=i {
             let block_to_insert = cp_chain
                 .get(j as u32)
                 .expect("cp of height must exist")
                 .block_id();
-            let new_cp_chain = cp_chain.clone().insert(block_to_insert);
+            let new_cp_chain = cp_chain
+                .clone()
+                .insert(block_to_insert.height, block_to_insert.hash);
 
             assert_eq!(
                 new_cp_chain, cp_chain,
@@ -39,15 +47,11 @@ fn checkpoint_destruction_is_sound() {
     // this could have caused a stack overflow due to drop recursion in Arc.
     // We test that a long linked list can clean itself up without blowing
     // out the stack.
-    let mut cp = CheckPoint::new(BlockId {
-        height: 0,
-        hash: hash!("g"),
-    });
+    let mut cp = CheckPoint::new(0, hash!("g"));
     let end = 10_000;
     for height in 1u32..end {
-        let hash = bitcoin::hashes::Hash::hash(height.to_be_bytes().as_slice());
-        let block = BlockId { height, hash };
-        cp = cp.push(block).unwrap();
+        let hash: BlockHash = bitcoin::hashes::Hash::hash(height.to_be_bytes().as_slice());
+        cp = cp.push(height, hash).unwrap();
     }
     assert_eq!(cp.iter().count() as u32, end);
 }

--- a/crates/electrum/benches/test_sync.rs
+++ b/crates/electrum/benches/test_sync.rs
@@ -77,10 +77,7 @@ pub fn test_sync_performance(c: &mut Criterion) {
     );
 
     // Setup receiver.
-    let genesis_cp = CheckPoint::new(bdk_core::BlockId {
-        height: 0,
-        hash: env.bitcoind.client.get_block_hash(0).unwrap(),
-    });
+    let genesis_cp = CheckPoint::new(0, env.bitcoind.client.get_block_hash(0).unwrap());
 
     {
         let electrum_client =

--- a/crates/electrum/tests/test_electrum.rs
+++ b/crates/electrum/tests/test_electrum.rs
@@ -93,7 +93,7 @@ pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
     let client = BdkElectrumClient::new(electrum_client);
 
     let mut graph = IndexedTxGraph::<ConfirmationBlockTime, _>::new(SpkTxOutIndex::<()>::default());
-    let (chain, _) = LocalChain::from_genesis_hash(env.bitcoind.client.get_block_hash(0)?);
+    let (chain, _) = LocalChain::from_genesis(env.bitcoind.client.get_block_hash(0)?);
 
     // Get receiving address.
     let receiver_spk = get_test_spk();
@@ -512,7 +512,7 @@ fn test_sync() -> anyhow::Result<()> {
     let addr_to_track = Address::from_script(&spk_to_track, bdk_chain::bitcoin::Network::Regtest)?;
 
     // Setup receiver.
-    let (mut recv_chain, _) = LocalChain::from_genesis_hash(env.bitcoind.client.get_block_hash(0)?);
+    let (mut recv_chain, _) = LocalChain::from_genesis(env.bitcoind.client.get_block_hash(0)?);
     let mut recv_graph = IndexedTxGraph::<ConfirmationBlockTime, _>::new({
         let mut recv_index = SpkTxOutIndex::default();
         recv_index.insert_spk((), spk_to_track.clone());
@@ -655,7 +655,7 @@ fn tx_can_become_unconfirmed_after_reorg() -> anyhow::Result<()> {
     let addr_to_track = Address::from_script(&spk_to_track, bdk_chain::bitcoin::Network::Regtest)?;
 
     // Setup receiver.
-    let (mut recv_chain, _) = LocalChain::from_genesis_hash(env.bitcoind.client.get_block_hash(0)?);
+    let (mut recv_chain, _) = LocalChain::from_genesis(env.bitcoind.client.get_block_hash(0)?);
     let mut recv_graph = IndexedTxGraph::<ConfirmationBlockTime, _>::new({
         let mut recv_index = SpkTxOutIndex::default();
         recv_index.insert_spk((), spk_to_track.clone());
@@ -741,7 +741,7 @@ fn test_sync_with_coinbase() -> anyhow::Result<()> {
     let addr_to_track = Address::from_script(&spk_to_track, bdk_chain::bitcoin::Network::Regtest)?;
 
     // Setup receiver.
-    let (mut recv_chain, _) = LocalChain::from_genesis_hash(env.bitcoind.client.get_block_hash(0)?);
+    let (mut recv_chain, _) = LocalChain::from_genesis(env.bitcoind.client.get_block_hash(0)?);
     let mut recv_graph = IndexedTxGraph::<ConfirmationBlockTime, _>::new({
         let mut recv_index = SpkTxOutIndex::default();
         recv_index.insert_spk((), spk_to_track.clone());
@@ -776,7 +776,7 @@ fn test_check_fee_calculation() -> anyhow::Result<()> {
     let addr_to_track = Address::from_script(&spk_to_track, bdk_chain::bitcoin::Network::Regtest)?;
 
     // Setup receiver.
-    let (mut recv_chain, _) = LocalChain::from_genesis_hash(env.bitcoind.client.get_block_hash(0)?);
+    let (mut recv_chain, _) = LocalChain::from_genesis(env.bitcoind.client.get_block_hash(0)?);
     let mut recv_graph = IndexedTxGraph::<ConfirmationBlockTime, _>::new({
         let mut recv_index = SpkTxOutIndex::default();
         recv_index.insert_spk((), spk_to_track.clone());

--- a/crates/esplora/src/async_ext.rs
+++ b/crates/esplora/src/async_ext.rs
@@ -227,9 +227,9 @@ async fn fetch_block<S: Sleeper>(
 async fn chain_update<S: Sleeper>(
     client: &esplora_client::AsyncClient<S>,
     latest_blocks: &BTreeMap<u32, BlockHash>,
-    local_tip: &CheckPoint,
+    local_tip: &CheckPoint<BlockHash>,
     anchors: &BTreeSet<(ConfirmationBlockTime, Txid)>,
-) -> Result<CheckPoint, Error> {
+) -> Result<CheckPoint<BlockHash>, Error> {
     let mut point_of_agreement = None;
     let mut local_cp_hash = local_tip.hash();
     let mut conflicts = vec![];
@@ -263,7 +263,7 @@ async fn chain_update<S: Sleeper>(
     };
 
     tip = tip
-        .extend(conflicts.into_iter().rev())
+        .extend(conflicts.into_iter().rev().map(|b| (b.height, b.hash)))
         .expect("evicted are in order");
 
     for (anchor, _txid) in anchors {
@@ -273,14 +273,14 @@ async fn chain_update<S: Sleeper>(
                 Some(hash) => hash,
                 None => continue,
             };
-            tip = tip.insert(BlockId { height, hash });
+            tip = tip.insert(height, hash);
         }
     }
 
     // insert the most recent blocks at the tip to make sure we update the tip and make the update
     // robust.
     for (&height, &hash) in latest_blocks.iter() {
-        tip = tip.insert(BlockId { height, hash });
+        tip = tip.insert(height, hash);
     }
 
     Ok(tip)
@@ -590,10 +590,7 @@ mod test {
 
         let genesis_hash =
             bitcoin::constants::genesis_block(bitcoin::Network::Testnet4).block_hash();
-        let cp = bdk_chain::CheckPoint::new(BlockId {
-            height: 0,
-            hash: genesis_hash,
-        });
+        let cp = bdk_chain::CheckPoint::new(0, genesis_hash);
 
         let anchors = BTreeSet::new();
         let res = chain_update(&client, &latest_blocks, &cp, &anchors).await;
@@ -666,7 +663,7 @@ mod test {
 
             // craft initial `local_chain`
             let local_chain = {
-                let (mut chain, _) = LocalChain::from_genesis_hash(env.genesis_hash()?);
+                let (mut chain, _) = LocalChain::from_genesis(env.genesis_hash()?);
                 // force `chain_update_blocking` to add all checkpoints in `t.initial_cps`
                 let anchors = t
                     .initial_cps

--- a/crates/esplora/tests/async_ext.rs
+++ b/crates/esplora/tests/async_ext.rs
@@ -30,7 +30,7 @@ pub async fn detect_receive_tx_cancel() -> anyhow::Result<()> {
     let client = Builder::new(base_url.as_str()).build_async()?;
 
     let mut graph = IndexedTxGraph::<ConfirmationBlockTime, _>::new(SpkTxOutIndex::<()>::default());
-    let (chain, _) = LocalChain::from_genesis_hash(env.bitcoind.client.get_block_hash(0)?);
+    let (chain, _) = LocalChain::from_genesis(env.bitcoind.client.get_block_hash(0)?);
 
     // Get receiving address.
     let receiver_spk = common::get_test_spk();

--- a/crates/esplora/tests/blocking_ext.rs
+++ b/crates/esplora/tests/blocking_ext.rs
@@ -30,7 +30,7 @@ pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
     let client = Builder::new(base_url.as_str()).build_blocking();
 
     let mut graph = IndexedTxGraph::<ConfirmationBlockTime, _>::new(SpkTxOutIndex::<()>::default());
-    let (chain, _) = LocalChain::from_genesis_hash(env.bitcoind.client.get_block_hash(0)?);
+    let (chain, _) = LocalChain::from_genesis(env.bitcoind.client.get_block_hash(0)?);
 
     // Get receiving address.
     let receiver_spk = common::get_test_spk();

--- a/crates/testenv/src/lib.rs
+++ b/crates/testenv/src/lib.rs
@@ -9,7 +9,6 @@ use bdk_chain::{
         ScriptBuf, ScriptHash, Transaction, TxIn, TxOut, Txid,
     },
     local_chain::CheckPoint,
-    BlockId,
 };
 use bitcoincore_rpc::{
     bitcoincore_rpc_json::{GetBlockTemplateModes, GetBlockTemplateRules},
@@ -294,13 +293,13 @@ impl TestEnv {
     }
 
     /// Create a checkpoint linked list of all the blocks in the chain.
-    pub fn make_checkpoint_tip(&self) -> CheckPoint {
-        CheckPoint::from_block_ids((0_u32..).map_while(|height| {
+    pub fn make_checkpoint_tip(&self) -> CheckPoint<BlockHash> {
+        CheckPoint::from_blocks((0_u32..).map_while(|height| {
             self.bitcoind
                 .client
                 .get_block_hash(height as u64)
                 .ok()
-                .map(|hash| BlockId { height, hash })
+                .map(|hash| (height, hash))
         }))
         .expect("must craft tip")
     }

--- a/examples/example_cli/src/lib.rs
+++ b/examples/example_cli/src/lib.rs
@@ -826,7 +826,7 @@ pub fn init_or_load<CS: clap::Subcommand, S: clap::Args>(
 
             let chain = Mutex::new({
                 let (mut chain, _) =
-                    LocalChain::from_genesis_hash(constants::genesis_block(network).block_hash());
+                    LocalChain::from_genesis(constants::genesis_block(network).block_hash());
                 chain.apply_changeset(&changeset.local_chain)?;
                 chain
             });
@@ -896,7 +896,7 @@ where
 
         // create new
         let (_, chain_changeset) =
-            LocalChain::from_genesis_hash(constants::genesis_block(network).block_hash());
+            LocalChain::from_genesis(constants::genesis_block(network).block_hash());
         changeset.network = Some(network);
         changeset.local_chain = chain_changeset;
         let mut db = Store::<ChangeSet>::create(db_magic, db_path)?;


### PR DESCRIPTION
Implements bitcoindevkit/bdk#1937.

### Description

This PR is a step towards header checkpointing for `bdk_electrum`. The goal is to be able to store whole headers in `CheckPoint` so they do not have to be re-downloaded. Storing headers this way would be a prerequisite for caching of merkle proofs and for median time passed.

### Notes to the reviewers

### Changelog notice

* `CheckPoint` takes in a generic.
* `LocalChain` and `ChangeSet` take in generics.
* `spk_client` types can take in generics.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing