### PR TITLE
feat(core): add `TxUpdate::map_anchors`

### DIFF
--- a/crates/core/src/tx_update.rs
+++ b/crates/core/src/tx_update.rs
@@ -33,6 +33,23 @@ impl<A> Default for TxUpdate<A> {
 }
 
 impl<A: Ord> TxUpdate<A> {
+    /// Transforms the [`TxUpdate`] to have `anchors` (`A`) of another type (`A2`).
+    ///
+    /// This takes in a closure with signature `FnMut(A) -> A2` which is called for each anchor to
+    /// transform it.
+    pub fn map_anchors<A2: Ord, F: FnMut(A) -> A2>(self, mut map: F) -> TxUpdate<A2> {
+        TxUpdate {
+            txs: self.txs,
+            txouts: self.txouts,
+            anchors: self
+                .anchors
+                .into_iter()
+                .map(|(a, txid)| (map(a), txid))
+                .collect(),
+            seen_ats: self.seen_ats,
+        }
+    }
+
     /// Extend this update with `other`.
     pub fn extend(&mut self, other: TxUpdate<A>) {
         self.txs.extend(other.txs);


### PR DESCRIPTION
### Description

Just a handy method to have. Just in case the anchor type of receiving `TxGraph` does not have the same anchor type that is outputted by the chain source.

### Notes to the reviewers

Non-breaking at all.

### Changelog notice

* Added `TxUpdate::map_anchors`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
