### PR TITLE
ci: pin `tokio-util` dependency version to build with rust 1.63

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -48,6 +48,7 @@ jobs:
           cargo update -p url --precise "2.5.0"
           cargo update -p cc --precise "1.0.105"
           cargo update -p tokio --precise "1.38.1"
+          cargo update -p tokio-util --precise "0.7.11"
       - name: Build
         run: cargo build ${{ matrix.features }}
       - name: Test

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ cargo update -p proptest --precise "1.2.0"
 cargo update -p url --precise "2.5.0"
 cargo update -p cc --precise "1.0.105"
 cargo update -p tokio --precise "1.38.1"
+cargo update -p tokio-util --precise "0.7.11"
 ```
 
 ## License


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
`tokio-util` version 0.7.12 raised `msrv` to 1.70.
The previous version 0.7.11 was pinned to CI to continue working.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->
* Pinned tokio-util dependency version to build with rust 1.63.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
