### PR TITLE
Bump bdk_wallet version to 1.0.0-beta.3

### DIFF
--- a/crates/bitcoind_rpc/Cargo.toml
+++ b/crates/bitcoind_rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_bitcoind_rpc"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"
@@ -22,7 +22,7 @@ bdk_core = { path = "../core", version = "0.1", default-features = false }
 
 [dev-dependencies]
 bdk_testenv = { path = "../testenv", default-features = false }
-bdk_chain = { path = "../chain", version = "0.18" }
+bdk_chain = { path = "../chain" }
 
 [features]
 default = ["std"]

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_chain"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_core"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"

--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_electrum"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -18,7 +18,7 @@ electrum-client = { version = "0.21", features = [ "proxy" ], default-features =
 
 [dev-dependencies]
 bdk_testenv = { path = "../testenv", default-features = false }
-bdk_chain = { path = "../chain", version = "0.18.0" }
+bdk_chain = { path = "../chain" }
 
 [features]
 default = ["use-rustls"]

--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_esplora"
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -22,7 +22,7 @@ futures = { version = "0.3.26", optional = true }
 miniscript = { version = "12.0.0", optional = true, default-features = false }
 
 [dev-dependencies]
-bdk_chain = { path = "../chain", version = "0.18.0" }
+bdk_chain = { path = "../chain" }
 bdk_testenv = { path = "../testenv", default-features = false }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 

--- a/crates/file_store/Cargo.toml
+++ b/crates/file_store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_file_store"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bitcoindevkit/bdk"

--- a/crates/testenv/Cargo.toml
+++ b/crates/testenv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_testenv"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bdk_wallet"
 homepage = "https://bitcoindevkit.org"
-version = "1.0.0-beta.2"
+version = "1.0.0-beta.3"
 repository = "https://github.com/bitcoindevkit/bdk"
 documentation = "https://docs.rs/bdk"
 description = "A modern, lightweight, descriptor-based wallet library"


### PR DESCRIPTION
### Description

Bump bdk_wallet version to 1.0.0-beta.3
    
bdk_core to 0.1.1
bdk_chain to 0.18.1
bdk_bitcoind_rpc to 0.14.1
bdk_electrum to 0.17.1
bdk_esplora to 0.17.1
bdk_file_store to 0.15.1
bdk_testenv to 0.8.1

