### PR TITLE
Bump bdk_wallet version to 1.0.0-beta.4

### DIFF
--- a/crates/bitcoind_rpc/Cargo.toml
+++ b/crates/bitcoind_rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_bitcoind_rpc"
-version = "0.14.1"
+version = "0.15.0"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"
@@ -18,7 +18,7 @@ workspace = true
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false }
 bitcoincore-rpc = { version = "0.19.0" }
-bdk_core = { path = "../core", version = "0.1", default-features = false }
+bdk_core = { path = "../core", version = "0.2.0", default-features = false }
 
 [dev-dependencies]
 bdk_testenv = { path = "../testenv", default-features = false }

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_chain"
-version = "0.18.1"
+version = "0.19.0"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"
@@ -17,7 +17,7 @@ workspace = true
 
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false }
-bdk_core = { path = "../core", version = "0.1", default-features = false }
+bdk_core = { path = "../core", version = "0.2.0", default-features = false }
 serde = { version = "1", optional = true, features = ["derive", "rc"] }
 miniscript = { version = "12.0.0", optional = true, default-features = false }
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_core"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"

--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_electrum"
-version = "0.17.1"
+version = "0.18.0"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -13,7 +13,7 @@ readme = "README.md"
 workspace = true
 
 [dependencies]
-bdk_core = { path = "../core", version = "0.1" }
+bdk_core = { path = "../core", version = "0.2.0" }
 electrum-client = { version = "0.21", features = [ "proxy" ], default-features = false }
 
 [dev-dependencies]

--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_esplora"
-version = "0.17.1"
+version = "0.18.0"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -15,7 +15,7 @@ readme = "README.md"
 workspace = true
 
 [dependencies]
-bdk_core = { path = "../core", version = "0.1", default-features = false }
+bdk_core = { path = "../core", version = "0.2.0", default-features = false }
 esplora-client = { version = "0.9.0", default-features = false }
 async-trait = { version = "0.1.66", optional = true }
 futures = { version = "0.3.26", optional = true }

--- a/crates/file_store/Cargo.toml
+++ b/crates/file_store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_file_store"
-version = "0.15.1"
+version = "0.16.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -14,7 +14,7 @@ readme = "README.md"
 workspace = true
 
 [dependencies]
-bdk_chain = { path = "../chain", version = "0.18.0", features = [ "serde", "miniscript" ] }
+bdk_chain = { path = "../chain", version = "0.19.0", features = [ "serde", "miniscript" ] }
 bincode = { version = "1" }
 serde = { version = "1", features = ["derive"] }
 

--- a/crates/testenv/Cargo.toml
+++ b/crates/testenv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_testenv"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"
@@ -16,7 +16,7 @@ readme = "README.md"
 workspace = true
 
 [dependencies]
-bdk_chain = { path = "../chain", version = "0.18", default-features = false }
+bdk_chain = { path = "../chain", version = "0.19.0", default-features = false }
 electrsd = { version = "0.28.0", features = [ "bitcoind_25_0", "esplora_a33e97e1", "legacy" ] }
 
 [features]

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bdk_wallet"
 homepage = "https://bitcoindevkit.org"
-version = "1.0.0-beta.3"
+version = "1.0.0-beta.4"
 repository = "https://github.com/bitcoindevkit/bdk"
 documentation = "https://docs.rs/bdk"
 description = "A modern, lightweight, descriptor-based wallet library"
@@ -21,8 +21,8 @@ miniscript = { version = "12.0.0", features = [ "serde" ], default-features = fa
 bitcoin = { version = "0.32.0", features = [ "serde", "base64" ], default-features = false }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
-bdk_chain = { path = "../chain", version = "0.18.0", features = [ "miniscript", "serde" ], default-features = false }
-bdk_file_store = { path = "../file_store", version = "0.15.0", optional = true }
+bdk_chain = { path = "../chain", version = "0.19.0", features = [ "miniscript", "serde" ], default-features = false }
+bdk_file_store = { path = "../file_store", version = "0.16.0", optional = true }
 
 # Optional dependencies
 bip39 = { version = "2.0", optional = true }


### PR DESCRIPTION
Bump bdk_wallet version to 1.0.0-beta.4

bdk_core to 0.2.0
bdk_chain to 0.19.0
bdk_bitcoind_rpc to 0.15.0
bdk_electrum to 0.18.0
bdk_esplora to 0.18.0
bdk_file_store to 0.16.0
bdk_testenv to 0.9.0

