### PR TITLE
fix(bdk_esplora, bdk_electrum): build and test with `--no-default-features`

### DIFF
--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -24,3 +24,8 @@ bdk_chain = { path = "../chain" }
 default = ["use-rustls"]
 use-rustls = ["electrum-client/use-rustls"]
 use-rustls-ring = ["electrum-client/use-rustls-ring"]
+
+[[test]]
+name = "use-rustls"
+path = "tests/test_electrum.rs"
+required-features = ["use-rustls"]

--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -26,6 +26,5 @@ use-rustls = ["electrum-client/use-rustls"]
 use-rustls-ring = ["electrum-client/use-rustls-ring"]
 
 [[test]]
-name = "use-rustls"
-path = "tests/test_electrum.rs"
+name = "test_electrum"
 required-features = ["use-rustls"]

--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -39,11 +39,9 @@ blocking-https-rustls = ["blocking", "esplora-client/blocking-https-rustls"]
 blocking-https-native = ["blocking", "esplora-client/blocking-https-native"]
 
 [[test]]
-name = "blocking"
-path = "tests/blocking_ext.rs"
+name = "blocking_ext"
 required-features = ["blocking"]
 
 [[test]]
-name = "async"
-path = "tests/async_ext.rs"
+name = "async_ext"
 required-features = ["async"]

--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -27,10 +27,23 @@ bdk_testenv = { path = "../testenv", default-features = false }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 
 [features]
-default = ["std", "async-https", "blocking-https-rustls"]
+default = ["std", "async-https", "blocking-https"]
 std = ["bdk_chain/std", "miniscript?/std"]
 async = ["async-trait", "futures", "esplora-client/async"]
 async-https = ["async", "esplora-client/async-https"]
 async-https-rustls = ["async", "esplora-client/async-https-rustls"]
+async-https-native = ["async", "esplora-client/async-https-native"]
 blocking = ["esplora-client/blocking"]
-blocking-https-rustls = ["esplora-client/blocking-https-rustls"]
+blocking-https = ["blocking", "esplora-client/blocking-https"]
+blocking-https-rustls = ["blocking", "esplora-client/blocking-https-rustls"]
+blocking-https-native = ["blocking", "esplora-client/blocking-https-native"]
+
+[[test]]
+name = "blocking"
+path = "tests/blocking_ext.rs"
+required-features = ["blocking"]
+
+[[test]]
+name = "async"
+path = "tests/async_ext.rs"
+required-features = ["async"]

--- a/crates/esplora/README.md
+++ b/crates/esplora/README.md
@@ -26,8 +26,11 @@ bdk_esplora = { version = "0.3", features = ["async-https"] }
 To use the extension traits:
 ```rust
 // for blocking
+#[cfg(feature = "blocking")]
 use bdk_esplora::EsploraExt;
+
 // for async
+#[cfg(feature = "async")]
 use bdk_esplora::EsploraAsyncExt;
 ```
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

It was noticed in #1603 that both `bdk_esplora` and `bdk_electrum` were not able to build and test successfully when `--no-default-features` was passed.

It wasn't noticed in CI, because the `example-crates` are in the same workspace as the main crates, therefore even though when passing `--no-default-features`, the examples were making the `blocking` feature to `bdk_esplora` and `use-rustls` to `bdk_electrum` available, therefore not failing in the tests.

This PR attempts to fix that, and is now used as base for #1603.

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

- Add `blocking-https` as default feature to `bdk_esplora`, and make `{async|blocking}-https-native available too.
- Add tests behind features for both `bdk_esplora` and `bdk_electrum`.

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
