### PR TITLE
feat(wallet)!: enable RBF by default on TxBuilder

### DIFF
--- a/crates/wallet/README.md
+++ b/crates/wallet/README.md
@@ -174,7 +174,6 @@ println!("Your new receive address is: {}", receive_address.address);
 <!--         let mut builder = wallet.build_tx(); -->
 <!--         builder -->
 <!--             .add_recipient(send_to.script_pubkey(), 50_000) -->
-<!--             .enable_rbf() -->
 <!--             .do_not_spend_change() -->
 <!--             .fee_rate(FeeRate::from_sat_per_vb(5.0)); -->
 <!--         builder.finish()? -->

--- a/crates/wallet/src/wallet/error.rs
+++ b/crates/wallet/src/wallet/error.rs
@@ -65,12 +65,10 @@ pub enum CreateTxError {
         /// Required `LockTime`
         required: absolute::LockTime,
     },
-    /// Cannot enable RBF with a `Sequence` >= 0xFFFFFFFE
-    RbfSequence,
     /// Cannot enable RBF with `Sequence` given a required OP_CSV
     RbfSequenceCsv {
         /// Given RBF `Sequence`
-        rbf: Sequence,
+        sequence: Sequence,
         /// Required OP_CSV `Sequence`
         csv: Sequence,
     },
@@ -131,14 +129,11 @@ impl fmt::Display for CreateTxError {
             } => {
                 write!(f, "TxBuilder requested timelock of `{:?}`, but at least `{:?}` is required to spend from this script", required, requested)
             }
-            CreateTxError::RbfSequence => {
-                write!(f, "Cannot enable RBF with a nSequence >= 0xFFFFFFFE")
-            }
-            CreateTxError::RbfSequenceCsv { rbf, csv } => {
+            CreateTxError::RbfSequenceCsv { sequence, csv } => {
                 write!(
                     f,
                     "Cannot enable RBF with nSequence `{:?}` given a required OP_CSV of `{:?}`",
-                    rbf, csv
+                    sequence, csv
                 )
             }
             CreateTxError::FeeTooLow { required } => {

--- a/crates/wallet/src/wallet/utils.rs
+++ b/crates/wallet/src/wallet/utils.rs
@@ -52,20 +52,20 @@ impl After {
     }
 }
 
-pub(crate) fn check_nsequence_rbf(rbf: Sequence, csv: Sequence) -> bool {
-    // The RBF value must enable relative timelocks
-    if !rbf.is_relative_lock_time() {
+pub(crate) fn check_nsequence_rbf(sequence: Sequence, csv: Sequence) -> bool {
+    // The nSequence value must enable relative timelocks
+    if !sequence.is_relative_lock_time() {
         return false;
     }
 
     // Both values should be represented in the same unit (either time-based or
     // block-height based)
-    if rbf.is_time_locked() != csv.is_time_locked() {
+    if sequence.is_time_locked() != csv.is_time_locked() {
         return false;
     }
 
     // The value should be at least `csv`
-    if rbf < csv {
+    if sequence < csv {
         return false;
     }
 

--- a/example-crates/example_wallet_electrum/src/main.rs
+++ b/example-crates/example_wallet_electrum/src/main.rs
@@ -82,9 +82,7 @@ fn main() -> Result<(), anyhow::Error> {
     }
 
     let mut tx_builder = wallet.build_tx();
-    tx_builder
-        .add_recipient(address.script_pubkey(), SEND_AMOUNT)
-        .enable_rbf();
+    tx_builder.add_recipient(address.script_pubkey(), SEND_AMOUNT);
 
     let mut psbt = tx_builder.finish()?;
     let finalized = wallet.sign(&mut psbt, SignOptions::default())?;

--- a/example-crates/example_wallet_esplora_async/src/main.rs
+++ b/example-crates/example_wallet_esplora_async/src/main.rs
@@ -77,9 +77,7 @@ async fn main() -> Result<(), anyhow::Error> {
     }
 
     let mut tx_builder = wallet.build_tx();
-    tx_builder
-        .add_recipient(address.script_pubkey(), SEND_AMOUNT)
-        .enable_rbf();
+    tx_builder.add_recipient(address.script_pubkey(), SEND_AMOUNT);
 
     let mut psbt = tx_builder.finish()?;
     let finalized = wallet.sign(&mut psbt, SignOptions::default())?;

--- a/example-crates/example_wallet_esplora_blocking/src/main.rs
+++ b/example-crates/example_wallet_esplora_blocking/src/main.rs
@@ -77,9 +77,7 @@ fn main() -> Result<(), anyhow::Error> {
     }
 
     let mut tx_builder = wallet.build_tx();
-    tx_builder
-        .add_recipient(address.script_pubkey(), SEND_AMOUNT)
-        .enable_rbf();
+    tx_builder.add_recipient(address.script_pubkey(), SEND_AMOUNT);
 
     let mut psbt = tx_builder.finish()?;
     let finalized = wallet.sign(&mut psbt, SignOptions::default())?;


### PR DESCRIPTION
### Description

Closes #791 

This PR enables RBF by default on `TxBuilder`

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice
- On TxParams, `rbf` becomes `sequence`
- Added `set_exact_sequence()`, so the user can define an arbitrary sequence value
- `n_sequence` now defaults to `0xFFFFFFFD` 
- Adjusted tests accordingly

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [x] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
