### PR TITLE
feat(bdk_electrum): add `use-openssl` as a feature

### DIFF
--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -24,6 +24,7 @@ bdk_chain = { path = "../chain" }
 default = ["use-rustls"]
 use-rustls = ["electrum-client/use-rustls"]
 use-rustls-ring = ["electrum-client/use-rustls-ring"]
+use-openssl = ["electrum-client/use-openssl"]
 
 [[test]]
 name = "test_electrum"


### PR DESCRIPTION
partially addresses #1598

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

It's a simple PR to expose the `use-openssl` from `electrum-client` to `bdk_electrum`. It partially addresses #1598, allowing the user to use `openssl` as an alternative to `rustls`, as there are some problems with it when handling some types of TLS certificates.

Do we need to add some sort of `bdk_electrum` tests using the new exposed `use-openssl` feature ?

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

- Adds `use-openssl` as feature to `bdk_electrum`, exposing `electrum-client` `use-openssl` feature.

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
