### PR TITLE
DEMO: Depend on a new psbt-v0 crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ authors = ["Bitcoin Dev Kit Developers"]
 [workspace.lints.clippy]
 print_stdout = "deny"
 print_stderr = "deny"
+
+[patch.crates-io.miniscript]
+path = "/home/tobin/build/github.com/tcharding/rust-miniscript/master"

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -23,13 +23,14 @@ serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 bdk_chain = { path = "../chain", version = "0.19.0", features = [ "miniscript", "serde" ], default-features = false }
 bdk_file_store = { path = "../file_store", version = "0.16.0", optional = true }
+psbt-v0 = { path = "/home/tobin/build/github.com/tcharding/rust-psbt-v0/master", version = "0.1.0", features = ["miniscript"], default-features = false }
 
 # Optional dependencies
 bip39 = { version = "2.0", optional = true }
 
 [features]
 default = ["std"]
-std = ["bitcoin/std", "bitcoin/rand-std", "miniscript/std", "bdk_chain/std"]
+std = ["bitcoin/std", "bitcoin/rand-std", "miniscript/std", "bdk_chain/std", "psbt-v0/std"]
 compiler = ["miniscript/compiler"]
 all-keys = ["keys-bip39"]
 keys-bip39 = ["bip39"]

--- a/crates/wallet/src/descriptor/mod.rs
+++ b/crates/wallet/src/descriptor/mod.rs
@@ -20,7 +20,7 @@ use alloc::vec::Vec;
 
 use bitcoin::bip32::{ChildNumber, DerivationPath, Fingerprint, KeySource, Xpub};
 use bitcoin::{key::XOnlyPublicKey, secp256k1, PublicKey};
-use bitcoin::{psbt, taproot};
+use bitcoin::taproot;
 use bitcoin::{Network, TxOut};
 
 use miniscript::descriptor::{
@@ -55,18 +55,12 @@ pub type ExtendedDescriptor = Descriptor<DescriptorPublicKey>;
 /// Alias for a [`Descriptor`] that contains extended **derived** keys
 pub type DerivedDescriptor = Descriptor<DefiniteDescriptorKey>;
 
-/// Alias for the type of maps that represent derivation paths in a [`psbt::Input`] or
-/// [`psbt::Output`]
-///
-/// [`psbt::Input`]: bitcoin::psbt::Input
-/// [`psbt::Output`]: bitcoin::psbt::Output
+/// Alias for the type of maps that represent derivation paths in a [`psbt_v0::Input`] or
+/// [`psbt_v0::Output`]
 pub type HdKeyPaths = BTreeMap<secp256k1::PublicKey, KeySource>;
 
-/// Alias for the type of maps that represent taproot key origins in a [`psbt::Input`] or
-/// [`psbt::Output`]
-///
-/// [`psbt::Input`]: bitcoin::psbt::Input
-/// [`psbt::Output`]: bitcoin::psbt::Output
+/// Alias for the type of maps that represent taproot key origins in a [`psbt_v0::Input`] or
+/// [`psbt_v0::Output`]
 pub type TapKeyOrigins = BTreeMap<XOnlyPublicKey, (Vec<taproot::TapLeafHash>, KeySource)>;
 
 /// Trait for types which can be converted into an [`ExtendedDescriptor`] and a [`KeyMap`] usable by a wallet in a specific [`Network`]
@@ -399,7 +393,7 @@ pub(crate) trait DescriptorMeta {
     ) -> Option<DerivedDescriptor>;
     fn derive_from_psbt_input(
         &self,
-        psbt_input: &psbt::Input,
+        psbt_input: &psbt_v0::Input,
         utxo: Option<TxOut>,
         secp: &SecpCtx,
     ) -> Option<DerivedDescriptor>;
@@ -553,7 +547,7 @@ impl DescriptorMeta for ExtendedDescriptor {
 
     fn derive_from_psbt_input(
         &self,
-        psbt_input: &psbt::Input,
+        psbt_input: &psbt_v0::Input,
         utxo: Option<TxOut>,
         secp: &SecpCtx,
     ) -> Option<DerivedDescriptor> {
@@ -610,7 +604,8 @@ mod test {
     use assert_matches::assert_matches;
     use bitcoin::hex::FromHex;
     use bitcoin::secp256k1::Secp256k1;
-    use bitcoin::{bip32, Psbt};
+    use bitcoin::bip32;
+    use psbt_v0::Psbt;
     use bitcoin::{NetworkKind, ScriptBuf};
 
     use super::*;
@@ -890,7 +885,7 @@ mod test {
 
     #[test]
     fn test_sh_wsh_sortedmulti_redeemscript() {
-        use miniscript::psbt::PsbtInputExt;
+        use psbt_v0::miniscript::PsbtInputExt;
 
         let secp = Secp256k1::new();
 
@@ -904,7 +899,7 @@ mod test {
 
         let script = ScriptBuf::from_hex("5321022f533b667e2ea3b36e21961c9fe9dca340fbe0af5210173a83ae0337ab20a57621026bb53a98e810bd0ee61a0ed1164ba6c024786d76554e793e202dc6ce9c78c4ea2102d5b8a7d66a41ffdb6f4c53d61994022e886b4f45001fb158b95c9164d45f8ca3210324b75eead2c1f9c60e8adeb5e7009fec7a29afcdb30d829d82d09562fe8bae8521032d34f8932200833487bd294aa219dcbe000b9f9b3d824799541430009f0fa55121037468f8ea99b6c64788398b5ad25480cad08f4b0d65be54ce3a55fd206b5ae4722103f72d3d96663b0ea99b0aeb0d7f273cab11a8de37885f1dddc8d9112adb87169357ae").unwrap();
 
-        let mut psbt_input = psbt::Input::default();
+        let mut psbt_input = psbt_v0::Input::default();
         psbt_input
             .update_with_descriptor_unchecked(&descriptor)
             .unwrap();

--- a/crates/wallet/src/descriptor/policy.rs
+++ b/crates/wallet/src/descriptor/policy.rs
@@ -67,8 +67,8 @@ use crate::wallet::utils::{After, Older, SecpCtx};
 use super::checksum::calc_checksum;
 use super::error::Error;
 use super::XKeyUtils;
-use bitcoin::psbt::{self, Psbt};
-use miniscript::psbt::PsbtInputSatisfier;
+use psbt_v0::Psbt;
+use psbt_v0::miniscript::PsbtInputSatisfier;
 
 /// A unique identifier for a key
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
@@ -785,9 +785,9 @@ fn make_generic_signature<M: Fn() -> SatisfiableItem, F: Fn(&Psbt) -> bool>(
 fn generic_sig_in_psbt<
     // C is for "check", it's a closure we use to *check* if a psbt input contains the signature
     // for a specific key
-    C: Fn(&psbt::Input, &SinglePubKey) -> bool,
+    C: Fn(&psbt_v0::Input, &SinglePubKey) -> bool,
     // E is for "extract", it extracts a key from the bip32 derivations found in the psbt input
-    E: Fn(&psbt::Input, Fingerprint) -> Option<SinglePubKey>,
+    E: Fn(&psbt_v0::Input, Fingerprint) -> Option<SinglePubKey>,
 >(
     psbt: &Psbt,
     key: &DescriptorPublicKey,

--- a/crates/wallet/src/psbt/mod.rs
+++ b/crates/wallet/src/psbt/mod.rs
@@ -14,7 +14,7 @@
 use alloc::vec::Vec;
 use bitcoin::Amount;
 use bitcoin::FeeRate;
-use bitcoin::Psbt;
+use psbt_v0::Psbt;
 use bitcoin::TxOut;
 
 // TODO upstream the functions here to `rust-bitcoin`?

--- a/crates/wallet/src/types.rs
+++ b/crates/wallet/src/types.rs
@@ -14,7 +14,7 @@ use core::convert::AsRef;
 
 use bdk_chain::ConfirmationTime;
 use bitcoin::transaction::{OutPoint, Sequence, TxOut};
-use bitcoin::{psbt, Weight};
+use bitcoin::Weight;
 
 use serde::{Deserialize, Serialize};
 
@@ -90,7 +90,7 @@ pub enum Utxo {
         sequence: Option<Sequence>,
         /// The information about the input we require to add it to a PSBT.
         // Box it to stop the type being too big.
-        psbt_input: Box<psbt::Input>,
+        psbt_input: Box<psbt_v0::Input>,
     },
 }
 

--- a/crates/wallet/src/wallet/error.rs
+++ b/crates/wallet/src/wallet/error.rs
@@ -16,7 +16,7 @@ use crate::descriptor::DescriptorError;
 use crate::wallet::coin_selection;
 use crate::{descriptor, KeychainKind};
 use alloc::string::String;
-use bitcoin::{absolute, psbt, Amount, OutPoint, Sequence, Txid};
+use bitcoin::{absolute, Amount, OutPoint, Sequence, Txid};
 use core::fmt;
 
 /// Errors returned by miniscript when updating inconsistent PSBTs
@@ -25,9 +25,9 @@ pub enum MiniscriptPsbtError {
     /// Descriptor key conversion error
     Conversion(miniscript::descriptor::ConversionError),
     /// Return error type for PsbtExt::update_input_with_descriptor
-    UtxoUpdate(miniscript::psbt::UtxoUpdateError),
+    UtxoUpdate(psbt_v0::miniscript::UtxoUpdateError),
     /// Return error type for PsbtExt::update_output_with_descriptor
-    OutputUpdate(miniscript::psbt::OutputUpdateError),
+    OutputUpdate(psbt_v0::miniscript::OutputUpdateError),
 }
 
 impl fmt::Display for MiniscriptPsbtError {
@@ -93,7 +93,7 @@ pub enum CreateTxError {
     /// Cannot build a tx without recipients
     NoRecipients,
     /// Partially signed bitcoin transaction error
-    Psbt(psbt::Error),
+    Psbt(psbt_v0::Error),
     /// In order to use the [`TxBuilder::add_global_xpubs`] option every extended
     /// key in the descriptor must either be a master key itself (having depth = 0) or have an
     /// explicit origin provided
@@ -198,8 +198,8 @@ impl From<MiniscriptPsbtError> for CreateTxError {
     }
 }
 
-impl From<psbt::Error> for CreateTxError {
-    fn from(err: psbt::Error) -> Self {
+impl From<psbt_v0::Error> for CreateTxError {
+    fn from(err: psbt_v0::Error) -> Self {
         CreateTxError::Psbt(err)
     }
 }

--- a/crates/wallet/src/wallet/tx_builder.rs
+++ b/crates/wallet/src/wallet/tx_builder.rs
@@ -44,7 +44,7 @@ use core::fmt;
 
 use alloc::sync::Arc;
 
-use bitcoin::psbt::{self, Psbt};
+use psbt_v0::Psbt;
 use bitcoin::script::PushBytes;
 use bitcoin::{
     absolute, Amount, FeeRate, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid,
@@ -131,7 +131,7 @@ pub(crate) struct TxParams {
     pub(crate) utxos: Vec<WeightedUtxo>,
     pub(crate) unspendable: HashSet<OutPoint>,
     pub(crate) manually_selected_only: bool,
-    pub(crate) sighash: Option<psbt::PsbtSighashType>,
+    pub(crate) sighash: Option<psbt_v0::PsbtSighashType>,
     pub(crate) ordering: TxOrdering,
     pub(crate) locktime: Option<absolute::LockTime>,
     pub(crate) rbf: Option<RbfValue>,
@@ -368,7 +368,7 @@ impl<'a, Cs> TxBuilder<'a, Cs> {
     pub fn add_foreign_utxo(
         &mut self,
         outpoint: OutPoint,
-        psbt_input: psbt::Input,
+        psbt_input: psbt_v0::Input,
         satisfaction_weight: Weight,
     ) -> Result<&mut Self, AddForeignUtxoError> {
         self.add_foreign_utxo_with_sequence(
@@ -383,7 +383,7 @@ impl<'a, Cs> TxBuilder<'a, Cs> {
     pub fn add_foreign_utxo_with_sequence(
         &mut self,
         outpoint: OutPoint,
-        psbt_input: psbt::Input,
+        psbt_input: psbt_v0::Input,
         satisfaction_weight: Weight,
         sequence: Sequence,
     ) -> Result<&mut Self, AddForeignUtxoError> {
@@ -450,7 +450,7 @@ impl<'a, Cs> TxBuilder<'a, Cs> {
     /// Sign with a specific sig hash
     ///
     /// **Use this option very carefully**
-    pub fn sighash(&mut self, sighash: psbt::PsbtSighashType) -> &mut Self {
+    pub fn sighash(&mut self, sighash: psbt_v0::PsbtSighashType) -> &mut Self {
         self.params.sighash = Some(sighash);
         self
     }
@@ -506,7 +506,7 @@ impl<'a, Cs> TxBuilder<'a, Cs> {
         self
     }
 
-    /// Only Fill-in the [`psbt::Input::witness_utxo`](bitcoin::psbt::Input::witness_utxo) field when spending from
+    /// Only Fill-in the [`psbt_v0::Input::witness_utxo`](bitcoin::psbt_v0::Input::witness_utxo) field when spending from
     /// SegWit descriptors.
     ///
     /// This reduces the size of the PSBT, but some signers might reject them due to the lack of
@@ -516,8 +516,8 @@ impl<'a, Cs> TxBuilder<'a, Cs> {
         self
     }
 
-    /// Fill-in the [`psbt::Output::redeem_script`](bitcoin::psbt::Output::redeem_script) and
-    /// [`psbt::Output::witness_script`](bitcoin::psbt::Output::witness_script) fields.
+    /// Fill-in the [`psbt_v0::Output::redeem_script`](bitcoin::psbt_v0::Output::redeem_script) and
+    /// [`psbt_v0::Output::witness_script`](bitcoin::psbt_v0::Output::witness_script) fields.
     ///
     /// This is useful for signers which always require it, like ColdCard hardware wallets.
     pub fn include_output_redeem_witness_script(&mut self) -> &mut Self {

--- a/crates/wallet/tests/psbt.rs
+++ b/crates/wallet/tests/psbt.rs
@@ -1,5 +1,6 @@
-use bdk_wallet::bitcoin::{Amount, FeeRate, Psbt, TxIn};
+use bdk_wallet::bitcoin::{Amount, FeeRate, TxIn};
 use bdk_wallet::{psbt, KeychainKind, SignOptions};
+use psbt_v0::Psbt;
 use core::str::FromStr;
 mod common;
 use common::*;

--- a/crates/wallet/tests/wallet.rs
+++ b/crates/wallet/tests/wallet.rs
@@ -18,7 +18,6 @@ use bdk_wallet::{KeychainKind, LoadError, LoadMismatch, LoadWithPersistError};
 use bitcoin::constants::ChainHash;
 use bitcoin::hashes::Hash;
 use bitcoin::key::Secp256k1;
-use bitcoin::psbt;
 use bitcoin::script::PushBytesBuf;
 use bitcoin::sighash::{EcdsaSighashType, TapSighashType};
 use bitcoin::taproot::TapNodeHash;
@@ -1528,7 +1527,7 @@ fn test_add_foreign_utxo() {
         .max_weight_to_satisfy()
         .unwrap();
 
-    let psbt_input = psbt::Input {
+    let psbt_input = psbt_v0::Input {
         witness_utxo: Some(utxo.txout.clone()),
         ..Default::default()
     };
@@ -1604,7 +1603,7 @@ fn test_calculate_fee_with_missing_foreign_utxo() {
         .max_weight_to_satisfy()
         .unwrap();
 
-    let psbt_input = psbt::Input {
+    let psbt_input = psbt_v0::Input {
         witness_utxo: Some(utxo.txout.clone()),
         ..Default::default()
     };
@@ -1631,7 +1630,7 @@ fn test_add_foreign_utxo_invalid_psbt_input() {
 
     let mut builder = wallet.build_tx();
     let result =
-        builder.add_foreign_utxo(outpoint, psbt::Input::default(), foreign_utxo_satisfaction);
+        builder.add_foreign_utxo(outpoint, psbt_v0::Input::default(), foreign_utxo_satisfaction);
     assert!(matches!(result, Err(AddForeignUtxoError::MissingUtxo)));
 }
 
@@ -1655,7 +1654,7 @@ fn test_add_foreign_utxo_where_outpoint_doesnt_match_psbt_input() {
         builder
             .add_foreign_utxo(
                 utxo2.outpoint,
-                psbt::Input {
+                psbt_v0::Input {
                     non_witness_utxo: Some(tx1.as_ref().clone()),
                     ..Default::default()
                 },
@@ -1668,7 +1667,7 @@ fn test_add_foreign_utxo_where_outpoint_doesnt_match_psbt_input() {
         builder
             .add_foreign_utxo(
                 utxo2.outpoint,
-                psbt::Input {
+                psbt_v0::Input {
                     non_witness_utxo: Some(tx2.as_ref().clone()),
                     ..Default::default()
                 },
@@ -1699,7 +1698,7 @@ fn test_add_foreign_utxo_only_witness_utxo() {
 
     {
         let mut builder = builder.clone();
-        let psbt_input = psbt::Input {
+        let psbt_input = psbt_v0::Input {
             witness_utxo: Some(utxo2.txout.clone()),
             ..Default::default()
         };
@@ -1714,7 +1713,7 @@ fn test_add_foreign_utxo_only_witness_utxo() {
 
     {
         let mut builder = builder.clone();
-        let psbt_input = psbt::Input {
+        let psbt_input = psbt_v0::Input {
             witness_utxo: Some(utxo2.txout.clone()),
             ..Default::default()
         };
@@ -1731,7 +1730,7 @@ fn test_add_foreign_utxo_only_witness_utxo() {
     {
         let mut builder = builder.clone();
         let tx2 = wallet2.get_tx(txid2).unwrap().tx_node.tx;
-        let psbt_input = psbt::Input {
+        let psbt_input = psbt_v0::Input {
             non_witness_utxo: Some(tx2.as_ref().clone()),
             ..Default::default()
         };
@@ -2864,7 +2863,7 @@ fn test_signing_only_one_of_multiple_inputs() {
     let mut psbt = builder.finish().unwrap();
 
     // add another input to the psbt that is at least passable.
-    let dud_input = bitcoin::psbt::Input {
+    let dud_input = psbt_v0::Input {
         witness_utxo: Some(TxOut {
             value: Amount::from_sat(100_000),
             script_pubkey: miniscript::Descriptor::<bitcoin::PublicKey>::from_str(

--- a/example-crates/example_cli/Cargo.toml
+++ b/example-crates/example_cli/Cargo.toml
@@ -10,6 +10,7 @@ bdk_chain = { path = "../../crates/chain", features = ["serde", "miniscript"]}
 bdk_coin_select = "0.3.0"
 bdk_file_store = { path = "../../crates/file_store" }
 bitcoin = { version = "0.32.0", features = ["base64"], default-features = false }
+psbt-v0 = { path = "/home/tobin/build/github.com/tcharding/rust-psbt-v0/master", version = "0.1.0", features = ["miniscript", "base64"], default-features = false }
 
 anyhow = "1"
 clap = { version = "3.2.23", features = ["derive", "env"] }

--- a/example-crates/example_cli/src/lib.rs
+++ b/example-crates/example_cli/src/lib.rs
@@ -10,13 +10,12 @@ use anyhow::bail;
 use anyhow::Context;
 use bdk_chain::bitcoin::{
     absolute, address::NetworkUnchecked, bip32, consensus, constants, hex::DisplayHex, relative,
-    secp256k1::Secp256k1, transaction, Address, Amount, Network, NetworkKind, PrivateKey, Psbt,
+    secp256k1::Secp256k1, transaction, Address, Amount, Network, NetworkKind, PrivateKey,
     PublicKey, Sequence, Transaction, TxIn, TxOut,
 };
 use bdk_chain::miniscript::{
     descriptor::{DescriptorSecretKey, SinglePubKey},
     plan::{Assets, Plan},
-    psbt::PsbtExt,
     Descriptor, DescriptorPublicKey,
 };
 use bdk_chain::ConfirmationBlockTime;
@@ -33,6 +32,7 @@ use bdk_coin_select::{
 use bdk_file_store::Store;
 use clap::{Parser, Subcommand};
 use rand::prelude::*;
+use psbt_v0::{Psbt, miniscript::PsbtExt};
 
 pub use anyhow;
 pub use clap;
@@ -402,7 +402,7 @@ where
     let mut psbt = Psbt::from_unsigned_tx(unsigned_tx)?;
     for (i, (plan, utxo)) in selected.iter().enumerate() {
         let psbt_input = &mut psbt.inputs[i];
-        plan.update_psbt_input(psbt_input);
+        psbt_v0::miniscript::plan::update_psbt_input(&plan, psbt_input);
         psbt_input.witness_utxo = Some(utxo.txout.clone());
     }
 


### PR DESCRIPTION
EDIT: Please see simpler idea posted below before bothering to read this.

**TL;DR What if we created a`psbt` crate in the `github.com/rust-bitcoin` org?**

This is just an idea, raising a PR to see if you guys would likely get behind it and/or involved.

This PR shows the diff required to make it work. The diff is on purpose verbose, it could be made much smaller. I did it like this as a demo to make sure I got everything.

I've hacked up a new `psbt-v0` crate with the goals of:

- Create crate directly from `rust-bitcoin v0.32.2` and `rust-miniscript 12.0.0` with minimal changes so it can be diff'ed an verified.
- Be a drop in replacement for the `psbt` modules in `bitcoin` and `miniscript`.

This hopes to enable the following:

- Make development on PSBT separate from development on `rust-bitcoin`
- Get a different set of maintainers involved
- Make development of PSBT crate more rapid, more fun, and more productive

My claim is that PSBT has different stakeholders to other code in `bitcoin` and `miniscript` and the fact that it lives in these two crates (specifically `bitcoin`) makes it harder to attract devs and harder to patch than necessary.

github: https://github.com/tcharding/rust-psbt-v0

Potential Roadmap:

`v0.1.0` would be the drop in replacement with minimal changes. Next we could potentially do:

- Re-write signing API
- Implement PSBTv2
- Re-write the whole thing with what we've learned over the last few years


### notes on testing

If you want to prove this works you'll need something like
- https://github.com/tcharding/rust-psbt-v0/pull/6
- https://github.com/rust-bitcoin/rust-miniscript/pull/750