### PR TITLE
fix!(wallet): `ChangeSet` should not be non-exhaustive

### DIFF
--- a/crates/wallet/src/wallet/changeset.rs
+++ b/crates/wallet/src/wallet/changeset.rs
@@ -8,7 +8,6 @@ type IndexedTxGraphChangeSet =
 
 /// A changeset for [`Wallet`](crate::Wallet).
 #[derive(Default, Debug, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
-#[non_exhaustive]
 pub struct ChangeSet {
     /// Descriptor for recipient addresses.
     pub descriptor: Option<Descriptor<DescriptorPublicKey>>,


### PR DESCRIPTION
Closes #1591 

### Description

As stated in #1591, it is handy to know when new values are added to `ChangeSet`.

### Notes to the reviewers

~

### Changelog notice

* Remove `#[non_exhaustive]` attribute from `wallet::ChangeSet`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
