### PR TITLE
deps(esplora): bump esplora-client to 0.10.0

### DIFF
--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 
 [dependencies]
 bdk_core = { path = "../core", version = "0.2.0", default-features = false }
-esplora-client = { version = "0.9.0", default-features = false }
+esplora-client = { version = "0.10.0", default-features = false }
 async-trait = { version = "0.1.66", optional = true }
 futures = { version = "0.3.26", optional = true }
 miniscript = { version = "12.0.0", optional = true, default-features = false }


### PR DESCRIPTION
Bumps rust-esplora-client to 0.10.0

also fixes #1120

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
