### PR TITLE
Recover file store previous state at open

### DIFF
--- a/crates/file_store/src/lib.rs
+++ b/crates/file_store/src/lib.rs
@@ -40,3 +40,51 @@ impl From<io::Error> for FileError {
 }
 
 impl std::error::Error for FileError {}
+
+/// An error while opening or creating the file store
+#[derive(Debug)]
+pub enum StoreError {
+    /// Entry iter error
+    EntryIter {
+        /// Index that caused the error
+        index: usize,
+        /// Iter error
+        iter: IterError,
+        /// Amount of bytes read so far
+        bytes_read: u64,
+    },
+    /// IO error, this may mean that the file is too short.
+    Io(io::Error),
+    /// Magic bytes do not match what is expected.
+    InvalidMagicBytes { got: Vec<u8>, expected: Vec<u8> },
+}
+
+impl core::fmt::Display for StoreError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::EntryIter {
+                index,
+                iter,
+                bytes_read,
+            } => write!(
+                f,
+                "{}: changeset index={}, bytes read={}",
+                iter, index, bytes_read
+            ),
+            Self::Io(e) => write!(f, "io error trying to read file: {}", e),
+            Self::InvalidMagicBytes { got, expected } => write!(
+                f,
+                "file has invalid magic bytes: expected={:?} got={:?}",
+                expected, got,
+            ),
+        }
+    }
+}
+
+impl std::error::Error for StoreError {}
+
+impl From<io::Error> for StoreError {
+    fn from(value: io::Error) -> Self {
+        Self::Io(value)
+    }
+}


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

The `Store::open` method doesn't recovers the previous `Store` state saved in the file and emplaces the file pointer just after the magic bytes prefix, this later is agravated by `Store::append_changeset` which sets the file pointer after the last written changeset. The combination of both causes the lost of any previous changeset there may have been in the file.

Is natural to think this shouldn't be the expected behavior, as @KnowWhoami pointed out in #1517, and the `Store` should recover the previous changesets stored in the file store.

To avoid producing breaking changes the expected logic has been implemented in a new `Store::reopen` method, which opens the file, iterates the changesets and returns a new `Store` with the file pointer correctly placed at the end of the already existing changesets. As this method checks the integrity of the stored changesets while iterating them, if any error is found, the method will return a `StoreError::EntryIter` error with the index of the offending changeset, the error caused by it and the number of bytes read when the error happened.

The `StoreError` is a new error enum including the following variants:
- `EntryIter`: any error related to the decoding of the changesets of the file.
- `Io`: errors related with file management internals.
- `InvalidMagicBytes`: error caused by mismatching with the expected magic bytes.
  
`StoreError::Io` and `StoreError::InvalidMagicBytes` are the same than `FileError::Io` and `FileError::InvalidMagicBytes`.  My idea is to propose `StoreError` as a replacement of `FileError` in the future. It has been implemented in this way to avoid the addition of extra nested variants at the moment of matching the error. 

Fixes #1517.

### Notes to the reviewers

I have committed the changes as `feat` and not `fix` because, although this PR fixes #1517, the changes do not imply a change in the current `Store` methods, but the addition of new one and a new `Error` enum.

### Changelog notice

- New `Store::reopen` method in `file_store`.
- New `StoreError` enum in `file_store`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
