### PR TITLE
fix(wallet): build with no default features

### DIFF
--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 
 [dependencies]
 rand_core = { version = "0.6.0" }
-miniscript = { version = "12.0.0", features = [ "serde" ], default-features = false }
+miniscript = { version = "12.0.0", features = [ "serde", "no-std" ], default-features = false }
 bitcoin = { version = "0.32.0", features = [ "serde", "base64" ], default-features = false }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }

--- a/crates/wallet/src/descriptor/policy.rs
+++ b/crates/wallet/src/descriptor/policy.rs
@@ -446,7 +446,7 @@ pub struct Policy {
 
 /// An extra condition that must be satisfied but that is out of control of the user
 /// TODO: use `bitcoin::LockTime` and `bitcoin::Sequence`
-#[derive(Hash, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Default, Serialize)]
+#[derive(Hash, Clone, Copy, Debug, PartialEq, Eq, Default, Serialize)]
 pub struct Condition {
     /// Optional CheckSequenceVerify condition
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -454,6 +454,18 @@ pub struct Condition {
     /// Optional timelock condition
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timelock: Option<absolute::LockTime>,
+}
+
+impl PartialOrd for Condition {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Condition {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.partial_cmp(other).expect("Sequence is Ord")
+    }
 }
 
 impl Condition {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
Candidate for fixing an issue preventing `bdk_wallet` to build with no default features.

Something to do with #1625 changed the way `bdk_wallet` resolves its dependency on rust-miniscript. Running `cargo build -p bdk_wallet --no-default-features` from the workspace root returns

> error: at least one of the `std` or `no-std` features must be enabled

I started by adding the "no-std" feature to the miniscript dependency in Cargo.toml which caused compilation to fail again because `Condition` is not `Ord` so I added that here but there might be an alternative solution I haven't thought of.

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
