### PR TITLE
ci: fix build-test job with --no-default-features, add miniscript/no-std

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -25,7 +25,7 @@ jobs:
             clippy: true
           - version: 1.63.0 # MSRV
         features:
-          - --no-default-features
+          - --no-default-features --features miniscript/no-std
           - --all-features
     steps:
       - name: checkout


### PR DESCRIPTION
### Description

Fixes the CI `build-test` job with `--no-default-features` by also adding `--features miniscript/no-std`.

Until `rust-miniscript` removes the `no-std` feature we need to enable it when `--no-default-features` is used to build `bdk_wallet` or the whole workspace. See also the `check-no-std` job which does the same plus enables the `bdk_chain/hashbrown` feature which is also needed to build `bdk_wallet` with `--no-default-features` but is already enabled when building the whole workspace.

### Notes to the reviewers

I think we didn't catch this on bitcoindevkit/bdk#1625 because the CI job names changed and I didn't update the branch merge requirements. Another possibility is it was passing because of cached build artifacts which I removed last night when I was trying to troubleshoot something else. I've updated the required CI jobs that need to pass before allowing a PR to be merged to `master` to include the ones with `--no-default-features --features bdk_chain/hashbrown` in the name.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing
