### PR TITLE
feat(chain,wallet)!: rm `ConfirmationTime`

### DIFF
--- a/crates/wallet/src/types.rs
+++ b/crates/wallet/src/types.rs
@@ -10,9 +10,9 @@
 // licenses.
 
 use alloc::boxed::Box;
+use chain::{ChainPosition, ConfirmationBlockTime};
 use core::convert::AsRef;
 
-use bdk_chain::ConfirmationTime;
 use bitcoin::transaction::{OutPoint, Sequence, TxOut};
 use bitcoin::{psbt, Weight};
 
@@ -61,8 +61,8 @@ pub struct LocalOutput {
     pub is_spent: bool,
     /// The derivation index for the script pubkey in the wallet
     pub derivation_index: u32,
-    /// The confirmation time for transaction containing this utxo
-    pub confirmation_time: ConfirmationTime,
+    /// The position of the output in the blockchain.
+    pub chain_position: ChainPosition<ConfirmationBlockTime>,
 }
 
 /// A [`Utxo`] with its `satisfaction_weight`.

--- a/crates/wallet/src/wallet/tx_builder.rs
+++ b/crates/wallet/src/wallet/tx_builder.rs
@@ -858,7 +858,6 @@ mod test {
         };
     }
 
-    use bdk_chain::ConfirmationTime;
     use bitcoin::consensus::deserialize;
     use bitcoin::hex::FromHex;
     use bitcoin::TxOut;
@@ -1018,7 +1017,7 @@ mod test {
                 txout: TxOut::NULL,
                 keychain: KeychainKind::External,
                 is_spent: false,
-                confirmation_time: ConfirmationTime::Unconfirmed { last_seen: 0 },
+                chain_position: chain::ChainPosition::Unconfirmed(0),
                 derivation_index: 0,
             },
             LocalOutput {
@@ -1029,10 +1028,13 @@ mod test {
                 txout: TxOut::NULL,
                 keychain: KeychainKind::Internal,
                 is_spent: false,
-                confirmation_time: ConfirmationTime::Confirmed {
-                    height: 32,
-                    time: 42,
-                },
+                chain_position: chain::ChainPosition::Confirmed(chain::ConfirmationBlockTime {
+                    block_id: chain::BlockId {
+                        height: 32,
+                        hash: bitcoin::BlockHash::all_zeros(),
+                    },
+                    confirmation_time: 42,
+                }),
                 derivation_index: 1,
             },
         ]


### PR DESCRIPTION
### Description

This PR removes `ConfirmationTime`, and favors `ChainPosition<ConfirmationBlockTime>` instead. The only difference between these two structures is that `ChainPosition<ConfirmationBlockTime>` contains an additional `BlockHash`. Additionally, `ConfirmationTime` was not used in many places. It was mainly for displaying information in `bdk_wallet::Wallet`.

We also impl `serde::Deserialize` and `serde::Serialize` for `ChainPosition`.

### Notes to the reviewers



### Changelog notice

* Remove `bdk_chain::ConfirmationTime`. Use `ChainPosition<ConfirmationBlockTime>` in place.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
