### PR TITLE
Inserting transactions in the `Wallet` should always include a `last_seen`.

### DIFF
--- a/crates/wallet/src/types.rs
+++ b/crates/wallet/src/types.rs
@@ -10,9 +10,9 @@
 // licenses.
 
 use alloc::boxed::Box;
+use chain::{ChainPosition, ConfirmationBlockTime};
 use core::convert::AsRef;
 
-use bdk_chain::ConfirmationTime;
 use bitcoin::transaction::{OutPoint, Sequence, TxOut};
 use bitcoin::{psbt, Weight};
 
@@ -61,8 +61,8 @@ pub struct LocalOutput {
     pub is_spent: bool,
     /// The derivation index for the script pubkey in the wallet
     pub derivation_index: u32,
-    /// The confirmation time for transaction containing this utxo
-    pub confirmation_time: ConfirmationTime,
+    /// The position of the output in the blockchain.
+    pub chain_position: ChainPosition<ConfirmationBlockTime>,
 }
 
 /// A [`Utxo`] with its `satisfaction_weight`.

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -2311,10 +2311,10 @@ impl Wallet {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("time now must surpass epoch anchor");
-        self.apply_update_at(update, Some(now.as_secs()))
+        self.apply_update_at(update, now.as_secs())
     }
 
-    /// Applies an `update` alongside an optional `seen_at` timestamp and stages the changes.
+    /// Applies an `update` alongside a `seen_at` timestamp and stages the changes.
     ///
     /// `seen_at` represents when the update is seen (in unix seconds). It is used to determine the
     /// `last_seen`s for all transactions in the update which have no corresponding anchor(s). The
@@ -2322,15 +2322,12 @@ impl Wallet {
     /// transactions (where the transaction with the lower `last_seen` value is omitted from the
     /// canonical history).
     ///
-    /// Not setting a `seen_at` value means unconfirmed transactions introduced by this update will
-    /// not be part of the canonical history of transactions.
-    ///
     /// Use [`apply_update`](Wallet::apply_update) to have the `seen_at` value automatically set to
     /// the current time.
     pub fn apply_update_at(
         &mut self,
         update: impl Into<Update>,
-        seen_at: Option<u64>,
+        seen_at: u64,
     ) -> Result<(), CannotConnectError> {
         let update = update.into();
         let mut changeset = match update.chain {
@@ -2345,7 +2342,7 @@ impl Wallet {
         changeset.merge(index_changeset.into());
         changeset.merge(
             self.indexed_graph
-                .apply_update_at(update.tx_update, seen_at)
+                .apply_update_at(update.tx_update, Some(seen_at))
                 .into(),
         );
         self.stage.merge(changeset);

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -33,7 +33,7 @@ use bdk_chain::{
         FullScanRequest, FullScanRequestBuilder, FullScanResult, SyncRequest, SyncRequestBuilder,
         SyncResult,
     },
-    tx_graph::{CanonicalTx, TxGraph, TxNode, TxUpdate},
+    tx_graph::{CanonicalTx, TxGraph, TxUpdate},
     BlockId, ChainPosition, ConfirmationBlockTime, DescriptorExt, FullTxOut, Indexed,
     IndexedTxGraph, Merge,
 };
@@ -2378,14 +2378,6 @@ impl Wallet {
     /// Get a reference to the inner [`TxGraph`].
     pub fn tx_graph(&self) -> &TxGraph<ConfirmationBlockTime> {
         self.indexed_graph.graph()
-    }
-
-    /// Iterate over transactions in the wallet that are unseen and unanchored likely
-    /// because they haven't been broadcast.
-    pub fn unbroadcast_transactions(
-        &self,
-    ) -> impl Iterator<Item = TxNode<'_, Arc<Transaction>, ConfirmationBlockTime>> {
-        self.tx_graph().txs_with_no_anchor_or_last_seen()
     }
 
     /// Get a reference to the inner [`KeychainTxOutIndex`].

--- a/crates/wallet/src/wallet/tx_builder.rs
+++ b/crates/wallet/src/wallet/tx_builder.rs
@@ -858,7 +858,6 @@ mod test {
         };
     }
 
-    use bdk_chain::ConfirmationTime;
     use bitcoin::consensus::deserialize;
     use bitcoin::hex::FromHex;
     use bitcoin::TxOut;
@@ -1018,7 +1017,7 @@ mod test {
                 txout: TxOut::NULL,
                 keychain: KeychainKind::External,
                 is_spent: false,
-                confirmation_time: ConfirmationTime::Unconfirmed { last_seen: 0 },
+                chain_position: chain::ChainPosition::Unconfirmed(0),
                 derivation_index: 0,
             },
             LocalOutput {
@@ -1029,10 +1028,13 @@ mod test {
                 txout: TxOut::NULL,
                 keychain: KeychainKind::Internal,
                 is_spent: false,
-                confirmation_time: ConfirmationTime::Confirmed {
-                    height: 32,
-                    time: 42,
-                },
+                chain_position: chain::ChainPosition::Confirmed(chain::ConfirmationBlockTime {
+                    block_id: chain::BlockId {
+                        height: 32,
+                        hash: bitcoin::BlockHash::all_zeros(),
+                    },
+                    confirmation_time: 42,
+                }),
                 derivation_index: 1,
             },
         ]

--- a/crates/wallet/tests/wallet.rs
+++ b/crates/wallet/tests/wallet.rs
@@ -4200,48 +4200,6 @@ fn test_thread_safety() {
 }
 
 #[test]
-fn test_insert_tx_balance_and_utxos() {
-    // creating many txs has no effect on the wallet's available utxos
-    let (mut wallet, _) = get_funded_wallet(get_test_tr_single_sig_xprv());
-    let addr = Address::from_str("bcrt1qc6fweuf4xjvz4x3gx3t9e0fh4hvqyu2qw4wvxm")
-        .unwrap()
-        .assume_checked();
-
-    let unspent: Vec<_> = wallet.list_unspent().collect();
-    assert!(!unspent.is_empty());
-
-    let balance = wallet.balance().total();
-    let fee = Amount::from_sat(143);
-    let amt = balance - fee;
-
-    for _ in 0..3 {
-        let mut builder = wallet.build_tx();
-        builder.add_recipient(addr.script_pubkey(), amt);
-        let mut psbt = builder.finish().unwrap();
-        assert!(wallet.sign(&mut psbt, SignOptions::default()).unwrap());
-        let tx = psbt.extract_tx().unwrap();
-        let _ = wallet.insert_tx(tx);
-    }
-    assert_eq!(wallet.list_unspent().collect::<Vec<_>>(), unspent);
-    assert_eq!(wallet.balance().confirmed, balance);
-
-    // manually setting a tx last_seen will consume the wallet's available utxos
-    let addr = Address::from_str("bcrt1qfjg5lv3dvc9az8patec8fjddrs4aqtauadnagr")
-        .unwrap()
-        .assume_checked();
-    let mut builder = wallet.build_tx();
-    builder.add_recipient(addr.script_pubkey(), amt);
-    let mut psbt = builder.finish().unwrap();
-    assert!(wallet.sign(&mut psbt, SignOptions::default()).unwrap());
-    let tx = psbt.extract_tx().unwrap();
-    let txid = tx.compute_txid();
-    let _ = wallet.insert_tx(tx);
-    insert_seen_at(&mut wallet, txid, 2);
-    assert!(wallet.list_unspent().next().is_none());
-    assert_eq!(wallet.balance().total().to_sat(), 0);
-}
-
-#[test]
 fn single_descriptor_wallet_can_create_tx_and_receive_change() {
     // create single descriptor wallet and fund it
     let mut wallet = Wallet::create_single(get_test_tr_single_sig_xprv())


### PR DESCRIPTION
Partially fixes #1642

### Description

As mentioned in #1642, `Wallet::insert_tx` has some confusing behavior. Callers typically expect that anything inserted into the wallet will not be replaced, and transaction inserted later will have precedence (in the case when we have conflicting txs).

This PR modifies the behavior of `Wallet::insert_tx` to always add the current unix timestamp as the `last_seen`-in-mempool value alongside the transaction being inserted. Since this is now a `std`-only method, we also introduce a `Wallet::insert_tx_at` where the `last_seen` timestamp is provided by the caller. We expect callers to only insert txs into the wallet after a successful broadcast. The documentation is updated to reflect this. `Wallet::unbroadcast_transactions` is removed since callers are not expected to store unbroadcasted transactions in wallet anymore.

In addition, the `seen_at` input is made mandatory for `Wallet::apply_update_at`. Without this, callers may end up replacing unconfirmed txs when building txs.

### Notes to the reviewers

I don't think this is the perfect solution because a failed broadcast may be due to a network issue. In this case, the caller may need to persist the transaction external to wallet.

### Changelog notice

* Change `Wallet::insert_tx` to always insert the tx alongside a `last_seen`-in-mempool timestamp (using the current timestamp).
* Add `Wallet::insert_tx_at`, which is a version og `insert_tx` where the user can explicitly set the `last_seen` timestamp.
* Change `Wallet::apply_update_at` to always expect a `last_seen` value (not have it wrapped in `Option`).
* Remove `Wallet::unbroadcast_transactions`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [x] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
