### PR TITLE
release/0.29, deps: Update `rusqlite` to 0.31

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -63,6 +63,9 @@ jobs:
           cargo update -p home --precise "0.5.5"
           cargo update -p regex --precise "1.7.3"
           cargo update -p security-framework-sys --precise "2.11.1"
+          cargo update -p url --precise "2.5.0"
+          cargo update -p rustls@0.23.18 --precise "0.23.17"
+          cargo update -p hashbrown@0.15.1 --precise "0.15.0"
       - name: Build
         run: cargo build --features bitcoin/std,miniscript/std,${{ matrix.features }} --no-default-features
       - name: Clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rand = "^0.8"
 sled = { version = "0.34", optional = true }
 electrum-client = { version = "0.18", optional = true }
 esplora-client = { version = "0.6", default-features = false, optional = true }
-rusqlite = { version = "0.27.0", optional = true }
+rusqlite = { version = "0.31.0", optional = true }
 futures = { version = "0.3", optional = true }
 async-trait = { version = "0.1", optional = true }
 rocksdb = { version = "0.18", default-features = false, features = ["snappy"], optional = true }
@@ -130,7 +130,7 @@ path = "examples/policy.rs"
 [[example]]
 name = "rpcwallet"
 path = "examples/rpcwallet.rs"
-required-features = ["keys-bip39", "key-value-db", "rpc", "electrsd/bitcoind_23_0"]
+required-features = ["keys-bip39", "key-value-db", "rpc", "electrsd/bitcoind_22_0"]
 
 [[example]]
 name = "psbt_signer"

--- a/README.md
+++ b/README.md
@@ -214,4 +214,7 @@ cargo update -p tokio-util --precise "0.7.11"
 cargo update -p home --precise "0.5.5"
 cargo update -p regex --precise "1.7.3"
 cargo update -p security-framework-sys --precise "2.11.1"
+cargo update -p url --precise "2.5.0"
+cargo update -p rustls@0.23.18 --precise "0.23.17"
+cargo update -p hashbrown@0.15.1 --precise "0.15.0"
 ```


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Builds on v0.29.0, the PR updates `rusqlite` dependency to 0.31.

The idea is that it will help facilitate the wallet migration process outlined in #1648

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

