### PR TITLE
refactor(chain)!: remove `inner` method from KeychainTxOutIndex

### DIFF
--- a/crates/chain/src/indexer/keychain_txout.rs
+++ b/crates/chain/src/indexer/keychain_txout.rs
@@ -204,14 +204,6 @@ impl<K> KeychainTxOutIndex<K> {
 
 /// Methods that are *re-exposed* from the internal [`SpkTxOutIndex`].
 impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
-    /// Return a reference to the internal [`SpkTxOutIndex`].
-    ///
-    /// **WARNING**: The internal index will contain lookahead spks. Refer to
-    /// [struct-level docs](KeychainTxOutIndex) for more about `lookahead`.
-    pub fn inner(&self) -> &SpkTxOutIndex<(K, u32)> {
-        &self.inner
-    }
-
     /// Get the set of indexed outpoints, corresponding to tracked keychains.
     pub fn outpoints(&self) -> &BTreeSet<KeychainIndexed<K, OutPoint>> {
         self.inner.outpoints()


### PR DESCRIPTION
Fix #1353 by removing the `inner` method from `keychain_txout` module. See commit message for details.

### Changelog notice

- `bdk_chain`: Removed method `KeychainTxOutIndex::inner`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [x] This pull request breaks the existing API
* [x] I'm linking the issue being fixed by this PR
