### PR TITLE
Draft: Better canonial history construction.

### DIFF
--- a/crates/bitcoind_rpc/tests/test_emitter.rs
+++ b/crates/bitcoind_rpc/tests/test_emitter.rs
@@ -5,7 +5,7 @@ use bdk_chain::{
     bitcoin::{Address, Amount, Txid},
     local_chain::{CheckPoint, LocalChain},
     spk_txout::SpkTxOutIndex,
-    Balance, BlockId, IndexedTxGraph, Merge,
+    Balance, BlockId, IndexedTxGraph, LastSeenPrioritizer, Merge,
 };
 use bdk_testenv::{anyhow, TestEnv};
 use bitcoin::{hashes::Hash, Block, OutPoint, ScriptBuf, WScriptHash};
@@ -308,7 +308,8 @@ fn get_balance(
     let outpoints = recv_graph.index.outpoints().clone();
     let balance = recv_graph
         .graph()
-        .balance(recv_chain, chain_tip, outpoints, |_, _| true);
+        .canonical_view(recv_chain, chain_tip, &LastSeenPrioritizer)
+        .balance(outpoints, |_, _| true);
     Ok(balance)
 }
 

--- a/crates/chain/src/canonical_view.rs
+++ b/crates/chain/src/canonical_view.rs
@@ -1,0 +1,511 @@
+use core::{convert::Infallible, fmt::Debug};
+
+use crate::{
+    alloc::{collections::VecDeque, vec::Vec},
+    collections::{HashMap, HashSet},
+    tx_graph::{TxDescendants, TxNode},
+    Anchor, Balance, ChainOracle, TxGraph, UnconfirmedOracle, COINBASE_MATURITY,
+};
+use alloc::sync::Arc;
+use bdk_core::BlockId;
+use bitcoin::{Amount, OutPoint, Script, Transaction, TxOut, Txid};
+
+/// A transaction that is part of the [`CanonicalView`].
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CanonicalTx<A, U> {
+    /// The position of the transaction in the [`CanonicalView`].
+    pub pos: CanonicalPos<A, U>,
+    /// The txid.
+    pub txid: Txid,
+    /// The transaction.
+    pub tx: Arc<Transaction>,
+}
+
+/// A transaction output that is part of the [`CanonicalView`].
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
+pub struct CanonicalTxOut<A, U, I> {
+    /// The position of the txout's residing transaction in the [`CanonicalView`].
+    pub pos: CanonicalPos<A, U>,
+    /// The index of the script pubkey of this txout.
+    pub spk_index: I,
+    /// The outpoint.
+    pub outpoint: OutPoint,
+    /// The txout.
+    pub txout: TxOut,
+    /// The canonical transaction spending this txout (if any).
+    pub spent_by: Option<Txid>,
+    /// Whether this output resides in a coinbase transaction.
+    pub is_on_coinbase: bool,
+}
+
+impl<A, U, I> CanonicalTxOut<A, U, I> {
+    /// Whether txout belongs in a confirmed transaction.
+    pub fn is_confirmed(&self) -> bool {
+        match self.pos {
+            CanonicalPos::Confirmed(_) => true,
+            CanonicalPos::Unconfirmed(_) => false,
+        }
+    }
+}
+
+impl<A: Anchor, U, I> CanonicalTxOut<A, U, I> {
+    /// Whether the `txout` is considered mature.
+    ///
+    /// Depending on the implementation of [`confirmation_height_upper_bound`] in [`Anchor`], this
+    /// method may return false-negatives. In other words, interpreted confirmation count may be
+    /// less than the actual value.
+    ///
+    /// [`confirmation_height_upper_bound`]: Anchor::confirmation_height_upper_bound
+    pub fn is_mature(&self, tip_height: u32) -> bool {
+        if self.is_on_coinbase {
+            let tx_height = match &self.pos {
+                CanonicalPos::Confirmed(anchor) => anchor.confirmation_height_upper_bound(),
+                CanonicalPos::Unconfirmed(_) => {
+                    debug_assert!(false, "coinbase tx can never be unconfirmed");
+                    return false;
+                }
+            };
+            let age = tip_height.saturating_sub(tx_height);
+            if age + 1 < COINBASE_MATURITY {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+/// A consistent view of transactions.
+///
+/// Function:
+/// * Return ordered history of transactions.
+/// * Quickly query whether a txid is in the canonical history and it's position.
+#[derive(Debug, Clone)]
+pub struct CanonicalView<A, U> {
+    pub(crate) tip: BlockId,
+    pub(crate) txs: HashMap<Txid, (CanonicalPos<A, U>, Arc<Transaction>)>,
+    pub(crate) ordered_txids: Vec<Txid>,
+    pub(crate) spends: HashMap<OutPoint, Txid>,
+}
+
+/// The position of the transaction in a [`CanonicalView`].
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Deserialize, serde::Serialize),
+    serde(bound(
+        deserialize = "A: serde::Deserialize<'de>, U: serde::Deserialize<'de>",
+        serialize = "A: serde::Serialize, U: serde::Serialize"
+    ))
+)]
+pub enum CanonicalPos<A, U> {
+    /// Confirmed with anchor `A`.
+    Confirmed(A),
+    /// Unconfirmed, positioned with `U`.
+    Unconfirmed(U),
+}
+
+impl<A, U> CanonicalPos<A, U> {
+    /// Whether the [`CanonicalPos`] is a confirmed position.
+    pub fn is_confirmed(&self) -> bool {
+        matches!(self, Self::Confirmed(_))
+    }
+
+    /// Get the upper bound of the chain data's confirmation height.
+    ///
+    /// Refer to [`Anchor::confirmation_height_upper_bound`].
+    pub fn confirmation_height_upper_bound(&self) -> Option<u32>
+    where
+        A: Anchor,
+    {
+        match self {
+            CanonicalPos::Confirmed(anchor) => Some(anchor.confirmation_height_upper_bound()),
+            CanonicalPos::Unconfirmed(_) => None,
+        }
+    }
+}
+
+impl<A: Anchor, U: Ord + Clone> CanonicalView<A, U> {
+    /// Yoo
+    pub fn new<CO: ChainOracle, UO: UnconfirmedOracle<UnconfirmedPos = U>>(
+        chain_oracle: &CO,
+        chain_tip: BlockId,
+        unconf_oracle: &UO,
+        tx_graph: &TxGraph<A>,
+    ) -> Result<Self, CanonicalError<CO::Error, UO::Error>> {
+        // Each outpoint represents a set of conflicting edges.
+        let mut next_ops = VecDeque::<OutPoint>::new();
+        let mut visited_ops = HashSet::<OutPoint>::new();
+        let mut included = HashMap::<Txid, (CanonicalPos<A, U>, Arc<Transaction>)>::new();
+        let mut included_in_order = Vec::<Txid>::new();
+        let mut excluded = HashSet::<Txid>::new();
+
+        fn insert_canon_tx<A, U>(
+            tx_node: &TxNode<Arc<Transaction>, A>,
+            canonical_pos: CanonicalPos<A, U>,
+            included: &mut HashMap<Txid, (CanonicalPos<A, U>, Arc<Transaction>)>,
+            included_in_order: &mut Vec<Txid>,
+            next_ops: &mut VecDeque<OutPoint>,
+        ) -> bool {
+            let is_new = included
+                .insert(tx_node.txid, (canonical_pos, tx_node.tx.clone()))
+                .is_none();
+            if is_new {
+                included_in_order.push(tx_node.txid);
+                next_ops.extend(
+                    (0..tx_node.output.len() as u32).map(|vout| OutPoint::new(tx_node.txid, vout)),
+                );
+            }
+            is_new
+        }
+
+        for tx_node in tx_graph.coinbase_txs() {
+            for anchor in tx_node.anchors {
+                let is_canon = chain_oracle
+                    .is_block_in_chain(anchor.anchor_block(), chain_tip)
+                    .map_err(CanonicalError::ChainOracle)?;
+                if is_canon == Some(true)
+                    && insert_canon_tx(
+                        &tx_node,
+                        CanonicalPos::Confirmed(anchor.clone()),
+                        &mut included,
+                        &mut included_in_order,
+                        &mut next_ops,
+                    )
+                {
+                    break;
+                }
+            }
+        }
+        next_ops.extend(tx_graph.root_outpoints());
+
+        //println!("[START: CREATE CANONICAL VIEW]");
+        while let Some(op) = next_ops.pop_front() {
+            if !visited_ops.insert(op) || excluded.contains(&op.txid) {
+                continue;
+            }
+            //println!("ITERATION: {}", op);
+
+            let conflicts = tx_graph
+                .outspends(op)
+                .iter()
+                .copied()
+                .filter(|txid| !excluded.contains(txid))
+                .collect::<Vec<Txid>>();
+
+            let mut conflicts_iter = conflicts.iter();
+            let mut canon_txid: Option<Txid> = 'find_canon_txid: loop {
+                let txid = match conflicts_iter.next() {
+                    Some(&txid) => txid,
+                    None => break None,
+                };
+                if let Some((CanonicalPos::Confirmed(_), _)) = included.get(&txid) {
+                    break Some(txid);
+                }
+                if let Some(tx_node) = tx_graph.get_tx_node(txid) {
+                    for anchor in tx_node.anchors {
+                        let is_canon = chain_oracle
+                            .is_block_in_chain(anchor.anchor_block(), chain_tip)
+                            .map_err(CanonicalError::ChainOracle)?;
+                        if is_canon == Some(true) {
+                            assert!(
+                                insert_canon_tx(
+                                    &tx_node,
+                                    CanonicalPos::Confirmed(anchor.clone()),
+                                    &mut included,
+                                    &mut included_in_order,
+                                    &mut next_ops,
+                                ),
+                                "we just checked that tx is not already canonical with anchor"
+                            );
+                            break 'find_canon_txid Some(txid);
+                        }
+                    }
+                }
+            };
+            if canon_txid.is_none() {
+                if let Some((unconf_pos, txid)) = unconf_oracle
+                    .pick_canonical(tx_graph, conflicts.clone())
+                    .map_err(CanonicalError::UnconfirmedOracle)?
+                {
+                    if let Some(tx_node) = tx_graph.get_tx_node(txid) {
+                        insert_canon_tx(
+                            &tx_node,
+                            CanonicalPos::Unconfirmed(unconf_pos),
+                            &mut included,
+                            &mut included_in_order,
+                            &mut next_ops,
+                        );
+                        //println!("\t FOUND UNCONFIRMED CANON: {}", txid);
+                        canon_txid = Some(txid);
+                    };
+                }
+            }
+
+            let _n = TxDescendants::from_multiple_include_root(
+                tx_graph,
+                conflicts
+                    .into_iter()
+                    .filter(|&txid| Some(txid) != canon_txid),
+                |_: usize, txid| {
+                    if excluded.insert(txid) {
+                        //println!("\t EXCLUDED: {}", txid);
+                        Some(())
+                    } else {
+                        None
+                    }
+                },
+            )
+            .count();
+        }
+
+        // remove excluded elements and sort.
+        included_in_order.retain(|txid| !excluded.contains(txid));
+        included.retain(|txid, _| !excluded.contains(txid));
+        let spends = included
+            .iter()
+            .flat_map(|(txid, (_, tx))| tx.input.iter().map(|txin| (txin.previous_output, *txid)))
+            .collect();
+        Ok(Self {
+            tip: chain_tip,
+            txs: included,
+            ordered_txids: included_in_order,
+            spends,
+        })
+    }
+
+    /// Whether this view has no transactions.
+    pub fn is_empty(&self) -> bool {
+        self.txs.is_empty()
+    }
+
+    /// Returns the number of transactions in the view.
+    pub fn len(&self) -> usize {
+        self.txs.len()
+    }
+
+    /// Get the canonical transaction of txid.
+    pub fn tx(&self, txid: Txid) -> Option<CanonicalTx<A, U>> {
+        get_tx(&self.txs, txid)
+    }
+
+    /// Get the canonical output of the given outpoint.
+    pub fn txout<I>(
+        &self,
+        outpoint: OutPoint,
+        index_from_outpoint: impl Fn(OutPoint) -> Option<I>,
+    ) -> Option<CanonicalTxOut<A, U, I>> {
+        let spk_i = index_from_outpoint(outpoint)?;
+        self.filter_txouts(core::iter::once((spk_i, outpoint)))
+            .next()
+    }
+
+    /// Get the canonical unspent output of the given outpoint.
+    pub fn unspent<I>(
+        &self,
+        outpoint: OutPoint,
+        index_from_outpoint: impl Fn(OutPoint) -> Option<I>,
+    ) -> Option<CanonicalTxOut<A, U, I>> {
+        let spk_i = index_from_outpoint(outpoint)?;
+        self.filter_unspents(core::iter::once((spk_i, outpoint)))
+            .next()
+    }
+
+    /// Get spend for given output (if any).
+    pub fn spend(&self, outpoint: OutPoint) -> Option<Txid> {
+        self.spends.get(&outpoint).copied()
+    }
+
+    /// Get spend for given output (if any), alongside the spending tx's canoncial position.
+    pub fn spend_with_pos(&self, outpoint: OutPoint) -> Option<(CanonicalPos<A, U>, Txid)> {
+        let spend_txid = self.spends.get(&outpoint).copied()?;
+        let spend_pos = self.tx(spend_txid).expect("must exist").pos;
+        Some((spend_pos, spend_txid))
+    }
+
+    /// Sort the canonical txs by key.
+    pub fn sort_txs_by_key<K, F>(&mut self, mut f: F)
+    where
+        F: FnMut(&Txid, &CanonicalPos<A, U>) -> K,
+        K: Ord,
+    {
+        let txs = &self.txs;
+        self.ordered_txids.sort_by_key(move |txid| {
+            let (pos, _) = txs.get(txid).expect("must have corresponding tx");
+            f(txid, pos)
+        });
+    }
+
+    /// Iterate over all transactions of the [`CanonicalView`].
+    pub fn txs(
+        &self,
+    ) -> impl ExactSizeIterator<Item = CanonicalTx<A, U>> + DoubleEndedIterator + '_ {
+        self.ordered_txids
+            .iter()
+            .map(|&txid| get_tx(&self.txs, txid).expect("corresponding tx must exist"))
+    }
+
+    /// Iterate over all transactions of [`CanonicalView`] by owning it.
+    pub fn into_txs(
+        self,
+    ) -> impl ExactSizeIterator<Item = CanonicalTx<A, U>> + DoubleEndedIterator {
+        self.ordered_txids
+            .into_iter()
+            .map(move |txid| get_tx(&self.txs, txid).expect("corresponding tx must exist"))
+    }
+
+    /// Obtain a subset of `outpoints` that are canonical.
+    pub fn filter_txouts<'a, I: 'a>(
+        &'a self,
+        outpoints: impl IntoIterator<Item = (I, OutPoint)> + 'a,
+    ) -> impl Iterator<Item = CanonicalTxOut<A, U, I>> + 'a {
+        outpoints.into_iter().filter_map(|(spk_index, outpoint)| {
+            get_txout(&self.txs, &self.spends, spk_index, outpoint)
+        })
+    }
+
+    /// Obtain a subset of `outpoints` that are canonical by taking ownership.
+    pub fn into_filter_txouts<I>(
+        self,
+        outpoints: impl IntoIterator<Item = (I, OutPoint)>,
+    ) -> impl Iterator<Item = CanonicalTxOut<A, U, I>> {
+        outpoints
+            .into_iter()
+            .filter_map(move |(spk_index, outpoint)| {
+                get_txout(&self.txs, &self.spends, spk_index, outpoint)
+            })
+    }
+
+    /// Obtain a subset of `outpoints` that are canonical and unspent.
+    pub fn filter_unspents<'a, I: 'a>(
+        &'a self,
+        outpoints: impl IntoIterator<Item = (I, OutPoint)> + 'a,
+    ) -> impl Iterator<Item = CanonicalTxOut<A, U, I>> + 'a {
+        self.filter_txouts(outpoints)
+            .filter(|txo| txo.spent_by.is_none())
+    }
+
+    /// Obtain a subset of `outpoints` that are canonical and unspent by taking ownership.
+    pub fn into_filter_unspents<I>(
+        self,
+        outpoints: impl IntoIterator<Item = (I, OutPoint)>,
+    ) -> impl Iterator<Item = CanonicalTxOut<A, U, I>> {
+        self.into_filter_txouts(outpoints)
+            .filter(|txo| txo.spent_by.is_none())
+    }
+
+    /// Get the total balance of `outpoints`.
+    pub fn balance<I>(
+        &self,
+        outpoints: impl IntoIterator<Item = (I, OutPoint)>,
+        mut trust_predicate: impl FnMut(&I, &Script) -> bool,
+    ) -> Balance {
+        let mut immature = Amount::ZERO;
+        let mut trusted_pending = Amount::ZERO;
+        let mut untrusted_pending = Amount::ZERO;
+        let mut confirmed = Amount::ZERO;
+
+        for txout in self.filter_unspents(outpoints) {
+            match &txout.pos {
+                CanonicalPos::Confirmed(_) => {
+                    if txout.is_mature(self.tip.height) {
+                        confirmed += txout.txout.value;
+                    } else {
+                        immature += txout.txout.value;
+                    }
+                }
+                CanonicalPos::Unconfirmed(_) => {
+                    if trust_predicate(&txout.spk_index, txout.txout.script_pubkey.as_script()) {
+                        trusted_pending += txout.txout.value;
+                    } else {
+                        untrusted_pending += txout.txout.value;
+                    }
+                }
+            }
+        }
+
+        Balance {
+            immature,
+            trusted_pending,
+            untrusted_pending,
+            confirmed,
+        }
+    }
+}
+
+fn get_tx<A: Anchor, U: Ord + Clone>(
+    txs: &HashMap<Txid, (CanonicalPos<A, U>, Arc<Transaction>)>,
+    txid: Txid,
+) -> Option<CanonicalTx<A, U>> {
+    txs.get(&txid)
+        .cloned()
+        .map(|(pos, tx)| CanonicalTx { pos, txid, tx })
+}
+
+fn get_txout<A: Anchor, U: Ord + Clone, I>(
+    txs: &HashMap<Txid, (CanonicalPos<A, U>, Arc<Transaction>)>,
+    spends: &HashMap<OutPoint, Txid>,
+    spk_index: I,
+    outpoint: OutPoint,
+) -> Option<CanonicalTxOut<A, U, I>> {
+    let (pos, tx) = txs.get(&outpoint.txid).cloned()?;
+    let txout = tx.output.get(outpoint.vout as usize).cloned()?;
+    let spent_by = spends.get(&outpoint).copied();
+    let is_on_coinbase = tx.is_coinbase();
+    Some(CanonicalTxOut {
+        pos,
+        spk_index,
+        outpoint,
+        txout,
+        spent_by,
+        is_on_coinbase,
+    })
+}
+
+/// Occurs when constructing a [`CanonicalView`] fails.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CanonicalError<CE, UE> {
+    /// The [`ChainOracle`] impl errored.
+    ChainOracle(CE),
+    /// The [`UnconfirmedOracle`] impl errored.
+    UnconfirmedOracle(UE),
+}
+
+impl<UE> CanonicalError<Infallible, UE> {
+    /// Transform into an [`UnconfirmedOracle`] error.
+    pub fn into_unconfirmed_oracle_error(self) -> UE {
+        match self {
+            CanonicalError::ChainOracle(_) => unreachable!("error is infallible"),
+            CanonicalError::UnconfirmedOracle(err) => err,
+        }
+    }
+}
+
+impl<CE> CanonicalError<CE, Infallible> {
+    /// Transform into a [`ChainOracle`] error.
+    pub fn into_chain_oracle_error(self) -> CE {
+        match self {
+            CanonicalError::ChainOracle(err) => err,
+            CanonicalError::UnconfirmedOracle(_) => unreachable!("error is infallible"),
+        }
+    }
+}
+
+impl<CE: core::fmt::Display, UE: core::fmt::Display> core::fmt::Display for CanonicalError<CE, UE> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            CanonicalError::ChainOracle(err) => write!(
+                f,
+                "chain oracle errored while constructing canonical view: {}",
+                err
+            ),
+            CanonicalError::UnconfirmedOracle(err) => write!(
+                f,
+                "unconfirmed oracle errored while constructing canonical view: {}",
+                err
+            ),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<CE: std::error::Error, UE: std::error::Error> std::error::Error for CanonicalError<CE, UE> {}

--- a/crates/chain/src/lib.rs
+++ b/crates/chain/src/lib.rs
@@ -43,6 +43,10 @@ pub mod tx_graph;
 pub use tx_graph::TxGraph;
 mod chain_oracle;
 pub use chain_oracle::*;
+mod unconfirmed_oracle;
+pub use unconfirmed_oracle::*;
+mod canonical_view;
+pub use canonical_view::*;
 
 #[doc(hidden)]
 pub mod example_utils;

--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -106,7 +106,7 @@ use core::{
     ops::{Deref, RangeInclusive},
 };
 
-impl<A> From<TxGraph<A>> for TxUpdate<A> {
+impl<A: Ord> From<TxGraph<A>> for TxUpdate<A> {
     fn from(graph: TxGraph<A>) -> Self {
         Self {
             txs: graph.full_txs().map(|tx_node| tx_node.tx).collect(),
@@ -114,7 +114,11 @@ impl<A> From<TxGraph<A>> for TxUpdate<A> {
                 .floating_txouts()
                 .map(|(op, txo)| (op, txo.clone()))
                 .collect(),
-            anchors: graph.anchors,
+            anchors: graph
+                .anchors
+                .into_iter()
+                .flat_map(|(txid, anchors)| anchors.into_iter().map(move |a| (a, txid)))
+                .collect(),
             seen_ats: graph.last_seen.into_iter().collect(),
         }
     }
@@ -135,15 +139,15 @@ impl<A: Ord + Clone> From<TxUpdate<A>> for TxGraph<A> {
 /// [module-level documentation]: crate::tx_graph
 #[derive(Clone, Debug, PartialEq)]
 pub struct TxGraph<A = ()> {
-    // all transactions that the graph is aware of in format: `(tx_node, tx_anchors)`
-    txs: HashMap<Txid, (TxNodeInternal, BTreeSet<A>)>,
+    txs: HashMap<Txid, TxNodeInternal>,
     spends: BTreeMap<OutPoint, HashSet<Txid>>,
-    anchors: BTreeSet<(A, Txid)>,
+    anchors: HashMap<Txid, BTreeSet<A>>,
     last_seen: HashMap<Txid, u64>,
 
     // This atrocity exists so that `TxGraph::outspends()` can return a reference.
     // FIXME: This can be removed once `HashSet::new` is a const fn.
     empty_outspends: HashSet<Txid>,
+    empty_anchors: BTreeSet<A>,
 }
 
 impl<A> Default for TxGraph<A> {
@@ -154,6 +158,7 @@ impl<A> Default for TxGraph<A> {
             anchors: Default::default(),
             last_seen: Default::default(),
             empty_outspends: Default::default(),
+            empty_anchors: Default::default(),
         }
     }
 }
@@ -238,7 +243,7 @@ impl<A> TxGraph<A> {
     ///
     /// This includes txouts of both full transactions as well as floating transactions.
     pub fn all_txouts(&self) -> impl Iterator<Item = (OutPoint, &TxOut)> {
-        self.txs.iter().flat_map(|(txid, (tx, _))| match tx {
+        self.txs.iter().flat_map(|(txid, tx)| match tx {
             TxNodeInternal::Whole(tx) => tx
                 .as_ref()
                 .output
@@ -260,7 +265,7 @@ impl<A> TxGraph<A> {
     pub fn floating_txouts(&self) -> impl Iterator<Item = (OutPoint, &TxOut)> {
         self.txs
             .iter()
-            .filter_map(|(txid, (tx_node, _))| match tx_node {
+            .filter_map(|(txid, tx_node)| match tx_node {
                 TxNodeInternal::Whole(_) => None,
                 TxNodeInternal::Partial(txouts) => Some(
                     txouts
@@ -273,17 +278,15 @@ impl<A> TxGraph<A> {
 
     /// Iterate over all full transactions in the graph.
     pub fn full_txs(&self) -> impl Iterator<Item = TxNode<'_, Arc<Transaction>, A>> {
-        self.txs
-            .iter()
-            .filter_map(|(&txid, (tx, anchors))| match tx {
-                TxNodeInternal::Whole(tx) => Some(TxNode {
-                    txid,
-                    tx: tx.clone(),
-                    anchors,
-                    last_seen_unconfirmed: self.last_seen.get(&txid).copied(),
-                }),
-                TxNodeInternal::Partial(_) => None,
-            })
+        self.txs.iter().filter_map(|(&txid, tx)| match tx {
+            TxNodeInternal::Whole(tx) => Some(TxNode {
+                txid,
+                tx: tx.clone(),
+                anchors: self.anchors.get(&txid).unwrap_or(&self.empty_anchors),
+                last_seen_unconfirmed: self.last_seen.get(&txid).copied(),
+            }),
+            TxNodeInternal::Partial(_) => None,
+        })
     }
 
     /// Iterate over graph transactions with no anchors or last-seen.
@@ -311,10 +314,10 @@ impl<A> TxGraph<A> {
     /// Get a transaction node by txid. This only returns `Some` for full transactions.
     pub fn get_tx_node(&self, txid: Txid) -> Option<TxNode<'_, Arc<Transaction>, A>> {
         match &self.txs.get(&txid)? {
-            (TxNodeInternal::Whole(tx), anchors) => Some(TxNode {
+            TxNodeInternal::Whole(tx) => Some(TxNode {
                 txid,
                 tx: tx.clone(),
-                anchors,
+                anchors: self.anchors.get(&txid).unwrap_or(&self.empty_anchors),
                 last_seen_unconfirmed: self.last_seen.get(&txid).copied(),
             }),
             _ => None,
@@ -323,7 +326,7 @@ impl<A> TxGraph<A> {
 
     /// Obtains a single tx output (if any) at the specified outpoint.
     pub fn get_txout(&self, outpoint: OutPoint) -> Option<&TxOut> {
-        match &self.txs.get(&outpoint.txid)?.0 {
+        match &self.txs.get(&outpoint.txid)? {
             TxNodeInternal::Whole(tx) => tx.as_ref().output.get(outpoint.vout as usize),
             TxNodeInternal::Partial(txouts) => txouts.get(&outpoint.vout),
         }
@@ -333,7 +336,7 @@ impl<A> TxGraph<A> {
     ///
     /// Returns a [`BTreeMap`] of vout to output of the provided `txid`.
     pub fn tx_outputs(&self, txid: Txid) -> Option<BTreeMap<u32, &TxOut>> {
-        Some(match &self.txs.get(&txid)?.0 {
+        Some(match &self.txs.get(&txid)? {
             TxNodeInternal::Whole(tx) => tx
                 .as_ref()
                 .output
@@ -496,7 +499,7 @@ impl<A> TxGraph<A> {
     }
 
     /// Get all transaction anchors known by [`TxGraph`].
-    pub fn all_anchors(&self) -> &BTreeSet<(A, Txid)> {
+    pub fn all_anchors(&self) -> &HashMap<Txid, BTreeSet<A>> {
         &self.anchors
     }
 
@@ -540,7 +543,7 @@ impl<A: Clone + Ord> TxGraph<A> {
     /// [`apply_changeset`]: Self::apply_changeset
     pub fn insert_txout(&mut self, outpoint: OutPoint, txout: TxOut) -> ChangeSet<A> {
         let mut changeset = ChangeSet::<A>::default();
-        let (tx_node, _) = self.txs.entry(outpoint.txid).or_default();
+        let tx_node = self.txs.entry(outpoint.txid).or_default();
         match tx_node {
             TxNodeInternal::Whole(_) => {
                 // ignore this txout we have the full one already.
@@ -573,7 +576,7 @@ impl<A: Clone + Ord> TxGraph<A> {
         let txid = tx.compute_txid();
         let mut changeset = ChangeSet::<A>::default();
 
-        let (tx_node, _) = self.txs.entry(txid).or_default();
+        let tx_node = self.txs.entry(txid).or_default();
         match tx_node {
             TxNodeInternal::Whole(existing_tx) => {
                 debug_assert_eq!(
@@ -625,13 +628,7 @@ impl<A: Clone + Ord> TxGraph<A> {
     /// `anchor`.
     pub fn insert_anchor(&mut self, txid: Txid, anchor: A) -> ChangeSet<A> {
         let mut changeset = ChangeSet::<A>::default();
-        if self.anchors.insert((anchor.clone(), txid)) {
-            let (_tx_node, anchors) = self.txs.entry(txid).or_default();
-            let _inserted = anchors.insert(anchor.clone());
-            debug_assert!(
-                _inserted,
-                "anchors in `.anchors` and `.txs` should be consistent"
-            );
+        if self.anchors.entry(txid).or_default().insert(anchor.clone()) {
             changeset.anchors.insert((anchor, txid));
         }
         changeset
@@ -711,7 +708,11 @@ impl<A: Clone + Ord> TxGraph<A> {
                 .floating_txouts()
                 .map(|(op, txout)| (op, txout.clone()))
                 .collect(),
-            anchors: self.anchors.clone(),
+            anchors: self
+                .anchors
+                .iter()
+                .flat_map(|(txid, anchors)| anchors.iter().map(|a| (a.clone(), *txid)))
+                .collect(),
             last_seen: self.last_seen.iter().map(|(&k, &v)| (k, v)).collect(),
         }
     }
@@ -763,12 +764,12 @@ impl<A: Anchor> TxGraph<A> {
         chain_tip: BlockId,
         txid: Txid,
     ) -> Result<Option<ChainPosition<&A>>, C::Error> {
-        let (tx_node, anchors) = match self.txs.get(&txid) {
+        let tx_node = match self.txs.get(&txid) {
             Some(v) => v,
             None => return Ok(None),
         };
 
-        for anchor in anchors {
+        for anchor in self.anchors.get(&txid).unwrap_or(&self.empty_anchors) {
             match chain.is_block_in_chain(anchor.anchor_block(), chain_tip)? {
                 Some(true) => return Ok(Some(ChainPosition::Confirmed(anchor))),
                 _ => continue,

--- a/crates/chain/src/unconfirmed_oracle.rs
+++ b/crates/chain/src/unconfirmed_oracle.rs
@@ -1,0 +1,87 @@
+use core::convert::Infallible;
+
+use bitcoin::Txid;
+
+use crate::{collections::HashMap, Anchor, TxGraph};
+
+/// Determines the canonical transaction from a set of conflicting unconfirmed transactions.
+///
+/// This is used for constructing the [`CanonicalView`].
+pub trait UnconfirmedOracle {
+    /// Error type.
+    type Error;
+
+    /// Unconfirmed position in the [`CanonicalView`].
+    type UnconfirmedPos: Ord + Clone;
+
+    /// Given a set of conflicting unconfirmed transactions, pick the transaction which is to be
+    /// part of the canoncial history.
+    ///
+    /// If this returns `None`, it signals that none of the conflicts are to be considered
+    /// canonical.
+    fn pick_canonical<A, T>(
+        &self,
+        tx_graph: &TxGraph<A>,
+        conflicting_txids: T,
+    ) -> Result<Option<(Self::UnconfirmedPos, Txid)>, Self::Error>
+    where
+        A: Anchor,
+        T: IntoIterator<Item = Txid>;
+}
+
+/// A simple [`UnconfirmedOracle`] implementation that uses `last_seen` in mempool values to
+/// prioritize unconfirmed transactions.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct LastSeenPrioritizer;
+
+impl UnconfirmedOracle for LastSeenPrioritizer {
+    type Error = Infallible;
+
+    /// Last seen in mempool.
+    type UnconfirmedPos = u64;
+
+    fn pick_canonical<A, T>(
+        &self,
+        tx_graph: &TxGraph<A>,
+        conflicting_txids: T,
+    ) -> Result<Option<(Self::UnconfirmedPos, Txid)>, Self::Error>
+    where
+        A: Anchor,
+        T: IntoIterator<Item = Txid>,
+    {
+        let mut best = Option::<(u64, Txid)>::None;
+        for txid in conflicting_txids {
+            let last_seen = tx_graph
+                .get_tx_node(txid)
+                .expect("must exist")
+                .last_seen_unconfirmed;
+            if let Some(last_seen) = last_seen {
+                let this_key = (last_seen, txid);
+                if Some(this_key) > best {
+                    best = Some(this_key);
+                }
+            }
+        }
+        Ok(best)
+    }
+}
+
+/// A [`UnconfirmedOracle`] implementation which allows setting a custom priority value per
+/// transaction.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CustomPrioritizer {
+    prioritized_txids: HashMap<Txid, i32>,
+}
+
+/// Transaction to prioritize is missing from [`TxGraph`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MissingTx(pub Txid);
+
+impl core::fmt::Display for MissingTx {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "missing transaction '{}'", self.0)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for MissingTx {}

--- a/crates/chain/tests/test_tx_graph.rs
+++ b/crates/chain/tests/test_tx_graph.rs
@@ -1122,11 +1122,13 @@ fn call_map_anchors_with_non_deterministic_anchor() {
     }
     assert!(new_txs.next().is_none());
 
-    let new_graph_anchors: Vec<_> = new_graph
+    let mut new_graph_anchors: Vec<_> = new_graph
         .all_anchors()
         .iter()
-        .map(|i| i.0.anchor_block)
+        .flat_map(|(_, anchors)| anchors)
+        .map(|a| a.anchor_block)
         .collect();
+    new_graph_anchors.sort();
     assert_eq!(
         new_graph_anchors,
         vec![

--- a/crates/chain/tests/test_tx_graph.rs
+++ b/crates/chain/tests/test_tx_graph.rs
@@ -725,9 +725,9 @@ fn test_descendants_no_repeat() {
         .collect::<Vec<_>>();
 
     let txs_c = (0..2)
-        .map(|vout| Transaction {
+        .map(|prev_tx_index| Transaction {
             input: vec![TxIn {
-                previous_output: OutPoint::new(txs_b[vout as usize].compute_txid(), vout),
+                previous_output: OutPoint::new(txs_b[prev_tx_index as usize].compute_txid(), 0),
                 ..TxIn::default()
             }],
             output: vec![TxOut::NULL],
@@ -772,6 +772,8 @@ fn test_descendants_no_repeat() {
 
     let mut graph = TxGraph::<()>::default();
     let mut expected_txids = Vec::new();
+
+    let _ = graph.insert_tx(tx_a.clone());
 
     // these are NOT descendants of `tx_a`
     for tx in txs_not_connected {

--- a/crates/electrum/tests/test_electrum.rs
+++ b/crates/electrum/tests/test_electrum.rs
@@ -3,7 +3,7 @@ use bdk_chain::{
     local_chain::LocalChain,
     spk_client::{FullScanRequest, SyncRequest, SyncResult},
     spk_txout::SpkTxOutIndex,
-    Balance, ConfirmationBlockTime, IndexedTxGraph, Indexer, Merge, TxGraph,
+    Balance, ConfirmationBlockTime, IndexedTxGraph, Indexer, LastSeenPrioritizer, Merge, TxGraph,
 };
 use bdk_electrum::BdkElectrumClient;
 use bdk_testenv::{anyhow, bitcoincore_rpc::RpcApi, TestEnv};
@@ -22,7 +22,8 @@ fn get_balance(
     let outpoints = recv_graph.index.outpoints().clone();
     let balance = recv_graph
         .graph()
-        .balance(recv_chain, chain_tip, outpoints, |_, _| true);
+        .canonical_view(recv_chain, chain_tip, &LastSeenPrioritizer)
+        .balance(outpoints, |_, _| true);
     Ok(balance)
 }
 

--- a/crates/testenv/src/utils.rs
+++ b/crates/testenv/src/utils.rs
@@ -1,4 +1,4 @@
-use bdk_chain::bitcoin;
+use bdk_chain::bitcoin::{self, TxIn};
 
 #[allow(unused_macros)]
 #[macro_export]
@@ -67,12 +67,21 @@ macro_rules! changeset {
     }};
 }
 
+/// Creates a "fake" transaction where `lt` is used to set the locktime and previous_output for
+/// uniqueness.
 #[allow(unused)]
 pub fn new_tx(lt: u32) -> bitcoin::Transaction {
     bitcoin::Transaction {
         version: bitcoin::transaction::Version::non_standard(0x00),
         lock_time: bitcoin::absolute::LockTime::from_consensus(lt),
-        input: vec![],
+        // Enforce single input otherwise we can't determine root spends.
+        input: vec![TxIn {
+            previous_output: bitcoin::OutPoint::new(
+                bitcoin::hashes::Hash::hash(lt.to_le_bytes().as_slice()),
+                0,
+            ),
+            ..Default::default()
+        }],
         output: vec![],
     }
 }

--- a/crates/wallet/src/types.rs
+++ b/crates/wallet/src/types.rs
@@ -10,9 +10,9 @@
 // licenses.
 
 use alloc::boxed::Box;
+use chain::{ChainPosition, ConfirmationBlockTime};
 use core::convert::AsRef;
 
-use bdk_chain::ConfirmationTime;
 use bitcoin::transaction::{OutPoint, Sequence, TxOut};
 use bitcoin::{psbt, Weight};
 
@@ -61,8 +61,8 @@ pub struct LocalOutput {
     pub is_spent: bool,
     /// The derivation index for the script pubkey in the wallet
     pub derivation_index: u32,
-    /// The confirmation time for transaction containing this utxo
-    pub confirmation_time: ConfirmationTime,
+    /// The position of the output in the blockchain.
+    pub chain_position: ChainPosition<ConfirmationBlockTime>,
 }
 
 /// A [`Utxo`] with its `satisfaction_weight`.

--- a/crates/wallet/src/types.rs
+++ b/crates/wallet/src/types.rs
@@ -10,7 +10,7 @@
 // licenses.
 
 use alloc::boxed::Box;
-use chain::{ChainPosition, ConfirmationBlockTime};
+use chain::{CanonicalPos, ConfirmationBlockTime};
 use core::convert::AsRef;
 
 use bitcoin::transaction::{OutPoint, Sequence, TxOut};
@@ -62,7 +62,7 @@ pub struct LocalOutput {
     /// The derivation index for the script pubkey in the wallet
     pub derivation_index: u32,
     /// The position of the output in the blockchain.
-    pub chain_position: ChainPosition<ConfirmationBlockTime>,
+    pub chain_position: CanonicalPos<ConfirmationBlockTime, u64>,
 }
 
 /// A [`Utxo`] with its `satisfaction_weight`.

--- a/crates/wallet/src/wallet/tx_builder.rs
+++ b/crates/wallet/src/wallet/tx_builder.rs
@@ -1017,7 +1017,7 @@ mod test {
                 txout: TxOut::NULL,
                 keychain: KeychainKind::External,
                 is_spent: false,
-                chain_position: chain::ChainPosition::Unconfirmed(0),
+                chain_position: chain::CanonicalPos::Unconfirmed(0),
                 derivation_index: 0,
             },
             LocalOutput {
@@ -1028,7 +1028,7 @@ mod test {
                 txout: TxOut::NULL,
                 keychain: KeychainKind::Internal,
                 is_spent: false,
-                chain_position: chain::ChainPosition::Confirmed(chain::ConfirmationBlockTime {
+                chain_position: chain::CanonicalPos::Confirmed(chain::ConfirmationBlockTime {
                     block_id: chain::BlockId {
                         height: 32,
                         hash: bitcoin::BlockHash::all_zeros(),

--- a/crates/wallet/src/wallet/tx_builder.rs
+++ b/crates/wallet/src/wallet/tx_builder.rs
@@ -858,7 +858,6 @@ mod test {
         };
     }
 
-    use bdk_chain::ConfirmationTime;
     use bitcoin::consensus::deserialize;
     use bitcoin::hex::FromHex;
     use bitcoin::TxOut;
@@ -1018,7 +1017,7 @@ mod test {
                 txout: TxOut::NULL,
                 keychain: KeychainKind::External,
                 is_spent: false,
-                confirmation_time: ConfirmationTime::Unconfirmed { last_seen: 0 },
+                chain_position: chain::ChainPosition::Unconfirmed(0),
                 derivation_index: 0,
             },
             LocalOutput {
@@ -1029,10 +1028,13 @@ mod test {
                 txout: TxOut::NULL,
                 keychain: KeychainKind::Internal,
                 is_spent: false,
-                confirmation_time: ConfirmationTime::Confirmed {
-                    height: 32,
-                    time: 42,
-                },
+                chain_position: chain::ChainPosition::Confirmed(chain::ConfirmationBlockTime {
+                    block_id: chain::BlockId {
+                        height: 32,
+                        hash: bitcoin::BlockHash::all_zeros(),
+                    },
+                    confirmation_time: 42,
+                }),
                 derivation_index: 1,
             },
         ]

--- a/crates/wallet/tests/common.rs
+++ b/crates/wallet/tests/common.rs
@@ -1,5 +1,5 @@
 #![allow(unused)]
-use bdk_chain::{tx_graph, BlockId, ChainPosition, ConfirmationBlockTime, TxGraph};
+use bdk_chain::{tx_graph, BlockId, CanonicalPos, ChainPosition, ConfirmationBlockTime, TxGraph};
 use bdk_wallet::{CreateParams, KeychainKind, LocalOutput, Update, Wallet};
 use bitcoin::{
     hashes::Hash, transaction, Address, Amount, BlockHash, FeeRate, Network, OutPoint, Transaction,
@@ -89,7 +89,7 @@ pub fn get_funded_wallet_with_change(descriptor: &str, change: &str) -> (Wallet,
     insert_anchor_from_conf(
         &mut wallet,
         tx0.compute_txid(),
-        ChainPosition::Confirmed(ConfirmationBlockTime {
+        CanonicalPos::Confirmed(ConfirmationBlockTime {
             block_id: BlockId {
                 height: 1_000,
                 hash: BlockHash::all_zeros(),
@@ -102,7 +102,7 @@ pub fn get_funded_wallet_with_change(descriptor: &str, change: &str) -> (Wallet,
     insert_anchor_from_conf(
         &mut wallet,
         tx1.compute_txid(),
-        ChainPosition::Confirmed(ConfirmationBlockTime {
+        CanonicalPos::Confirmed(ConfirmationBlockTime {
             block_id: BlockId {
                 height: 2_000,
                 hash: BlockHash::all_zeros(),
@@ -214,9 +214,9 @@ pub fn feerate_unchecked(sat_vb: f64) -> FeeRate {
 pub fn insert_anchor_from_conf(
     wallet: &mut Wallet,
     txid: Txid,
-    position: ChainPosition<ConfirmationBlockTime>,
+    position: CanonicalPos<ConfirmationBlockTime, u64>,
 ) {
-    if let ChainPosition::Confirmed(anchor) = position {
+    if let CanonicalPos::Confirmed(anchor) = position {
         wallet
             .apply_update(Update {
                 tx_update: tx_graph::TxUpdate {

--- a/example-crates/example_bitcoind_rpc_polling/src/main.rs
+++ b/example-crates/example_bitcoind_rpc_polling/src/main.rs
@@ -13,7 +13,7 @@ use bdk_bitcoind_rpc::{
 };
 use bdk_chain::{
     bitcoin::{Block, Transaction},
-    local_chain, Merge,
+    local_chain, LastSeenPrioritizer, Merge,
 };
 use example_cli::{
     anyhow,
@@ -182,14 +182,12 @@ fn main() -> anyhow::Result<()> {
                 if last_print.elapsed() >= STDOUT_PRINT_DELAY {
                     last_print = Instant::now();
                     let synced_to = chain.tip();
-                    let balance = {
-                        graph.graph().balance(
-                            &*chain,
-                            synced_to.block_id(),
-                            graph.index.outpoints().iter().cloned(),
-                            |(k, _), _| k == &Keychain::Internal,
-                        )
-                    };
+                    let balance = graph
+                        .graph()
+                        .canonical_view(&*chain, synced_to.block_id(), &LastSeenPrioritizer)
+                        .balance(graph.index.outpoints().iter().cloned(), |(k, _), _| {
+                            k == &Keychain::Internal
+                        });
                     println!(
                         "[{:>10}s] synced to {} @ {} | total: {}",
                         start.elapsed().as_secs_f32(),
@@ -319,14 +317,12 @@ fn main() -> anyhow::Result<()> {
                 if last_print.map_or(Duration::MAX, |i| i.elapsed()) >= STDOUT_PRINT_DELAY {
                     last_print = Some(Instant::now());
                     let synced_to = chain.tip();
-                    let balance = {
-                        graph.graph().balance(
-                            &*chain,
-                            synced_to.block_id(),
-                            graph.index.outpoints().iter().cloned(),
-                            |(k, _), _| k == &Keychain::Internal,
-                        )
-                    };
+                    let balance = graph
+                        .graph()
+                        .canonical_view(&*chain, synced_to.block_id(), &LastSeenPrioritizer)
+                        .balance(graph.index.outpoints().iter().cloned(), |(k, _), _| {
+                            k == &Keychain::Internal
+                        });
                     println!(
                         "[{:>10}s] synced to {} @ {} / {} | total: {}",
                         start.elapsed().as_secs_f32(),


### PR DESCRIPTION
### Description

The way we are determining the canonical history of transactions/outputs in `bdk_chain` is inefficient and inflexible:

* The algorithm used in [`TxGraph::try_get_chain_position`](https://github.com/bitcoindevkit/bdk/blob/647d2855941d0c46412efa797db4ae157fb544d5/crates/chain/src/tx_graph.rs#L760) is costly when we have many conflicting unconfirmed txs `O(n^2)`.
* There is only one way (one algorithm) to struct a "canonical history" and transactions with no anchor or last_seen will not be considered to be part of it. Because we use the canonical history for the UTXO set, non-broadcasted transactions added to the `TxGraph` may be replaced. 
  * #1642
  * #1644

To fix this, I have introduced the following in the PR:

* `UnconfirmedOracle` is used to determine the *maybe* canonical transaction between a set of conflicting unconfirmed transactions. It can return `None` to signal that none of the presented transactions are canonical. This can be used to create different policies as to which transactions to include in the canonical history.
* `CanonicalView` represents a canonical view of transactions. The algorithm to create it iterates from the "roots" of the `TxGraph` (roots are either coinbase transactions, or outpoints which we have no residing transaction). Each set of conflicting spends only needs to be iterated over once.

### Notes to the reviewers

This is a proof of concept. Not sure which parts should be included in `v1.0`. Tests are passing (except of doc tests).

### Changelog notice

TODO

### Checklists

#### All Submissions:

* [ ] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
