### PR TITLE
docs: fix incorrect links to wallet examples

### DIFF
--- a/crates/wallet/README.md
+++ b/crates/wallet/README.md
@@ -50,10 +50,10 @@ that the `Wallet` can use to update its view of the chain.
 
 **Examples**
 
-* [`example-crates/wallet_esplora_async`](https://github.com/bitcoindevkit/bdk/tree/master/example-crates/wallet_esplora_async)
-* [`example-crates/wallet_esplora_blocking`](https://github.com/bitcoindevkit/bdk/tree/master/example-crates/wallet_esplora_blocking)
-* [`example-crates/wallet_electrum`](https://github.com/bitcoindevkit/bdk/tree/master/example-crates/wallet_electrum)
-* [`example-crates/wallet_rpc`](https://github.com/bitcoindevkit/bdk/tree/master/example-crates/wallet_rpc)
+* [`example-crates/example_wallet_esplora_async`](https://github.com/bitcoindevkit/bdk/tree/master/example-crates/example_wallet_esplora_async)
+* [`example-crates/example_wallet_esplora_blocking`](https://github.com/bitcoindevkit/bdk/tree/master/example-crates/example_wallet_esplora_blocking)
+* [`example-crates/example_wallet_electrum`](https://github.com/bitcoindevkit/bdk/tree/master/example-crates/example_wallet_electrum)
+* [`example-crates/example_wallet_rpc`](https://github.com/bitcoindevkit/bdk/tree/master/example-crates/example_wallet_rpc)
 
 ## Persistence
 


### PR DESCRIPTION
### Description

This PR updates the examples found in the wallet crate to use working links to GitHub.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

