### PR TITLE
ci: pin deps for MSRV

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -49,6 +49,8 @@ jobs:
           cargo update -p cc --precise "1.0.105"
           cargo update -p tokio --precise "1.38.1"
           cargo update -p tokio-util --precise "0.7.11"
+          cargo update -p indexmap --precise "2.5.0"
+          cargo update -p security-framework-sys --precise "2.11.1"
       - name: Build
         run: cargo build --workspace --exclude 'example_*' ${{ matrix.features }}
       - name: Test

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ cargo update -p url --precise "2.5.0"
 cargo update -p cc --precise "1.0.105"
 cargo update -p tokio --precise "1.38.1"
 cargo update -p tokio-util --precise "0.7.11"
+cargo update -p indexmap --precise "2.5.0"
+cargo update -p security-framework-sys --precise "2.11.1"
 ```
 
 ## License


### PR DESCRIPTION
Pin deps in CI to build on MSRV

- pin `indexmap` to 2.5.0
- pin `security-framework-sys` to 2.11.1

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

