### PR TITLE
fix(electrum): `bdk_electrum` coinbase merkle and `populate_with_txids` exploit fixes

### DIFF
--- a/crates/electrum/src/bdk_electrum_client.rs
+++ b/crates/electrum/src/bdk_electrum_client.rs
@@ -563,6 +563,27 @@ mod test {
 
     #[cfg(feature = "default")]
     #[test]
+    fn test_populate_with_txids_without_output() {
+        let env = TestEnv::new().unwrap();
+        let electrum_client =
+            electrum_client::Client::new(env.electrsd.electrum_url.as_str()).unwrap();
+        let client = BdkElectrumClient::new(electrum_client);
+
+        // Setup transaction with no outputs.
+        let tx = new_tx(0);
+
+        // Populate tx_cache with `tx` to make it fetchable.
+        client.populate_tx_cache(vec![tx.clone()]);
+
+        // Test that populate_with_txids does not panic or process a tx with no output.
+        let mut tx_update = TxUpdate::default();
+        let _ = client.populate_with_txids(&mut tx_update, vec![tx.compute_txid()]);
+
+        assert_eq!(tx_update.txs, Vec::new());
+    }
+
+    #[cfg(feature = "default")]
+    #[test]
     fn test_fetch_prev_txout_with_coinbase() {
         let env = TestEnv::new().unwrap();
         let electrum_client =


### PR DESCRIPTION
Fixes bitcoindevkit/bdk#1698, bitcoindevkit/bdk#2249.

### Description

The aim of this PR is to fix a few exploits that were found within `bdk_electrum`. Most notably:


- Transaction Merkle proof verification does not check the Merkle proof for the coinbase. This enables an attack by which an attacker can fake a deeply-confirmed payment to a BDK wallet. (https://delvingbitcoin.org/t/great-consensus-cleanup-revival/710#merkle-tree-attacks-using-64-bytes-transactions-8)
- An Electrum server can trigger a panic in `populate_with_txids` by returning a transaction with no output.
- `fetch_prev_txout` should not try to query the prevouts of coinbase transactions. This will query a transaction to the Electrum server which will return an error and will make the overall `sync` fail.


### Notes to the reviewers

- The "validate coinbase merkle test" commit needs significant review. My initial thoughts were to put `MockElectrumClient` into `bdk_testenv`, but because `bdk_testenv`'s `electrum-client` is re-exported from `electrsd`, a separate dependency would have to be added just for `electrum-client` 0.22 support. However, since we are doing in-line tests to access private functions, there is a strong argument for leaving the test structures where they are currently at. Or perhaps there is a better way to specifically test `validate_merkle_for_anchor` that does not involve creating a `MockElectrumClient`, similar to what @evanlinjin is doing here: https://github.com/evanlinjin/experiments/blob/main/electrum_c/src/state.rs.

### Changelog notice

* `fetch_prev_txout` no longer queries coinbase transactions.
* Coinbase tx merkle path is also validated during tx merkle path verification.
* `populate_with_txids` will no longer panic on transactions with no outputs.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
