### PR TITLE
fix(testenv): disable downloads (bitcoind and electrsd) for docs.rs builds in …

### DIFF
--- a/crates/bitcoind_rpc/tests/test_emitter.rs
+++ b/crates/bitcoind_rpc/tests/test_emitter.rs
@@ -1,3 +1,5 @@
+#![cfg(not(docsrs))]
+
 use std::collections::{BTreeMap, BTreeSet};
 
 use bdk_bitcoind_rpc::Emitter;

--- a/crates/electrum/tests/test_electrum.rs
+++ b/crates/electrum/tests/test_electrum.rs
@@ -1,3 +1,5 @@
+#![cfg(not(docsrs))]
+
 use bdk_chain::{
     bitcoin::{hashes::Hash, Address, Amount, ScriptBuf, WScriptHash},
     local_chain::LocalChain,

--- a/crates/esplora/src/async_ext.rs
+++ b/crates/esplora/src/async_ext.rs
@@ -503,6 +503,7 @@ mod test {
     }
 
     /// Ensure that update does not remove heights (from original), and all anchor heights are included.
+    #[cfg(not(docsrs))]
     #[tokio::test]
     pub async fn test_finalize_chain_update() -> anyhow::Result<()> {
         struct TestCase<'a> {

--- a/crates/esplora/src/blocking_ext.rs
+++ b/crates/esplora/src/blocking_ext.rs
@@ -492,6 +492,7 @@ mod test {
     }
 
     /// Ensure that update does not remove heights (from original), and all anchor heights are included.
+    #[cfg(not(docsrs))]
     #[test]
     pub fn test_finalize_chain_update() -> anyhow::Result<()> {
         struct TestCase<'a> {
@@ -655,6 +656,7 @@ mod test {
         Ok(())
     }
 
+    #[cfg(not(docsrs))]
     #[test]
     fn update_local_chain() -> anyhow::Result<()> {
         const TIP_HEIGHT: u32 = 50;

--- a/crates/esplora/tests/async_ext.rs
+++ b/crates/esplora/tests/async_ext.rs
@@ -1,3 +1,5 @@
+#![cfg(not(docsrs))]
+
 use bdk_chain::spk_client::{FullScanRequest, SyncRequest};
 use bdk_chain::{ConfirmationBlockTime, TxGraph};
 use bdk_esplora::EsploraAsyncExt;

--- a/crates/esplora/tests/blocking_ext.rs
+++ b/crates/esplora/tests/blocking_ext.rs
@@ -1,3 +1,5 @@
+#![cfg(not(docsrs))]
+
 use bdk_chain::spk_client::{FullScanRequest, SyncRequest};
 use bdk_chain::{ConfirmationBlockTime, TxGraph};
 use bdk_esplora::EsploraExt;

--- a/crates/testenv/src/lib.rs
+++ b/crates/testenv/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
 pub mod utils;
 
 use bdk_chain::{
@@ -25,12 +27,14 @@ use std::time::Duration;
 
 /// Struct for running a regtest environment with a single `bitcoind` node with an `electrs`
 /// instance connected to it.
+#[cfg_attr(docsrs, doc(cfg(not(docsrs))))]
 pub struct TestEnv {
     pub bitcoind: electrsd::bitcoind::BitcoinD,
     pub electrsd: electrsd::ElectrsD,
 }
 
 /// Configuration parameters.
+#[cfg_attr(docsrs, doc(cfg(not(docsrs))))]
 #[derive(Debug)]
 pub struct Config<'a> {
     /// [`bitcoind::Conf`]
@@ -39,6 +43,7 @@ pub struct Config<'a> {
     pub electrsd: electrsd::Conf<'a>,
 }
 
+#[cfg(not(docsrs))]
 impl<'a> Default for Config<'a> {
     /// Use the default configuration plus set `http_enabled = true` for [`electrsd::Conf`]
     /// which is required for testing `bdk_esplora`.
@@ -54,6 +59,7 @@ impl<'a> Default for Config<'a> {
     }
 }
 
+#[cfg(not(docsrs))]
 impl TestEnv {
     /// Construct a new [`TestEnv`] instance with the default configuration used by BDK.
     pub fn new() -> anyhow::Result<Self> {
@@ -310,7 +316,7 @@ impl TestEnv {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(docsrs)))]
 mod test {
     use crate::TestEnv;
     use core::time::Duration;


### PR DESCRIPTION
…crate testenv

### Description

address this issue https://github.com/orgs/bitcoindevkit/projects/14/views/1?pane=issue&itemId=81939679&issue=bitcoindevkit%7Cbdk%7C1627 
where docs.rs build is failing for bdk_testenv crate

Update: to get tests to pass `RUSTFLAGS="--cfg docsrs" cargo +nightly test` I had to add ignore flags for the docs env to all three blockchain client crates (bitcoid_rpc, electrum, esplora)

### Notes to the reviewers

I was not able to reproduce the build issue locally, so this will have to be tested live unless someone else can reproduce the build error https://docs.rs/crate/bdk_testenv/0.10.0/builds/1377651

more details in this thread on discord https://discord.com/channels/753336465005608961/1265333904324427849/1304476756660719668


#### Bugfixes:

* [ ] I'm linking the issue being fixed by this PR
