### PR TITLE
types: Make Utxo::Foreign::sequence not optional

### DIFF
--- a/crates/wallet/src/types.rs
+++ b/crates/wallet/src/types.rs
@@ -87,7 +87,7 @@ pub enum Utxo {
         /// The location of the output.
         outpoint: OutPoint,
         /// The nSequence value to set for this input.
-        sequence: Option<Sequence>,
+        sequence: Sequence,
         /// The information about the input we require to add it to a PSBT.
         // Box it to stop the type being too big.
         psbt_input: Box<psbt::Input>,
@@ -129,7 +129,7 @@ impl Utxo {
     pub fn sequence(&self) -> Option<Sequence> {
         match self {
             Utxo::Local(_) => None,
-            Utxo::Foreign { sequence, .. } => *sequence,
+            Utxo::Foreign { sequence, .. } => Some(*sequence),
         }
     }
 }

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -1653,7 +1653,7 @@ impl Wallet {
                         WeightedUtxo {
                             utxo: Utxo::Foreign {
                                 outpoint: txin.previous_output,
-                                sequence: Some(txin.sequence),
+                                sequence: txin.sequence,
                                 psbt_input: Box::new(psbt::Input {
                                     witness_utxo: Some(txout.clone()),
                                     non_witness_utxo: Some(prev_tx.as_ref().clone()),

--- a/crates/wallet/src/wallet/tx_builder.rs
+++ b/crates/wallet/src/wallet/tx_builder.rs
@@ -408,7 +408,7 @@ impl<'a, Cs> TxBuilder<'a, Cs> {
             satisfaction_weight,
             utxo: Utxo::Foreign {
                 outpoint,
-                sequence: Some(sequence),
+                sequence,
                 psbt_input: Box::new(psbt_input),
             },
         });


### PR DESCRIPTION
It's never kept internally as optional at this point.
