### PR TITLE
test(wallet): create tx locktime cltv for a specific time

### DIFF
--- a/crates/wallet/src/test_utils.rs
+++ b/crates/wallet/src/test_utils.rs
@@ -160,6 +160,13 @@ pub fn get_test_single_sig_cltv() -> &'static str {
     "wsh(and_v(v:pk(cVpPVruEDdmutPzisEsYvtST1usBR3ntr8pXSyt6D2YYqXRyPcFW),after(100000)))"
 }
 
+/// `wsh` descriptor with policy `and(pk(A),after(1_734_230_218))`
+// the parameter passed to miniscript fragment `after` has to equal or greater than 500_000_000
+// in order to use a lock based on unix time
+pub fn get_test_single_sig_cltv_timestamp() -> &'static str {
+    "wsh(and_v(v:pk(cVpPVruEDdmutPzisEsYvtST1usBR3ntr8pXSyt6D2YYqXRyPcFW),after(1734230218)))"
+}
+
 /// taproot single key descriptor
 pub fn get_test_tr_single_sig() -> &'static str {
     "tr(cNJmN3fH9DDbDt131fQNkVakkpzawJBSeybCUNmP1BovpmGQ45xG)"

--- a/crates/wallet/tests/wallet.rs
+++ b/crates/wallet/tests/wallet.rs
@@ -610,6 +610,21 @@ fn test_create_tx_default_locktime_cltv() {
 }
 
 #[test]
+fn test_create_tx_locktime_cltv_timestamp() {
+    let (mut wallet, _) = get_funded_wallet_single(get_test_single_sig_cltv_timestamp());
+    let addr = wallet.next_unused_address(KeychainKind::External);
+    let mut builder = wallet.build_tx();
+    builder.add_recipient(addr.script_pubkey(), Amount::from_sat(25_000));
+    let mut psbt = builder.finish().unwrap();
+
+    assert_eq!(psbt.unsigned_tx.lock_time.to_consensus_u32(), 1_734_230_218);
+
+    let finalized = wallet.sign(&mut psbt, SignOptions::default()).unwrap();
+
+    assert!(finalized);
+}
+
+#[test]
 fn test_create_tx_custom_locktime() {
     let (mut wallet, _) = get_funded_wallet_wpkh();
     let addr = wallet.next_unused_address(KeychainKind::External);


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description
This PR adds a unit test that checks the satisfaction of timestamp-based timelocks. The goal is to test the absolute time therefore the variable passed to the miniscript fragment `after` has to be equal to or greater that 500_000_000 otherwise it would be checking the block height.


### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->
This unit test tries to check if bitcoindevkit/bdk_wallet#183 is still an issue.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing