### PR TITLE
chore(deps): bump hashbrown to v0.14.5

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 [dependencies]
 bitcoin = { version = "0.32", default-features = false }
 serde = { version = "1", optional = true, features = ["derive", "rc"] }
-hashbrown = { version = "0.9.1", optional = true }
+hashbrown = { version = "0.14.5", optional = true, default-features = false, features = ["ahash", "inline-more"] }
 
 [features]
 default = ["std"]


### PR DESCRIPTION
Bump [`hashbrown`](https://crates.io/crates/hashbrown) to v0.15

I ran [`cargo build-all-features` and `cargo test-all-features`](https://github.com/frewsxcv/cargo-all-features) locally for the `core` crate with no issues. Here's the output for the former:

```
cargo build-all-features

    Building crate=bdk_core features=[]
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.04s
    Building crate=bdk_core features=[hashbrown]
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.04s
    Building crate=bdk_core features=[serde]
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.05s
    Building crate=bdk_core features=[std]
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.04s
    Building crate=bdk_core features=[hashbrown,serde]
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.04s
    Building crate=bdk_core features=[hashbrown,std]
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.04s
    Building crate=bdk_core features=[serde,std]
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.04s
    Building crate=bdk_core features=[hashbrown,serde,std]
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.04s
```

The relevant changelog can be found between [here](https://github.com/rust-lang/hashbrown/blob/master/CHANGELOG.md#v0100---2021-01-16) and [here](https://github.com/rust-lang/hashbrown/blob/master/CHANGELOG.md#v0151---2024-11-03)

The only notable breaking change I found was that the MSRV was bumped to v1.63. However, this is the same MSRV as we already use, so it's not a breaking change for us.