### PR TITLE
fix(testenv): disable downloads (bitcoind and electrsd) for docs.rs b…

### DIFF
--- a/crates/bitcoind_rpc/Cargo.toml
+++ b/crates/bitcoind_rpc/Cargo.toml
@@ -21,7 +21,7 @@ bitcoincore-rpc = { version = "0.19.0" }
 bdk_core = { path = "../core", version = "0.3.0", default-features = false }
 
 [dev-dependencies]
-bdk_testenv = { path = "../testenv", default-features = false }
+bdk_testenv = { path = "../testenv" }
 bdk_chain = { path = "../chain" }
 
 [features]

--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -17,7 +17,7 @@ bdk_core = { path = "../core", version = "0.3.0" }
 electrum-client = { version = "0.21", features = [ "proxy" ], default-features = false }
 
 [dev-dependencies]
-bdk_testenv = { path = "../testenv", default-features = false }
+bdk_testenv = { path = "../testenv" }
 bdk_chain = { path = "../chain" }
 
 [features]

--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -23,7 +23,7 @@ miniscript = { version = "12.0.0", optional = true, default-features = false }
 
 [dev-dependencies]
 bdk_chain = { path = "../chain" }
-bdk_testenv = { path = "../testenv", default-features = false }
+bdk_testenv = { path = "../testenv" }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 
 [features]

--- a/crates/testenv/Cargo.toml
+++ b/crates/testenv/Cargo.toml
@@ -17,9 +17,16 @@ workspace = true
 
 [dependencies]
 bdk_chain = { path = "../chain", version = "0.20.0", default-features = false }
-electrsd = { version = "0.28.0", features = [ "bitcoind_25_0", "esplora_a33e97e1", "legacy" ] }
+electrsd = { version = "0.28.0", features = [ "legacy" ], default-features = false }
+
+[dev-dependencies]
+bdk_testenv = { path = "." }
 
 [features]
-default = ["std"]
+default = ["std", "download"]
+download = ["electrsd/bitcoind_25_0", "electrsd/esplora_a33e97e1"]
 std = ["bdk_chain/std"]
 serde = ["bdk_chain/serde"]
+
+[package.metadata.docs.rs]
+no-default-features = true


### PR DESCRIPTION
…uilds of crate testenv

### Description

address this issue https://github.com/bitcoindevkit/bdk/issues/1627
where docs.rs build is failing for bdk_testenv crate

original PR: https://github.com/bitcoindevkit/bdk/pull/1679

### Notes to the reviewers

I was not able to reproduce the build issue locally, so this will have to be tested live unless someone else can reproduce the build error https://docs.rs/crate/bdk_testenv/0.10.0/builds/1377651

more details in this thread on discord https://discord.com/channels/753336465005608961/1265333904324427849/1304476756660719668

#### Bugfixes:

* [x] I'm linking the issue being fixed by this PR
