### PR TITLE
Feature(testenv)/run regtest tests in series

### DIFF
--- a/crates/bitcoind_rpc/Cargo.toml
+++ b/crates/bitcoind_rpc/Cargo.toml
@@ -23,6 +23,7 @@ bdk_core = { path = "../core", version = "0.3.0", default-features = false }
 [dev-dependencies]
 bdk_testenv = { path = "../testenv", default-features = false }
 bdk_chain = { path = "../chain" }
+serial_test = { version = "=0.8.0" }
 
 [features]
 default = ["std"]

--- a/crates/bitcoind_rpc/tests/test_emitter.rs
+++ b/crates/bitcoind_rpc/tests/test_emitter.rs
@@ -10,6 +10,7 @@ use bdk_chain::{
 use bdk_testenv::{anyhow, TestEnv};
 use bitcoin::{hashes::Hash, Block, OutPoint, ScriptBuf, WScriptHash};
 use bitcoincore_rpc::RpcApi;
+use serial_test::serial;
 
 /// Ensure that blocks are emitted in order even after reorg.
 ///
@@ -18,6 +19,7 @@ use bitcoincore_rpc::RpcApi;
 /// 3. Reorg highest 6 blocks.
 /// 4. Emit blocks from [`Emitter`] and re-update the [`LocalChain`].
 #[test]
+#[serial]
 pub fn test_sync_local_chain() -> anyhow::Result<()> {
     let env = TestEnv::new()?;
     let network_tip = env.rpc_client().get_block_count()?;
@@ -129,6 +131,7 @@ pub fn test_sync_local_chain() -> anyhow::Result<()> {
 ///
 /// [`EmittedUpdate::into_tx_graph_update`]: bdk_bitcoind_rpc::EmittedUpdate::into_tx_graph_update
 #[test]
+#[serial]
 fn test_into_tx_graph() -> anyhow::Result<()> {
     let env = TestEnv::new()?;
 
@@ -240,6 +243,7 @@ fn test_into_tx_graph() -> anyhow::Result<()> {
 /// TODO: If the reorg height is lower than the fallback height, how do we find a block height to
 /// emit that can connect with our receiver chain?
 #[test]
+#[serial]
 fn ensure_block_emitted_after_reorg_is_at_reorg_height() -> anyhow::Result<()> {
     const EMITTER_START_HEIGHT: usize = 100;
     const CHAIN_TIP_HEIGHT: usize = 110;
@@ -315,6 +319,7 @@ fn get_balance(
 /// If a block is reorged out, ensure that containing transactions that do not exist in the
 /// replacement block(s) become unconfirmed.
 #[test]
+#[serial]
 fn tx_can_become_unconfirmed_after_reorg() -> anyhow::Result<()> {
     const PREMINE_COUNT: usize = 101;
     const ADDITIONAL_COUNT: usize = 11;
@@ -406,6 +411,7 @@ fn tx_can_become_unconfirmed_after_reorg() -> anyhow::Result<()> {
 /// When we call Emitter::mempool multiple times, mempool txs should not be re-emitted, even if the
 /// chain tip is extended.
 #[test]
+#[serial]
 fn mempool_avoids_re_emission() -> anyhow::Result<()> {
     const BLOCKS_TO_MINE: usize = 101;
     const MEMPOOL_TX_COUNT: usize = 2;
@@ -471,6 +477,7 @@ fn mempool_avoids_re_emission() -> anyhow::Result<()> {
 /// that `mempool` should always re-emit txs that have introduced at a height greater than the last
 /// emitted block height.
 #[test]
+#[serial]
 fn mempool_re_emits_if_tx_introduction_height_not_reached() -> anyhow::Result<()> {
     const PREMINE_COUNT: usize = 101;
     const MEMPOOL_TX_COUNT: usize = 21;
@@ -559,6 +566,7 @@ fn mempool_re_emits_if_tx_introduction_height_not_reached() -> anyhow::Result<()
 
 /// Ensure we force re-emit all mempool txs after reorg.
 #[test]
+#[serial]
 fn mempool_during_reorg() -> anyhow::Result<()> {
     const TIP_DIFF: usize = 10;
     const PREMINE_COUNT: usize = 101;
@@ -682,6 +690,7 @@ fn mempool_during_reorg() -> anyhow::Result<()> {
 /// The block hash of 99b should be different than 99a, but their previous block hashes should
 /// be the same.
 #[test]
+#[serial]
 fn no_agreement_point() -> anyhow::Result<()> {
     const PREMINE_COUNT: usize = 101;
 

--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -19,6 +19,7 @@ electrum-client = { version = "0.21", features = [ "proxy" ], default-features =
 [dev-dependencies]
 bdk_testenv = { path = "../testenv", default-features = false }
 bdk_chain = { path = "../chain" }
+serial_test = { version = "=0.8.0" }
 
 [features]
 default = ["use-rustls"]

--- a/crates/electrum/tests/test_electrum.rs
+++ b/crates/electrum/tests/test_electrum.rs
@@ -8,6 +8,7 @@ use bdk_chain::{
 use bdk_electrum::BdkElectrumClient;
 use bdk_testenv::{anyhow, bitcoincore_rpc::RpcApi, TestEnv};
 use core::time::Duration;
+use serial_test::serial;
 use std::collections::{BTreeSet, HashSet};
 use std::str::FromStr;
 
@@ -55,6 +56,7 @@ where
 }
 
 #[test]
+#[serial]
 pub fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
     let env = TestEnv::new()?;
     let electrum_client = electrum_client::Client::new(env.electrsd.electrum_url.as_str())?;
@@ -163,6 +165,7 @@ pub fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
 
 /// Test the bounds of the address scan depending on the `stop_gap`.
 #[test]
+#[serial]
 pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     let env = TestEnv::new()?;
     let electrum_client = electrum_client::Client::new(env.electrsd.electrum_url.as_str())?;
@@ -290,6 +293,7 @@ pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
 /// reorg and no-reorg situations. After the transaction is confirmed after reorg, check if floating
 /// txouts for previous outputs were inserted for transaction fee calculation.
 #[test]
+#[serial]
 fn test_sync() -> anyhow::Result<()> {
     const SEND_AMOUNT: Amount = Amount::from_sat(10_000);
 
@@ -432,6 +436,7 @@ fn test_sync() -> anyhow::Result<()> {
 /// 3. Perform 8 separate reorgs on each block with a confirmed tx.
 /// 4. Check [`Balance`] after each reorg to ensure unconfirmed amount is correct.
 #[test]
+#[serial]
 fn tx_can_become_unconfirmed_after_reorg() -> anyhow::Result<()> {
     const REORG_COUNT: usize = 8;
     const SEND_AMOUNT: Amount = Amount::from_sat(10_000);


### PR DESCRIPTION

### Description

This PR is a proposed solution to https://github.com/bitcoindevkit/bdk_wallet/issues/43
It enforces running tests that use bitcoind or electrsd in series (rather than parallel)

### Notes to the reviewers

Originally I had suggested just including a test troubleshooting section in docs to show ways to run in series

#### Bugfixes:

* [x] I'm linking the issue being fixed by this PR
