### PR TITLE
Check time when persisting in `rusqlite` impl

### DIFF
--- a/crates/chain/src/rusqlite_impl.rs
+++ b/crates/chain/src/rusqlite_impl.rs
@@ -352,9 +352,10 @@ where
                 Self::TXS_TABLE_NAME,
             ))?;
         for (&txid, &last_seen) in &self.last_seen {
+            let checked_time = last_seen.to_sql()?;
             statement.execute(named_params! {
                 ":txid": Impl(txid),
-                ":last_seen": Some(last_seen),
+                ":last_seen": Some(checked_time),
             })?;
         }
 


### PR DESCRIPTION
Closes #1713

Any implementation overflowing the `i64` type would be clearly faulty, so I just pass up the error if the conversion fails.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
