### PR TITLE
chore(core)!: rename `SyncResult` to `SyncResponse`

### DIFF
--- a/crates/core/src/spk_client.rs
+++ b/crates/core/src/spk_client.rs
@@ -322,14 +322,14 @@ impl<I> SyncRequest<I> {
 /// See also [`SyncRequest`].
 #[must_use]
 #[derive(Debug)]
-pub struct SyncResult<A = ConfirmationBlockTime> {
+pub struct SyncResponse<A = ConfirmationBlockTime> {
     /// Relevant transaction data discovered during the scan.
     pub tx_update: crate::TxUpdate<A>,
     /// Changes to the chain discovered during the scan.
     pub chain_update: Option<CheckPoint>,
 }
 
-impl<A> Default for SyncResult<A> {
+impl<A> Default for SyncResponse<A> {
     fn default() -> Self {
         Self {
             tx_update: Default::default(),

--- a/crates/core/src/spk_client.rs
+++ b/crates/core/src/spk_client.rs
@@ -459,7 +459,7 @@ impl<K: Ord + Clone> FullScanRequest<K> {
 /// See also [`FullScanRequest`].
 #[must_use]
 #[derive(Debug)]
-pub struct FullScanResult<K, A = ConfirmationBlockTime> {
+pub struct FullScanResponse<K, A = ConfirmationBlockTime> {
     /// Relevant transaction data discovered during the scan.
     pub tx_update: crate::TxUpdate<A>,
     /// Last active indices for the corresponding keychains (`K`). An index is active if it had a
@@ -469,7 +469,7 @@ pub struct FullScanResult<K, A = ConfirmationBlockTime> {
     pub chain_update: Option<CheckPoint>,
 }
 
-impl<K, A> Default for FullScanResult<K, A> {
+impl<K, A> Default for FullScanResponse<K, A> {
     fn default() -> Self {
         Self {
             tx_update: Default::default(),

--- a/crates/electrum/src/bdk_electrum_client.rs
+++ b/crates/electrum/src/bdk_electrum_client.rs
@@ -1,7 +1,7 @@
 use bdk_core::{
     bitcoin::{block::Header, BlockHash, OutPoint, ScriptBuf, Transaction, Txid},
     collections::{BTreeMap, HashMap},
-    spk_client::{FullScanRequest, FullScanResult, SyncRequest, SyncResponse},
+    spk_client::{FullScanRequest, FullScanResponse, SyncRequest, SyncResponse},
     BlockId, CheckPoint, ConfirmationBlockTime, TxUpdate,
 };
 use electrum_client::{ElectrumApi, Error, HeaderNotification};
@@ -126,7 +126,7 @@ impl<E: ElectrumApi> BdkElectrumClient<E> {
         stop_gap: usize,
         batch_size: usize,
         fetch_prev_txouts: bool,
-    ) -> Result<FullScanResult<K>, Error> {
+    ) -> Result<FullScanResponse<K>, Error> {
         let mut request: FullScanRequest<K> = request.into();
 
         let tip_and_latest_blocks = match request.chain_tip() {
@@ -159,7 +159,7 @@ impl<E: ElectrumApi> BdkElectrumClient<E> {
             _ => None,
         };
 
-        Ok(FullScanResult {
+        Ok(FullScanResponse {
             tx_update,
             chain_update,
             last_active_indices,

--- a/crates/electrum/src/bdk_electrum_client.rs
+++ b/crates/electrum/src/bdk_electrum_client.rs
@@ -1,7 +1,7 @@
 use bdk_core::{
     bitcoin::{block::Header, BlockHash, OutPoint, ScriptBuf, Transaction, Txid},
     collections::{BTreeMap, HashMap},
-    spk_client::{FullScanRequest, FullScanResult, SyncRequest, SyncResult},
+    spk_client::{FullScanRequest, FullScanResult, SyncRequest, SyncResponse},
     BlockId, CheckPoint, ConfirmationBlockTime, TxUpdate,
 };
 use electrum_client::{ElectrumApi, Error, HeaderNotification};
@@ -194,7 +194,7 @@ impl<E: ElectrumApi> BdkElectrumClient<E> {
         request: impl Into<SyncRequest<I>>,
         batch_size: usize,
         fetch_prev_txouts: bool,
-    ) -> Result<SyncResult, Error> {
+    ) -> Result<SyncResponse, Error> {
         let mut request: SyncRequest<I> = request.into();
 
         let tip_and_latest_blocks = match request.chain_tip() {
@@ -229,7 +229,7 @@ impl<E: ElectrumApi> BdkElectrumClient<E> {
             None => None,
         };
 
-        Ok(SyncResult {
+        Ok(SyncResponse {
             tx_update,
             chain_update,
         })

--- a/crates/electrum/src/lib.rs
+++ b/crates/electrum/src/lib.rs
@@ -1,7 +1,7 @@
 //! This crate is used for returning updates from Electrum servers.
 //!
 //! Updates are returned as either a [`SyncResponse`] (if [`BdkElectrumClient::sync()`] is called),
-//! or a [`FullScanResult`] (if [`BdkElectrumClient::full_scan()`] is called).
+//! or a [`FullScanResponse`] (if [`BdkElectrumClient::full_scan()`] is called).
 //!
 //! In most cases [`BdkElectrumClient::sync()`] is used to sync the transaction histories of scripts
 //! that the application cares about, for example the scripts for all the receive addresses of a
@@ -15,7 +15,7 @@
 //!
 //! [`example_electrum`]: https://github.com/bitcoindevkit/bdk/tree/master/example-crates/example_electrum
 //! [`SyncResponse`]: bdk_core::spk_client::SyncResponse
-//! [`FullScanResult`]: bdk_core::spk_client::FullScanResult
+//! [`FullScanResponse`]: bdk_core::spk_client::FullScanResponse
 
 #![warn(missing_docs)]
 

--- a/crates/electrum/src/lib.rs
+++ b/crates/electrum/src/lib.rs
@@ -1,6 +1,6 @@
 //! This crate is used for returning updates from Electrum servers.
 //!
-//! Updates are returned as either a [`SyncResult`] (if [`BdkElectrumClient::sync()`] is called),
+//! Updates are returned as either a [`SyncResponse`] (if [`BdkElectrumClient::sync()`] is called),
 //! or a [`FullScanResult`] (if [`BdkElectrumClient::full_scan()`] is called).
 //!
 //! In most cases [`BdkElectrumClient::sync()`] is used to sync the transaction histories of scripts
@@ -14,7 +14,7 @@
 //! Refer to [`example_electrum`] for a complete example.
 //!
 //! [`example_electrum`]: https://github.com/bitcoindevkit/bdk/tree/master/example-crates/example_electrum
-//! [`SyncResult`]: bdk_core::spk_client::SyncResult
+//! [`SyncResponse`]: bdk_core::spk_client::SyncResponse
 //! [`FullScanResult`]: bdk_core::spk_client::FullScanResult
 
 #![warn(missing_docs)]

--- a/crates/electrum/tests/test_electrum.rs
+++ b/crates/electrum/tests/test_electrum.rs
@@ -1,7 +1,7 @@
 use bdk_chain::{
     bitcoin::{hashes::Hash, Address, Amount, ScriptBuf, WScriptHash},
     local_chain::LocalChain,
-    spk_client::{FullScanRequest, SyncRequest, SyncResult},
+    spk_client::{FullScanRequest, SyncRequest, SyncResponse},
     spk_txout::SpkTxOutIndex,
     Balance, ConfirmationBlockTime, IndexedTxGraph, Indexer, Merge, TxGraph,
 };
@@ -31,7 +31,7 @@ fn sync_with_electrum<I, Spks>(
     spks: Spks,
     chain: &mut LocalChain,
     graph: &mut IndexedTxGraph<ConfirmationBlockTime, I>,
-) -> anyhow::Result<SyncResult>
+) -> anyhow::Result<SyncResponse>
 where
     I: Indexer,
     I::ChangeSet: Default + Merge,

--- a/crates/esplora/src/async_ext.rs
+++ b/crates/esplora/src/async_ext.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use bdk_core::collections::{BTreeMap, BTreeSet, HashSet};
-use bdk_core::spk_client::{FullScanRequest, FullScanResult, SyncRequest, SyncResult};
+use bdk_core::spk_client::{FullScanRequest, FullScanResult, SyncRequest, SyncResponse};
 use bdk_core::{
     bitcoin::{BlockHash, OutPoint, ScriptBuf, Txid},
     BlockId, CheckPoint, ConfirmationBlockTime, Indexed, TxUpdate,
@@ -45,7 +45,7 @@ pub trait EsploraAsyncExt {
         &self,
         request: R,
         parallel_requests: usize,
-    ) -> Result<SyncResult, Error>;
+    ) -> Result<SyncResponse, Error>;
 }
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
@@ -104,7 +104,7 @@ impl EsploraAsyncExt for esplora_client::AsyncClient {
         &self,
         request: R,
         parallel_requests: usize,
-    ) -> Result<SyncResult, Error> {
+    ) -> Result<SyncResponse, Error> {
         let mut request = request.into();
 
         let chain_tip = request.chain_tip();
@@ -151,7 +151,7 @@ impl EsploraAsyncExt for esplora_client::AsyncClient {
             _ => None,
         };
 
-        Ok(SyncResult {
+        Ok(SyncResponse {
             chain_update,
             tx_update,
         })

--- a/crates/esplora/src/async_ext.rs
+++ b/crates/esplora/src/async_ext.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use bdk_core::collections::{BTreeMap, BTreeSet, HashSet};
-use bdk_core::spk_client::{FullScanRequest, FullScanResult, SyncRequest, SyncResponse};
+use bdk_core::spk_client::{FullScanRequest, FullScanResponse, SyncRequest, SyncResponse};
 use bdk_core::{
     bitcoin::{BlockHash, OutPoint, ScriptBuf, Txid},
     BlockId, CheckPoint, ConfirmationBlockTime, Indexed, TxUpdate,
@@ -32,7 +32,7 @@ pub trait EsploraAsyncExt {
         request: R,
         stop_gap: usize,
         parallel_requests: usize,
-    ) -> Result<FullScanResult<K>, Error>;
+    ) -> Result<FullScanResponse<K>, Error>;
 
     /// Sync a set of scripts, txids, and/or outpoints against Esplora.
     ///
@@ -56,7 +56,7 @@ impl EsploraAsyncExt for esplora_client::AsyncClient {
         request: R,
         stop_gap: usize,
         parallel_requests: usize,
-    ) -> Result<FullScanResult<K>, Error> {
+    ) -> Result<FullScanResponse<K>, Error> {
         let mut request = request.into();
         let keychains = request.keychains();
 
@@ -93,7 +93,7 @@ impl EsploraAsyncExt for esplora_client::AsyncClient {
             _ => None,
         };
 
-        Ok(FullScanResult {
+        Ok(FullScanResponse {
             chain_update,
             tx_update,
             last_active_indices,

--- a/crates/esplora/src/blocking_ext.rs
+++ b/crates/esplora/src/blocking_ext.rs
@@ -1,5 +1,5 @@
 use bdk_core::collections::{BTreeMap, BTreeSet, HashSet};
-use bdk_core::spk_client::{FullScanRequest, FullScanResult, SyncRequest, SyncResponse};
+use bdk_core::spk_client::{FullScanRequest, FullScanResponse, SyncRequest, SyncResponse};
 use bdk_core::{
     bitcoin::{BlockHash, OutPoint, ScriptBuf, Txid},
     BlockId, CheckPoint, ConfirmationBlockTime, Indexed, TxUpdate,
@@ -30,7 +30,7 @@ pub trait EsploraExt {
         request: R,
         stop_gap: usize,
         parallel_requests: usize,
-    ) -> Result<FullScanResult<K>, Error>;
+    ) -> Result<FullScanResponse<K>, Error>;
 
     /// Sync a set of scripts, txids, and/or outpoints against Esplora.
     ///
@@ -52,7 +52,7 @@ impl EsploraExt for esplora_client::BlockingClient {
         request: R,
         stop_gap: usize,
         parallel_requests: usize,
-    ) -> Result<FullScanResult<K>, Error> {
+    ) -> Result<FullScanResponse<K>, Error> {
         let mut request = request.into();
 
         let chain_tip = request.chain_tip();
@@ -90,7 +90,7 @@ impl EsploraExt for esplora_client::BlockingClient {
             _ => None,
         };
 
-        Ok(FullScanResult {
+        Ok(FullScanResponse {
             chain_update,
             tx_update,
             last_active_indices,

--- a/crates/esplora/src/blocking_ext.rs
+++ b/crates/esplora/src/blocking_ext.rs
@@ -1,5 +1,5 @@
 use bdk_core::collections::{BTreeMap, BTreeSet, HashSet};
-use bdk_core::spk_client::{FullScanRequest, FullScanResult, SyncRequest, SyncResult};
+use bdk_core::spk_client::{FullScanRequest, FullScanResult, SyncRequest, SyncResponse};
 use bdk_core::{
     bitcoin::{BlockHash, OutPoint, ScriptBuf, Txid},
     BlockId, CheckPoint, ConfirmationBlockTime, Indexed, TxUpdate,
@@ -43,7 +43,7 @@ pub trait EsploraExt {
         &self,
         request: R,
         parallel_requests: usize,
-    ) -> Result<SyncResult, Error>;
+    ) -> Result<SyncResponse, Error>;
 }
 
 impl EsploraExt for esplora_client::BlockingClient {
@@ -101,7 +101,7 @@ impl EsploraExt for esplora_client::BlockingClient {
         &self,
         request: R,
         parallel_requests: usize,
-    ) -> Result<SyncResult, Error> {
+    ) -> Result<SyncResponse, Error> {
         let mut request: SyncRequest<I> = request.into();
 
         let chain_tip = request.chain_tip();
@@ -142,7 +142,7 @@ impl EsploraExt for esplora_client::BlockingClient {
             _ => None,
         };
 
-        Ok(SyncResult {
+        Ok(SyncResponse {
             chain_update,
             tx_update,
         })

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -26,7 +26,7 @@ use bdk_chain::{
     indexer::keychain_txout::KeychainTxOutIndex,
     local_chain::{ApplyHeaderError, CannotConnectError, CheckPoint, CheckPointIter, LocalChain},
     spk_client::{
-        FullScanRequest, FullScanRequestBuilder, FullScanResult, SyncRequest, SyncRequestBuilder,
+        FullScanRequest, FullScanRequestBuilder, FullScanResponse, SyncRequest, SyncRequestBuilder,
         SyncResponse,
     },
     tx_graph::{CalculateFeeError, CanonicalTx, TxGraph, TxUpdate},
@@ -132,8 +132,8 @@ pub struct Update {
     pub chain: Option<CheckPoint>,
 }
 
-impl From<FullScanResult<KeychainKind>> for Update {
-    fn from(value: FullScanResult<KeychainKind>) -> Self {
+impl From<FullScanResponse<KeychainKind>> for Update {
+    fn from(value: FullScanResponse<KeychainKind>) -> Self {
         Self {
             last_active_indices: value.last_active_indices,
             tx_update: value.tx_update,

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -27,7 +27,7 @@ use bdk_chain::{
     local_chain::{ApplyHeaderError, CannotConnectError, CheckPoint, CheckPointIter, LocalChain},
     spk_client::{
         FullScanRequest, FullScanRequestBuilder, FullScanResult, SyncRequest, SyncRequestBuilder,
-        SyncResult,
+        SyncResponse,
     },
     tx_graph::{CalculateFeeError, CanonicalTx, TxGraph, TxUpdate},
     BlockId, ChainPosition, ConfirmationBlockTime, DescriptorExt, FullTxOut, Indexed,
@@ -142,8 +142,8 @@ impl From<FullScanResult<KeychainKind>> for Update {
     }
 }
 
-impl From<SyncResult> for Update {
-    fn from(value: SyncResult) -> Self {
+impl From<SyncResponse> for Update {
+    fn from(value: SyncResponse) -> Self {
         Self {
             last_active_indices: BTreeMap::new(),
             tx_update: value.tx_update,


### PR DESCRIPTION
fixes #1647 

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

As mentioned in #1647 issue, the usage of `Result` in Rust is conventionally meant to be an enum type with error variant, and it's appropriate here.

It should be `SyncResponse` instead, as it's the most appropriate alongside the other types `SyncRequest` and `SyncProgress` already being used.

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

- Change `bdk_core::spk_client`'s `SyncResult` to `SyncResponse`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
