### PR TITLE
feat(chain,wallet)!: Transitive `ChainPosition`

### DIFF
--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -293,7 +293,7 @@ fn test_list_owned_txouts() {
             let confirmed_txouts_txid = txouts
                 .iter()
                 .filter_map(|(_, full_txout)| {
-                    if matches!(full_txout.chain_position, ChainPosition::Confirmed(_)) {
+                    if matches!(full_txout.chain_position, ChainPosition::Confirmed { .. }) {
                         Some(full_txout.outpoint.txid)
                     } else {
                         None
@@ -304,7 +304,7 @@ fn test_list_owned_txouts() {
             let unconfirmed_txouts_txid = txouts
                 .iter()
                 .filter_map(|(_, full_txout)| {
-                    if matches!(full_txout.chain_position, ChainPosition::Unconfirmed(_)) {
+                    if matches!(full_txout.chain_position, ChainPosition::Unconfirmed { .. }) {
                         Some(full_txout.outpoint.txid)
                     } else {
                         None
@@ -315,7 +315,7 @@ fn test_list_owned_txouts() {
             let confirmed_utxos_txid = utxos
                 .iter()
                 .filter_map(|(_, full_txout)| {
-                    if matches!(full_txout.chain_position, ChainPosition::Confirmed(_)) {
+                    if matches!(full_txout.chain_position, ChainPosition::Confirmed { .. }) {
                         Some(full_txout.outpoint.txid)
                     } else {
                         None
@@ -326,7 +326,7 @@ fn test_list_owned_txouts() {
             let unconfirmed_utxos_txid = utxos
                 .iter()
                 .filter_map(|(_, full_txout)| {
-                    if matches!(full_txout.chain_position, ChainPosition::Unconfirmed(_)) {
+                    if matches!(full_txout.chain_position, ChainPosition::Unconfirmed { .. }) {
                         Some(full_txout.outpoint.txid)
                     } else {
                         None
@@ -618,7 +618,7 @@ fn test_get_chain_position() {
             },
             anchor: None,
             last_seen: Some(2),
-            exp_pos: Some(ChainPosition::Unconfirmed(2)),
+            exp_pos: Some(ChainPosition::Unconfirmed { last_seen: Some(2) }),
         },
         TestCase {
             name: "tx anchor in best chain - confirmed",
@@ -631,7 +631,10 @@ fn test_get_chain_position() {
             },
             anchor: Some(blocks[1]),
             last_seen: None,
-            exp_pos: Some(ChainPosition::Confirmed(blocks[1])),
+            exp_pos: Some(ChainPosition::Confirmed {
+                anchor: blocks[1],
+                transitively: None,
+            }),
         },
         TestCase {
             name: "tx unknown anchor with last_seen - unconfirmed",
@@ -644,7 +647,7 @@ fn test_get_chain_position() {
             },
             anchor: Some(block_id!(2, "B'")),
             last_seen: Some(2),
-            exp_pos: Some(ChainPosition::Unconfirmed(2)),
+            exp_pos: Some(ChainPosition::Unconfirmed { last_seen: Some(2) }),
         },
         TestCase {
             name: "tx unknown anchor - no chain pos",

--- a/crates/wallet/src/wallet/export.rs
+++ b/crates/wallet/src/wallet/export.rs
@@ -129,10 +129,10 @@ impl FullyNodedExport {
 
         let blockheight = if include_blockheight {
             wallet.transactions().next().map_or(0, |canonical_tx| {
-                match canonical_tx.chain_position {
-                    bdk_chain::ChainPosition::Confirmed(a) => a.block_id.height,
-                    bdk_chain::ChainPosition::Unconfirmed(_) => 0,
-                }
+                canonical_tx
+                    .chain_position
+                    .confirmation_height_upper_bound()
+                    .unwrap_or(0)
             })
         } else {
             0

--- a/crates/wallet/src/wallet/tx_builder.rs
+++ b/crates/wallet/src/wallet/tx_builder.rs
@@ -1017,7 +1017,7 @@ mod test {
                 txout: TxOut::NULL,
                 keychain: KeychainKind::External,
                 is_spent: false,
-                chain_position: chain::ChainPosition::Unconfirmed(0),
+                chain_position: chain::ChainPosition::Unconfirmed { last_seen: Some(0) },
                 derivation_index: 0,
             },
             LocalOutput {
@@ -1028,13 +1028,16 @@ mod test {
                 txout: TxOut::NULL,
                 keychain: KeychainKind::Internal,
                 is_spent: false,
-                chain_position: chain::ChainPosition::Confirmed(chain::ConfirmationBlockTime {
-                    block_id: chain::BlockId {
-                        height: 32,
-                        hash: bitcoin::BlockHash::all_zeros(),
+                chain_position: chain::ChainPosition::Confirmed {
+                    anchor: chain::ConfirmationBlockTime {
+                        block_id: chain::BlockId {
+                            height: 32,
+                            hash: bitcoin::BlockHash::all_zeros(),
+                        },
+                        confirmation_time: 42,
                     },
-                    confirmation_time: 42,
-                }),
+                    transitively: None,
+                },
                 derivation_index: 1,
             },
         ]


### PR DESCRIPTION
### Description

Change `ChainPosition` to be able to represent transitive anchors and unconfirm-without-last-seen values.

As mentioned in https://github.com/bitcoindevkit/bdk/pull/1670#issuecomment-2484535021, we want this merged first so that we have minimal changes to the API after 1670 is merged.

### Changelog notice

* Change `ChainPosition` so that it is able to represent transitive anchors and unconfirmed-without-last-seen values.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

~* [ ] I've added tests for the new feature~
* [x] I've added docs for the new feature

