### PR TITLE
chore(chain)!: use `debug_assert!` on `apply_update`

### DIFF
--- a/crates/chain/src/local_chain.rs
+++ b/crates/chain/src/local_chain.rs
@@ -174,7 +174,7 @@ impl LocalChain {
     pub fn apply_update(&mut self, update: CheckPoint) -> Result<ChangeSet, CannotConnectError> {
         let (new_tip, changeset) = merge_chains(self.tip.clone(), update)?;
         self.tip = new_tip;
-        self._check_changeset_is_applied(&changeset);
+        debug_assert!(self._check_changeset_is_applied(&changeset));
         Ok(changeset)
     }
 


### PR DESCRIPTION
fixes #1689

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description
As mentioned in issue #1689 the `debug_assert!` is being used on other `LocalChain` methods, such as: `from_changeset`, and `apply_changeset` but it was missing on `apply_update`.

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

- Add usage of `debug_assert!()` to `LocalChain::apply_update`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
