### PR TITLE
WIP: Benchmark `TxGraph` queries

### DIFF
--- a/.github/workflows/nightly_docs.yml
+++ b/.github/workflows/nightly_docs.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
       - name: Set default toolchain
-        run: rustup default nightly-2024-05-12
+        run: rustup default nightly-2024-11-17
       - name: Set profile
         run: rustup set profile minimal
       - name: Update toolchain

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target
+**/target
 Cargo.lock
 /.vscode
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,9 @@ authors = ["Bitcoin Dev Kit Developers"]
 [workspace.lints.clippy]
 print_stdout = "deny"
 print_stderr = "deny"
+
+[workspace.lints.rust.unexpected_cfgs]
+level = "forbid"
+check-cfg = [
+    "cfg(bdk_bench)",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "example-crates/example_wallet_esplora_async",
     "example-crates/example_wallet_rpc",
 ]
+exclude = ["bench"]
 
 [workspace.package]
 authors = ["Bitcoin Dev Kit Developers"]

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "bdk_bench"
+version = "0.1.0"
+edition = "2021"
+
+[[bench]]
+name = "bench"
+harness = false
+
+[dependencies]
+bdk_chain = { path = "../crates/chain" }
+criterion = { version = "0.5", default-features = false }

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -8,5 +8,5 @@ name = "bench"
 harness = false
 
 [dependencies]
-bdk_chain = { path = "../crates/chain" }
+bdk_chain = { path = "../crates/chain", features = ["criterion"] }
 criterion = { version = "0.5", default-features = false }

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,3 @@
+# To run benches
+
+`cargo bench`

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,3 +1,5 @@
-# To run benches
+# BDK bench
 
-`cargo bench`
+To run benchmarks in the current directory:
+    
+`RUSTFLAGS="--cfg=bdk_bench" cargo bench`

--- a/bench/benches/bench.rs
+++ b/bench/benches/bench.rs
@@ -1,0 +1,7 @@
+extern crate bdk_chain;
+extern crate criterion;
+
+use criterion::{criterion_group, criterion_main};
+
+criterion_group!(benches, bdk_chain::tx_graph::bench::filter_chain_unspents);
+criterion_main!(benches);

--- a/bench/benches/bench.rs
+++ b/bench/benches/bench.rs
@@ -3,5 +3,9 @@ extern crate criterion;
 
 use criterion::{criterion_group, criterion_main};
 
-criterion_group!(benches, bdk_chain::tx_graph::bench::filter_chain_unspents);
+criterion_group!(benches,
+    bdk_chain::tx_graph::bench::filter_chain_unspents,
+    bdk_chain::tx_graph::bench::list_canonical_txs,
+    bdk_chain::tx_graph::bench::nested_conflicts,
+);
 criterion_main!(benches);

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -20,7 +20,6 @@ bitcoin = { version = "0.32.0", default-features = false }
 bdk_core = { path = "../core", version = "0.3.0", default-features = false }
 serde = { version = "1", optional = true, features = ["derive", "rc"] }
 miniscript = { version = "12.0.0", optional = true, default-features = false }
-criterion = { version = "0.5", default-features = false }
 
 # Feature dependencies
 rusqlite = { version = "0.31.0", features = ["bundled"], optional = true }
@@ -30,6 +29,9 @@ serde_json = { version = "1", optional = true }
 rand = "0.8"
 proptest = "1.2.0"
 bdk_testenv = { path = "../testenv", default-features = false }
+
+[target.'cfg(bdk_bench)'.dependencies]
+criterion = { version = "0.5", optional = true, default-features = false }
 
 
 [features]

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -20,6 +20,7 @@ bitcoin = { version = "0.32.0", default-features = false }
 bdk_core = { path = "../core", version = "0.3.0", default-features = false }
 serde = { version = "1", optional = true, features = ["derive", "rc"] }
 miniscript = { version = "12.0.0", optional = true, default-features = false }
+criterion = { version = "0.5", default-features = false }
 
 # Feature dependencies
 rusqlite = { version = "0.31.0", features = ["bundled"], optional = true }

--- a/crates/chain/src/lib.rs
+++ b/crates/chain/src/lib.rs
@@ -68,6 +68,8 @@ pub use bdk_core::*;
 #[allow(unused_imports)]
 #[macro_use]
 extern crate alloc;
+#[cfg(bdk_bench)]
+extern crate criterion;
 #[cfg(feature = "rusqlite")]
 pub extern crate rusqlite;
 #[cfg(feature = "serde")]

--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -1557,6 +1557,7 @@ fn tx_outpoint_range(txid: Txid) -> RangeInclusive<OutPoint> {
 /// Bench
 #[allow(unused)]
 #[allow(missing_docs)]
+#[cfg(bdk_bench)]
 pub mod bench {
     use std::str::FromStr;
 
@@ -1652,14 +1653,13 @@ pub mod bench {
     pub fn filter_chain_unspents(bench: &mut Criterion) {
         let (graph, chain) = get_params();
         // TODO: insert conflicts
-        let outpoints = graph.index.outpoints().clone();
         bench.bench_function("filter_chain_unspents", |b| {
             b.iter(|| {
                 TxGraph::filter_chain_unspents(
                     graph.graph(),
                     &chain,
                     chain.tip().block_id(),
-                    outpoints.clone(),
+                    graph.index.outpoints().clone(),
                 )
             })
         });


### PR DESCRIPTION
Add `bench` directory to the workspace and begin benchmarking performance of tx-graph queries. I'm currently working on creating benches for these scenarios

- [ ] Finding the canonical set from a large number of tx conflicts
- [ ] Same as above, but further complicated by "nesting" conflicts
- [ ] Conflicts with potentially many descendants

cc #1687 

### Notes to the reviewers


### Changelog notice


### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
