### PR TITLE
Sqlite - allow persisting anchor without tx

### DIFF
--- a/crates/chain/src/rusqlite_impl.rs
+++ b/crates/chain/src/rusqlite_impl.rs
@@ -1,4 +1,4 @@
-//! Module for stuff
+//! Support for persisting `bdk_chain` structures to SQLite using [`rusqlite`].
 
 use crate::*;
 use core::str::FromStr;

--- a/crates/chain/src/rusqlite_impl.rs
+++ b/crates/chain/src/rusqlite_impl.rs
@@ -376,8 +376,15 @@ where
             "REPLACE INTO {}(txid, block_height, block_hash, anchor) VALUES(:txid, :block_height, :block_hash, jsonb(:anchor))",
             Self::ANCHORS_TABLE_NAME,
         ))?;
+        let mut statement_txid = db_tx.prepare_cached(&format!(
+            "INSERT OR IGNORE INTO {}(txid) VALUES(:txid)",
+            Self::TXS_TABLE_NAME,
+        ))?;
         for (anchor, txid) in &self.anchors {
             let anchor_block = anchor.anchor_block();
+            statement_txid.execute(named_params! {
+                ":txid": Impl(*txid)
+            })?;
             statement.execute(named_params! {
                 ":txid": Impl(*txid),
                 ":block_height": anchor_block.height,


### PR DESCRIPTION
### Description

Previously, we may error when we insert an anchor where the txid being anchored has no corresponding tx.

closes #1712 
replaces #961 

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
