### PR TITLE
fix(tx_builder)!: make TxBuilder Send safe, remove Clone trait

### DIFF
--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -1195,7 +1195,7 @@ impl Wallet {
     /// [`TxBuilder`]: crate::TxBuilder
     pub fn build_tx(&mut self) -> TxBuilder<'_, DefaultCoinSelectionAlgorithm> {
         TxBuilder {
-            wallet: alloc::rc::Rc::new(core::cell::RefCell::new(self)),
+            wallet: self,
             params: TxParams::default(),
             coin_selection: DefaultCoinSelectionAlgorithm::default(),
         }
@@ -1701,7 +1701,7 @@ impl Wallet {
         };
 
         Ok(TxBuilder {
-            wallet: alloc::rc::Rc::new(core::cell::RefCell::new(self)),
+            wallet: self,
             params,
             coin_selection: DefaultCoinSelectionAlgorithm::default(),
         })

--- a/crates/wallet/tests/wallet.rs
+++ b/crates/wallet/tests/wallet.rs
@@ -1645,11 +1645,10 @@ fn test_add_foreign_utxo_only_witness_utxo() {
         .max_weight_to_satisfy()
         .unwrap();
 
-    let mut builder = wallet1.build_tx();
-    builder.add_recipient(addr.script_pubkey(), Amount::from_sat(60_000));
-
     {
-        let mut builder = builder.clone();
+        let mut builder = wallet1.build_tx();
+        builder.add_recipient(addr.script_pubkey(), Amount::from_sat(60_000));
+
         let psbt_input = psbt::Input {
             witness_utxo: Some(utxo2.txout.clone()),
             ..Default::default()
@@ -1664,7 +1663,9 @@ fn test_add_foreign_utxo_only_witness_utxo() {
     }
 
     {
-        let mut builder = builder.clone();
+        let mut builder = wallet1.build_tx();
+        builder.add_recipient(addr.script_pubkey(), Amount::from_sat(60_000));
+
         let psbt_input = psbt::Input {
             witness_utxo: Some(utxo2.txout.clone()),
             ..Default::default()
@@ -1680,7 +1681,9 @@ fn test_add_foreign_utxo_only_witness_utxo() {
     }
 
     {
-        let mut builder = builder.clone();
+        let mut builder = wallet1.build_tx();
+        builder.add_recipient(addr.script_pubkey(), Amount::from_sat(60_000));
+
         let tx2 = wallet2.get_tx(txid2).unwrap().tx_node.tx;
         let psbt_input = psbt::Input {
             non_witness_utxo: Some(tx2.as_ref().clone()),
@@ -4168,4 +4171,10 @@ fn test_transactions_sort_by() {
         .map(|tx| tx.chain_position.confirmation_height_upper_bound())
         .collect();
     assert_eq!([None, Some(2000), Some(1000)], conf_heights.as_slice());
+}
+
+#[test]
+fn test_tx_builder_is_send_safe() {
+    let (mut wallet, _txid) = get_funded_wallet_wpkh();
+    let _box: Box<dyn Send + Sync> = Box::new(wallet.build_tx());
 }


### PR DESCRIPTION
### Description

Inspired by discord chat with @stevenroose as a way to make the `TxBuilder` Send safe. 

See his original patch on 1.0.0-beta.5: https://gist.github.com/stevenroose/f7736dfedfaa64bbdbb0da5875df28fc

### Notes to the reviewers

I had to remove the `Clone` trait on `TxBuilder` but it was only being used in tests.

### Changelog notice

- TxBuilder is now Send safe and does not implement the Clone trait

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature