### PR TITLE
ci: pin `rustls` dependency version to build with rust 1.63

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -51,6 +51,7 @@ jobs:
           cargo update -p tokio-util --precise "0.7.11"
           cargo update -p indexmap --precise "2.5.0"
           cargo update -p security-framework-sys --precise "2.11.1"
+          cargo update -p rustls@0.23.18 --precise "0.23.17"
       - name: Build
         run: cargo build --workspace --exclude 'example_*' ${{ matrix.features }}
       - name: Test

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ cargo update -p tokio --precise "1.38.1"
 cargo update -p tokio-util --precise "0.7.11"
 cargo update -p indexmap --precise "2.5.0"
 cargo update -p security-framework-sys --precise "2.11.1"
+cargo update -p rustls@0.23.18 --precise "0.23.17"
 ```
 
 ## License


### PR DESCRIPTION
### Description
`rustls` version 0.23.18 raised msrv to 1.71.
Version 0.23.17 was pinned to CI to continue working.

### Changelog notice

* Pinned rustls dependency version to build with rust 1.63.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing