### PR TITLE
deps(esplora): bump `esplora-client` to 0.11.0

### DIFF
--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -16,12 +16,13 @@ workspace = true
 
 [dependencies]
 bdk_core = { path = "../core", version = "0.3.0", default-features = false }
-esplora-client = { version = "0.10.0", default-features = false }
+esplora-client = { version = "0.11.0", default-features = false } 
 async-trait = { version = "0.1.66", optional = true }
 futures = { version = "0.3.26", optional = true }
 miniscript = { version = "12.0.0", optional = true, default-features = false }
 
 [dev-dependencies]
+esplora-client = { version = "0.11.0" } 
 bdk_chain = { path = "../chain" }
 bdk_testenv = { path = "../testenv" }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
@@ -29,6 +30,7 @@ tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 [features]
 default = ["std", "async-https", "blocking-https"]
 std = ["bdk_chain/std", "miniscript?/std"]
+tokio = ["esplora-client/tokio"]
 async = ["async-trait", "futures", "esplora-client/async"]
 async-https = ["async", "esplora-client/async-https"]
 async-https-rustls = ["async", "esplora-client/async-https-rustls"]

--- a/crates/esplora/README.md
+++ b/crates/esplora/README.md
@@ -10,17 +10,24 @@ The extension traits are primarily intended to satisfy [`SyncRequest`]s with [`s
 
 For blocking-only:
 ```toml
-bdk_esplora = { version = "0.3", features = ["blocking"] }
+bdk_esplora = { version = "0.19", features = ["blocking"] }
 ```
 
 For async-only:
 ```toml
-bdk_esplora = { version = "0.3", features = ["async"] }
+bdk_esplora = { version = "0.19", features = ["async"] }
 ```
 
 For async-only (with https):
+
+You can additionally specify to use either rustls or native-tls, e.g. `async-https-native`, and this applies to both async and blocking features.
 ```toml
-bdk_esplora = { version = "0.3", features = ["async-https"] }
+bdk_esplora = { version = "0.19", features = ["async-https"] }
+```
+
+For async-only (with tokio):
+```toml
+bdk_esplora = { version = "0.19", features = ["async", "tokio"] }
 ```
 
 To use the extension traits:
@@ -34,7 +41,7 @@ use bdk_esplora::EsploraExt;
 use bdk_esplora::EsploraAsyncExt;
 ```
 
-For full examples, refer to [`example-crates/wallet_esplora_blocking`](https://github.com/bitcoindevkit/bdk/tree/master/example-crates/wallet_esplora_blocking) and [`example-crates/wallet_esplora_async`](https://github.com/bitcoindevkit/bdk/tree/master/example-crates/wallet_esplora_async).
+For full examples, refer to [`example_wallet_esplora_blocking`](https://github.com/bitcoindevkit/bdk/tree/master/example-crates/example_wallet_esplora_blocking) and [`example_wallet_esplora_async`](https://github.com/bitcoindevkit/bdk/tree/master/example-crates/example_wallet_esplora_async).
 
 [`esplora-client`]: https://docs.rs/esplora-client/
 [`bdk_chain`]: https://docs.rs/bdk-chain/

--- a/example-crates/example_wallet_esplora_async/Cargo.toml
+++ b/example-crates/example_wallet_esplora_async/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 bdk_wallet = { path = "../../crates/wallet", features = ["rusqlite"] }
-bdk_esplora = { path = "../../crates/esplora", features = ["async-https"] }
+bdk_esplora = { path = "../../crates/esplora", features = ["async-https", "tokio"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 anyhow = "1"


### PR DESCRIPTION
Update `bdk_esplora` to depend on esplora-client 0.11.0

### Notes to the reviewers

bitcoindevkit/rust-esplora-client#103 added a generic type parameter to `AsyncClient` representing a user-defined `Sleeper` and that change is reflected here in order to call the underlying API methods. We also add a new build feature "tokio" that enables the corresponding feature in rust-esplora-client.

closes #1742 

### Changelog notice

`bdk_esplora`: Bump `esplora-client` to 0.11.0

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
* [x] This pull request breaks the existing API
* [x] I'm linking the issue being fixed by this PR
