### PR TITLE
chore: Revert `rustls` pin dependency

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -51,7 +51,6 @@ jobs:
           cargo update -p tokio-util --precise "0.7.11"
           cargo update -p indexmap --precise "2.5.0"
           cargo update -p security-framework-sys --precise "2.11.1"
-          cargo update -p rustls@0.23.18 --precise "0.23.17"
       - name: Build
         run: cargo build --workspace --exclude 'example_*' ${{ matrix.features }}
       - name: Test

--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ cargo update -p tokio --precise "1.38.1"
 cargo update -p tokio-util --precise "0.7.11"
 cargo update -p indexmap --precise "2.5.0"
 cargo update -p security-framework-sys --precise "2.11.1"
-cargo update -p rustls@0.23.18 --precise "0.23.17"
 ```
 
 ## License


### PR DESCRIPTION
### Description

The recent release of `rustls` (0.23.19) reverts it's MSRV to 1.63 so the pin is no longer necessary.

### Notes to the reviewers

Some context:
* https://github.com/bitcoindevkit/rust-electrum-client/pull/158
* https://github.com/rustls/rustls/pull/2244

### Changelog notice

* Revert MSRV pin of `rustls`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
