### PR TITLE
deps(electrum): bump `electrum-client` to 0.22.0

### DIFF
--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 
 [dependencies]
 bdk_core = { path = "../core", version = "0.3.0" }
-electrum-client = { version = "0.21", features = [ "proxy" ], default-features = false }
+electrum-client = { version = "0.22", features = [ "proxy" ], default-features = false }
 
 [dev-dependencies]
 bdk_testenv = { path = "../testenv" }


### PR DESCRIPTION
Partially resolves #1742.

### Description

Updates the `electrum-client` dependency to 0.22.0 for `bdk_electrum`.

### Notes to the reviewers

### Changelog notice

* Updated `electrum-client` dependency to 0.22.0.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
