### PR TITLE
Remove serde json dependency from chain crate

### DIFF
--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -23,7 +23,6 @@ miniscript = { version = "12.0.0", optional = true, default-features = false }
 
 # Feature dependencies
 rusqlite = { version = "0.31.0", features = ["bundled"], optional = true }
-serde_json = { version = "1", optional = true }
 
 [dev-dependencies]
 rand = "0.8"
@@ -36,4 +35,4 @@ default = ["std", "miniscript"]
 std = ["bitcoin/std", "miniscript?/std", "bdk_core/std"]
 serde = ["dep:serde", "bitcoin/serde", "miniscript?/serde", "bdk_core/serde"]
 hashbrown = ["bdk_core/hashbrown"]
-rusqlite = ["std", "dep:rusqlite", "serde", "serde_json"]
+rusqlite = ["std", "dep:rusqlite", "serde"]

--- a/crates/chain/src/lib.rs
+++ b/crates/chain/src/lib.rs
@@ -100,27 +100,3 @@ impl<T> core::ops::Deref for Impl<T> {
         &self.0
     }
 }
-
-/// A wrapper that we use to impl remote traits for types in our crate or dependency crates that impl [`Anchor`].
-pub struct AnchorImpl<T>(pub T);
-
-impl<T> AnchorImpl<T> {
-    /// Returns the inner `T`.
-    pub fn into_inner(self) -> T {
-        self.0
-    }
-}
-
-impl<T> From<T> for AnchorImpl<T> {
-    fn from(value: T) -> Self {
-        Self(value)
-    }
-}
-
-impl<T> core::ops::Deref for AnchorImpl<T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}

--- a/crates/chain/src/rusqlite_impl.rs
+++ b/crates/chain/src/rusqlite_impl.rs
@@ -549,7 +549,7 @@ mod test {
 
     #[test]
     fn can_persist_anchors_and_txs_independently() -> anyhow::Result<()> {
-        type ChangeSet = tx_graph::ChangeSet<BlockId>;
+        type ChangeSet = tx_graph::ChangeSet<ConfirmationBlockTime>;
         let mut conn = rusqlite::Connection::open_in_memory()?;
 
         // init tables
@@ -567,9 +567,12 @@ mod test {
         };
         let tx = Arc::new(tx);
         let txid = tx.compute_txid();
-        let anchor = BlockId {
-            height: 21,
-            hash: hash!("anchor"),
+        let anchor = ConfirmationBlockTime {
+            block_id: BlockId {
+                height: 21,
+                hash: hash!("anchor"),
+            },
+            confirmation_time: 1342,
         };
 
         // First persist the anchor

--- a/crates/chain/src/rusqlite_impl.rs
+++ b/crates/chain/src/rusqlite_impl.rs
@@ -61,7 +61,7 @@ fn set_schema_version(
 pub fn migrate_schema(
     db_tx: &Transaction,
     schema_name: &str,
-    versioned_scripts: &[String],
+    versioned_scripts: &[&str],
 ) -> rusqlite::Result<()> {
     init_schemas_table(db_tx)?;
     let current_version = schema_version(db_tx, schema_name)?;
@@ -269,7 +269,7 @@ impl tx_graph::ChangeSet<ConfirmationBlockTime> {
         migrate_schema(
             db_tx,
             Self::SCHEMA_NAME,
-            &[Self::schema_v0(), Self::schema_v1()],
+            &[&Self::schema_v0(), &Self::schema_v1()],
         )
     }
 
@@ -435,7 +435,7 @@ impl local_chain::ChangeSet {
 
     /// Initialize sqlite tables for persisting [`local_chain::LocalChain`].
     pub fn init_sqlite_tables(db_tx: &rusqlite::Transaction) -> rusqlite::Result<()> {
-        migrate_schema(db_tx, Self::SCHEMA_NAME, &[Self::schema_v0()])
+        migrate_schema(db_tx, Self::SCHEMA_NAME, &[&Self::schema_v0()])
     }
 
     /// Construct a [`LocalChain`](local_chain::LocalChain) from sqlite database.
@@ -511,7 +511,7 @@ impl keychain_txout::ChangeSet {
     /// Initialize sqlite tables for persisting
     /// [`KeychainTxOutIndex`](keychain_txout::KeychainTxOutIndex).
     pub fn init_sqlite_tables(db_tx: &rusqlite::Transaction) -> rusqlite::Result<()> {
-        migrate_schema(db_tx, Self::SCHEMA_NAME, &[Self::schema_v0()])
+        migrate_schema(db_tx, Self::SCHEMA_NAME, &[&Self::schema_v0()])
     }
 
     /// Construct [`KeychainTxOutIndex`](keychain_txout::KeychainTxOutIndex) from sqlite database
@@ -635,7 +635,7 @@ mod test {
         // Create initial database with v0 sqlite schema
         {
             let db_tx = conn.transaction()?;
-            migrate_schema(&db_tx, ChangeSet::SCHEMA_NAME, &[ChangeSet::schema_v0()])?;
+            migrate_schema(&db_tx, ChangeSet::SCHEMA_NAME, &[&ChangeSet::schema_v0()])?;
             db_tx.commit()?;
         }
 
@@ -703,7 +703,7 @@ mod test {
             migrate_schema(
                 &db_tx,
                 ChangeSet::SCHEMA_NAME,
-                &[ChangeSet::schema_v0(), ChangeSet::schema_v1()],
+                &[&ChangeSet::schema_v0(), &ChangeSet::schema_v1()],
             )?;
             db_tx.commit()?;
         }

--- a/crates/chain/src/rusqlite_impl.rs
+++ b/crates/chain/src/rusqlite_impl.rs
@@ -157,22 +157,6 @@ impl ToSql for Impl<bitcoin::Amount> {
     }
 }
 
-impl<A: Anchor + serde::de::DeserializeOwned> FromSql for AnchorImpl<A> {
-    fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {
-        serde_json::from_str(value.as_str()?)
-            .map(AnchorImpl)
-            .map_err(from_sql_error)
-    }
-}
-
-impl<A: Anchor + serde::Serialize> ToSql for AnchorImpl<A> {
-    fn to_sql(&self) -> rusqlite::Result<ToSqlOutput<'_>> {
-        serde_json::to_string(&self.0)
-            .map(Into::into)
-            .map_err(to_sql_error)
-    }
-}
-
 #[cfg(feature = "miniscript")]
 impl FromSql for Impl<miniscript::Descriptor<miniscript::DescriptorPublicKey>> {
     fn column_result(value: ValueRef<'_>) -> FromSqlResult<Self> {

--- a/crates/wallet/src/wallet/changeset.rs
+++ b/crates/wallet/src/wallet/changeset.rs
@@ -1,3 +1,4 @@
+use alloc::string::String;
 use bdk_chain::{
     indexed_tx_graph, keychain_txout, local_chain, tx_graph, ConfirmationBlockTime, Merge,
 };
@@ -71,9 +72,9 @@ impl ChangeSet {
     /// Name of table to store wallet descriptors and network.
     pub const WALLET_TABLE_NAME: &'static str = "bdk_wallet";
 
-    /// Initialize sqlite tables for wallet tables.
-    pub fn init_sqlite_tables(db_tx: &chain::rusqlite::Transaction) -> chain::rusqlite::Result<()> {
-        let schema_v0: &[&str] = &[&format!(
+    /// Get v0 sqlite [ChangeSet] schema
+    pub fn schema_v0() -> String {
+        format!(
             "CREATE TABLE {} ( \
                 id INTEGER PRIMARY KEY NOT NULL CHECK (id = 0), \
                 descriptor TEXT, \
@@ -81,8 +82,16 @@ impl ChangeSet {
                 network TEXT \
                 ) STRICT;",
             Self::WALLET_TABLE_NAME,
-        )];
-        crate::rusqlite_impl::migrate_schema(db_tx, Self::WALLET_SCHEMA_NAME, &[schema_v0])?;
+        )
+    }
+
+    /// Initialize sqlite tables for wallet tables.
+    pub fn init_sqlite_tables(db_tx: &chain::rusqlite::Transaction) -> chain::rusqlite::Result<()> {
+        crate::rusqlite_impl::migrate_schema(
+            db_tx,
+            Self::WALLET_SCHEMA_NAME,
+            &[Self::schema_v0()],
+        )?;
 
         bdk_chain::local_chain::ChangeSet::init_sqlite_tables(db_tx)?;
         bdk_chain::tx_graph::ChangeSet::<ConfirmationBlockTime>::init_sqlite_tables(db_tx)?;

--- a/crates/wallet/src/wallet/changeset.rs
+++ b/crates/wallet/src/wallet/changeset.rs
@@ -90,7 +90,7 @@ impl ChangeSet {
         crate::rusqlite_impl::migrate_schema(
             db_tx,
             Self::WALLET_SCHEMA_NAME,
-            &[Self::schema_v0()],
+            &[&Self::schema_v0()],
         )?;
 
         bdk_chain::local_chain::ChangeSet::init_sqlite_tables(db_tx)?;


### PR DESCRIPTION
### Description

As expressed by @LLFourn _We want to not depend on serde_json. If we keep it around for serializing anchors we won't be able to remove it in the future because it will always be needed to do migrations_
Currently there is only one widely used anchor, `ConfirmationBlockTime`.

The decision was to constrain support to just be for a single anchor type ConfirmationBlockTime. The anchor table will represent all fields of `ConfirmationBlockTime`, each one in its own column.

The reasons:

- No one is using rusqlite with any other anchor type, and if they are, they can do something custom anyway.
- The anchor representation may change in the future, supporting for multiple Anchor types here will cause more problems for migration later on.

Resolves #1695 

### Notes to the reviewers

<details>
    <summary>Why the type of the confirmation_time column is INTEGER?</summary>
    
By [sqlite3 docs](https://www.sqlite.org/datatype3.html):

> Each value stored in an SQLite database (or manipulated by the database engine) has one of the following storage classes:
> ...
> INTEGER. The value is a *signed integer*, stored in 0, 1, 2, 3, 4, 6, or 8 bytes depending on the magnitude of the value.

(Remember confirmation time is `u64`)
> REAL. The value is a floating point value, stored as an 8-byte IEEE floating point number.
> ...    
> SQLite uses a more general dynamic type system. In SQLite, the datatype of a value is associated with the value itself, not with its container.
> ...
> In order to maximize compatibility between SQLite and other database engines, ..., SQLite supports the concept of "type affinity" on columns. The type affinity of a column is the recommended type for data stored in that column. The important idea here is that the type is recommended, not required. Any column can still store any type of data. It is just that some columns, given the choice, will prefer to use one storage class over another. The preferred storage class for a column is called its "affinity".
> ...
> A column with NUMERIC affinity may contain values using all five storage classes. When text data is inserted into a NUMERIC column, **the storage class of the text is converted to INTEGER or REAL (in order of preference)** if the text is a well-formed integer or real literal, respectively.
> A column that uses INTEGER affinity behaves the same as a column with NUMERIC affinity.

But anchor table was defined using the STRICT keyword, again, by sqlite docs: 

> ... The STRICT keyword causes the following differences:
> ...
> SQLite attempts to coerce the data into the appropriate type using the usual affinity rules, as PostgreSQL, MySQL, SQL Server, and Oracle all do. *If the value cannot be losslessly converted* in the specified datatype, then an SQLITE_CONSTRAINT_DATATYPE error is raised.


So, the *TLDR*, with some help of this [blog post](https://jakegoulding.com/blog/2011/02/06/sqlite-64-bit-integers/) is:
- SQLite INTEGER supported values range from `-2**63 to (2**63-1)`
- If the number is bigger it will treat the number as REAL.
- As the SQLite table is defined with the STRICT keyword, it should enforce a losslessly conversion or fail with SQLITE_CONSTRAINT_DATATYPE.

</details>

<details>
    <summary>Why not setting confirmation_time as BLOB or NUMERIC?</summary>
    


I don't have a strong opinion on this. INTEGER was the first numeric type I found, then later I found NUMERIC and they seemed to behave in the same way, so I didn't change the type.

I discarded BLOB and ANY first because they didn't provide a clear idea of what was being stored in the column, but in retrospective they seem to remove all the considerations that I had to do above, so maybe they are better fitted for the type.
</details>

<details>
    <summary>Why adding a default value to confirmation_time column if the anchor column constraint is to be NOT NULL so all copied values will be filled?</summary>
    

 `confirmation_time` should have the same constraint as `anchor`, to be `NOT NULL`, but as UPDATE statements might be executed in already filled tables, you must provide a default value for all the rows you are going to add the new column to. As the `confirmation_time` extraction of the json blob in anchor cannot be performed in the same step, I had to add this default value.
    
This is flexibilizing the schema of the tables and extending the bug surface it may have, but I'm assuming the application layer will enforce the addition of a valid `confirmation_time` always.
</details>

<details>
    <summary>Why the default value of confirmation_time column is -1?</summary>


    
Considering the other alternatives were to use the max value, min value or zero and confirmation time should always be positive, I considered `-1` just to be computer and human readable enough to perceive there must be something wrong if the `ConfirmationBlockTime` retrieved by the load of the wallet has this value set as the confirmation time.
</details>

<details>
    <summary>Why to not be STRICT with each statement?</summary>


    
It is a constraint only applicable to tables on creation.
</details>

<details>
    <summary>Why not creating a whole new table without anchor column and with the confirmation_time column, copy the content from one to the other and drop the former table?</summary>
    


Computation cost. I didn't benchmark it, and I don't know how efficient is SQLite engine under the hood, but at first sight it seems copying a single column is better than copying four.
</details>

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice


- Reduce `rusqlite` implementation only to `ChangeSet<ConfirmationBlockTime>`.
- Replace `anchor` column in sqlite by `confirmation_time`.
- Modify `migrate_schema` `versioned_script` parameter's type to `&[&str]`.
- Transformed existing schemas in methods to allow their individual application.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [x] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
