### PR TITLE
fix(electrum): Avoid fetching prev txout of coinbase txs

### DIFF
--- a/crates/electrum/src/bdk_electrum_client.rs
+++ b/crates/electrum/src/bdk_electrum_client.rs
@@ -422,6 +422,11 @@ impl<E: ElectrumApi> BdkElectrumClient<E> {
     ) -> Result<(), Error> {
         let mut no_dup = HashSet::<Txid>::new();
         for tx in &tx_update.txs {
+            // Do not try fetch `previous_output`s of coinbase transactions. This will always error
+            // and make our full-scan/sync request fail.
+            if tx.is_coinbase() {
+                continue;
+            }
             if no_dup.insert(tx.compute_txid()) {
                 for vin in &tx.input {
                     let outpoint = vin.previous_output;


### PR DESCRIPTION
### Description

Coinbase txs do not have previous txs. The previous txout fields are always of empty txids. Requesting such a transaction from electrum will return an error and fail our full-scan/sync request. This will be unfortunate if a miner decides to use a wallet which uses BDK + Electrum.

### Changelog notice

* Fix fetch prev txout logic in `bdk_electrum` to not fetch prev outputs of coinbase txs.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
