### PR TITLE
fix(electrum): prevent `fetch_prev_txout` from querying coinbase transactions

### DIFF
--- a/crates/electrum/src/bdk_electrum_client.rs
+++ b/crates/electrum/src/bdk_electrum_client.rs
@@ -422,7 +422,7 @@ impl<E: ElectrumApi> BdkElectrumClient<E> {
     ) -> Result<(), Error> {
         let mut no_dup = HashSet::<Txid>::new();
         for tx in &tx_update.txs {
-            if no_dup.insert(tx.compute_txid()) {
+            if !tx.is_coinbase() && no_dup.insert(tx.compute_txid()) {
                 for vin in &tx.input {
                     let outpoint = vin.previous_output;
                     let vout = outpoint.vout;


### PR DESCRIPTION
Fixes #1698.

### Description

`fetch_prev_txout` should not try to query the prevouts of coinbase transactions, as it may result in the Electrum server returning an error which would cause the overall `sync`/`full_scan` to fail. Without this critical bug fix,  `bdk_electrum` will crash when someone tracks an address being mined to.

### Notes to the reviewers

### Changelog notice

* `fetch_prev_txout` no longer queries coinbase transactions.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
