### PR TITLE
Change coin_selection and DescriptorExt::dust_value to use Amount type

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -53,6 +53,7 @@ jobs:
           cargo update -p security-framework-sys --precise "2.11.1"
           cargo update -p csv --precise "1.3.0"
           cargo update -p unicode-width --precise "0.1.13"
+          cargo update -p rustls@0.23.20 --precise "0.23.19"
       - name: Build
         run: cargo build --workspace --exclude 'example_*' ${{ matrix.features }}
       - name: Test

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ cargo update -p indexmap --precise "2.5.0"
 cargo update -p security-framework-sys --precise "2.11.1"
 cargo update -p csv --precise "1.3.0"
 cargo update -p unicode-width --precise "0.1.13"
+cargo update -p rustls@0.23.20 --precise "0.23.19"
 ```
 
 ## License

--- a/crates/chain/src/descriptor_ext.rs
+++ b/crates/chain/src/descriptor_ext.rs
@@ -1,5 +1,6 @@
 use crate::miniscript::{Descriptor, DescriptorPublicKey};
 use bitcoin::hashes::{hash_newtype, sha256, Hash};
+use bitcoin::Amount;
 
 hash_newtype! {
     /// Represents the unique ID of a descriptor.
@@ -13,9 +14,9 @@ hash_newtype! {
 
 /// A trait to extend the functionality of a miniscript descriptor.
 pub trait DescriptorExt {
-    /// Returns the minimum value (in satoshis) at which an output is broadcastable.
+    /// Returns the minimum [`Amount`] at which an output is broadcast-able.
     /// Panics if the descriptor wildcard is hardened.
-    fn dust_value(&self) -> u64;
+    fn dust_value(&self) -> Amount;
 
     /// Returns the descriptor ID, calculated as the sha256 hash of the spk derived from the
     /// descriptor at index 0.
@@ -23,12 +24,11 @@ pub trait DescriptorExt {
 }
 
 impl DescriptorExt for Descriptor<DescriptorPublicKey> {
-    fn dust_value(&self) -> u64 {
+    fn dust_value(&self) -> Amount {
         self.at_derivation_index(0)
             .expect("descriptor can't have hardened derivation")
             .script_pubkey()
             .minimal_non_dust()
-            .to_sat()
     }
 
     fn descriptor_id(&self) -> DescriptorId {

--- a/crates/wallet/tests/wallet.rs
+++ b/crates/wallet/tests/wallet.rs
@@ -3887,7 +3887,7 @@ fn test_spend_coinbase() {
         Err(CreateTxError::CoinSelection(
             coin_selection::InsufficientFunds {
                 needed: _,
-                available: 0
+                available: Amount::ZERO
             }
         ))
     ));
@@ -3902,7 +3902,7 @@ fn test_spend_coinbase() {
         Err(CreateTxError::CoinSelection(
             coin_selection::InsufficientFunds {
                 needed: _,
-                available: 0
+                available: Amount::ZERO
             }
         ))
     );

--- a/example-crates/example_cli/src/lib.rs
+++ b/example-crates/example_cli/src/lib.rs
@@ -324,7 +324,7 @@ where
         .expect("must exist")
         .1;
 
-    let min_drain_value = change_desc.dust_value();
+    let min_drain_value = change_desc.dust_value().to_sat();
 
     let target = Target {
         outputs: TargetOutputs::fund_outputs(


### PR DESCRIPTION
### Description

refactor(coin_selection)!: use Amount and SignedAmount for API and internally
refactor(chain)!: use Amount for DescriptorExt::dust_value()

Using named types make the API and internal code easier to read and reason about since it makes it clear that the values are bitcoin amounts. Also to create these types the units (ie .from_sat()) must be specified.

### Notes to the reviewers

For coin_selection using Amount and SignedAmount makes internal code safer against overflow errors. In particular because these types will panic if an amount overflow occurs. Using u64/i64 on the other hand can silently rollover. See: https://doc.rust-lang.org/book/ch03-02-data-types.html#integer-overflow

This is a continuation of the work done in #1595.  Since this is an API breaking change I would like to include it in the 1.0.0-beta milestone if possible.

### Changelog notice

- Change coin_selection to use Amount instead of u64 for all bitcoin amounts.
- Change DescriptorExt::dust_value() to return an Amount instead of u64.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [x] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
