### PR TITLE
proof of concept: implement `cancel_tx`

### DIFF
--- a/crates/wallet/src/wallet/tx_details.rs
+++ b/crates/wallet/src/wallet/tx_details.rs
@@ -1,0 +1,83 @@
+//! `TxDetails`
+
+use alloc::vec::Vec;
+use serde::{Deserialize, Serialize};
+
+use bitcoin::Txid;
+
+use crate::collections::HashMap;
+
+/// Kind of change that can be applied to [`TxDetails`]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Record {
+    /// tx canceled
+    Canceled,
+    /// new details added. note, when applied this will overwrite existing
+    Details(Details),
+}
+
+/// Communicates changes to [`TxDetails`]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChangeSet {
+    /// records
+    pub records: Vec<(Txid, Record)>,
+}
+
+impl bdk_chain::Merge for ChangeSet {
+    fn merge(&mut self, other: Self) {
+        self.records.extend(other.records);
+    }
+
+    fn is_empty(&self) -> bool {
+        self.records.is_empty()
+    }
+}
+
+/// The details of a wallet transaction
+///
+/// In the future this may be extended to include more metadata.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Details {
+    /// Cancellation status, `true` if the tx was canceled
+    pub is_canceled: bool,
+}
+
+/// Object that stores transaction metadata
+#[derive(Debug, Clone, Default)]
+pub(crate) struct TxDetails {
+    /// maps txid to details
+    pub map: HashMap<Txid, Details>,
+}
+
+impl TxDetails {
+    /// Marks a tx canceled
+    pub fn cancel_tx(&mut self, txid: Txid) -> ChangeSet {
+        let mut change = ChangeSet::default();
+
+        let val = self.map.entry(txid).or_default();
+
+        if val.is_canceled {
+            return change;
+        }
+
+        val.is_canceled = true;
+
+        change.records = vec![(txid, Record::Canceled)];
+
+        change
+    }
+
+    /// Applies the given `changeset` to `self`
+    pub fn apply_changeset(&mut self, changeset: ChangeSet) {
+        for (txid, record) in changeset.records {
+            match record {
+                Record::Details(det) => {
+                    let _ = self.map.insert(txid, det);
+                }
+                Record::Canceled => {
+                    let _ = self.cancel_tx(txid);
+                }
+            }
+        }
+    }
+}

--- a/example-crates/example_wallet_esplora_async/Cargo.toml
+++ b/example-crates/example_wallet_esplora_async/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bdk_wallet = { path = "../../crates/wallet", features = ["rusqlite"] }
+bdk_wallet = { path = "../../crates/wallet", features = ["rusqlite", "test-utils"] }
 bdk_esplora = { path = "../../crates/esplora", features = ["async-https", "tokio"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 anyhow = "1"

--- a/example-crates/example_wallet_esplora_async/src/main.rs
+++ b/example-crates/example_wallet_esplora_async/src/main.rs
@@ -1,21 +1,25 @@
+#![allow(unused)]
 use std::{collections::BTreeSet, io::Write};
 
 use anyhow::Ok;
 use bdk_esplora::{esplora_client, EsploraAsyncExt};
 use bdk_wallet::{
-    bitcoin::{Amount, Network},
+    bitcoin::{Amount, Network, ScriptBuf},
     rusqlite::Connection,
     KeychainKind, SignOptions, Wallet,
 };
 
+use bdk_wallet::test_utils::*;
+
 const SEND_AMOUNT: Amount = Amount::from_sat(5000);
 const STOP_GAP: usize = 5;
-const PARALLEL_REQUESTS: usize = 5;
+const PARALLEL_REQUESTS: usize = 1;
 
-const DB_PATH: &str = "bdk-example-esplora-async.sqlite";
+const DB_PATH: &str = ".bdk-example-esplora-async.sqlite";
 const NETWORK: Network = Network::Signet;
-const EXTERNAL_DESC: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/0/*)";
-const INTERNAL_DESC: &str = "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/1/*)";
+const EXTERNAL_DESC: &str = "tr(tprv8ZgxMBicQKsPczwfSDDHGpmNeWzKaMajLtkkNUdBoisixK3sW3YTC8subMCsTJB7sM4kaJJ7K1cNVM37aZoJ7dMBt2HRYLQzoFPqPMC8cTr/86'/1'/0'/0/*)";
+const INTERNAL_DESC: &str = "tr(tprv8ZgxMBicQKsPczwfSDDHGpmNeWzKaMajLtkkNUdBoisixK3sW3YTC8subMCsTJB7sM4kaJJ7K1cNVM37aZoJ7dMBt2HRYLQzoFPqPMC8cTr/86'/1'/0'/1/*)";
+
 const ESPLORA_URL: &str = "http://signet.bitcoindevkit.net";
 
 #[tokio::main]
@@ -35,16 +39,8 @@ async fn main() -> Result<(), anyhow::Error> {
             .create_wallet(&mut conn)?,
     };
 
-    let address = wallet.next_unused_address(KeychainKind::External);
-    wallet.persist(&mut conn)?;
-    println!("Next unused address: ({}) {}", address.index, address);
-
-    let balance = wallet.balance();
-    println!("Wallet balance before syncing: {}", balance.total());
-
-    print!("Syncing...");
+    // Sync
     let client = esplora_client::Builder::new(ESPLORA_URL).build_async()?;
-
     let request = wallet.start_full_scan().inspect({
         let mut stdout = std::io::stdout();
         let mut once = BTreeSet::<KeychainKind>::new();
@@ -53,39 +49,48 @@ async fn main() -> Result<(), anyhow::Error> {
                 print!("\nScanning keychain [{:?}]", keychain);
             }
             print!(" {:<3}", spk_i);
-            stdout.flush().expect("must flush")
+            stdout.flush().unwrap();
         }
     });
-
     let update = client
         .full_scan(request, STOP_GAP, PARALLEL_REQUESTS)
         .await?;
-
     wallet.apply_update(update)?;
     wallet.persist(&mut conn)?;
     println!();
+    let old_balance = wallet.balance();
+    println!("Balance after sync: {}", old_balance.total());
 
-    let balance = wallet.balance();
-    println!("Wallet balance after syncing: {}", balance.total());
-
-    if balance.total() < SEND_AMOUNT {
-        println!(
-            "Please send at least {} to the receiving address",
-            SEND_AMOUNT
-        );
-        std::process::exit(0);
-    }
-
-    let mut tx_builder = wallet.build_tx();
-    tx_builder.add_recipient(address.script_pubkey(), SEND_AMOUNT);
-
-    let mut psbt = tx_builder.finish()?;
-    let finalized = wallet.sign(&mut psbt, SignOptions::default())?;
-    assert!(finalized);
-
+    // Build tx that sends all to a foreign recipient
+    let recip = ScriptBuf::from_hex("0014446906a6560d8ad760db3156706e72e171f3a2aa")?;
+    let mut b = wallet.build_tx();
+    b.drain_to(recip).drain_wallet();
+    let mut psbt = b.finish()?;
+    assert!(wallet.sign(&mut psbt, SignOptions::default())?);
     let tx = psbt.extract_tx()?;
-    client.broadcast(&tx).await?;
-    println!("Tx broadcasted! Txid: {}", tx.compute_txid());
+    let txid = tx.compute_txid();
+    insert_tx(&mut wallet, tx.clone());
+    wallet.persist(&mut conn)?;
+
+    println!("Balance after send: {}", wallet.balance().total());
+    assert_eq!(wallet.balance().total(), Amount::ZERO);
+
+    // Cancel spend
+    wallet.cancel_tx(&tx);
+    assert_eq!(wallet.balance(), old_balance);
+    println!("Balance after cancel: {}", wallet.balance().total());
+    wallet.persist(&mut conn)?;
+
+    // Load one more time
+    wallet = Wallet::load()
+        .load_wallet(&mut conn)?
+        .expect("must load existing");
+
+    assert_eq!(
+        wallet.balance(),
+        old_balance,
+        "balance did not match original"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
### Description

This is not a merge candidate. The goal of this PR is implement `cancel_tx`, as doing so has the potential to fix a long-standing TODO in the library saying "make this free up reserved utxos when that's implemented". This was initiated in response to user feedback claiming that the method has no effect.

issue bitcoindevkit/bdk_wallet#41 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
