### PR TITLE
fix(chain): detect incoming transaction being replaced/canceled

### DIFF
--- a/crates/esplora/tests/async_ext.rs
+++ b/crates/esplora/tests/async_ext.rs
@@ -1,8 +1,14 @@
+use bdk_chain::keychain_txout::{KeychainTxOutIndex, SyncRequestBuilderExt};
+use bdk_chain::local_chain::LocalChain;
 use bdk_chain::spk_client::{FullScanRequest, SyncRequest};
-use bdk_chain::{ConfirmationBlockTime, TxGraph};
+use bdk_chain::{ConfirmationBlockTime, IndexedTxGraph, TxGraph};
+use bdk_core::bitcoin::key::Secp256k1;
 use bdk_esplora::EsploraAsyncExt;
+use bdk_testenv::bitcoincore_rpc::json::CreateRawTransactionInput;
+use bdk_testenv::bitcoincore_rpc::RawTx;
 use esplora_client::{self, Builder};
-use std::collections::{BTreeSet, HashSet};
+use miniscript::Descriptor;
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::str::FromStr;
 use std::thread::sleep;
 use std::time::Duration;
@@ -10,6 +16,125 @@ use std::time::Duration;
 use bdk_chain::bitcoin::{Address, Amount};
 use bdk_testenv::{anyhow, bitcoincore_rpc::RpcApi, TestEnv};
 
+#[tokio::test]
+pub async fn detect_receive_tx_cancel() -> anyhow::Result<()> {
+    const SEND_TX_FEE: Amount = Amount::from_sat(1000);
+    const UNDO_SEND_TX_FEE: Amount = Amount::from_sat(2000);
+
+    let env = TestEnv::new()?;
+    let rpc_client = env.rpc_client();
+    let base_url = format!("http://{}", &env.electrsd.esplora_url.clone().unwrap());
+    let client = Builder::new(base_url.as_str()).build_async()?;
+
+    let (receiver_desc, _) = Descriptor::parse_descriptor(&Secp256k1::signing_only(), "tr([73c5da0a/86'/0'/0']xprv9xgqHN7yz9MwCkxsBPN5qetuNdQSUttZNKw1dcYTV4mkaAFiBVGQziHs3NRSWMkCzvgjEe3n9xV8oYywvM8at9yRqyaZVz6TYYhX98VjsUk/0/*)")
+        .expect("must be valid");
+    let mut graph = IndexedTxGraph::<ConfirmationBlockTime, _>::new(KeychainTxOutIndex::new(0));
+    let _ = graph.index.insert_descriptor((), receiver_desc.clone())?;
+    let (chain, _) = LocalChain::from_genesis_hash(env.bitcoind.client.get_block_hash(0)?);
+
+    // Derive the receiving address from the descriptor.
+    let ((_, receiver_spk), _) = graph.index.reveal_next_spk(()).unwrap();
+    let receiver_addr = Address::from_script(&receiver_spk, bdk_chain::bitcoin::Network::Regtest)?;
+
+    env.mine_blocks(101, None)?;
+
+    // Select a UTXO to use as an input for constructing our test transactions.
+    let selected_utxo = rpc_client
+        .list_unspent(None, None, None, Some(false), None)?
+        .into_iter()
+        // Find a block reward tx.
+        .find(|utxo| utxo.amount == Amount::from_int_btc(50))
+        .expect("must find a block reward UTXO");
+
+    // Derive the sender's address from the selected UTXO.
+    let sender_spk = selected_utxo.script_pub_key.clone();
+    let sender_addr = Address::from_script(&sender_spk, bdk_chain::bitcoin::Network::Regtest)
+        .expect("Failed to derive address from UTXO");
+
+    // Setup the common inputs used by both `send_tx` and `undo_send_tx`.
+    let inputs = [CreateRawTransactionInput {
+        txid: selected_utxo.txid,
+        vout: selected_utxo.vout,
+        sequence: None,
+    }];
+
+    // Create and sign the `send_tx` that sends funds to the receiver address.
+    let send_tx_outputs = HashMap::from([(
+        receiver_addr.to_string(),
+        selected_utxo.amount - SEND_TX_FEE,
+    )]);
+    let send_tx = rpc_client.create_raw_transaction(&inputs, &send_tx_outputs, None, Some(true))?;
+    let send_tx = rpc_client
+        .sign_raw_transaction_with_wallet(send_tx.raw_hex(), None, None)?
+        .transaction()?;
+
+    // Create and sign the `undo_send_tx` transaction. This redirects funds back to the sender
+    // address.
+    let undo_send_outputs = HashMap::from([(
+        sender_addr.to_string(),
+        selected_utxo.amount - UNDO_SEND_TX_FEE,
+    )]);
+    let undo_send_tx =
+        rpc_client.create_raw_transaction(&inputs, &undo_send_outputs, None, Some(true))?;
+    let undo_send_tx = rpc_client
+        .sign_raw_transaction_with_wallet(undo_send_tx.raw_hex(), None, None)?
+        .transaction()?;
+
+    // Sync after broadcasting the `send_tx`. Ensure that we detect and receive the `send_tx`.
+    let send_txid = env.rpc_client().send_raw_transaction(send_tx.raw_hex())?;
+    env.wait_until_electrum_sees_txid(send_txid, Duration::from_secs(6))?;
+    let sync_request = SyncRequest::builder()
+        .chain_tip(chain.tip())
+        .revealed_spks_from_indexer(&graph.index, ..)
+        .unconfirmed_outpoints(
+            graph.graph().canonical_iter(&chain, chain.tip().block_id()),
+            &graph.index,
+        );
+    let sync_response = client.sync(sync_request, 1).await?;
+    assert!(
+        sync_response
+            .tx_update
+            .txs
+            .iter()
+            .any(|tx| tx.compute_txid() == send_txid),
+        "sync response must include the send_tx"
+    );
+    let changeset = graph.apply_update(sync_response.tx_update.clone());
+    assert!(
+        changeset.tx_graph.txs.contains(&send_tx),
+        "tx graph must deem send_tx relevant and include it"
+    );
+
+    // Sync after broadcasting the `undo_send_tx`. Ensure that we detect and receive the
+    // `undo_send_tx`.
+    let undo_send_txid = env
+        .rpc_client()
+        .send_raw_transaction(undo_send_tx.raw_hex())?;
+    env.wait_until_electrum_sees_txid(undo_send_txid, Duration::from_secs(6))?;
+    let sync_request = SyncRequest::builder()
+        .chain_tip(chain.tip())
+        .revealed_spks_from_indexer(&graph.index, ..)
+        .unconfirmed_outpoints(
+            graph.graph().canonical_iter(&chain, chain.tip().block_id()),
+            &graph.index,
+        );
+    let sync_response = client.sync(sync_request, 1).await?;
+    assert!(
+        sync_response
+            .tx_update
+            .txs
+            .iter()
+            .any(|tx| tx.compute_txid() == undo_send_txid),
+        "sync response must include the undo_send_tx"
+    );
+    let changeset = graph.apply_update(sync_response.tx_update.clone());
+    assert!(
+        changeset.tx_graph.txs.contains(&undo_send_tx),
+        "tx graph must deem undo_send_tx relevant and include it"
+    );
+
+    Ok(())
+}
 #[tokio::test]
 pub async fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
     let env = TestEnv::new()?;

--- a/crates/esplora/tests/blocking_ext.rs
+++ b/crates/esplora/tests/blocking_ext.rs
@@ -1,14 +1,140 @@
+use bdk_chain::keychain_txout::{KeychainTxOutIndex, SyncRequestBuilderExt};
+use bdk_chain::local_chain::LocalChain;
 use bdk_chain::spk_client::{FullScanRequest, SyncRequest};
-use bdk_chain::{ConfirmationBlockTime, TxGraph};
+use bdk_chain::{ConfirmationBlockTime, IndexedTxGraph, TxGraph};
+use bdk_core::bitcoin::key::Secp256k1;
 use bdk_esplora::EsploraExt;
+use bdk_testenv::bitcoincore_rpc::json::CreateRawTransactionInput;
+use bdk_testenv::bitcoincore_rpc::RawTx;
 use esplora_client::{self, Builder};
-use std::collections::{BTreeSet, HashSet};
+use miniscript::Descriptor;
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::str::FromStr;
 use std::thread::sleep;
 use std::time::Duration;
 
 use bdk_chain::bitcoin::{Address, Amount};
 use bdk_testenv::{anyhow, bitcoincore_rpc::RpcApi, TestEnv};
+
+#[test]
+pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
+    const SEND_TX_FEE: Amount = Amount::from_sat(1000);
+    const UNDO_SEND_TX_FEE: Amount = Amount::from_sat(2000);
+
+    let env = TestEnv::new()?;
+    let rpc_client = env.rpc_client();
+    let base_url = format!("http://{}", &env.electrsd.esplora_url.clone().unwrap());
+    let client = Builder::new(base_url.as_str()).build_blocking();
+
+    let (receiver_desc, _) = Descriptor::parse_descriptor(&Secp256k1::signing_only(), "tr([73c5da0a/86'/0'/0']xprv9xgqHN7yz9MwCkxsBPN5qetuNdQSUttZNKw1dcYTV4mkaAFiBVGQziHs3NRSWMkCzvgjEe3n9xV8oYywvM8at9yRqyaZVz6TYYhX98VjsUk/0/*)")
+        .expect("must be valid");
+    let mut graph = IndexedTxGraph::<ConfirmationBlockTime, _>::new(KeychainTxOutIndex::new(0));
+    let _ = graph.index.insert_descriptor((), receiver_desc.clone())?;
+    let (chain, _) = LocalChain::from_genesis_hash(env.bitcoind.client.get_block_hash(0)?);
+
+    // Derive the receiving address from the descriptor.
+    let ((_, receiver_spk), _) = graph.index.reveal_next_spk(()).unwrap();
+    let receiver_addr = Address::from_script(&receiver_spk, bdk_chain::bitcoin::Network::Regtest)?;
+
+    env.mine_blocks(101, None)?;
+
+    // Select a UTXO to use as an input for constructing our test transactions.
+    let selected_utxo = rpc_client
+        .list_unspent(None, None, None, Some(false), None)?
+        .into_iter()
+        // Find a block reward tx.
+        .find(|utxo| utxo.amount == Amount::from_int_btc(50))
+        .expect("must find a block reward UTXO");
+
+    // Derive the sender's address from the selected UTXO.
+    let sender_spk = selected_utxo.script_pub_key.clone();
+    let sender_addr = Address::from_script(&sender_spk, bdk_chain::bitcoin::Network::Regtest)
+        .expect("Failed to derive address from UTXO");
+
+    // Setup the common inputs used by both `send_tx` and `undo_send_tx`.
+    let inputs = [CreateRawTransactionInput {
+        txid: selected_utxo.txid,
+        vout: selected_utxo.vout,
+        sequence: None,
+    }];
+
+    // Create and sign the `send_tx` that sends funds to the receiver address.
+    let send_tx_outputs = HashMap::from([(
+        receiver_addr.to_string(),
+        selected_utxo.amount - SEND_TX_FEE,
+    )]);
+    let send_tx = rpc_client.create_raw_transaction(&inputs, &send_tx_outputs, None, Some(true))?;
+    let send_tx = rpc_client
+        .sign_raw_transaction_with_wallet(send_tx.raw_hex(), None, None)?
+        .transaction()?;
+
+    // Create and sign the `undo_send_tx` transaction. This redirects funds back to the sender
+    // address.
+    let undo_send_outputs = HashMap::from([(
+        sender_addr.to_string(),
+        selected_utxo.amount - UNDO_SEND_TX_FEE,
+    )]);
+    let undo_send_tx =
+        rpc_client.create_raw_transaction(&inputs, &undo_send_outputs, None, Some(true))?;
+    let undo_send_tx = rpc_client
+        .sign_raw_transaction_with_wallet(undo_send_tx.raw_hex(), None, None)?
+        .transaction()?;
+
+    // Sync after broadcasting the `send_tx`. Ensure that we detect and receive the `send_tx`.
+    let send_txid = env.rpc_client().send_raw_transaction(send_tx.raw_hex())?;
+    env.wait_until_electrum_sees_txid(send_txid, Duration::from_secs(6))?;
+    let sync_request = SyncRequest::builder()
+        .chain_tip(chain.tip())
+        .revealed_spks_from_indexer(&graph.index, ..)
+        .unconfirmed_outpoints(
+            graph.graph().canonical_iter(&chain, chain.tip().block_id()),
+            &graph.index,
+        );
+    let sync_response = client.sync(sync_request, 1)?;
+    assert!(
+        sync_response
+            .tx_update
+            .txs
+            .iter()
+            .any(|tx| tx.compute_txid() == send_txid),
+        "sync response must include the send_tx"
+    );
+    let changeset = graph.apply_update(sync_response.tx_update.clone());
+    assert!(
+        changeset.tx_graph.txs.contains(&send_tx),
+        "tx graph must deem send_tx relevant and include it"
+    );
+
+    // Sync after broadcasting the `undo_send_tx`. Ensure that we detect and receive the
+    // `undo_send_tx`.
+    let undo_send_txid = env
+        .rpc_client()
+        .send_raw_transaction(undo_send_tx.raw_hex())?;
+    env.wait_until_electrum_sees_txid(undo_send_txid, Duration::from_secs(6))?;
+    let sync_request = SyncRequest::builder()
+        .chain_tip(chain.tip())
+        .revealed_spks_from_indexer(&graph.index, ..)
+        .unconfirmed_outpoints(
+            graph.graph().canonical_iter(&chain, chain.tip().block_id()),
+            &graph.index,
+        );
+    let sync_response = client.sync(sync_request, 1)?;
+    assert!(
+        sync_response
+            .tx_update
+            .txs
+            .iter()
+            .any(|tx| tx.compute_txid() == undo_send_txid),
+        "sync response must include the undo_send_tx"
+    );
+    let changeset = graph.apply_update(sync_response.tx_update.clone());
+    assert!(
+        changeset.tx_graph.txs.contains(&undo_send_tx),
+        "tx graph must deem undo_send_tx relevant and include it"
+    );
+
+    Ok(())
+}
 
 #[test]
 pub fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {


### PR DESCRIPTION
Fixes #1740.

### Description

This PR addresses a potential double-spending issue by implementing the following changes:

#### Redefine Transaction Relevancy in `IndexedTxGraph`
Transactions are now considered relevant if they:
* Reference the wallet's spks in their inputs/outputs.
* Share inputs with any transaction already in the `TxGraph`.

#### Include Unconfirmed Spends in Chain Sync Requests
* Unconfirmed outputs can now be provided via `SyncRequestExt::unconfirmed_spends`, which enables the chain source to detect replaced or canceled transactions.
* Deprecated `Wallet::start_sync_with_revealed_spks` in favor of `start_sync`, which supports unconfirmed spends.

### Notes to the reviewers

TODO:
* [ ] Add esplora test.

### Changelog notice

* Redefine what a relevant transaction is in `IndexedTxGraph`.
* Providing unconfirmed spends in chain sync requests, enabling detection of replaced or canceled transactions.
* Deprecated `Wallet::start_sync_with_revealed_spks` in favor of the more comprehensive `Wallet::start_sync`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
