### PR TITLE
chore(bdk_chain): bump rusqlite dependency from 0.31.0 to 0.32

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -46,7 +46,7 @@ jobs:
           cargo update -p home --precise "0.5.5"
           cargo update -p proptest --precise "1.2.0"
           cargo update -p url --precise "2.5.0"
-          cargo update -p cc --precise "1.0.105"
+          cargo update -p cc --precise "1.1.6"
           cargo update -p tokio --precise "1.38.1"
           cargo update -p tokio-util --precise "0.7.11"
           cargo update -p indexmap --precise "2.5.0"

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1", optional = true, features = ["derive", "rc"] }
 miniscript = { version = "12.0.0", optional = true, default-features = false }
 
 # Feature dependencies
-rusqlite = { version = "0.31.0", features = ["bundled"], optional = true }
+rusqlite = { version = "0.32", features = ["bundled"], optional = true }
 
 [dev-dependencies]
 rand = "0.8"


### PR DESCRIPTION
### Description

This PR bumps the `chain` crates feature dependency on `rusqlite` to the more recent version `0.32`. 

### Notes to the reviewers

I omitted the patch version because all versions 0.32.x must be compatible per the semver spec. 

I submitted this PR because the "outdated" dependency breaks dependency resolution in my project. 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
