### PR TITLE
feat(wallet): add check for network and genesis_hash consistency

### DIFF
--- a/crates/wallet/src/descriptor/error.rs
+++ b/crates/wallet/src/descriptor/error.rs
@@ -43,6 +43,8 @@ pub enum Error {
     Hex(bitcoin::hex::HexToBytesError),
     /// The provided wallet descriptors are identical
     ExternalAndInternalAreTheSame,
+    /// The provided parameters mismatch
+    Mismatch(MismatchError),
 }
 
 impl From<crate::keys::KeyError> for Error {
@@ -83,6 +85,7 @@ impl fmt::Display for Error {
             Self::ExternalAndInternalAreTheSame => {
                 write!(f, "External and internal descriptors are the same")
             }
+            Self::Mismatch(mismatch) => write!(f, "The provided parameters mismatch: {mismatch:?}"),
         }
     }
 }
@@ -124,4 +127,16 @@ impl From<crate::descriptor::policy::PolicyError> for Error {
     fn from(err: crate::descriptor::policy::PolicyError) -> Self {
         Error::Policy(err)
     }
+}
+
+#[derive(Debug, PartialEq)]
+/// Represents a mismatch within the parameters that passed as [`crate::wallet::CreateParams`].
+pub enum MismatchError {
+    /// Genesis hash does not match.
+    Genesis {
+        /// The genesis hash for the given network parameter.
+        network: bitcoin::BlockHash,
+        /// The genesis hash given as parameter.
+        parameter: bitcoin::BlockHash,
+    },
 }


### PR DESCRIPTION
fixes bitcoindevkit/bdk_wallet#46
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Adds a new check on both `create_with_params` and `load_with_params` to validate that the given `genesis_hash` parameter matches the `genesis_hash` for expected `Network`, returns a new `DescriptorError::Mismatch` or `LoadError::LoadMismatch` error variants, respectively.

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

I'm not sure if adding the check on `load_with_params` is needed, and if that branch will ever be reached, at least it seems not trivial to test it using the standard of tests we currently have, that its: 1) creating a wallet; 2) loading and asserting the expected checks.


<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice
- Adds a new check for consistency of `genesis_hash` and `network` parameters.
- Adds a new error `MismatchError` enum and `Descriptor::Mismatch` variant.

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
