### PR TITLE
ci: apply `zizmor` security audit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -24,5 +24,7 @@ jobs:
       issues: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions-rust-lang/audit@v1
         name: Audit Rust Dependencies

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install lcov tools
         run: sudo apt-get install lcov -y
       - name: Install Rust toolchain

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -52,8 +52,10 @@ jobs:
         if: matrix.rust.version == '1.63.0'
         run: ./ci/pin-msrv.sh
       - name: Build + Test
+        env:
+          MATRIX_RUST_VERSION: ${{ matrix.rust.version }}
         run: |
-          if [ "${{matrix.rust.version}}" = '1.63.0' ]; then
+          if [ $MATRIX_RUST_VERSION = '1.63.0' ]; then
             cargo build --workspace --exclude 'example_*' --exclude 'bdk_electrum' ${{ matrix.features }}
             cargo test --workspace --exclude 'example_*' --exclude 'bdk_electrum' ${{ matrix.features }}
           else

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: "Checkout repo"
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: "Read rust version"
         id: read_toolchain
         run: echo "rust_version=$(cat rust-version)" >> $GITHUB_OUTPUT
@@ -32,6 +34,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -64,6 +68,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -96,6 +102,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
         # Install a recent version of clang that supports wasm32
       - run: wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - || exit 1
       - run: sudo apt-get update || exit 1
@@ -123,6 +131,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -141,6 +151,8 @@ jobs:
       checks: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions-rs/toolchain@v1
         with:
             toolchain: ${{ needs.prepare.outputs.rust_version }}
@@ -172,6 +184,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/cron-update-rust.yml
+++ b/.github/workflows/cron-update-rust.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: tibdex/github-app-token@v2
         id: generate-token

--- a/.github/workflows/nightly_docs.yml
+++ b/.github/workflows/nightly_docs.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set default toolchain
         run: rustup default nightly
       - name: Set profile
@@ -36,6 +38,7 @@ jobs:
       - name: Checkout `bitcoindevkit.org`
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           ssh-key: ${{ secrets.DOCS_PUSH_SSH_KEY }}
           repository: bitcoindevkit/bitcoindevkit.org
           ref: master


### PR DESCRIPTION
fixes #1775

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

I used `zizmor` on all current CI workflows, it's a tool that helps detecting possible vulnerabilities in our CI jobs, see https://woodruffw.github.io/zizmor/.

It can run against most of it's audit rules, however the ones that require the GitHub API Token would require some with access to it in order to test against it. So this PR does not cover for impostor-commit, ref-confusion known-vulnerable-actions audit rules.

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

- Do not persist credentials on GitHub Actions. 

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
