### PR TITLE
ci: Fix `build_docs` job

### DIFF
--- a/.github/workflows/nightly_docs.yml
+++ b/.github/workflows/nightly_docs.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
       - name: Set default toolchain
-        run: rustup default nightly-2024-05-12
+        run: rustup default nightly
       - name: Set profile
         run: rustup set profile minimal
       - name: Update toolchain


### PR DESCRIPTION
### Description

Multiple PRs has been failing the `build_docs` job.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing