### PR TITLE
fix electrum conftime_req filter for needs_block_height

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -14,7 +14,7 @@ jobs:
   Codecov:
     name: Code Coverage
     if: false # disabled
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       RUSTFLAGS: "-Cinstrument-coverage"
       RUSTDOCFLAGS: "-Cinstrument-coverage"

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -66,6 +66,7 @@ jobs:
           cargo update -p url --precise "2.5.0"
           cargo update -p rustls@0.23.20 --precise "0.23.19"
           cargo update -p hashbrown@0.15.2 --precise "0.15.0"
+          cargo update -p ureq --precise "2.10.1"
       - name: Build
         run: cargo build --features bitcoin/std,miniscript/std,${{ matrix.features }} --no-default-features
       - name: Clippy

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -64,8 +64,8 @@ jobs:
           cargo update -p regex --precise "1.7.3"
           cargo update -p security-framework-sys --precise "2.11.1"
           cargo update -p url --precise "2.5.0"
-          cargo update -p rustls@0.23.18 --precise "0.23.17"
-          cargo update -p hashbrown@0.15.1 --precise "0.15.0"
+          cargo update -p rustls@0.23.20 --precise "0.23.19"
+          cargo update -p hashbrown@0.15.2 --precise "0.15.0"
       - name: Build
         run: cargo build --features bitcoin/std,miniscript/std,${{ matrix.features }} --no-default-features
       - name: Clippy

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -14,7 +14,7 @@ jobs:
 
   build-test:
     name: Build and test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         rust:
@@ -77,7 +77,7 @@ jobs:
 
   test-readme-examples:
     name: Test README.md examples
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -167,7 +167,7 @@ jobs:
 
   fmt:
     name: Rust fmt
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/nightly_docs.yml
+++ b/.github/workflows/nightly_docs.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build_docs:
     name: Build docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -43,7 +43,7 @@ jobs:
     name: 'Publish docs'
     if: github.ref == 'refs/heads/master'
     needs: [build_docs]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout `bitcoindevkit.org`
         uses: actions/checkout@v4

--- a/.github/workflows/nightly_docs.yml
+++ b/.github/workflows/nightly_docs.yml
@@ -28,7 +28,9 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:
-          components: clippy
+          components: clippy, rustfmt
+      - name: Cargo update
+        run: cargo update
       - name: Build docs
         run: cargo rustdoc --verbose --features=compiler,electrum,esplora,use-esplora-blocking,compact_filters,rpc,key-value-db,sqlite,all-keys,verify,hardware-signer -- --cfg docsrs -Dwarnings
       - name: Upload artifact

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ path = "examples/policy.rs"
 [[example]]
 name = "rpcwallet"
 path = "examples/rpcwallet.rs"
-required-features = ["keys-bip39", "key-value-db", "rpc", "electrsd/bitcoind_22_0"]
+required-features = ["keys-bip39", "key-value-db", "rpc", "electrsd/bitcoind_22_1"]
 
 [[example]]
 name = "psbt_signer"

--- a/README.md
+++ b/README.md
@@ -215,6 +215,6 @@ cargo update -p home --precise "0.5.5"
 cargo update -p regex --precise "1.7.3"
 cargo update -p security-framework-sys --precise "2.11.1"
 cargo update -p url --precise "2.5.0"
-cargo update -p rustls@0.23.18 --precise "0.23.17"
-cargo update -p hashbrown@0.15.1 --precise "0.15.0"
+cargo update -p rustls@0.23.20 --precise "0.23.19"
+cargo update -p hashbrown@0.15.2 --precise "0.15.0"
 ```

--- a/README.md
+++ b/README.md
@@ -217,4 +217,5 @@ cargo update -p security-framework-sys --precise "2.11.1"
 cargo update -p url --precise "2.5.0"
 cargo update -p rustls@0.23.20 --precise "0.23.19"
 cargo update -p hashbrown@0.15.2 --precise "0.15.0"
+cargo update -p ureq --precise "2.10.1"
 ```

--- a/examples/compiler.rs
+++ b/examples/compiler.rs
@@ -35,7 +35,6 @@ use bdk::{KeychainKind, Wallet};
 /// can be derived from the policy.
 ///
 /// This example demonstrates the interaction between a bdk wallet and miniscript policy.
-
 fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init_from_env(
         env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),

--- a/examples/policy.rs
+++ b/examples/policy.rs
@@ -27,7 +27,6 @@ use bdk::wallet::signer::SignersContainer;
 ///
 /// This example demos a Policy output for a 2of2 multisig between between 2 parties, where the wallet holds
 /// one of the Extend Private key.
-
 fn main() -> Result<(), Box<dyn Error>> {
     env_logger::init_from_env(
         env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info"),

--- a/src/blockchain/electrum.rs
+++ b/src/blockchain/electrum.rs
@@ -168,7 +168,7 @@ impl WalletSync for ElectrumBlockchain {
                     let needs_block_height = conftime_req
                         .request()
                         .filter_map(|txid| txid_to_height.get(txid).cloned())
-                        .filter(|height| block_times.contains_key(height))
+                        .filter(|height| !block_times.contains_key(height))
                         .take(chunk_size)
                         .collect::<HashSet<u32>>();
 

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -214,6 +214,7 @@ pub(crate) trait DatabaseUtils: Database {
 impl<T: Database> DatabaseUtils for T {}
 
 #[cfg(test)]
+#[allow(missing_docs)]
 pub mod test {
     use bitcoin::consensus::encode::deserialize;
     use bitcoin::consensus::serialize;

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -134,9 +134,7 @@ impl IntoWalletDescriptor for (ExtendedDescriptor, KeyMap) {
             network: Network,
         }
 
-        impl<'s, 'd> miniscript::Translator<DescriptorPublicKey, String, DescriptorError>
-            for Translator<'s, 'd>
-        {
+        impl miniscript::Translator<DescriptorPublicKey, String, DescriptorError> for Translator<'_, '_> {
             fn pk(&mut self, pk: &DescriptorPublicKey) -> Result<String, DescriptorError> {
                 let secp = &self.secp;
 

--- a/src/keys/mod.rs
+++ b/src/keys/mod.rs
@@ -949,7 +949,7 @@ impl std::fmt::Display for KeyError {
 impl std::error::Error for KeyError {}
 
 #[cfg(test)]
-pub mod test {
+mod test {
     use bitcoin::bip32;
 
     use super::*;

--- a/src/wallet/coin_selection.rs
+++ b/src/wallet/coin_selection.rs
@@ -868,7 +868,7 @@ mod test {
         vec![utxo; utxos_number]
     }
 
-    fn sum_random_utxos(mut rng: &mut StdRng, utxos: &mut Vec<WeightedUtxo>) -> u64 {
+    fn sum_random_utxos(mut rng: &mut StdRng, utxos: &mut [WeightedUtxo]) -> u64 {
         let utxos_picked_len = rng.gen_range(2..utxos.len() / 2);
         utxos.shuffle(&mut rng);
         utxos[..utxos_picked_len]

--- a/src/wallet/coin_selection.rs
+++ b/src/wallet/coin_selection.rs
@@ -119,8 +119,11 @@ use std::convert::TryInto;
 /// overridden
 #[cfg(not(test))]
 pub type DefaultCoinSelectionAlgorithm = BranchAndBoundCoinSelection;
+
+/// Default deterministic coin selection algorithm for testing used by [`TxBuilder`](super::tx_builder::TxBuilder) if not
+/// overridden
 #[cfg(test)]
-pub type DefaultCoinSelectionAlgorithm = LargestFirstCoinSelection; // make the tests more predictable
+pub type DefaultCoinSelectionAlgorithm = LargestFirstCoinSelection;
 
 // Base weight of a Txin, not counting the weight needed for satisfying it.
 // prev_txid (32 bytes) + prev_vout (4 bytes) + sequence (4 bytes)

--- a/src/wallet/tx_builder.rs
+++ b/src/wallet/tx_builder.rs
@@ -167,7 +167,7 @@ impl std::default::Default for FeePolicy {
     }
 }
 
-impl<'a, Cs: Clone, Ctx, D> Clone for TxBuilder<'a, D, Cs, Ctx> {
+impl<Cs: Clone, Ctx, D> Clone for TxBuilder<'_, D, Cs, Ctx> {
     fn clone(&self) -> Self {
         TxBuilder {
             wallet: self.wallet,
@@ -584,7 +584,7 @@ impl<'a, D: BatchDatabase, Cs: CoinSelectionAlgorithm<D>, Ctx: TxBuilderContext>
     }
 }
 
-impl<'a, D: BatchDatabase, Cs: CoinSelectionAlgorithm<D>> TxBuilder<'a, D, Cs, CreateTx> {
+impl<D: BatchDatabase, Cs: CoinSelectionAlgorithm<D>> TxBuilder<'_, D, Cs, CreateTx> {
     /// Replace the recipients already added with a new list
     pub fn set_recipients(&mut self, recipients: Vec<(ScriptBuf, u64)>) -> &mut Self {
         self.params.recipients = recipients;
@@ -658,7 +658,7 @@ impl<'a, D: BatchDatabase, Cs: CoinSelectionAlgorithm<D>> TxBuilder<'a, D, Cs, C
 }
 
 // methods supported only by bump_fee
-impl<'a, D: BatchDatabase> TxBuilder<'a, D, DefaultCoinSelectionAlgorithm, BumpFee> {
+impl<D: BatchDatabase> TxBuilder<'_, D, DefaultCoinSelectionAlgorithm, BumpFee> {
     /// Explicitly tells the wallet that it is allowed to reduce the amount of the output matching this
     /// `script_pubkey` in order to bump the transaction fee. Without specifying this the wallet
     /// will attempt to find a change output to shrink instead.


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

This PR fixes a bug introduced in https://github.com/bitcoindevkit/bdk/commit/04994e4f7f1073e7bef29528339369994d4b3666#diff-57bf66f87897e694c5ebfdfe0fd366774dda30b43eab93c1a0fdc802d0eb8c8dR171

In that commit `block_times.get(height).is_none()` was converted to `block_times.contains_key(height)`, inverting the code logic.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

