### PR TITLE
test(wallet): small cleanups to test_wallet_transactions_relevant

### DIFF
--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -19,7 +19,6 @@ use alloc::{
     sync::Arc,
     vec::Vec,
 };
-use chain::Indexer;
 use core::{cmp::Ordering, fmt, mem, ops::Deref};
 
 use bdk_chain::{
@@ -32,7 +31,7 @@ use bdk_chain::{
     },
     tx_graph::{CalculateFeeError, CanonicalTx, TxGraph, TxUpdate},
     BlockId, ChainPosition, ConfirmationBlockTime, DescriptorExt, FullTxOut, Indexed,
-    IndexedTxGraph, Merge,
+    IndexedTxGraph, Indexer, Merge,
 };
 use bitcoin::{
     absolute,


### PR DESCRIPTION
### Description

This cleans up the `test_wallet_transactions_relevant` test based on suggestions that didn't make it into #1779.

### Notes to the reviewers

Also included a small use cleanup in wallet/mod.

### Changelog notice

None.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
