### PR TITLE
feat(wallet)!: use miniscript `plan` in place of old policy mod

### DIFF
--- a/crates/wallet/src/descriptor/policy.rs
+++ b/crates/wallet/src/descriptor/policy.rs
@@ -63,6 +63,7 @@ use crate::descriptor::ExtractPolicy;
 use crate::keys::ExtScriptContext;
 use crate::wallet::signer::{SignerId, SignersContainer};
 use crate::wallet::utils::{After, Older, SecpCtx};
+use crate::Condition;
 
 use super::checksum::calc_checksum;
 use super::error::Error;
@@ -444,18 +445,6 @@ pub struct Policy {
     pub contribution: Satisfaction,
 }
 
-/// An extra condition that must be satisfied but that is out of control of the user
-/// TODO: use `bitcoin::LockTime` and `bitcoin::Sequence`
-#[derive(Hash, Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Default, Serialize)]
-pub struct Condition {
-    /// Optional CheckSequenceVerify condition
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub csv: Option<Sequence>,
-    /// Optional timelock condition
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub timelock: Option<absolute::LockTime>,
-}
-
 impl Condition {
     fn merge_nlocktime(
         a: absolute::LockTime,
@@ -478,7 +467,7 @@ impl Condition {
         }
     }
 
-    pub(crate) fn merge(mut self, other: &Condition) -> Result<Self, PolicyError> {
+    fn merge(mut self, other: &Condition) -> Result<Self, PolicyError> {
         match (self.csv, other.csv) {
             (Some(a), Some(b)) => self.csv = Some(Self::merge_nsequence(a, b)?),
             (None, any) => self.csv = any,

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -1791,7 +1791,7 @@ impl Wallet {
 
         // attempt to finalize
         if sign_options.try_finalize {
-            self.finalize_psbt(psbt, sign_options)
+            self.finalize_psbt(psbt)
         } else {
             Ok(false)
         }
@@ -1834,11 +1834,7 @@ impl Wallet {
     /// Returns `true` if the PSBT could be finalized, and `false` otherwise.
     ///
     /// The [`SignOptions`] can be used to tweak the behavior of the finalizer.
-    pub fn finalize_psbt(
-        &self,
-        psbt: &mut Psbt,
-        _sign_options: SignOptions,
-    ) -> Result<bool, SignerError> {
+    pub fn finalize_psbt(&self, psbt: &mut Psbt) -> Result<bool, SignerError> {
         let tx = &psbt.unsigned_tx;
         let mut finished = true;
 

--- a/crates/wallet/tests/create_tx_plan.rs
+++ b/crates/wallet/tests/create_tx_plan.rs
@@ -1,0 +1,197 @@
+use bitcoin::{absolute, relative, secp256k1::Secp256k1, Amount, ScriptBuf, Sequence};
+use miniscript::{
+    descriptor::{DescriptorPublicKey, KeyMap},
+    plan::Assets,
+    Descriptor, ForEachKey,
+};
+
+use bdk_wallet::error::{CreateTxError, PlanError};
+use bdk_wallet::miniscript;
+use bdk_wallet::test_utils::*;
+
+fn parse_descriptor(s: &str) -> (Descriptor<DescriptorPublicKey>, KeyMap) {
+    <Descriptor<DescriptorPublicKey>>::parse_descriptor(&Secp256k1::new(), s)
+        .expect("failed to parse descriptor")
+}
+
+#[test]
+fn construct_plan_from_assets() {
+    // technically this is tested in rust-miniscript and is only
+    // here for demonstration
+    let (desc, _) = parse_descriptor(get_test_single_sig_cltv());
+
+    let mut pk = vec![];
+    desc.for_each_key(|k| {
+        pk.push(k.clone());
+        true
+    });
+
+    // locktime not met
+    let lt = absolute::LockTime::from_consensus(99_999);
+    let assets = Assets::new().add(pk.clone()).after(lt);
+    let definite_desc = desc.at_derivation_index(0).unwrap();
+    definite_desc.plan(&assets).unwrap_err();
+
+    // no keys
+    let lt = absolute::LockTime::from_consensus(100_000);
+    let assets = Assets::new().after(lt);
+    let definite_desc = desc.at_derivation_index(0).unwrap();
+    definite_desc.plan(&assets).unwrap_err();
+
+    // assets are sufficient
+    let lt = absolute::LockTime::from_consensus(100_000);
+    let assets = Assets::new().add(pk).after(lt);
+    let definite_desc = desc.at_derivation_index(0).unwrap();
+    definite_desc.plan(&assets).unwrap();
+}
+
+#[test]
+fn create_tx_assets() -> anyhow::Result<()> {
+    let abs_locktime = absolute::LockTime::from_consensus(100_000);
+    let abs_locktime_t = absolute::LockTime::from_consensus(1734230218);
+    let rel_locktime = relative::LockTime::from_consensus(6).unwrap();
+    let rel_locktime_144 = relative::LockTime::from_consensus(144).unwrap();
+
+    let default_locktime = absolute::LockTime::from_consensus(2000);
+    let default_sequence = Sequence::ENABLE_RBF_NO_LOCKTIME;
+
+    // Test that the assets we pass in are enough to spend outputs defined by a descriptor
+    struct TestCase {
+        name: &'static str,
+        desc: &'static str,
+        assets: Option<Assets>,
+        exp_cltv: absolute::LockTime,
+        exp_sequence: Sequence,
+        // whether the result of `finish` is Ok
+        exp_result: bool,
+    }
+    let cases = vec![
+        TestCase {
+            name: "single sig no assets ok",
+            desc: get_test_tr_single_sig(),
+            assets: None,
+            exp_cltv: default_locktime,
+            exp_sequence: default_sequence,
+            exp_result: true,
+        },
+        TestCase {
+            name: "single sig + cltv",
+            desc: get_test_single_sig_cltv(),
+            assets: Some(Assets::new().after(abs_locktime)),
+            exp_cltv: abs_locktime,
+            exp_sequence: default_sequence,
+            exp_result: true,
+        },
+        TestCase {
+            name: "single sig + cltv timestamp",
+            desc: get_test_single_sig_cltv_timestamp(),
+            assets: Some(Assets::new().after(abs_locktime_t)),
+            exp_cltv: abs_locktime_t,
+            exp_sequence: default_sequence,
+            exp_result: true,
+        },
+        TestCase {
+            name: "single sig + csv",
+            desc: get_test_single_sig_csv(),
+            assets: Some(Assets::new().older(rel_locktime)),
+            exp_cltv: default_locktime,
+            exp_sequence: Sequence(6),
+            exp_result: true,
+        },
+        TestCase {
+            name: "optional csv, no assets ok",
+            desc: get_test_a_or_b_plus_csv(),
+            assets: None,
+            exp_cltv: default_locktime,
+            exp_sequence: default_sequence,
+            exp_result: true,
+        },
+        TestCase {
+            name: "optional csv, use csv",
+            desc: get_test_a_or_b_plus_csv(),
+            assets: {
+                // 2 possible spend paths. we only include the key we
+                // intend to sign with
+                let (_, keymap) = parse_descriptor(get_test_a_or_b_plus_csv());
+                let pk = keymap
+                    .keys()
+                    .find(|k| k.master_fingerprint().to_string() == "9c5eab64")
+                    .unwrap();
+                let assets = Assets::new().add(pk.clone()).older(rel_locktime_144);
+                Some(assets)
+            },
+            exp_cltv: default_locktime,
+            exp_sequence: Sequence(144),
+            exp_result: true,
+        },
+        TestCase {
+            name: "insufficient assets cltv",
+            desc: get_test_single_sig_cltv(),
+            assets: Some(Assets::new().after(absolute::LockTime::from_consensus(99_999))),
+            exp_cltv: default_locktime,
+            exp_sequence: default_sequence,
+            exp_result: false,
+        },
+        TestCase {
+            name: "insufficient assets csv",
+            desc: get_test_single_sig_csv(),
+            assets: Some(Assets::new().older(relative::LockTime::from_height(5))),
+            exp_cltv: default_locktime,
+            exp_sequence: default_sequence,
+            exp_result: false,
+        },
+        TestCase {
+            name: "insufficient assets (no assets)",
+            desc: get_test_single_sig_cltv(),
+            assets: None,
+            exp_cltv: default_locktime,
+            exp_sequence: default_sequence,
+            exp_result: false,
+        },
+        TestCase {
+            name: "wrong locktime (after)",
+            desc: get_test_single_sig_csv(),
+            assets: Some(Assets::new().after(abs_locktime)),
+            exp_cltv: default_locktime,
+            exp_sequence: default_sequence,
+            exp_result: false,
+        },
+        TestCase {
+            name: "wrong locktime (older)",
+            desc: get_test_single_sig_cltv(),
+            assets: Some(Assets::new().older(rel_locktime)),
+            exp_cltv: default_locktime,
+            exp_sequence: default_sequence,
+            exp_result: false,
+        },
+    ];
+
+    let recip = ScriptBuf::from_hex("0014446906a6560d8ad760db3156706e72e171f3a2aa")?;
+
+    for test in cases {
+        let (mut wallet, _) = get_funded_wallet_single(test.desc);
+        assert_eq!(wallet.latest_checkpoint().height(), 2_000);
+        let mut builder = wallet.build_tx();
+        if let Some(assets) = test.assets {
+            builder.add_assets(assets);
+        }
+        builder.add_recipient(recip.clone(), Amount::from_sat(10_000));
+        if test.exp_result {
+            let psbt = builder.finish().expect("tx builder should not fail");
+            assert_eq!(psbt.unsigned_tx.lock_time, test.exp_cltv, "{}", test.name);
+            assert_eq!(
+                psbt.unsigned_tx.input[0].sequence, test.exp_sequence,
+                "{}",
+                test.name
+            );
+        } else {
+            let err = builder.finish().expect_err("expected create tx fail");
+            assert!(
+                matches!(err, CreateTxError::Plan(PlanError::Plan(_))),
+                "{}",
+                test.name
+            );
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
This PR integrates features of the miniscript `plan` module into the wallet internals, in particular when it comes to coin selection and tx building. If accepted, the result is that the new interface may eventually replace bdk's current `policy` code.

fixes bitcoindevkit/bdk_wallet#4

### Notes to the reviewers


### Changelog notice


### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [x] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
