### PR TITLE
Update bdk 0.30.x README docs to deprecate the bdk library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v0.30.1]
+
+### Fixed
+
+- Fix electrum conftime_req filter for needs_block_height #1782
+
 ## [v0.30.0]
 
 ### Summary
@@ -700,4 +706,5 @@ final transaction is created by calling `finish` on the builder.
 [v0.28.2]: https://github.com/bitcoindevkit/bdk/compare/v0.28.1...v0.28.2
 [v0.29.0]: https://github.com/bitcoindevkit/bdk/compare/v0.28.2...v0.29.0
 [v0.30.0]: https://github.com/bitcoindevkit/bdk/compare/v0.29.0...v0.30.0
-[Unreleased]: https://github.com/bitcoindevkit/bdk/compare/v0.30.0...HEAD
+[v0.30.1]: https://github.com/bitcoindevkit/bdk/compare/v0.30.0...v0.30.1
+[Unreleased]: https://github.com/bitcoindevkit/bdk/compare/v0.30.1...release/0.29

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk"
-version = "0.30.0"
+version = "0.30.1"
 authors = ["Alekos Filini <alekos.filini@gmail.com>", "Riccardo Casatta <riccardo@casatta.it>"]
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@
   </h4>
 </div>
 
+## !! DEPRECATED !!
+
+The [bdk](https://crates.io/crates/bdk) library is now deprecated and replaced by [bdk_wallet](https://crates.io/crates/bdk_wallet). All projects should migrate to [bdk_wallet 1.0.0](https://crates.io/crates/bdk_wallet/1.0.0) or newer as soon as possible. For migration instructions see the ["Book of BDK"](https://bitcoindevkit.github.io/book-of-bdk/) chapter on ["Migrating from 0.x"](https://bitcoindevkit.github.io/book-of-bdk/getting-started/migrating/). 
+
+The BDK team will continue to publish `bdk` `0.30.x` bug fix releases as needed, but only for a limited time.
+
 ## About
 
 The `bdk` library aims to be the core building block for Bitcoin wallets of any kind.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,17 @@
 
 //! A modern, lightweight, descriptor-based wallet library written in Rust.
 //!
+//! ## !! DEPRECATED !!
+//!
+//! The [bdk](https://crates.io/crates/bdk) library is now deprecated and replaced by
+//! [bdk_wallet](https://crates.io/crates/bdk_wallet). All projects should migrate to
+//! [bdk_wallet 1.0.0](https://crates.io/crates/bdk_wallet/1.0.0) or newer as soon as possible. For
+//! migration instructions see the ["Book of BDK"](https://bitcoindevkit.github.io/book-of-bdk/)
+//! chapter on ["Migrating from 0.x"](https://bitcoindevkit.github.io/book-of-bdk/getting-started/migrating/).
+//!
+//! The BDK team will continue to publish `bdk` `0.30.x` bug fix releases as needed, but only for a
+//! limited time.
+//!
 //! # About
 //!
 //! The BDK library aims to be the core building block for Bitcoin wallets of any kind.


### PR DESCRIPTION
### Description

This is needed to direct new and existing users to upgrade to the new `bdk_wallet`1.0 library.

I also used this PR to bump the version and changelog to v0.30.1 so we're ready to publish the fix in #1782.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing