### PR TITLE
fix(chain): sanitize derivation index before apply changeset

### DIFF
--- a/crates/chain/src/indexer/keychain_txout.rs
+++ b/crates/chain/src/indexer/keychain_txout.rs
@@ -793,7 +793,12 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
     pub fn apply_changeset(&mut self, changeset: ChangeSet) {
         for (&desc_id, &index) in &changeset.last_revealed {
             let v = self.last_revealed.entry(desc_id).or_default();
-            *v = index.max(*v);
+            let sanitized_index = if index > BIP32_MAX_INDEX {
+                BIP32_MAX_INDEX
+            } else {
+                index
+            };
+            *v = sanitized_index.max(*v);
             self.replenish_inner_index_did(desc_id, self.lookahead);
         }
     }

--- a/crates/chain/tests/test_keychain_txout_index.rs
+++ b/crates/chain/tests/test_keychain_txout_index.rs
@@ -601,6 +601,19 @@ fn lookahead_to_target() {
 }
 
 #[test]
+fn insert_descriptor_should_reject_hardened_steps() {
+    use bdk_chain::keychain_txout::KeychainTxOutIndex;
+
+    // This descriptor has hardened child steps
+    let s = "wpkh([e273fe42/84h/1h/0h/0h]tpubDEBY7DLZ5kK6pMC2qdtVvKpe6CiAmVDx1SiLtLS3V4GAGyRvsuVbCYReJ9oQz1rfMapghJyUAYLqkqJ3Xadp3GSTCtdAFcKPgzAXC1hzz8a/*h)";
+    let (desc, _) =
+        <Descriptor<DescriptorPublicKey>>::parse_descriptor(&Secp256k1::new(), s).unwrap();
+
+    let mut indexer = KeychainTxOutIndex::<&str>::new(10);
+    assert!(indexer.insert_descriptor("keychain", desc).is_err())
+}
+
+#[test]
 fn applying_changesets_one_by_one_vs_aggregate_must_have_same_result() {
     let desc = parse_descriptor(DESCRIPTORS[0]);
     let changesets: &[ChangeSet] = &[

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -2547,6 +2547,12 @@ fn create_indexer(
                     InsertDescriptorError::KeychainAlreadyAssigned { .. } => {
                         unreachable!("this is the first time we're assigning internal")
                     }
+                    InsertDescriptorError::Miniscript(err) => {
+                        crate::descriptor::error::Error::Miniscript(err)
+                    }
+                    InsertDescriptorError::HardenedDerivationXpub => {
+                        crate::descriptor::error::Error::HardenedDerivationXpub
+                    }
                 }
             })?);
     }


### PR DESCRIPTION
fix: bitcoindevkit/bdk_wallet#60 

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
Right now, ff a descriptor has hardened child steps when inserting a descriptor throws a panic. This PR adds a previous descriptor sanitization controlling such cases.

An additional problem pointed out by @ValuedMammal is that when the apply_changest is applied a malicious crafter index could be greater that `BIP32_MAX_INDEX`. This PR adds a verification to handle such cases.
### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing