### PR TITLE
feat(wallet): add `TxBuilder::replace_tx`

### DIFF
--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -1545,7 +1545,9 @@ impl Wallet {
     ///
     /// Returns an error if the transaction is already confirmed or doesn't explicitly signal
     /// *replace by fee* (RBF). If the transaction can be fee bumped then it returns a [`TxBuilder`]
-    /// pre-populated with the inputs and outputs of the original transaction.
+    /// pre-populated with the inputs and outputs of the original transaction. If you just
+    /// want to build a transaction that conflicts with the tx of the given `txid`, consider
+    /// using [`TxBuilder::replace_tx`].
     ///
     /// ## Example
     ///
@@ -2525,7 +2527,7 @@ macro_rules! floating_rate {
 /// Macro for getting a wallet for use in a doctest
 macro_rules! doctest_wallet {
     () => {{
-        use $crate::bitcoin::{BlockHash, Transaction, absolute, TxOut, Network, hashes::Hash};
+        use $crate::bitcoin::{absolute, transaction, Amount, BlockHash, Transaction, TxOut, Network, hashes::Hash};
         use $crate::chain::{ConfirmationBlockTime, BlockId, TxGraph, tx_graph};
         use $crate::{Update, KeychainKind, Wallet};
         use $crate::test_utils::*;


### PR DESCRIPTION
This PR adds a new method `TxBuilder::replace_tx` that offers a simple way of creating replacements without relying on the mechanics of `build_fee_bump`. See #1374 for context and motivating discussion.

In summary, there are a few limitations with the current `build_fee_bump`:

1. It doesn't prevent the wallet from accidentally selecting the outputs of the replaced tx as inputs to the replacement
2. The UX is somewhat rigid because it assumes all of the same inputs and outputs should appear in the replacement. (however despite this second point we somehow neglect to reuse the original drain script?)

In contrast `replace_tx` is useful when we only need to create a conflict and flexible enough to further tweak the parameters as desired.

### Notes to the reviewers

- `TxBuilder::add_utxos` is modified to look for potentially spent outputs, provided that the given outpoint exists in the replaceable set.


### Changelog notice

- Added method `TxBuilder::replace_tx`
- Added method `TxBuilder::previous_fee`


### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
