### PR TITLE
refactor: move `tx_template` from `bdk_chain` to `bdk_testenv`

### DIFF
--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -27,7 +27,7 @@ rusqlite = { version = "0.31.0", features = ["bundled"], optional = true }
 [dev-dependencies]
 rand = "0.8"
 proptest = "1.2.0"
-bdk_testenv = { path = "../testenv", default-features = false }
+bdk_testenv = { path = "../testenv", default-features = false, features = ["miniscript"] }
 criterion = { version = "0.2" }
 
 [features]

--- a/crates/chain/benches/canonicalization.rs
+++ b/crates/chain/benches/canonicalization.rs
@@ -1,248 +1,274 @@
-use bdk_chain::{keychain_txout::KeychainTxOutIndex, local_chain::LocalChain, IndexedTxGraph};
-use bdk_core::{BlockId, CheckPoint};
-use bdk_core::{ConfirmationBlockTime, TxUpdate};
-use bdk_testenv::hash;
-use bitcoin::{
-    absolute, constants, hashes::Hash, key::Secp256k1, transaction, Amount, BlockHash, Network,
-    OutPoint, ScriptBuf, Transaction, TxIn, TxOut,
-};
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use miniscript::{Descriptor, DescriptorPublicKey};
-use std::sync::Arc;
+use bdk_chain::local_chain::LocalChain;
+use bdk_chain::spk_txout::SpkTxOutIndex;
+use bdk_chain::TxGraph;
+use bdk_core::BlockId;
+use bdk_testenv::tx_template::{init_graph, TxInTemplate, TxOutTemplate, TxTemplate};
+use bdk_testenv::{block_id, hash, local_chain};
+use bitcoin::Amount;
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::borrow::Cow;
 
-type Keychain = ();
-type KeychainTxGraph = IndexedTxGraph<ConfirmationBlockTime, KeychainTxOutIndex<Keychain>>;
-
-/// New tx guaranteed to have at least one output
-fn new_tx(lt: u32) -> Transaction {
-    Transaction {
-        version: transaction::Version::TWO,
-        lock_time: absolute::LockTime::from_consensus(lt),
-        input: vec![],
-        output: vec![TxOut::NULL],
-    }
-}
-
-fn spk_at_index(txout_index: &KeychainTxOutIndex<Keychain>, index: u32) -> ScriptBuf {
-    txout_index
-        .get_descriptor(())
-        .unwrap()
-        .at_derivation_index(index)
-        .unwrap()
-        .script_pubkey()
-}
-
-fn genesis_block_id() -> BlockId {
-    BlockId {
-        height: 0,
-        hash: constants::genesis_block(Network::Regtest).block_hash(),
-    }
-}
-
-fn tip_block_id() -> BlockId {
-    BlockId {
-        height: 100,
-        hash: BlockHash::all_zeros(),
-    }
-}
-
-/// Add ancestor tx confirmed at `block_id` with `locktime` (used for uniqueness).
-/// The transaction always pays 1 BTC to SPK 0.
-fn add_ancestor_tx(graph: &mut KeychainTxGraph, block_id: BlockId, locktime: u32) -> OutPoint {
-    let spk_0 = spk_at_index(&graph.index, 0);
-    let tx = Transaction {
-        input: vec![TxIn {
-            previous_output: OutPoint::new(hash!("bogus"), locktime),
-            ..Default::default()
-        }],
-        output: vec![TxOut {
-            value: Amount::ONE_BTC,
-            script_pubkey: spk_0,
-        }],
-        ..new_tx(locktime)
-    };
-    let txid = tx.compute_txid();
-    let _ = graph.insert_tx(tx);
-    let _ = graph.insert_anchor(
-        txid,
-        ConfirmationBlockTime {
-            block_id,
-            confirmation_time: 100,
-        },
-    );
-    OutPoint { txid, vout: 0 }
-}
-
-fn setup<F: Fn(&mut KeychainTxGraph, &LocalChain)>(f: F) -> (KeychainTxGraph, LocalChain) {
-    const DESC: &str = "tr([ab28dc00/86h/1h/0h]tpubDCdDtzAMZZrkwKBxwNcGCqe4FRydeD9rfMisoi7qLdraG79YohRfPW4YgdKQhpgASdvh612xXNY5xYzoqnyCgPbkpK4LSVcH5Xv4cK7johH/0/*)";
-    let cp = CheckPoint::from_block_ids([genesis_block_id(), tip_block_id()])
-        .expect("blocks must be chronological");
-    let chain = LocalChain::from_tip(cp).unwrap();
-
-    let (desc, _) =
-        <Descriptor<DescriptorPublicKey>>::parse_descriptor(&Secp256k1::new(), DESC).unwrap();
-    let mut index = KeychainTxOutIndex::new(10);
-    index.insert_descriptor((), desc).unwrap();
-    let mut tx_graph = KeychainTxGraph::new(index);
-
-    f(&mut tx_graph, &chain);
-    (tx_graph, chain)
-}
-
-fn run_list_canonical_txs(tx_graph: &KeychainTxGraph, chain: &LocalChain, exp_txs: usize) {
-    let txs = tx_graph
-        .graph()
-        .list_canonical_txs(chain, chain.tip().block_id());
-    assert_eq!(txs.count(), exp_txs);
-}
-
-fn run_filter_chain_txouts(tx_graph: &KeychainTxGraph, chain: &LocalChain, exp_txos: usize) {
-    let utxos = tx_graph.graph().filter_chain_txouts(
+fn filter_chain_unspents(
+    tx_graph: &TxGraph<BlockId>,
+    spk_index: &SpkTxOutIndex<u32>,
+    chain: &LocalChain,
+    exp_txos: usize,
+) {
+    let utxos = tx_graph.filter_chain_unspents(
         chain,
         chain.tip().block_id(),
-        tx_graph.index.outpoints().clone(),
+        spk_index.outpoints().clone(),
     );
     assert_eq!(utxos.count(), exp_txos);
 }
 
-fn run_filter_chain_unspents(tx_graph: &KeychainTxGraph, chain: &LocalChain, exp_utxos: usize) {
-    let utxos = tx_graph.graph().filter_chain_unspents(
-        chain,
-        chain.tip().block_id(),
-        tx_graph.index.outpoints().clone(),
-    );
-    assert_eq!(utxos.count(), exp_utxos);
+fn filter_chain_txouts(
+    tx_graph: &TxGraph<BlockId>,
+    spk_index: &SpkTxOutIndex<u32>,
+    chain: &LocalChain,
+    exp_txos: usize,
+) {
+    let utxos =
+        tx_graph.filter_chain_txouts(chain, chain.tip().block_id(), spk_index.outpoints().clone());
+    assert_eq!(utxos.count(), exp_txos);
 }
 
-pub fn many_conflicting_unconfirmed(c: &mut Criterion) {
-    const CONFLICTING_TX_COUNT: u32 = 2100;
-    let (tx_graph, chain) = black_box(setup(|tx_graph, _chain| {
-        let previous_output = add_ancestor_tx(tx_graph, tip_block_id(), 0);
-        // Create conflicting txs that spend from `previous_output`.
-        let spk_1 = spk_at_index(&tx_graph.index, 1);
-        for i in 1..=CONFLICTING_TX_COUNT {
-            let tx = Transaction {
-                input: vec![TxIn {
-                    previous_output,
+fn list_canonical_txs(tx_graph: &TxGraph<BlockId>, chain: &LocalChain, exp_txs: usize) {
+    let txs = tx_graph.list_canonical_txs(chain, chain.tip().block_id());
+    assert_eq!(txs.count(), exp_txs);
+}
+
+fn setup_many_conflicting_unconfirmed(
+    tx_count: u32,
+) -> (TxGraph<BlockId>, SpkTxOutIndex<u32>, LocalChain) {
+    let chain = local_chain![(0, hash!("genesis")), (100, hash!("abcd"))];
+    let mut templates = Vec::new();
+
+    templates.push(TxTemplate {
+        tx_name: Cow::Borrowed("ancestor_tx"),
+        inputs: Cow::Borrowed(&[TxInTemplate::Bogus]),
+        outputs: Cow::Owned(vec![TxOutTemplate::new(Amount::ONE_BTC.to_sat(), Some(0))]),
+        anchors: Cow::Owned(vec![block_id!(100, "abcd")]),
+        last_seen: None,
+    });
+
+    for i in 1..=tx_count {
+        templates.push(TxTemplate {
+            tx_name: format!("conflict_tx_{}", i).into(),
+            inputs: Cow::Owned(vec![TxInTemplate::PrevTx("ancestor_tx".into(), 0)]),
+            outputs: Cow::Owned(vec![TxOutTemplate::new(
+                Amount::ONE_BTC.to_sat() - (i as u64 * 10),
+                Some(1),
+            )]),
+            last_seen: Some(i as u64),
+            ..Default::default()
+        });
+    }
+
+    let (tx_graph, spk_index, _) = init_graph(templates);
+    (tx_graph, spk_index, chain)
+}
+
+/// chain of unconfirmed transactions
+fn setup_many_chained_unconfirmed(
+    tx_chain_count: u32,
+) -> (TxGraph<BlockId>, SpkTxOutIndex<u32>, LocalChain) {
+    let chain = local_chain![(0, hash!("genesis"))];
+    let mut templates = Vec::new();
+
+    templates.push(TxTemplate {
+        tx_name: Cow::Borrowed("ancestor_tx"),
+        inputs: Cow::Borrowed(&[TxInTemplate::Bogus]),
+        outputs: Cow::Owned(vec![TxOutTemplate::new(Amount::ONE_BTC.to_sat(), Some(0))]),
+        anchors: Cow::Owned(vec![block_id!(100, "abcd")]),
+        last_seen: None,
+    });
+
+    for i in 0..tx_chain_count {
+        templates.push(TxTemplate {
+            tx_name: format!("chain_tx_{}", i).into(),
+            inputs: if i == 0 {
+                Cow::Owned(vec![TxInTemplate::PrevTx("ancestor_tx".into(), 0)])
+            } else {
+                Cow::Owned(vec![TxInTemplate::PrevTx(
+                    format!("chain_tx_{}", i - 1).into(),
+                    0,
+                )])
+            },
+            last_seen: Some(i as u64),
+            ..Default::default()
+        });
+    }
+
+    let (tx_graph, spk_index, _) = init_graph(templates);
+    (tx_graph, spk_index, chain)
+}
+
+/// graph with nested conflicting transactions
+fn setup_nested_conflicts(
+    graph_depth: usize,
+    conflicts_per_output: usize,
+) -> (TxGraph<BlockId>, SpkTxOutIndex<u32>, LocalChain) {
+    let chain = local_chain![(0, hash!("genesis"))];
+    let mut templates = Vec::new();
+
+    templates.push(TxTemplate {
+        tx_name: "ancestor_tx".into(),
+        inputs: Cow::Borrowed(&[TxInTemplate::Bogus]),
+        outputs: Cow::Owned(vec![TxOutTemplate::new(Amount::ONE_BTC.to_sat(), Some(0))]),
+        anchors: Cow::Owned(vec![block_id!(100, "abcd")]),
+        last_seen: None,
+    });
+
+    let mut previous_outputs = vec!["ancestor_tx".to_string()];
+
+    for depth in 1..graph_depth {
+        let mut next_outputs = Vec::new();
+
+        for (parent_index, previous_output_name) in previous_outputs.drain(..).enumerate() {
+            for conflict_i in 1..=conflicts_per_output {
+                let tx_name = format!(
+                    "depth_{}_parent_{}_conflict_{}",
+                    depth, parent_index, conflict_i
+                );
+
+                let last_seen = depth as u64 * conflict_i as u64;
+
+                templates.push(TxTemplate {
+                    tx_name: tx_name.clone().into(),
+                    inputs: Cow::Owned(vec![TxInTemplate::PrevTx(
+                        previous_output_name.clone().into(),
+                        0,
+                    )]),
+                    outputs: Cow::Owned(vec![TxOutTemplate::new(
+                        Amount::ONE_BTC.to_sat() - (depth as u64 * 200 - conflict_i as u64),
+                        Some(0),
+                    )]),
+                    last_seen: Some(last_seen),
                     ..Default::default()
-                }],
-                output: vec![TxOut {
-                    value: Amount::ONE_BTC - Amount::from_sat(i as u64 * 10),
-                    script_pubkey: spk_1.clone(),
-                }],
-                ..new_tx(i)
-            };
-            let mut update = TxUpdate::default();
-            update.seen_ats = [(tx.compute_txid(), i as u64)].into();
-            update.txs = vec![Arc::new(tx)];
-            let _ = tx_graph.apply_update(update);
-        }
-    }));
-    c.bench_function("many_conflicting_unconfirmed::list_canonical_txs", {
-        let (tx_graph, chain) = (tx_graph.clone(), chain.clone());
-        move |b| b.iter(|| run_list_canonical_txs(&tx_graph, &chain, 2))
-    });
-    c.bench_function("many_conflicting_unconfirmed::filter_chain_txouts", {
-        let (tx_graph, chain) = (tx_graph.clone(), chain.clone());
-        move |b| b.iter(|| run_filter_chain_txouts(&tx_graph, &chain, 2))
-    });
-    c.bench_function("many_conflicting_unconfirmed::filter_chain_unspents", {
-        let (tx_graph, chain) = (tx_graph.clone(), chain.clone());
-        move |b| b.iter(|| run_filter_chain_unspents(&tx_graph, &chain, 1))
-    });
-}
+                });
 
-pub fn many_chained_unconfirmed(c: &mut Criterion) {
-    const TX_CHAIN_COUNT: u32 = 2100;
-    let (tx_graph, chain) = black_box(setup(|tx_graph, _chain| {
-        let mut previous_output = add_ancestor_tx(tx_graph, tip_block_id(), 0);
-        // Create a chain of unconfirmed txs where each subsequent tx spends the output of the
-        // previous one.
-        for i in 0..TX_CHAIN_COUNT {
-            // Create tx.
-            let tx = Transaction {
-                input: vec![TxIn {
-                    previous_output,
-                    ..Default::default()
-                }],
-                ..new_tx(i)
-            };
-            let txid = tx.compute_txid();
-            let mut update = TxUpdate::default();
-            update.seen_ats = [(txid, i as u64)].into();
-            update.txs = vec![Arc::new(tx)];
-            let _ = tx_graph.apply_update(update);
-            // Store the next prevout.
-            previous_output = OutPoint::new(txid, 0);
-        }
-    }));
-    c.bench_function("many_chained_unconfirmed::list_canonical_txs", {
-        let (tx_graph, chain) = (tx_graph.clone(), chain.clone());
-        move |b| b.iter(|| run_list_canonical_txs(&tx_graph, &chain, 2101))
-    });
-    c.bench_function("many_chained_unconfirmed::filter_chain_txouts", {
-        let (tx_graph, chain) = (tx_graph.clone(), chain.clone());
-        move |b| b.iter(|| run_filter_chain_txouts(&tx_graph, &chain, 1))
-    });
-    c.bench_function("many_chained_unconfirmed::filter_chain_unspents", {
-        let (tx_graph, chain) = (tx_graph.clone(), chain.clone());
-        move |b| b.iter(|| run_filter_chain_unspents(&tx_graph, &chain, 0))
-    });
-}
-
-pub fn nested_conflicts(c: &mut Criterion) {
-    const CONFLICTS_PER_OUTPUT: usize = 3;
-    const GRAPH_DEPTH: usize = 7;
-    let (tx_graph, chain) = black_box(setup(|tx_graph, _chain| {
-        let mut prev_ops = core::iter::once(add_ancestor_tx(tx_graph, tip_block_id(), 0))
-            .collect::<Vec<OutPoint>>();
-        for depth in 1..GRAPH_DEPTH {
-            for previous_output in core::mem::take(&mut prev_ops) {
-                for conflict_i in 1..=CONFLICTS_PER_OUTPUT {
-                    let mut last_seen = depth * conflict_i;
-                    if last_seen % 2 == 0 {
-                        last_seen /= 2;
-                    }
-                    let ((_, script_pubkey), _) = tx_graph.index.next_unused_spk(()).unwrap();
-                    let value =
-                        Amount::ONE_BTC - Amount::from_sat(depth as u64 * 200 - conflict_i as u64);
-                    let tx = Transaction {
-                        input: vec![TxIn {
-                            previous_output,
-                            ..Default::default()
-                        }],
-                        output: vec![TxOut {
-                            value,
-                            script_pubkey,
-                        }],
-                        ..new_tx(conflict_i as _)
-                    };
-                    let txid = tx.compute_txid();
-                    prev_ops.push(OutPoint::new(txid, 0));
-                    let _ = tx_graph.insert_seen_at(txid, last_seen as _);
-                    let _ = tx_graph.insert_tx(tx);
-                }
+                next_outputs.push(tx_name);
             }
         }
-    }));
+
+        previous_outputs = next_outputs;
+    }
+
+    let (tx_graph, spk_index, _) = init_graph(templates);
+    (tx_graph, spk_index, chain)
+}
+
+/// Benchmark for many conflicting unconfirmed transactions
+fn bench_many_conflicting_unconfirmed(c: &mut Criterion) {
+    const CONFLICTING_TX_COUNT: u32 = 2100;
+
+    let (tx_graph, spk_index, chain) = setup_many_conflicting_unconfirmed(CONFLICTING_TX_COUNT);
+
+    c.bench_function("many_conflicting_unconfirmed::list_canonical_txs", {
+        let tx_graph = tx_graph.clone();
+        let chain = chain.clone();
+        move |b| {
+            b.iter(|| list_canonical_txs(&tx_graph, &chain, 2));
+        }
+    });
+
+    c.bench_function("many_conflicting_unconfirmed::filter_chain_txouts", {
+        let tx_graph = tx_graph.clone();
+        let spk_index = spk_index.clone();
+        let chain = chain.clone();
+        move |b| {
+            b.iter(|| filter_chain_txouts(&tx_graph, &spk_index, &chain, 2));
+        }
+    });
+
+    c.bench_function(
+        "many_conflicting_unconfirmed::filter_chain_unspents",
+        move |b| {
+            b.iter(|| {
+                filter_chain_unspents(&tx_graph, &spk_index, &chain, 1);
+            });
+        },
+    );
+}
+
+/// Benchmark for many chained unconfirmed transactions
+pub fn bench_many_chained_unconfirmed(c: &mut Criterion) {
+    const TX_CHAIN_COUNT: u32 = 2100;
+
+    let (tx_graph, spk_index, chain) = setup_many_chained_unconfirmed(TX_CHAIN_COUNT);
+
+    c.bench_function("many_chained_unconfirmed::list_canonical_txs", {
+        let tx_graph = tx_graph.clone();
+        let chain = chain.clone();
+        move |b| {
+            b.iter(|| {
+                list_canonical_txs(&tx_graph, &chain, (TX_CHAIN_COUNT + 1).try_into().unwrap());
+            });
+        }
+    });
+
+    c.bench_function("many_chained_unconfirmed::filter_chain_txouts", {
+        let tx_graph = tx_graph.clone();
+        let chain = chain.clone();
+        let spk_index = spk_index.clone();
+        move |b| {
+            b.iter(|| {
+                filter_chain_txouts(&tx_graph, &spk_index, &chain, 1);
+            });
+        }
+    });
+
+    c.bench_function("many_chained_unconfirmed::filter_chain_unspents", {
+        move |b| {
+            b.iter(|| {
+                filter_chain_unspents(&tx_graph, &spk_index, &chain, 0);
+            });
+        }
+    });
+}
+
+/// Benchmark for nested conflicts
+pub fn bench_nested_conflicts(c: &mut Criterion) {
+    const CONFLICTS_PER_OUTPUT: usize = 3;
+    const GRAPH_DEPTH: usize = 7;
+
+    let (tx_graph, spk_index, chain) = setup_nested_conflicts(GRAPH_DEPTH, CONFLICTS_PER_OUTPUT);
+
     c.bench_function("nested_conflicts_unconfirmed::list_canonical_txs", {
-        let (tx_graph, chain) = (tx_graph.clone(), chain.clone());
-        move |b| b.iter(|| run_list_canonical_txs(&tx_graph, &chain, GRAPH_DEPTH))
+        let tx_graph = tx_graph.clone();
+        let chain = chain.clone();
+        move |b| {
+            b.iter(|| {
+                list_canonical_txs(&tx_graph, &chain, GRAPH_DEPTH);
+            });
+        }
     });
+
     c.bench_function("nested_conflicts_unconfirmed::filter_chain_txouts", {
-        let (tx_graph, chain) = (tx_graph.clone(), chain.clone());
-        move |b| b.iter(|| run_filter_chain_txouts(&tx_graph, &chain, GRAPH_DEPTH))
+        let tx_graph = tx_graph.clone();
+        let chain = chain.clone();
+        let spk_index = spk_index.clone();
+        move |b| {
+            b.iter(|| {
+                filter_chain_txouts(&tx_graph, &spk_index, &chain, GRAPH_DEPTH);
+            });
+        }
     });
+
     c.bench_function("nested_conflicts_unconfirmed::filter_chain_unspents", {
-        let (tx_graph, chain) = (tx_graph.clone(), chain.clone());
-        move |b| b.iter(|| run_filter_chain_unspents(&tx_graph, &chain, 1))
+        move |b| {
+            b.iter(|| {
+                filter_chain_unspents(&tx_graph, &spk_index, &chain, 1);
+            });
+        }
     });
 }
 
 criterion_group!(
     benches,
-    many_conflicting_unconfirmed,
-    many_chained_unconfirmed,
-    nested_conflicts,
+    bench_many_conflicting_unconfirmed,
+    bench_many_chained_unconfirmed,
+    bench_nested_conflicts,
 );
 criterion_main!(benches);

--- a/crates/chain/tests/common/mod.rs
+++ b/crates/chain/tests/common/mod.rs
@@ -1,5 +1,0 @@
-#![cfg(feature = "miniscript")]
-
-mod tx_template;
-#[allow(unused_imports)]
-pub use tx_template::*;

--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -1,8 +1,5 @@
 #![cfg(feature = "miniscript")]
 
-#[macro_use]
-mod common;
-
 use std::{collections::BTreeSet, sync::Arc};
 
 use bdk_chain::{

--- a/crates/testenv/Cargo.toml
+++ b/crates/testenv/Cargo.toml
@@ -18,15 +18,14 @@ workspace = true
 [dependencies]
 bdk_chain = { path = "../chain", version = "0.21.1", default-features = false }
 electrsd = { version = "0.28.0", features = [ "legacy" ], default-features = false }
-
-[dev-dependencies]
-bdk_testenv = { path = "." }
+rand = {version = "0.8", optional = true}
 
 [features]
 default = ["std", "download"]
 download = ["electrsd/bitcoind_25_0", "electrsd/esplora_a33e97e1"]
 std = ["bdk_chain/std"]
 serde = ["bdk_chain/serde"]
+miniscript = ["bdk_chain/miniscript", "rand"]
 
 [package.metadata.docs.rs]
 no-default-features = true

--- a/crates/testenv/src/lib.rs
+++ b/crates/testenv/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod tx_template;
 pub mod utils;
 
 use bdk_chain::{


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
This PR implements the following changes:
- moves `TxTemplate` from `crates/chain/tests/common/mod.rs` to `testenv`. 
- refactors `init_graph` function and `TxTemplate` struct to use `Cow` 
- redoes the canonical benchmark tests introduced by bitcoindevkit/bdk#1670 using TxTemplates

Closes bitcoindevkit/bdk#1936

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing