### PR TITLE
ci: pin `rustls` for msrv

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -54,7 +54,7 @@ jobs:
           cargo update -p security-framework-sys --precise "2.11.1"
           cargo update -p csv --precise "1.3.0"
           cargo update -p unicode-width --precise "0.1.13"
-          cargo update -p rustls@0.23.20 --precise "0.23.19"
+          cargo update -p rustls@0.23.21 --precise "0.23.19"
       - name: Build
         run: cargo build --workspace --exclude 'example_*' ${{ matrix.features }}
       - name: Test

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ cargo update -p indexmap --precise "2.5.0"
 cargo update -p security-framework-sys --precise "2.11.1"
 cargo update -p csv --precise "1.3.0"
 cargo update -p unicode-width --precise "0.1.13"
-cargo update -p rustls@0.23.20 --precise "0.23.19"
+cargo update -p rustls@0.23.21 --precise "0.23.19"
 ```
 
 ## License


### PR DESCRIPTION
Fix the current CI issue by pinning `rustls` again to 0.23.19

