### PR TITLE
ci: add secondary MSRV job of 1.75.0

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -55,7 +55,6 @@ jobs:
             cargo update -p security-framework-sys --precise "2.11.1"
             cargo update -p csv --precise "1.3.0"
             cargo update -p unicode-width --precise "0.1.13"
-            cargo update -p rustls@0.23.21 --precise "0.23.19"
           elif [ "${{matrix.rust.version}}" = '1.75.0' ]; then
             cargo update -p home --precise "0.5.9"
           fi

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -14,7 +14,7 @@ jobs:
       - name: "Read rust version"
         id: read_toolchain
         run: echo "rust_version=$(cat rust-version)" >> $GITHUB_OUTPUT
-  
+
   build-test:
     needs: prepare
     name: Build and test
@@ -24,7 +24,8 @@ jobs:
         rust:
           - version: ${{ needs.prepare.outputs.rust_version }}
             clippy: true
-          - version: 1.63.0 # MSRV
+          - version: 1.63.0 # Overall MSRV
+          - version: 1.75.0 # Specific MSRV for `bdk_electrum`
         features:
           - --no-default-features --features miniscript/no-std
           - --all-features
@@ -40,25 +41,38 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.7.5
       - name: Pin dependencies for MSRV
-        if: matrix.rust.version == '1.63.0'
         run: |
-          cargo update -p zstd-sys --precise "2.0.8+zstd.1.5.5"
-          cargo update -p time --precise "0.3.20"
-          cargo update -p home --precise "0.5.5"
-          cargo update -p proptest --precise "1.2.0"
-          cargo update -p url --precise "2.5.0"
-          cargo update -p cc --precise "1.0.105"
-          cargo update -p tokio --precise "1.38.1"
-          cargo update -p tokio-util --precise "0.7.11"
-          cargo update -p indexmap --precise "2.5.0"
-          cargo update -p security-framework-sys --precise "2.11.1"
-          cargo update -p csv --precise "1.3.0"
-          cargo update -p unicode-width --precise "0.1.13"
-          cargo update -p rustls@0.23.21 --precise "0.23.19"
+          if [ "${{matrix.rust.version}}" = '1.63.0' ]; then
+            cargo update -p zstd-sys --precise "2.0.8+zstd.1.5.5"
+            cargo update -p time --precise "0.3.20"
+            cargo update -p home --precise "0.5.5"
+            cargo update -p proptest --precise "1.2.0"
+            cargo update -p url --precise "2.5.0"
+            cargo update -p cc --precise "1.0.105"
+            cargo update -p tokio --precise "1.38.1"
+            cargo update -p tokio-util --precise "0.7.11"
+            cargo update -p indexmap --precise "2.5.0"
+            cargo update -p security-framework-sys --precise "2.11.1"
+            cargo update -p csv --precise "1.3.0"
+            cargo update -p unicode-width --precise "0.1.13"
+            cargo update -p rustls@0.23.21 --precise "0.23.19"
+          elif [ "${{matrix.rust.version}}" = '1.75.0' ]; then
+            cargo update -p home --precise "0.5.9"
+          fi
       - name: Build
-        run: cargo build --workspace --exclude 'example_*' ${{ matrix.features }}
+        run: |
+          if [ "${{matrix.rust.version}}" = '1.63.0' ]; then
+            cargo build --workspace --exclude 'example_*' --exclude 'bdk_electrum' ${{ matrix.features }}
+          else
+            cargo build --workspace --exclude 'example_*' ${{ matrix.features }}
+          fi
       - name: Test
-        run: cargo test --workspace --exclude 'example_*' ${{ matrix.features }}
+        run: |
+          if [ "${{matrix.rust.version}}" = '1.63.0' ]; then
+            cargo test --workspace --exclude 'example_*' --exclude 'bdk_electrum' ${{ matrix.features }}
+          else
+            cargo test --workspace --exclude 'example_*' ${{ matrix.features }}
+          fi
 
   check-no-std:
     needs: prepare

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -17,7 +17,7 @@ jobs:
 
   build-test:
     needs: prepare
-    name: Build and test
+    name: Build & Test
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -40,36 +40,20 @@ jobs:
             profile: minimal
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.7.5
-      - name: Pin dependencies for MSRV
+      - name: Pin dependencies for 1.75
+        if: matrix.rust.version == '1.75.0'
         run: |
-          if [ "${{matrix.rust.version}}" = '1.63.0' ]; then
-            cargo update -p zstd-sys --precise "2.0.8+zstd.1.5.5"
-            cargo update -p time --precise "0.3.20"
-            cargo update -p home --precise "0.5.5"
-            cargo update -p proptest --precise "1.2.0"
-            cargo update -p url --precise "2.5.0"
-            cargo update -p cc --precise "1.0.105"
-            cargo update -p tokio --precise "1.38.1"
-            cargo update -p tokio-util --precise "0.7.11"
-            cargo update -p indexmap --precise "2.5.0"
-            cargo update -p security-framework-sys --precise "2.11.1"
-            cargo update -p csv --precise "1.3.0"
-            cargo update -p unicode-width --precise "0.1.13"
-          elif [ "${{matrix.rust.version}}" = '1.75.0' ]; then
-            cargo update -p home --precise "0.5.9"
-          fi
-      - name: Build
+          cargo update -p home --precise "0.5.9"
+      - name: Pin dependencies for MSRV
+        if: matrix.rust.version == '1.63.0'
+        run: ./ci/pin-msrv.sh
+      - name: Build + Test
         run: |
           if [ "${{matrix.rust.version}}" = '1.63.0' ]; then
             cargo build --workspace --exclude 'example_*' --exclude 'bdk_electrum' ${{ matrix.features }}
-          else
-            cargo build --workspace --exclude 'example_*' ${{ matrix.features }}
-          fi
-      - name: Test
-        run: |
-          if [ "${{matrix.rust.version}}" = '1.63.0' ]; then
             cargo test --workspace --exclude 'example_*' --exclude 'bdk_electrum' ${{ matrix.features }}
           else
+            cargo build --workspace --exclude 'example_*' ${{ matrix.features }}
             cargo test --workspace --exclude 'example_*' ${{ matrix.features }}
           fi
 
@@ -151,6 +135,7 @@ jobs:
 
   clippy_check:
     needs: prepare
+    name: Rust clippy
     runs-on: ubuntu-latest
     permissions:
       checks: write

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Fully working examples of how to use these components are in `/example-crates`:
 [`bdk_chain`]: https://docs.rs/bdk-chain/
 
 ## Minimum Supported Rust Version (MSRV)
-The BDK library maintains a MSRV of 1.63.0. This includes the following crates 
+The BDK library maintains a MSRV of 1.63.0. This includes the following crates:
 
 - `bdk_core`
 - `bdk_chain`
@@ -73,7 +73,7 @@ The BDK library maintains a MSRV of 1.63.0. This includes the following crates
 
 The MSRV of `bdk_electrum` is 1.75.0.
 
-To build with the MSRV of 1.63.0 you will need to pin dependencies by running the [`pin-msrv.sh`](./ci/pin-msrv.sh) script
+To build with the MSRV of 1.63.0 you will need to pin dependencies by running the [`pin-msrv.sh`](./ci/pin-msrv.sh) script.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -73,22 +73,7 @@ The BDK library maintains a MSRV of 1.63.0. This includes the following crates
 
 The MSRV of `bdk_electrum` is 1.75.0.
 
-To build with the MSRV you will need to pin dependencies as follows:
-
-```shell
-cargo update -p zstd-sys --precise "2.0.8+zstd.1.5.5"
-cargo update -p time --precise "0.3.20"
-cargo update -p home --precise "0.5.5"
-cargo update -p proptest --precise "1.2.0"
-cargo update -p url --precise "2.5.0"
-cargo update -p cc --precise "1.0.105"
-cargo update -p tokio --precise "1.38.1"
-cargo update -p tokio-util --precise "0.7.11"
-cargo update -p indexmap --precise "2.5.0"
-cargo update -p security-framework-sys --precise "2.11.1"
-cargo update -p csv --precise "1.3.0"
-cargo update -p unicode-width --precise "0.1.13"
-```
+To build with the MSRV of 1.63.0 you will need to pin dependencies by running the [`pin-msrv.sh`](./ci/pin-msrv.sh) script
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,15 @@ Fully working examples of how to use these components are in `/example-crates`:
 [`bdk_chain`]: https://docs.rs/bdk-chain/
 
 ## Minimum Supported Rust Version (MSRV)
-This library should compile with any combination of features with Rust 1.63.0.
+The BDK library maintains a MSRV of 1.63.0. This includes the following crates 
+
+- `bdk_core`
+- `bdk_chain`
+- `bdk_bitcoind_rpc`.
+- `bdk_esplora`.
+- `bdk_wallet`.
+
+The MSRV of `bdk_electrum` is 1.75.0.
 
 To build with the MSRV you will need to pin dependencies as follows:
 
@@ -80,7 +88,6 @@ cargo update -p indexmap --precise "2.5.0"
 cargo update -p security-framework-sys --precise "2.11.1"
 cargo update -p csv --precise "1.3.0"
 cargo update -p unicode-width --precise "0.1.13"
-cargo update -p rustls@0.23.21 --precise "0.23.19"
 ```
 
 ## License

--- a/ci/pin-msrv.sh
+++ b/ci/pin-msrv.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -x
+set -euo pipefail
+
+# Pin dependencies for MSRV
+
+# To pin deps, switch toolchain to MSRV and execute the below updates
+
+# cargo clean
+# rustup default 1.63.0
+
+cargo update -p zstd-sys --precise "2.0.8+zstd.1.5.5"
+cargo update -p time --precise "0.3.20"
+cargo update -p home --precise "0.5.5"
+cargo update -p proptest --precise "1.2.0"
+cargo update -p url --precise "2.5.0"
+cargo update -p cc --precise "1.0.105"
+cargo update -p tokio --precise "1.38.1"
+cargo update -p tokio-util --precise "0.7.11"
+cargo update -p indexmap --precise "2.5.0"
+cargo update -p security-framework-sys --precise "2.11.1"
+cargo update -p csv --precise "1.3.0"
+cargo update -p unicode-width --precise "0.1.13"

--- a/ci/pin-msrv.sh
+++ b/ci/pin-msrv.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # To pin deps, switch toolchain to MSRV and execute the below updates
 
 # cargo clean
-# rustup default 1.63.0
+# rustup override set 1.63.0
 
 cargo update -p zstd-sys --precise "2.0.8+zstd.1.5.5"
 cargo update -p time --precise "0.3.20"

--- a/crates/electrum/README.md
+++ b/crates/electrum/README.md
@@ -3,5 +3,13 @@
 BDK Electrum extends [`electrum-client`] to update [`bdk_chain`] structures
 from an Electrum server.
 
+## Minimum Supported Rust Version (MSRV)
+This crate has a MSRV of 1.75.0.
+
+To build with MSRV you will need to pin dependencies as follows:
+```shell
+cargo update -p home --precise "0.5.9"
+```
+
 [`electrum-client`]: https://docs.rs/electrum-client/
 [`bdk_chain`]: https://docs.rs/bdk-chain/


### PR DESCRIPTION
partially fixes #1750

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

It adds a secondary MSRV version of `1.75.0` for the `bdk_electrum` crate, excluding it from the `1.63.0` MSRV dependency pinning and CI step.

As it's the new CI will run without `bdk_electrum` for `1.63.0` MSRV step, will run another step for `1.75.0` MSRV and the latest stable.

Currently,, the only affected crate is `electrum-client`, therefore `bdk-electrum`, as it relies directly on `rustls` which migrated to `1.71.0` MSRV. The `esplora-client` relies on `rustls` as a dependency of `minreq` or `reqwest`, but those crates didn't upgraded it's `rustls` versions yet.

In a further PR it should also bump the `electrum-client` crate to it's latest version, which relies on `1.75.0` MSRV, see https://github.com/bitcoindevkit/rust-electrum-client/pull/159.

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

It's open for discussion if this approach is the expected one, or another one would be better.

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

- Add a secondary MSRV of `1.75.0` for `bdk_electrum`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
