### PR TITLE
Update Dependencies for Compatibility and Security (Fixes #1797)

### DIFF
--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -22,13 +22,13 @@ serde = { version = "1", optional = true, features = ["derive", "rc"] }
 miniscript = { version = "12.0.0", optional = true, default-features = false }
 
 # Feature dependencies
-rusqlite = { version = "0.31.0", features = ["bundled"], optional = true }
+rusqlite = { version = "0.32.1", features = ["bundled"], optional = true }
 
 [dev-dependencies]
 rand = "0.8"
 proptest = "1.2.0"
 bdk_testenv = { path = "../testenv", default-features = false }
-criterion = { version = "0.2" }
+criterion = { version = "0.5.1" }
 
 [features]
 default = ["std", "miniscript"]

--- a/crates/testenv/Cargo.toml
+++ b/crates/testenv/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 
 [dependencies]
 bdk_chain = { path = "../chain", version = "0.21.1", default-features = false }
-electrsd = { version = "0.28.0", features = [ "legacy" ], default-features = false }
+electrsd = { version = "0.29.0", features = [ "legacy" ], default-features = false }
 
 [dev-dependencies]
 bdk_testenv = { path = "." }

--- a/example-crates/example_bitcoind_rpc_polling/Cargo.toml
+++ b/example-crates/example_bitcoind_rpc_polling/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2021"
 bdk_chain = { path = "../../crates/chain", features = ["serde"] }
 bdk_bitcoind_rpc = { path = "../../crates/bitcoind_rpc" }
 example_cli = { path = "../example_cli" }
-ctrlc = { version = "^2" }
+ctrlc = { version = "3.4.5" }

--- a/example-crates/example_wallet_rpc/Cargo.toml
+++ b/example-crates/example_wallet_rpc/Cargo.toml
@@ -11,4 +11,4 @@ bdk_bitcoind_rpc = { path = "../../crates/bitcoind_rpc" }
 
 anyhow = "1"
 clap = { version = "4.5.17", features = ["derive", "env"] }
-ctrlc = "2.0.1"
+ctrlc = "3.4.5"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

This pull request addresses Issue bitcoindevkit/bdk_wallet#32 and updates several dependencies in the project:

- **`bdk_chain`**: Updated `rusqlite` from `0.31.0` to `0.32.1` for improved compatibility and security.
- **`bdk_chain`**: Updated `criterion` from `^0.2` to `0.5.1` in dev dependencies for bug fixes and new features.
- **`bdk_testenv`**: Updated `electrsd` from `^0.28.0` to `0.29.0` to ensure compatibility with the latest versions of `electrs`.
- **`example_wallet_rpc`** and **`example_bitcoind_rpc_polling`**: Updated `ctrlc` from `^2` to `3.4.5` for better compatibility with newer versions of `ctrlc`.

### Notes to the reviewers

- The updates address part of Issue bitcoindevkit/bdk_wallet#32. A key point is the security vulnerability related to `tokio` (RUSTSEC-2023-0001). The fix is pending as part of future updates.
- There is still one more dependency update (hashbrown) in the `bdk_core` crate left to complete. This will be addressed in a subsequent PR.
- Testing is focused on ensuring the stability and compatibility of the crates after these updates. Please pay particular attention to the interaction between `rusqlite`, `criterion`, `electrsd`, and `ctrlc`.

### Changelog notice

- Updated several dependencies to newer, more secure versions.
  - `rusqlite` updated to `0.32.1`.
  - `criterion` updated to `0.5.1`.
  - `electrsd` updated to `0.29.0`.
  - `ctrlc` updated to `3.4.5`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
