### PR TITLE
feat(wallet): support Testnet4 in valid networks

### DIFF
--- a/crates/wallet/src/descriptor/dsl.rs
+++ b/crates/wallet/src/descriptor/dsl.rs
@@ -817,7 +817,7 @@ mod test {
     use crate::descriptor::{DescriptorError, DescriptorMeta};
     use crate::keys::{DescriptorKey, IntoDescriptorKey, ValidNetworks};
     use bitcoin::bip32;
-    use bitcoin::Network::{Bitcoin, Regtest, Signet, Testnet};
+    use bitcoin::Network::{Bitcoin, Regtest, Signet, Testnet, Testnet4};
     use bitcoin::PrivateKey;
 
     // test the descriptor!() macro
@@ -1115,7 +1115,10 @@ mod test {
         let (_desc, _key_map, valid_networks) = descriptor!(pkh(desc_key)).unwrap();
         assert_eq!(
             valid_networks,
-            [Testnet, Regtest, Signet].iter().cloned().collect()
+            [Testnet, Testnet4, Regtest, Signet]
+                .iter()
+                .cloned()
+                .collect()
         );
 
         let xprv = bip32::Xpriv::from_str("xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi").unwrap();

--- a/crates/wallet/src/descriptor/mod.rs
+++ b/crates/wallet/src/descriptor/mod.rs
@@ -804,6 +804,10 @@ mod test {
         assert!(desc.is_ok());
 
         let desc = "wpkh(tprv8ZgxMBicQKsPdpkqS7Eair4YxjcuuvDPNYmKX3sCniCf16tHEVrjjiSXEkFRnUH77yXc6ZcwHHcLNfjdi5qUvw3VDfgYiH5mNsj5izuiu2N/1/2/*)"
+            .into_wallet_descriptor(&secp, Network::Testnet4);
+        assert!(desc.is_ok());
+
+        let desc = "wpkh(tprv8ZgxMBicQKsPdpkqS7Eair4YxjcuuvDPNYmKX3sCniCf16tHEVrjjiSXEkFRnUH77yXc6ZcwHHcLNfjdi5qUvw3VDfgYiH5mNsj5izuiu2N/1/2/*)"
             .into_wallet_descriptor(&secp, Network::Regtest);
         assert!(desc.is_ok());
 

--- a/crates/wallet/src/keys/bip39.rs
+++ b/crates/wallet/src/keys/bip39.rs
@@ -173,7 +173,7 @@ mod test {
         let (desc, keys, networks) = crate::descriptor!(wpkh(key)).unwrap();
         assert_eq!(desc.to_string(), "wpkh([be83839f/44'/0'/0']xpub6DCQ1YcqvZtSwGWMrwHELPehjWV3f2MGZ69yBADTxFEUAoLwb5Mp5GniQK6tTp3AgbngVz9zEFbBJUPVnkG7LFYt8QMTfbrNqs6FNEwAPKA/0/*)#0r8v4nkv");
         assert_eq!(keys.len(), 1);
-        assert_eq!(networks.len(), 4);
+        assert_eq!(networks, any_network());
     }
 
     #[test]
@@ -187,7 +187,7 @@ mod test {
         let (desc, keys, networks) = crate::descriptor!(wpkh(key)).unwrap();
         assert_eq!(desc.to_string(), "wpkh([8f6cb80c/44'/0'/0']xpub6DWYS8bbihFevy29M4cbw4ZR3P5E12jB8R88gBDWCTCNpYiDHhYWNywrCF9VZQYagzPmsZpxXpytzSoxynyeFr4ZyzheVjnpLKuse4fiwZw/0/*)#h0j0tg5m");
         assert_eq!(keys.len(), 1);
-        assert_eq!(networks.len(), 4);
+        assert_eq!(networks, any_network());
     }
 
     #[test]

--- a/crates/wallet/src/keys/mod.rs
+++ b/crates/wallet/src/keys/mod.rs
@@ -45,11 +45,12 @@ pub mod bip39;
 /// Set of valid networks for a key
 pub type ValidNetworks = HashSet<Network>;
 
-/// Create a set containing mainnet, testnet, signet, and regtest
+/// Create a set containing mainnet, testnet, testnet4, signet, and regtest
 pub fn any_network() -> ValidNetworks {
     vec![
         Network::Bitcoin,
         Network::Testnet,
+        Network::Testnet4,
         Network::Regtest,
         Network::Signet,
     ]
@@ -60,11 +61,16 @@ pub fn any_network() -> ValidNetworks {
 pub fn mainnet_network() -> ValidNetworks {
     vec![Network::Bitcoin].into_iter().collect()
 }
-/// Create a set containing testnet and regtest
+/// Create a set containing test networks
 pub fn test_networks() -> ValidNetworks {
-    vec![Network::Testnet, Network::Regtest, Network::Signet]
-        .into_iter()
-        .collect()
+    vec![
+        Network::Testnet,
+        Network::Testnet4,
+        Network::Regtest,
+        Network::Signet,
+    ]
+    .into_iter()
+    .collect()
 }
 /// Compute the intersection of two sets
 pub fn merge_networks(a: &ValidNetworks, b: &ValidNetworks) -> ValidNetworks {


### PR DESCRIPTION
Adds support for `Testnet4` in valid networks.

fixes #1429 

### Notes to the reviewers

The `Testnet4` variant is included in `keys::any_network` and `keys::test_networks`. Tests are updated accordingly and a new assertion is added to `test_descriptor_from_str_with_keys_network` checking the result of `into_wallet_descriptor` when the specified network is `Network::Testnet4`.

### Changelog notice

Added:
- `Wallet` can now be constructed using `Network::Testnet4`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
