### PR TITLE
Introduce `evicted-at`/`last-evicted` timestamps

### DIFF
--- a/crates/chain/benches/canonicalization.rs
+++ b/crates/chain/benches/canonicalization.rs
@@ -132,10 +132,8 @@ pub fn many_conflicting_unconfirmed(c: &mut Criterion) {
                 }],
                 ..new_tx(i)
             };
-            let update = TxUpdate {
-                txs: vec![Arc::new(tx)],
-                ..Default::default()
-            };
+            let mut update = TxUpdate::default();
+            update.txs = vec![Arc::new(tx)];
             let _ = tx_graph.apply_update_at(update, Some(i as u64));
         }
     }));
@@ -169,10 +167,8 @@ pub fn many_chained_unconfirmed(c: &mut Criterion) {
                 ..new_tx(i)
             };
             let txid = tx.compute_txid();
-            let update = TxUpdate {
-                txs: vec![Arc::new(tx)],
-                ..Default::default()
-            };
+            let mut update = TxUpdate::default();
+            update.txs = vec![Arc::new(tx)];
             let _ = tx_graph.apply_update_at(update, Some(i as u64));
             // Store the next prevout.
             previous_output = OutPoint::new(txid, 0);

--- a/crates/chain/src/indexer/keychain_txout.rs
+++ b/crates/chain/src/indexer/keychain_txout.rs
@@ -7,13 +7,11 @@ use crate::{
     spk_client::{FullScanRequestBuilder, SyncRequestBuilder},
     spk_iter::BIP32_MAX_INDEX,
     spk_txout::SpkTxOutIndex,
-    Anchor, CanonicalIter, CanonicalReason, ChainOracle, DescriptorExt, DescriptorId, Indexed,
-    Indexer, KeychainIndexed, SpkIterator,
+    DescriptorExt, DescriptorId, Indexed, Indexer, KeychainIndexed, SpkIterator,
 };
 use alloc::{borrow::ToOwned, vec::Vec};
 use bitcoin::{Amount, OutPoint, ScriptBuf, SignedAmount, Transaction, TxOut, Txid};
 use core::{
-    convert::Infallible,
     fmt::Debug,
     ops::{Bound, RangeBounds},
 };
@@ -138,6 +136,12 @@ impl<K> Default for KeychainTxOutIndex<K> {
     }
 }
 
+impl<K> AsRef<SpkTxOutIndex<(K, u32)>> for KeychainTxOutIndex<K> {
+    fn as_ref(&self) -> &SpkTxOutIndex<(K, u32)> {
+        self.inner()
+    }
+}
+
 impl<K: Clone + Ord + Debug> Indexer for KeychainTxOutIndex<K> {
     type ChangeSet = ChangeSet;
 
@@ -201,6 +205,11 @@ impl<K> KeychainTxOutIndex<K> {
             last_revealed: Default::default(),
             lookahead,
         }
+    }
+
+    /// Get a reference to the internal [`SpkTxOutIndex`].
+    pub fn inner(&self) -> &SpkTxOutIndex<(K, u32)> {
+        &self.inner
     }
 }
 
@@ -881,20 +890,6 @@ pub trait SyncRequestBuilderExt<K> {
 
     /// Add [`Script`](bitcoin::Script)s that are revealed by the `indexer` but currently unused.
     fn unused_spks_from_indexer(self, indexer: &KeychainTxOutIndex<K>) -> Self;
-
-    /// Add unconfirmed txids and their associated spks.
-    ///
-    /// We expect that the chain source should include these txids in their spk histories. If not,
-    /// the transaction has been evicted for some reason and we will inform the receiving
-    /// structures in the response.
-    fn check_unconfirmed_statuses<A, C>(
-        self,
-        indexer: &KeychainTxOutIndex<K>,
-        canonical_iter: CanonicalIter<A, C>,
-    ) -> Self
-    where
-        A: Anchor,
-        C: ChainOracle<Error = Infallible>;
 }
 
 impl<K: Clone + Ord + core::fmt::Debug> SyncRequestBuilderExt<K> for SyncRequestBuilder<(K, u32)> {
@@ -907,29 +902,6 @@ impl<K: Clone + Ord + core::fmt::Debug> SyncRequestBuilderExt<K> for SyncRequest
 
     fn unused_spks_from_indexer(self, indexer: &KeychainTxOutIndex<K>) -> Self {
         self.spks_with_indexes(indexer.unused_spks())
-    }
-
-    fn check_unconfirmed_statuses<A, C>(
-        self,
-        indexer: &KeychainTxOutIndex<K>,
-        canonical_iter: CanonicalIter<A, C>,
-    ) -> Self
-    where
-        A: Anchor,
-        C: ChainOracle<Error = Infallible>,
-    {
-        self.expected_txids_of_spk(
-            canonical_iter
-                .map(|res| res.expect("infallible"))
-                .filter(|(_, _, reason)| matches!(reason, CanonicalReason::ObservedIn { .. }))
-                .flat_map(|(txid, tx, _)| {
-                    indexer
-                        .inner
-                        .relevant_spks_of_tx(tx.as_ref())
-                        .into_iter()
-                        .map(move |spk| (txid, spk))
-                }),
-        )
     }
 }
 

--- a/crates/chain/src/indexer/spk_txout.rs
+++ b/crates/chain/src/indexer/spk_txout.rs
@@ -42,6 +42,12 @@ pub struct SpkTxOutIndex<I> {
     spk_txouts: BTreeSet<(I, OutPoint)>,
 }
 
+impl<I> AsRef<SpkTxOutIndex<I>> for SpkTxOutIndex<I> {
+    fn as_ref(&self) -> &SpkTxOutIndex<I> {
+        self
+    }
+}
+
 impl<I> Default for SpkTxOutIndex<I> {
     fn default() -> Self {
         Self {

--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -110,19 +110,19 @@ use core::{
 
 impl<A: Ord> From<TxGraph<A>> for TxUpdate<A> {
     fn from(graph: TxGraph<A>) -> Self {
-        Self {
-            txs: graph.full_txs().map(|tx_node| tx_node.tx).collect(),
-            txouts: graph
-                .floating_txouts()
-                .map(|(op, txo)| (op, txo.clone()))
-                .collect(),
-            anchors: graph
-                .anchors
-                .into_iter()
-                .flat_map(|(txid, anchors)| anchors.into_iter().map(move |a| (a, txid)))
-                .collect(),
-            seen_ats: graph.last_seen.into_iter().collect(),
-        }
+        let mut tx_update = TxUpdate::default();
+        tx_update.txs = graph.full_txs().map(|tx_node| tx_node.tx).collect();
+        tx_update.txouts = graph
+            .floating_txouts()
+            .map(|(op, txo)| (op, txo.clone()))
+            .collect();
+        tx_update.anchors = graph
+            .anchors
+            .into_iter()
+            .flat_map(|(txid, anchors)| anchors.into_iter().map(move |a| (a, txid)))
+            .collect();
+        tx_update.seen_ats = graph.last_seen.into_iter().collect();
+        tx_update
     }
 }
 

--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -145,6 +145,7 @@ pub struct TxGraph<A = ConfirmationBlockTime> {
     spends: BTreeMap<OutPoint, HashSet<Txid>>,
     anchors: HashMap<Txid, BTreeSet<A>>,
     last_seen: HashMap<Txid, u64>,
+    last_evicted: HashMap<Txid, u64>,
 
     txs_by_highest_conf_heights: BTreeSet<(u32, Txid)>,
     txs_by_last_seen: BTreeSet<(u64, Txid)>,
@@ -162,6 +163,7 @@ impl<A> Default for TxGraph<A> {
             spends: Default::default(),
             anchors: Default::default(),
             last_seen: Default::default(),
+            last_evicted: Default::default(),
             txs_by_highest_conf_heights: Default::default(),
             txs_by_last_seen: Default::default(),
             empty_outspends: Default::default(),
@@ -715,6 +717,34 @@ impl<A: Anchor> TxGraph<A> {
         changeset
     }
 
+    /// Inserts the given `evicted_at` for `txid` into [`TxGraph`].
+    ///
+    /// The `evicted_at` timestamp represents the last known time when the transaction was observed
+    /// to be missing from the mempool. If `txid` was previously recorded with an earlier
+    /// `evicted_at` value, it is updated only if the new value is greater.
+    pub fn insert_evicted_at(&mut self, txid: Txid, evicted_at: u64) -> ChangeSet<A> {
+        let is_changed = match self.last_evicted.entry(txid) {
+            hash_map::Entry::Occupied(mut e) => {
+                let last_evicted = e.get_mut();
+                let change = *last_evicted < evicted_at;
+                if change {
+                    *last_evicted = evicted_at;
+                }
+                change
+            }
+            hash_map::Entry::Vacant(e) => {
+                e.insert(evicted_at);
+                true
+            }
+        };
+
+        let mut changeset = ChangeSet::<A>::default();
+        if is_changed {
+            changeset.last_evicted.insert(txid, evicted_at);
+        }
+        changeset
+    }
+
     /// Extends this graph with the given `update`.
     ///
     /// The returned [`ChangeSet`] is the set difference between `update` and `self` (transactions that
@@ -736,6 +766,10 @@ impl<A: Anchor> TxGraph<A> {
     /// `last_seen` value is used internally to determine precedence of conflicting unconfirmed
     /// transactions (where the transaction with the lower `last_seen` value is omitted from the
     /// canonical history).
+    ///
+    /// `evicted_at` is used to track when a transaction was last observed in the mempool before
+    /// disappearing. It helps determine whether a transaction was potentially replaced, allowing
+    /// the graph to filter out missing transactions that should no longer be considered valid.
     ///
     /// Not setting a `seen_at` value means unconfirmed transactions introduced by this update will
     /// not be part of the canonical history of transactions.
@@ -765,6 +799,14 @@ impl<A: Anchor> TxGraph<A> {
                 changeset.merge(self.insert_seen_at(txid, seen_at));
             }
         }
+        for txid in update.evicted {
+            // We want the `evicted_at` value to override the `last_seen` value of the transaction.
+            // If there is no `last_seen`, there is no need for the `evicted_at` value since the
+            // transaction will not be canonical anyway.
+            if let Some(&evicted_at) = self.last_seen.get(&txid) {
+                changeset.merge(self.insert_evicted_at(txid, evicted_at));
+            }
+        }
         changeset
     }
 
@@ -782,6 +824,7 @@ impl<A: Anchor> TxGraph<A> {
                 .flat_map(|(txid, anchors)| anchors.iter().map(|a| (a.clone(), *txid)))
                 .collect(),
             last_seen: self.last_seen.iter().map(|(&k, &v)| (k, v)).collect(),
+            last_evicted: self.last_evicted.iter().map(|(&k, &v)| (k, v)).collect(),
         }
     }
 
@@ -798,6 +841,9 @@ impl<A: Anchor> TxGraph<A> {
         }
         for (txid, seen_at) in changeset.last_seen {
             let _ = self.insert_seen_at(txid, seen_at);
+        }
+        for (txid, evicted_at) in changeset.last_evicted {
+            let _ = self.insert_evicted_at(txid, evicted_at);
         }
     }
 }
@@ -969,9 +1015,14 @@ impl<A: Anchor> TxGraph<A> {
 
     /// List txids by descending last-seen order.
     ///
-    /// Transactions without last-seens are excluded.
-    pub fn txids_by_descending_last_seen(&self) -> impl ExactSizeIterator<Item = (u64, Txid)> + '_ {
-        self.txs_by_last_seen.iter().copied().rev()
+    /// Transactions without last-seens are excluded. Transactions with a last-evicted timestamp
+    /// equal or higher than it's last-seen timestamp are excluded.
+    pub fn txids_by_descending_last_seen(&self) -> impl Iterator<Item = (u64, Txid)> + '_ {
+        self.txs_by_last_seen
+            .iter()
+            .copied()
+            .rev()
+            .filter(|(last_seen, txid)| !matches!(self.last_evicted.get(txid), Some(last_evicted) if last_evicted >= last_seen))
     }
 
     /// Returns a [`CanonicalIter`].
@@ -1139,6 +1190,8 @@ pub struct ChangeSet<A = ()> {
     pub anchors: BTreeSet<(A, Txid)>,
     /// Added last-seen unix timestamps of transactions.
     pub last_seen: BTreeMap<Txid, u64>,
+    /// Added timestamps of when a transaction is last evicted from the mempool.
+    pub last_evicted: BTreeMap<Txid, u64>,
 }
 
 impl<A> Default for ChangeSet<A> {
@@ -1148,6 +1201,7 @@ impl<A> Default for ChangeSet<A> {
             txouts: Default::default(),
             anchors: Default::default(),
             last_seen: Default::default(),
+            last_evicted: Default::default(),
         }
     }
 }
@@ -1202,6 +1256,14 @@ impl<A: Ord> Merge for ChangeSet<A> {
                 .filter(|(txid, update_ls)| self.last_seen.get(txid) < Some(update_ls))
                 .collect::<Vec<_>>(),
         );
+        // last_evicted timestamps should only increase
+        self.last_evicted.extend(
+            other
+                .last_evicted
+                .into_iter()
+                .filter(|(txid, update_lm)| self.last_evicted.get(txid) < Some(update_lm))
+                .collect::<Vec<_>>(),
+        );
     }
 
     fn is_empty(&self) -> bool {
@@ -1209,6 +1271,7 @@ impl<A: Ord> Merge for ChangeSet<A> {
             && self.txouts.is_empty()
             && self.anchors.is_empty()
             && self.last_seen.is_empty()
+            && self.last_evicted.is_empty()
     }
 }
 
@@ -1228,6 +1291,7 @@ impl<A: Ord> ChangeSet<A> {
                 self.anchors.into_iter().map(|(a, txid)| (f(a), txid)),
             ),
             last_seen: self.last_seen,
+            last_evicted: self.last_evicted,
         }
     }
 }

--- a/crates/chain/tests/test_tx_graph.rs
+++ b/crates/chain/tests/test_tx_graph.rs
@@ -1231,69 +1231,60 @@ fn tx_graph_update_conversion() {
 
     let test_cases: &[TestCase] = &[
         ("empty_update", TxUpdate::default()),
-        (
-            "single_tx",
-            TxUpdate {
-                txs: vec![make_tx(0).into()],
-                ..Default::default()
-            },
-        ),
-        (
-            "two_txs",
-            TxUpdate {
-                txs: vec![make_tx(0).into(), make_tx(1).into()],
-                ..Default::default()
-            },
-        ),
-        (
-            "with_floating_txouts",
-            TxUpdate {
-                txs: vec![make_tx(0).into(), make_tx(1).into()],
-                txouts: [
-                    (OutPoint::new(hash!("a"), 0), make_txout(0)),
-                    (OutPoint::new(hash!("a"), 1), make_txout(1)),
-                    (OutPoint::new(hash!("b"), 0), make_txout(2)),
-                ]
-                .into(),
-                ..Default::default()
-            },
-        ),
-        (
-            "with_anchors",
-            TxUpdate {
-                txs: vec![make_tx(0).into(), make_tx(1).into()],
-                txouts: [
-                    (OutPoint::new(hash!("a"), 0), make_txout(0)),
-                    (OutPoint::new(hash!("a"), 1), make_txout(1)),
-                    (OutPoint::new(hash!("b"), 0), make_txout(2)),
-                ]
-                .into(),
-                anchors: [
-                    (ConfirmationBlockTime::default(), hash!("a")),
-                    (ConfirmationBlockTime::default(), hash!("b")),
-                ]
-                .into(),
-                ..Default::default()
-            },
-        ),
-        (
-            "with_seen_ats",
-            TxUpdate {
-                txs: vec![make_tx(0).into(), make_tx(1).into()],
-                txouts: [
-                    (OutPoint::new(hash!("a"), 0), make_txout(0)),
-                    (OutPoint::new(hash!("a"), 1), make_txout(1)),
-                    (OutPoint::new(hash!("d"), 0), make_txout(2)),
-                ]
-                .into(),
-                anchors: [
-                    (ConfirmationBlockTime::default(), hash!("a")),
-                    (ConfirmationBlockTime::default(), hash!("b")),
-                ]
-                .into(),
-                seen_ats: [(hash!("c"), 12346)].into_iter().collect(),
-            },
-        ),
+        ("single_tx", {
+            let mut tx_update = TxUpdate::default();
+            tx_update.txs = vec![make_tx(0).into()];
+            tx_update
+        }),
+        ("two_txs", {
+            let mut tx_update = TxUpdate::default();
+            tx_update.txs = vec![make_tx(0).into(), make_tx(1).into()];
+            tx_update
+        }),
+        ("with_floating_txouts", {
+            let mut tx_update = TxUpdate::default();
+            tx_update.txs = vec![make_tx(0).into(), make_tx(1).into()];
+            tx_update.txouts = [
+                (OutPoint::new(hash!("a"), 0), make_txout(0)),
+                (OutPoint::new(hash!("a"), 1), make_txout(1)),
+                (OutPoint::new(hash!("b"), 0), make_txout(2)),
+            ]
+            .into();
+            tx_update
+        }),
+        ("with_anchors", {
+            let mut tx_update = TxUpdate::default();
+            tx_update.txs = vec![make_tx(0).into(), make_tx(1).into()];
+            tx_update.txouts = [
+                (OutPoint::new(hash!("a"), 0), make_txout(0)),
+                (OutPoint::new(hash!("a"), 1), make_txout(1)),
+                (OutPoint::new(hash!("b"), 0), make_txout(2)),
+            ]
+            .into();
+            tx_update.anchors = [
+                (ConfirmationBlockTime::default(), hash!("a")),
+                (ConfirmationBlockTime::default(), hash!("b")),
+            ]
+            .into();
+            tx_update
+        }),
+        ("with_seen_ats", {
+            let mut tx_update = TxUpdate::default();
+            tx_update.txs = vec![make_tx(0).into(), make_tx(1).into()];
+            tx_update.txouts = [
+                (OutPoint::new(hash!("a"), 0), make_txout(0)),
+                (OutPoint::new(hash!("a"), 1), make_txout(1)),
+                (OutPoint::new(hash!("d"), 0), make_txout(2)),
+            ]
+            .into();
+            tx_update.anchors = [
+                (ConfirmationBlockTime::default(), hash!("a")),
+                (ConfirmationBlockTime::default(), hash!("b")),
+            ]
+            .into();
+            tx_update.seen_ats = [(hash!("c"), 12346)].into_iter().collect();
+            tx_update
+        }),
     ];
 
     for (test_name, update) in test_cases {

--- a/crates/chain/tests/test_tx_graph.rs
+++ b/crates/chain/tests/test_tx_graph.rs
@@ -115,7 +115,8 @@ fn insert_txouts() {
             txs: [Arc::new(update_tx.clone())].into(),
             txouts: update_ops.clone().into(),
             anchors: [(conf_anchor, update_tx.compute_txid()),].into(),
-            last_seen: [(hash!("tx2"), 1000000)].into()
+            last_seen: [(hash!("tx2"), 1000000)].into(),
+            last_evicted: [].into(),
         }
     );
 
@@ -168,7 +169,8 @@ fn insert_txouts() {
             txs: [Arc::new(update_tx.clone())].into(),
             txouts: update_ops.into_iter().chain(original_ops).collect(),
             anchors: [(conf_anchor, update_tx.compute_txid()),].into(),
-            last_seen: [(hash!("tx2"), 1000000)].into()
+            last_seen: [(hash!("tx2"), 1000000)].into(),
+            last_evicted: [].into(),
         }
     );
 }

--- a/crates/core/src/spk_client.rs
+++ b/crates/core/src/spk_client.rs
@@ -167,6 +167,23 @@ impl<I> SyncRequestBuilder<I> {
         self
     }
 
+    /// Add transactions that are expected to exist under a given spk.
+    ///
+    /// This is useful for detecting a malicious replacement of an incoming transaction.
+    pub fn expected_txids_of_spk(
+        mut self,
+        txs: impl IntoIterator<Item = (Txid, ScriptBuf)>,
+    ) -> Self {
+        for (txid, spk) in txs {
+            self.inner
+                .spk_histories
+                .entry(spk)
+                .or_default()
+                .insert(txid);
+        }
+        self
+    }
+
     /// Add [`Txid`]s that will be synced against.
     pub fn txids(mut self, txids: impl IntoIterator<Item = Txid>) -> Self {
         self.inner.txids.extend(txids);

--- a/crates/core/src/spk_client.rs
+++ b/crates/core/src/spk_client.rs
@@ -170,7 +170,7 @@ impl<I> SyncRequestBuilder<I> {
     /// Add transactions that are expected to exist under a given spk.
     ///
     /// This is useful for detecting a malicious replacement of an incoming transaction.
-    pub fn expected_txids_of_spk(
+    pub fn expected_unconfirmed_spk_txids(
         mut self,
         txs: impl IntoIterator<Item = (Txid, ScriptBuf)>,
     ) -> Self {

--- a/crates/core/src/tx_update.rs
+++ b/crates/core/src/tx_update.rs
@@ -1,4 +1,4 @@
-use crate::collections::{BTreeMap, BTreeSet, HashMap};
+use crate::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use alloc::{sync::Arc, vec::Vec};
 use bitcoin::{OutPoint, Transaction, TxOut, Txid};
 
@@ -34,6 +34,8 @@ pub struct TxUpdate<A = ()> {
     /// Seen at times for transactions. This records when a transaction was most recently seen in
     /// the user's mempool for the sake of tie-breaking other conflicting transactions.
     pub seen_ats: HashMap<Txid, u64>,
+    /// A set of txids missing from the mempool.
+    pub evicted: HashSet<Txid>,
 }
 
 impl<A> Default for TxUpdate<A> {
@@ -43,6 +45,7 @@ impl<A> Default for TxUpdate<A> {
             txouts: Default::default(),
             anchors: Default::default(),
             seen_ats: Default::default(),
+            evicted: Default::default(),
         }
     }
 }
@@ -62,6 +65,7 @@ impl<A: Ord> TxUpdate<A> {
                 .map(|(a, txid)| (map(a), txid))
                 .collect(),
             seen_ats: self.seen_ats,
+            evicted: self.evicted,
         }
     }
 
@@ -71,5 +75,6 @@ impl<A: Ord> TxUpdate<A> {
         self.txouts.extend(other.txouts);
         self.anchors.extend(other.anchors);
         self.seen_ats.extend(other.seen_ats);
+        self.evicted.extend(other.evicted);
     }
 }

--- a/crates/core/src/tx_update.rs
+++ b/crates/core/src/tx_update.rs
@@ -4,7 +4,22 @@ use bitcoin::{OutPoint, Transaction, TxOut, Txid};
 
 /// Data object used to communicate updates about relevant transactions from some chain data source
 /// to the core model (usually a `bdk_chain::TxGraph`).
+///
+/// ```rust
+/// use bdk_core::TxUpdate;
+/// # use std::sync::Arc;
+/// # use bitcoin::{Transaction, transaction::Version, absolute::LockTime};
+/// # let version = Version::ONE;
+/// # let lock_time = LockTime::ZERO;
+/// # let tx = Arc::new(Transaction { input: vec![], output: vec![], version, lock_time });
+/// # let txid = tx.compute_txid();
+/// # let anchor = ();
+/// let mut tx_update = TxUpdate::default();
+/// tx_update.txs.push(tx);
+/// tx_update.anchors.insert((anchor, txid));
+/// ```
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct TxUpdate<A = ()> {
     /// Full transactions. These are transactions that were determined to be relevant to the wallet
     /// given the request.

--- a/crates/electrum/src/bdk_electrum_client.rs
+++ b/crates/electrum/src/bdk_electrum_client.rs
@@ -571,10 +571,8 @@ mod test {
         // `fetch_prev_txout` on a coinbase transaction will trigger a `fetch_tx` on a transaction
         // with a txid of all zeros. If `fetch_prev_txout` attempts to fetch this transaction, this
         // assertion will fail.
-        let mut tx_update = TxUpdate {
-            txs: vec![Arc::new(coinbase_tx)],
-            ..Default::default()
-        };
+        let mut tx_update = TxUpdate::default();
+        tx_update.txs = vec![Arc::new(coinbase_tx)];
         assert!(client.fetch_prev_txout(&mut tx_update).is_ok());
 
         // Ensure that the txouts are empty.

--- a/crates/electrum/tests/test_electrum.rs
+++ b/crates/electrum/tests/test_electrum.rs
@@ -1,6 +1,8 @@
 use bdk_chain::{
-    bitcoin::{hashes::Hash, Address, Amount, ScriptBuf, WScriptHash},
+    bitcoin::{hashes::Hash, secp256k1::Secp256k1, Address, Amount, ScriptBuf, WScriptHash},
+    indexer::keychain_txout::KeychainTxOutIndex,
     local_chain::LocalChain,
+    miniscript::Descriptor,
     spk_client::{FullScanRequest, SyncRequest, SyncResponse},
     spk_txout::SpkTxOutIndex,
     Balance, ConfirmationBlockTime, IndexedTxGraph, Indexer, Merge, TxGraph,
@@ -14,7 +16,7 @@ use bdk_testenv::{
 };
 use core::time::Duration;
 use electrum_client::ElectrumApi;
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::str::FromStr;
 
 // Batch size for `sync_with_electrum`.
@@ -58,6 +60,127 @@ where
     let _ = graph.apply_update(update.tx_update.clone());
 
     Ok(update)
+}
+
+// Ensure that a wallet can detect a malicious replacement of an incoming transaction.
+//
+// This checks that both the Electrum chain source and the receiving structures properly track the
+// replaced transaction as missing.
+#[test]
+pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
+    const SEND_TX_FEE: Amount = Amount::from_sat(1000);
+    const UNDO_SEND_TX_FEE: Amount = Amount::from_sat(2000);
+
+    use bdk_chain::keychain_txout::SyncRequestBuilderExt;
+    let env = TestEnv::new()?;
+    let rpc_client = env.rpc_client();
+    let electrum_client = electrum_client::Client::new(env.electrsd.electrum_url.as_str())?;
+    let client = BdkElectrumClient::new(electrum_client);
+
+    let (receiver_desc, _) = Descriptor::parse_descriptor(&Secp256k1::signing_only(), "tr([73c5da0a/86'/0'/0']xprv9xgqHN7yz9MwCkxsBPN5qetuNdQSUttZNKw1dcYTV4mkaAFiBVGQziHs3NRSWMkCzvgjEe3n9xV8oYywvM8at9yRqyaZVz6TYYhX98VjsUk/0/*)")
+        .expect("must be valid");
+    let mut graph = IndexedTxGraph::<ConfirmationBlockTime, _>::new(KeychainTxOutIndex::new(0));
+    let _ = graph.index.insert_descriptor((), receiver_desc.clone())?;
+    let (chain, _) = LocalChain::from_genesis_hash(env.bitcoind.client.get_block_hash(0)?);
+
+    // Derive the receiving address from the descriptor.
+    let ((_, receiver_spk), _) = graph.index.reveal_next_spk(()).unwrap();
+    let receiver_addr = Address::from_script(&receiver_spk, bdk_chain::bitcoin::Network::Regtest)?;
+
+    env.mine_blocks(101, None)?;
+
+    // Select a UTXO to use as an input for constructing our test transactions.
+    let selected_utxo = rpc_client
+        .list_unspent(None, None, None, Some(false), None)?
+        .into_iter()
+        // Find a block reward tx.
+        .find(|utxo| utxo.amount == Amount::from_int_btc(50))
+        .expect("Must find a block reward UTXO");
+
+    // Derive the sender's address from the selected UTXO.
+    let sender_spk = selected_utxo.script_pub_key.clone();
+    let sender_addr = Address::from_script(&sender_spk, bdk_chain::bitcoin::Network::Regtest)
+        .expect("Failed to derive address from UTXO");
+
+    // Setup the common inputs used by both `send_tx` and `undo_send_tx`.
+    let inputs = [CreateRawTransactionInput {
+        txid: selected_utxo.txid,
+        vout: selected_utxo.vout,
+        sequence: None,
+    }];
+
+    // Create and sign the `send_tx` that sends funds to the receiver address.
+    let send_tx_outputs = HashMap::from([(
+        receiver_addr.to_string(),
+        selected_utxo.amount - SEND_TX_FEE,
+    )]);
+    let send_tx = rpc_client.create_raw_transaction(&inputs, &send_tx_outputs, None, Some(true))?;
+    let send_tx = rpc_client
+        .sign_raw_transaction_with_wallet(send_tx.raw_hex(), None, None)?
+        .transaction()?;
+
+    // Create and sign the `undo_send_tx` transaction. This redirects funds back to the sender
+    // address.
+    let undo_send_outputs = HashMap::from([(
+        sender_addr.to_string(),
+        selected_utxo.amount - UNDO_SEND_TX_FEE,
+    )]);
+    let undo_send_tx =
+        rpc_client.create_raw_transaction(&inputs, &undo_send_outputs, None, Some(true))?;
+    let undo_send_tx = rpc_client
+        .sign_raw_transaction_with_wallet(undo_send_tx.raw_hex(), None, None)?
+        .transaction()?;
+
+    // Sync after broadcasting the `send_tx`. Ensure that we detect and receive the `send_tx`.
+    let send_txid = env.rpc_client().send_raw_transaction(send_tx.raw_hex())?;
+    env.wait_until_electrum_sees_txid(send_txid, Duration::from_secs(6))?;
+    let sync_request = SyncRequest::builder()
+        .chain_tip(chain.tip())
+        .revealed_spks_from_indexer(&graph.index, ..)
+        .check_unconfirmed_statuses(
+            &graph.index,
+            graph.graph().canonical_iter(&chain, chain.tip().block_id()),
+        );
+    let sync_response = client.sync(sync_request, BATCH_SIZE, true)?;
+    assert!(
+        sync_response
+            .tx_update
+            .txs
+            .iter()
+            .any(|tx| tx.compute_txid() == send_txid),
+        "sync response must include the send_tx"
+    );
+    let changeset = graph.apply_update(sync_response.tx_update.clone());
+    assert!(
+        changeset.tx_graph.txs.contains(&send_tx),
+        "tx graph must deem send_tx relevant and include it"
+    );
+
+    // Sync after broadcasting the `undo_send_tx`. Verify that `send_tx` is now missing from the
+    // mempool.
+    let undo_send_txid = env
+        .rpc_client()
+        .send_raw_transaction(undo_send_tx.raw_hex())?;
+    env.wait_until_electrum_sees_txid(undo_send_txid, Duration::from_secs(6))?;
+    let sync_request = SyncRequest::builder()
+        .chain_tip(chain.tip())
+        .revealed_spks_from_indexer(&graph.index, ..)
+        .check_unconfirmed_statuses(
+            &graph.index,
+            graph.graph().canonical_iter(&chain, chain.tip().block_id()),
+        );
+    let sync_response = client.sync(sync_request, BATCH_SIZE, true)?;
+    assert!(
+        sync_response.tx_update.evicted.contains(&send_txid),
+        "sync response must track send_tx as missing from mempool"
+    );
+    let changeset = graph.apply_update(sync_response.tx_update.clone());
+    assert!(
+        changeset.tx_graph.last_evicted.contains_key(&send_txid),
+        "tx graph must track send_tx as missing"
+    );
+
+    Ok(())
 }
 
 /// If an spk history contains a tx that spends another unconfirmed tx (chained mempool history),

--- a/crates/electrum/tests/test_electrum.rs
+++ b/crates/electrum/tests/test_electrum.rs
@@ -137,10 +137,11 @@ pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
     let sync_request = SyncRequest::builder()
         .chain_tip(chain.tip())
         .revealed_spks_from_indexer(&graph.index, ..)
-        .check_unconfirmed_statuses(
-            &graph.index,
-            graph.graph().canonical_iter(&chain, chain.tip().block_id()),
-        );
+        .expected_unconfirmed_spk_txids(graph.expected_unconfirmed_spk_txids(
+            &chain,
+            chain.tip().block_id(),
+            ..,
+        )?);
     let sync_response = client.sync(sync_request, BATCH_SIZE, true)?;
     assert!(
         sync_response
@@ -165,10 +166,11 @@ pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
     let sync_request = SyncRequest::builder()
         .chain_tip(chain.tip())
         .revealed_spks_from_indexer(&graph.index, ..)
-        .check_unconfirmed_statuses(
-            &graph.index,
-            graph.graph().canonical_iter(&chain, chain.tip().block_id()),
-        );
+        .expected_unconfirmed_spk_txids(graph.expected_unconfirmed_spk_txids(
+            &chain,
+            chain.tip().block_id(),
+            ..,
+        )?);
     let sync_response = client.sync(sync_request, BATCH_SIZE, true)?;
     assert!(
         sync_response.tx_update.evicted.contains(&send_txid),

--- a/crates/esplora/tests/async_ext.rs
+++ b/crates/esplora/tests/async_ext.rs
@@ -94,10 +94,11 @@ pub async fn detect_receive_tx_cancel() -> anyhow::Result<()> {
     let sync_request = SyncRequest::builder()
         .chain_tip(chain.tip())
         .revealed_spks_from_indexer(&graph.index, ..)
-        .check_unconfirmed_statuses(
-            &graph.index,
-            graph.graph().canonical_iter(&chain, chain.tip().block_id()),
-        );
+        .expected_unconfirmed_spk_txids(graph.expected_unconfirmed_spk_txids(
+            &chain,
+            chain.tip().block_id(),
+            ..,
+        )?);
     let sync_response = client.sync(sync_request, 1).await?;
     assert!(
         sync_response
@@ -122,10 +123,11 @@ pub async fn detect_receive_tx_cancel() -> anyhow::Result<()> {
     let sync_request = SyncRequest::builder()
         .chain_tip(chain.tip())
         .revealed_spks_from_indexer(&graph.index, ..)
-        .check_unconfirmed_statuses(
-            &graph.index,
-            graph.graph().canonical_iter(&chain, chain.tip().block_id()),
-        );
+        .expected_unconfirmed_spk_txids(graph.expected_unconfirmed_spk_txids(
+            &chain,
+            chain.tip().block_id(),
+            ..,
+        )?);
     let sync_response = client.sync(sync_request, 1).await?;
     assert!(
         sync_response.tx_update.evicted.contains(&send_txid),

--- a/crates/esplora/tests/blocking_ext.rs
+++ b/crates/esplora/tests/blocking_ext.rs
@@ -94,10 +94,11 @@ pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
     let sync_request = SyncRequest::builder()
         .chain_tip(chain.tip())
         .revealed_spks_from_indexer(&graph.index, ..)
-        .check_unconfirmed_statuses(
-            &graph.index,
-            graph.graph().canonical_iter(&chain, chain.tip().block_id()),
-        );
+        .expected_unconfirmed_spk_txids(graph.expected_unconfirmed_spk_txids(
+            &chain,
+            chain.tip().block_id(),
+            ..,
+        )?);
     let sync_response = client.sync(sync_request, 1)?;
     assert!(
         sync_response
@@ -122,10 +123,11 @@ pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
     let sync_request = SyncRequest::builder()
         .chain_tip(chain.tip())
         .revealed_spks_from_indexer(&graph.index, ..)
-        .check_unconfirmed_statuses(
-            &graph.index,
-            graph.graph().canonical_iter(&chain, chain.tip().block_id()),
-        );
+        .expected_unconfirmed_spk_txids(graph.expected_unconfirmed_spk_txids(
+            &chain,
+            chain.tip().block_id(),
+            ..,
+        )?);
     let sync_response = client.sync(sync_request, 1)?;
     assert!(
         sync_response.tx_update.evicted.contains(&send_txid),

--- a/crates/esplora/tests/blocking_ext.rs
+++ b/crates/esplora/tests/blocking_ext.rs
@@ -1,14 +1,144 @@
-use bdk_chain::spk_client::{FullScanRequest, SyncRequest};
-use bdk_chain::{ConfirmationBlockTime, TxGraph};
+use bdk_chain::{
+    bitcoin::{secp256k1::Secp256k1, Address, Amount},
+    indexer::keychain_txout::KeychainTxOutIndex,
+    local_chain::LocalChain,
+    miniscript::Descriptor,
+    spk_client::{FullScanRequest, SyncRequest},
+    ConfirmationBlockTime, IndexedTxGraph, TxGraph,
+};
 use bdk_esplora::EsploraExt;
 use esplora_client::{self, Builder};
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeSet, HashMap, HashSet};
 use std::str::FromStr;
 use std::thread::sleep;
 use std::time::Duration;
 
-use bdk_chain::bitcoin::{Address, Amount};
-use bdk_testenv::{anyhow, bitcoincore_rpc::RpcApi, TestEnv};
+use bdk_testenv::{
+    anyhow,
+    bitcoincore_rpc::{json::CreateRawTransactionInput, RawTx, RpcApi},
+    TestEnv,
+};
+
+// Ensure that a wallet can detect a malicious replacement of an incoming transaction.
+//
+// This checks that both the Electrum chain source and the receiving structures properly track the
+// replaced transaction as missing.
+#[test]
+pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
+    const SEND_TX_FEE: Amount = Amount::from_sat(1000);
+    const UNDO_SEND_TX_FEE: Amount = Amount::from_sat(2000);
+
+    use bdk_chain::keychain_txout::SyncRequestBuilderExt;
+    let env = TestEnv::new()?;
+    let rpc_client = env.rpc_client();
+    let base_url = format!("http://{}", &env.electrsd.esplora_url.clone().unwrap());
+    let client = Builder::new(base_url.as_str()).build_blocking();
+
+    let (receiver_desc, _) = Descriptor::parse_descriptor(&Secp256k1::signing_only(), "tr([73c5da0a/86'/0'/0']xprv9xgqHN7yz9MwCkxsBPN5qetuNdQSUttZNKw1dcYTV4mkaAFiBVGQziHs3NRSWMkCzvgjEe3n9xV8oYywvM8at9yRqyaZVz6TYYhX98VjsUk/0/*)")
+        .expect("must be valid");
+    let mut graph = IndexedTxGraph::<ConfirmationBlockTime, _>::new(KeychainTxOutIndex::new(0));
+    let _ = graph.index.insert_descriptor((), receiver_desc.clone())?;
+    let (chain, _) = LocalChain::from_genesis_hash(env.bitcoind.client.get_block_hash(0)?);
+
+    // Derive the receiving address from the descriptor.
+    let ((_, receiver_spk), _) = graph.index.reveal_next_spk(()).unwrap();
+    let receiver_addr = Address::from_script(&receiver_spk, bdk_chain::bitcoin::Network::Regtest)?;
+
+    env.mine_blocks(101, None)?;
+
+    // Select a UTXO to use as an input for constructing our test transactions.
+    let selected_utxo = rpc_client
+        .list_unspent(None, None, None, Some(false), None)?
+        .into_iter()
+        // Find a block reward tx.
+        .find(|utxo| utxo.amount == Amount::from_int_btc(50))
+        .expect("Must find a block reward UTXO");
+
+    // Derive the sender's address from the selected UTXO.
+    let sender_spk = selected_utxo.script_pub_key.clone();
+    let sender_addr = Address::from_script(&sender_spk, bdk_chain::bitcoin::Network::Regtest)
+        .expect("Failed to derive address from UTXO");
+
+    // Setup the common inputs used by both `send_tx` and `undo_send_tx`.
+    let inputs = [CreateRawTransactionInput {
+        txid: selected_utxo.txid,
+        vout: selected_utxo.vout,
+        sequence: None,
+    }];
+
+    // Create and sign the `send_tx` that sends funds to the receiver address.
+    let send_tx_outputs = HashMap::from([(
+        receiver_addr.to_string(),
+        selected_utxo.amount - SEND_TX_FEE,
+    )]);
+    let send_tx = rpc_client.create_raw_transaction(&inputs, &send_tx_outputs, None, Some(true))?;
+    let send_tx = rpc_client
+        .sign_raw_transaction_with_wallet(send_tx.raw_hex(), None, None)?
+        .transaction()?;
+
+    // Create and sign the `undo_send_tx` transaction. This redirects funds back to the sender
+    // address.
+    let undo_send_outputs = HashMap::from([(
+        sender_addr.to_string(),
+        selected_utxo.amount - UNDO_SEND_TX_FEE,
+    )]);
+    let undo_send_tx =
+        rpc_client.create_raw_transaction(&inputs, &undo_send_outputs, None, Some(true))?;
+    let undo_send_tx = rpc_client
+        .sign_raw_transaction_with_wallet(undo_send_tx.raw_hex(), None, None)?
+        .transaction()?;
+
+    // Sync after broadcasting the `send_tx`. Ensure that we detect and receive the `send_tx`.
+    let send_txid = env.rpc_client().send_raw_transaction(send_tx.raw_hex())?;
+    env.wait_until_electrum_sees_txid(send_txid, Duration::from_secs(6))?;
+    let sync_request = SyncRequest::builder()
+        .chain_tip(chain.tip())
+        .revealed_spks_from_indexer(&graph.index, ..)
+        .check_unconfirmed_statuses(
+            &graph.index,
+            graph.graph().canonical_iter(&chain, chain.tip().block_id()),
+        );
+    let sync_response = client.sync(sync_request, 1)?;
+    assert!(
+        sync_response
+            .tx_update
+            .txs
+            .iter()
+            .any(|tx| tx.compute_txid() == send_txid),
+        "sync response must include the send_tx"
+    );
+    let changeset = graph.apply_update(sync_response.tx_update.clone());
+    assert!(
+        changeset.tx_graph.txs.contains(&send_tx),
+        "tx graph must deem send_tx relevant and include it"
+    );
+
+    // Sync after broadcasting the `undo_send_tx`. Verify that `send_tx` is now missing from the
+    // mempool.
+    let undo_send_txid = env
+        .rpc_client()
+        .send_raw_transaction(undo_send_tx.raw_hex())?;
+    env.wait_until_electrum_sees_txid(undo_send_txid, Duration::from_secs(6))?;
+    let sync_request = SyncRequest::builder()
+        .chain_tip(chain.tip())
+        .revealed_spks_from_indexer(&graph.index, ..)
+        .check_unconfirmed_statuses(
+            &graph.index,
+            graph.graph().canonical_iter(&chain, chain.tip().block_id()),
+        );
+    let sync_response = client.sync(sync_request, 1)?;
+    assert!(
+        sync_response.tx_update.evicted.contains(&send_txid),
+        "sync response must track send_tx as missing from mempool"
+    );
+    let changeset = graph.apply_update(sync_response.tx_update.clone());
+    assert!(
+        changeset.tx_graph.last_evicted.contains_key(&send_txid),
+        "tx graph must track send_tx as missing"
+    );
+
+    Ok(())
+}
 
 #[test]
 pub fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {

--- a/example-crates/example_wallet_rpc/src/main.rs
+++ b/example-crates/example_wallet_rpc/src/main.rs
@@ -3,7 +3,7 @@ use bdk_bitcoind_rpc::{
     Emitter,
 };
 use bdk_wallet::{
-    bitcoin::{Block, Network, Transaction},
+    bitcoin::{Block, Network},
     file_store::Store,
     KeychainKind, Wallet,
 };
@@ -73,7 +73,7 @@ impl Args {
 enum Emission {
     SigTerm,
     Block(bdk_bitcoind_rpc::BlockEvent<Block>),
-    Mempool(Vec<(Transaction, u64)>),
+    Mempool(bdk_bitcoind_rpc::MempoolEvent),
 }
 
 fn main() -> anyhow::Result<()> {
@@ -157,7 +157,7 @@ fn main() -> anyhow::Result<()> {
             }
             Emission::Mempool(mempool_emission) => {
                 let start_apply_mempool = Instant::now();
-                wallet.apply_unconfirmed_txs(mempool_emission);
+                wallet.apply_unconfirmed_txs(mempool_emission.emitted_txs);
                 wallet.persist(&mut db)?;
                 println!(
                     "Applied unconfirmed transactions in {}s",


### PR DESCRIPTION
Fixes #1740.

### Description

This PR replaces #1765. For context and the original discussion that led to this change, please refer to [this comment](https://github.com/bitcoindevkit/bdk/pull/1765#issuecomment-2611491174).

This PR addresses a potential malicious double-spending issue by introducing improvements to unconfirmed transaction tracking. Key changes include the addition of `TxUpdate::missing` that tracks transactions that have been replaced and are no longer in the mempool, and the inclusion of `last_evicted` and `evicted_at` timestamps in `TxGraph` to track when a transaction was last deemed missing. 

`SpkWithExpectedTxids` is introduced in `SpkClient` to track expected `Txid`s for each `spk`. During a sync, if any `Txid`s from `SpkWithExpectedTxids` are not in the current history of an `spk` obtained from the chain source, those `Txid`s are considered missing. Support for `SpkWithExpectedTxids` has been added to both `bdk_electrum` and `bdk_esplora` chain source crates.

The canonicalization algorithm is updated to disregard transactions with a `last_evicted` timestamp greater than or equal to their `last_seen` timestamp, except in cases where transitivity rules apply.

### Changelog notice

* `TxUpdate::missing` tracks transactions that have been replaced and are no longer present in mempool.
* `last_evicted` and `evicted_at` timestamps in `TxGraph` track when a transaction was last marked as missing from the mempool.
* The canonicalization algorithm now disregards transactions with a `last_evicted` timestamp greater than or equal to it's `last_seen` timestamp, except when a canonical descendant exists due to rules of transitivity.
* `SpkWithExpectedTxids` in `SpkClient` keeps track of expected `Txid`s for each `spk`.
* `SpkWithExpectedTxids` support added for `bdk_electrum` and `bdk_esplora`.
* `SyncRequestBuilder::expected_txids_of_spk` adds an association between `Txid` and `spk`.
* `SyncRequestExt::check_unconfirmed_statuses` adds unconfirmed transactions alongside their `spk`s during sync.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [x] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
