### PR TITLE
fix(wallet): use `map_keychain` in `Wallet::build_fee_bump`

### DIFF
--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -1676,7 +1676,7 @@ impl Wallet {
         if tx.output.len() > 1 {
             let mut change_index = None;
             for (index, txout) in tx.output.iter().enumerate() {
-                let change_keychain = KeychainKind::Internal;
+                let change_keychain = self.map_keychain(KeychainKind::Internal);
                 match txout_index.index_of_spk(txout.script_pubkey.clone()) {
                     Some((keychain, _)) if *keychain == change_keychain => {
                         change_index = Some(index)


### PR DESCRIPTION
Previously we failed to remove the change output if the wallet has no internal keychain which caused tx building to fail at the new higher feerate. Fix this by mapping the internal keychain to the de-facto change keychain so that the drain output can be recalculated.

fixes #1807

### Changelog notice

Fixed

- wallet: Fixed an issue preventing `build_fee_bump` from re-targeting the drain value for some wallets

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing


#### Bugfixes:

* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
