### PR TITLE
Add zizmor github actions security analysis workflow

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -2,6 +2,8 @@ on: [push, pull_request]
 
 name: Code Coverage
 
+permissions: {}
+
 jobs:
   Codecov:
     name: Code Coverage

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -2,6 +2,8 @@ on: [push, pull_request]
 
 name: CI
 
+permissions: {}
+
 jobs:
 
   prepare:

--- a/.github/workflows/cron-update-rust.yml
+++ b/.github/workflows/cron-update-rust.yml
@@ -1,4 +1,7 @@
 name: Update rust version
+
+permissions: {}
+
 on:
   schedule:
     - cron: "0 0 15 * *" # At 00:00 on day-of-month 15.

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,35 @@
+name: Zizmor Actions Analysis
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
+
+      - name: Install zizmor
+        run: cargo install zizmor --locked --version 1.6.0
+
+      - name: Run zizmor 🌈
+        run: zizmor --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+          category: zizmor


### PR DESCRIPTION
### Description

Added workflow to run zizmor github actions security analysis. 

See: https://woodruffw.github.io/zizmor/usage/#use-in-github-actions

### Notes to the reviewers

I built this PR on top of #1778.

I pinned zizmor to version 1.6.0.

### Changelog notice

ci: add zizmor github actions security analysis workflow and fix possible vulnerabilities

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
