### PR TITLE
Have `bdk_electrum` take Electrum client by reference

### DIFF
--- a/crates/electrum/tests/test_electrum.rs
+++ b/crates/electrum/tests/test_electrum.rs
@@ -27,7 +27,7 @@ fn get_balance(
 }
 
 fn sync_with_electrum<I, Spks>(
-    client: &BdkElectrumClient<electrum_client::Client>,
+    client: &BdkElectrumClient<&electrum_client::Client>,
     spks: Spks,
     chain: &mut LocalChain,
     graph: &mut IndexedTxGraph<ConfirmationBlockTime, I>,
@@ -58,7 +58,7 @@ where
 pub fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
     let env = TestEnv::new()?;
     let electrum_client = electrum_client::Client::new(env.electrsd.electrum_url.as_str())?;
-    let client = BdkElectrumClient::new(electrum_client);
+    let client = BdkElectrumClient::new(&electrum_client);
 
     let receive_address0 =
         Address::from_str("bcrt1qc6fweuf4xjvz4x3gx3t9e0fh4hvqyu2qw4wvxm")?.assume_checked();
@@ -166,7 +166,7 @@ pub fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
 pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     let env = TestEnv::new()?;
     let electrum_client = electrum_client::Client::new(env.electrsd.electrum_url.as_str())?;
-    let client = BdkElectrumClient::new(electrum_client);
+    let client = BdkElectrumClient::new(&electrum_client);
     let _block_hashes = env.mine_blocks(101, None)?;
 
     // Now let's test the gap limit. First of all get a chain of 10 addresses.
@@ -295,7 +295,7 @@ fn test_sync() -> anyhow::Result<()> {
 
     let env = TestEnv::new()?;
     let electrum_client = electrum_client::Client::new(env.electrsd.electrum_url.as_str())?;
-    let client = BdkElectrumClient::new(electrum_client);
+    let client = BdkElectrumClient::new(&electrum_client);
 
     // Setup addresses.
     let addr_to_mine = env
@@ -438,7 +438,7 @@ fn tx_can_become_unconfirmed_after_reorg() -> anyhow::Result<()> {
 
     let env = TestEnv::new()?;
     let electrum_client = electrum_client::Client::new(env.electrsd.electrum_url.as_str())?;
-    let client = BdkElectrumClient::new(electrum_client);
+    let client = BdkElectrumClient::new(&electrum_client);
 
     // Setup addresses.
     let addr_to_mine = env

--- a/example-crates/example_electrum/src/main.rs
+++ b/example-crates/example_electrum/src/main.rs
@@ -124,7 +124,8 @@ fn main() -> anyhow::Result<()> {
         }
     };
 
-    let client = BdkElectrumClient::new(electrum_cmd.electrum_args().client(network)?);
+    let electrum_client = electrum_cmd.electrum_args().client(network)?;
+    let client = BdkElectrumClient::new(&electrum_client);
 
     // Tell the electrum client about the txs we've already got locally so it doesn't re-download them
     client.populate_tx_cache(

--- a/example-crates/example_wallet_electrum/src/main.rs
+++ b/example-crates/example_wallet_electrum/src/main.rs
@@ -45,7 +45,8 @@ fn main() -> Result<(), anyhow::Error> {
     println!("Wallet balance before syncing: {}", balance.total());
 
     print!("Syncing...");
-    let client = BdkElectrumClient::new(electrum_client::Client::new(ELECTRUM_URL)?);
+    let electrum_client = electrum_client::Client::new(ELECTRUM_URL)?;
+    let client = BdkElectrumClient::new(&electrum_client);
 
     // Populate the electrum client's transaction cache so it doesn't redownload transaction we
     // already have.


### PR DESCRIPTION
### Description

Previously, `BdkElectrumClient::new` would unnecessarily take an owned `electrum_client::Client` value, which rendered reusing the same client (i.e., connection) for other tasks impossible.

Here, we switch to have `BdkElectrumClient` take a `Deref` with target `ElectrumApi`, which allows to give the `electrum_client::Client` *by reference* to `BdkElectrumClient`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [x] This pull request breaks the existing API