### PR TITLE
deps(bdk_testenv)!: bump `electrsd` to `0.36.1`

### DIFF
--- a/ci/pin-msrv.sh
+++ b/ci/pin-msrv.sh
@@ -10,6 +10,4 @@ set -euo pipefail
 # cargo clean
 # rustup override set 1.85.0
 
-cargo update -p home --precise "0.5.11"
-cargo update -p time --precise "0.3.45"
-cargo update -p time-core --precise "0.1.7"
+# e.g cargo update -p home --precise "0.5.11"

--- a/crates/bitcoind_rpc/tests/common/mod.rs
+++ b/crates/bitcoind_rpc/tests/common/mod.rs
@@ -1,0 +1,20 @@
+use bdk_testenv::anyhow;
+use bdk_testenv::TestEnv;
+
+/// This trait is used for testing. It allows creating a new [`bitcoincore_rpc::Client`] connected
+/// to the instance of bitcoind running in the test environment. This way the `TestEnv` and the
+/// `Emitter` aren't required to share the same client. In the future when we no longer depend on
+/// `bitcoincore-rpc`, this can be updated to return the production client that is used by BDK.
+pub trait ClientExt {
+    /// Creates a new [`bitcoincore_rpc::Client`] connected to the current node instance.
+    fn get_rpc_client(&self) -> anyhow::Result<bitcoincore_rpc::Client>;
+}
+
+impl ClientExt for TestEnv {
+    fn get_rpc_client(&self) -> anyhow::Result<bitcoincore_rpc::Client> {
+        Ok(bitcoincore_rpc::Client::new(
+            &self.bitcoind.rpc_url(),
+            bitcoincore_rpc::Auth::CookieFile(self.bitcoind.params.cookie_file.clone()),
+        )?)
+    }
+}

--- a/crates/electrum/benches/test_sync.rs
+++ b/crates/electrum/benches/test_sync.rs
@@ -10,7 +10,7 @@ use bdk_core::{
     CheckPoint,
 };
 use bdk_electrum::BdkElectrumClient;
-use bdk_testenv::{anyhow, bitcoincore_rpc::RpcApi, TestEnv};
+use bdk_testenv::{anyhow, TestEnv};
 use criterion::{criterion_group, criterion_main, Criterion};
 use electrum_client::ElectrumApi;
 use std::{collections::BTreeSet, time::Duration};
@@ -77,7 +77,15 @@ pub fn test_sync_performance(c: &mut Criterion) {
     );
 
     // Setup receiver.
-    let genesis_cp = CheckPoint::new(0, env.bitcoind.client.get_block_hash(0).unwrap());
+    let genesis_cp = CheckPoint::new(
+        0,
+        env.bitcoind
+            .client
+            .get_block_hash(0)
+            .unwrap()
+            .block_hash()
+            .unwrap(),
+    );
 
     {
         let electrum_client =

--- a/crates/electrum/src/bdk_electrum_client.rs
+++ b/crates/electrum/src/bdk_electrum_client.rs
@@ -702,7 +702,7 @@ mod test {
     use bdk_chain::bitcoin::{constants, Network, OutPoint, ScriptBuf, Transaction, TxIn};
     use bdk_chain::CheckPoint;
     use bdk_core::{collections::BTreeMap, spk_client::SyncRequest};
-    use bdk_testenv::{anyhow, bitcoincore_rpc::RpcApi, utils::new_tx, TestEnv};
+    use bdk_testenv::{anyhow, utils::new_tx, TestEnv};
     use core::time::Duration;
     use electrum_client::Error as ElectrumError;
     use std::sync::Arc;
@@ -786,13 +786,14 @@ mod test {
         let addr = env
             .rpc_client()
             .get_new_address(None, None)?
+            .address()?
             .assume_checked();
         let txid = env.send(&addr, Amount::from_sat(50_000))?;
 
         // Mine block that confirms transaction.
         env.mine_blocks(1, None)?;
         env.wait_until_electrum_sees_block(Duration::from_secs(6))?;
-        let height: u32 = env.rpc_client().get_block_count()? as u32;
+        let height: u32 = env.rpc_client().get_block_count()?.into_model().0 as u32;
 
         // Add the pre-reorg block that the tx is confirmed in to the header cache.
         let header = electrum_client.inner.block_header(height as usize)?;

--- a/crates/esplora/src/async_ext.rs
+++ b/crates/esplora/src/async_ext.rs
@@ -560,7 +560,7 @@ mod test {
         BlockId,
     };
     use bdk_core::{bitcoin, ConfirmationBlockTime};
-    use bdk_testenv::{anyhow, bitcoincore_rpc::RpcApi, TestEnv};
+    use bdk_testenv::{anyhow, TestEnv};
     use esplora_client::Builder;
 
     use crate::async_ext::{chain_update, fetch_latest_blocks};
@@ -577,7 +577,7 @@ mod test {
         let env = TestEnv::new()?;
         let base_url = format!("http://{}", &env.electrsd.esplora_url.clone().unwrap());
         let client = Builder::new(base_url.as_str()).build_async()?;
-        let initial_height = env.rpc_client().get_block_count()? as u32;
+        let initial_height = env.rpc_client().get_block_count()?.into_model().0 as u32;
 
         let mine_to = 16;
         let _ = env.mine_blocks((mine_to - initial_height) as usize, None)?;
@@ -673,7 +673,11 @@ mod test {
                             ConfirmationBlockTime {
                                 block_id: BlockId {
                                     height,
-                                    hash: env.bitcoind.client.get_block_hash(height as _)?,
+                                    hash: env
+                                        .bitcoind
+                                        .client
+                                        .get_block_hash(height as _)?
+                                        .block_hash()?,
                                 },
                                 confirmation_time: height as _,
                             },
@@ -713,7 +717,11 @@ mod test {
                             ConfirmationBlockTime {
                                 block_id: BlockId {
                                     height,
-                                    hash: env.bitcoind.client.get_block_hash(height as _)?,
+                                    hash: env
+                                        .bitcoind
+                                        .client
+                                        .get_block_hash(height as _)?
+                                        .block_hash()?,
                                 },
                                 confirmation_time: height as _,
                             },

--- a/crates/esplora/src/blocking_ext.rs
+++ b/crates/esplora/src/blocking_ext.rs
@@ -518,7 +518,7 @@ mod test {
     use bdk_chain::local_chain::LocalChain;
     use bdk_chain::BlockId;
     use bdk_core::ConfirmationBlockTime;
-    use bdk_testenv::{anyhow, bitcoincore_rpc::RpcApi, TestEnv};
+    use bdk_testenv::{anyhow, TestEnv};
     use esplora_client::{BlockHash, Builder};
     use std::collections::{BTreeMap, BTreeSet};
     use std::time::Duration;
@@ -543,7 +543,7 @@ mod test {
         let env = TestEnv::new()?;
         let base_url = format!("http://{}", &env.electrsd.esplora_url.clone().unwrap());
         let client = Builder::new(base_url.as_str()).build_blocking();
-        let initial_height = env.rpc_client().get_block_count()? as u32;
+        let initial_height = env.rpc_client().get_block_count()?.into_model().0 as u32;
 
         let mine_to = 16;
         let _ = env.mine_blocks((mine_to - initial_height) as usize, None)?;
@@ -639,7 +639,11 @@ mod test {
                             ConfirmationBlockTime {
                                 block_id: BlockId {
                                     height,
-                                    hash: env.bitcoind.client.get_block_hash(height as _)?,
+                                    hash: env
+                                        .bitcoind
+                                        .client
+                                        .get_block_hash(height as _)?
+                                        .block_hash()?,
                                 },
                                 confirmation_time: height as _,
                             },
@@ -678,7 +682,11 @@ mod test {
                             ConfirmationBlockTime {
                                 block_id: BlockId {
                                     height,
-                                    hash: env.bitcoind.client.get_block_hash(height as _)?,
+                                    hash: env
+                                        .bitcoind
+                                        .client
+                                        .get_block_hash(height as _)?
+                                        .block_hash()?,
                                 },
                                 confirmation_time: height as _,
                             },
@@ -741,10 +749,10 @@ mod test {
         let env = TestEnv::new()?;
         let blocks = {
             let bitcoind_client = &env.bitcoind.client;
-            assert_eq!(bitcoind_client.get_block_count()?, 1);
+            assert_eq!(bitcoind_client.get_block_count()?.0, 1);
             [
-                (0, bitcoind_client.get_block_hash(0)?),
-                (1, bitcoind_client.get_block_hash(1)?),
+                (0, bitcoind_client.get_block_hash(0)?.block_hash()?),
+                (1, bitcoind_client.get_block_hash(1)?.block_hash()?),
             ]
             .into_iter()
             .chain((2..).zip(env.mine_blocks((TIP_HEIGHT - 1) as usize, None)?))

--- a/crates/esplora/tests/blocking_ext.rs
+++ b/crates/esplora/tests/blocking_ext.rs
@@ -4,11 +4,10 @@ use bdk_chain::spk_client::{FullScanRequest, SyncRequest};
 use bdk_chain::spk_txout::SpkTxOutIndex;
 use bdk_chain::{ConfirmationBlockTime, IndexedTxGraph, TxGraph};
 use bdk_esplora::EsploraExt;
-use bdk_testenv::bitcoincore_rpc::json::CreateRawTransactionInput;
-use bdk_testenv::bitcoincore_rpc::RawTx;
-use bdk_testenv::{anyhow, bitcoincore_rpc::RpcApi, TestEnv};
+use bdk_testenv::corepc_node::{Input, Output};
+use bdk_testenv::{anyhow, TestEnv};
 use esplora_client::{self, Builder};
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeSet, HashSet};
 use std::str::FromStr;
 use std::thread::sleep;
 use std::time::Duration;
@@ -30,7 +29,7 @@ pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
     let client = Builder::new(base_url.as_str()).build_blocking();
 
     let mut graph = IndexedTxGraph::<ConfirmationBlockTime, _>::new(SpkTxOutIndex::<()>::default());
-    let (chain, _) = LocalChain::from_genesis(env.bitcoind.client.get_block_hash(0)?);
+    let (chain, _) = LocalChain::from_genesis(env.genesis_hash()?);
 
     // Get receiving address.
     let receiver_spk = common::get_test_spk();
@@ -41,48 +40,58 @@ pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
 
     // Select a UTXO to use as an input for constructing our test transactions.
     let selected_utxo = rpc_client
-        .list_unspent(None, None, None, Some(false), None)?
+        .list_unspent()?
+        .0
         .into_iter()
         // Find a block reward tx.
-        .find(|utxo| utxo.amount == Amount::from_int_btc(50))
-        .expect("Must find a block reward UTXO");
+        .find(|utxo| utxo.amount == Amount::from_int_btc(50).to_btc())
+        .expect("Must find a block reward UTXO")
+        .into_model()?;
 
     // Derive the sender's address from the selected UTXO.
-    let sender_spk = selected_utxo.script_pub_key.clone();
+    let sender_spk = selected_utxo.script_pubkey.clone();
     let sender_addr = Address::from_script(&sender_spk, bdk_chain::bitcoin::Network::Regtest)
         .expect("Failed to derive address from UTXO");
 
     // Setup the common inputs used by both `send_tx` and `undo_send_tx`.
-    let inputs = [CreateRawTransactionInput {
+    let inputs = [Input {
         txid: selected_utxo.txid,
-        vout: selected_utxo.vout,
+        vout: selected_utxo.vout as u64,
         sequence: None,
     }];
 
     // Create and sign the `send_tx` that sends funds to the receiver address.
-    let send_tx_outputs = HashMap::from([(
-        receiver_addr.to_string(),
-        selected_utxo.amount - SEND_TX_FEE,
-    )]);
-    let send_tx = rpc_client.create_raw_transaction(&inputs, &send_tx_outputs, None, Some(true))?;
+    let send_tx_outputs = [Output::new(
+        receiver_addr,
+        selected_utxo.amount.to_unsigned()? - SEND_TX_FEE,
+    )];
+
     let send_tx = rpc_client
-        .sign_raw_transaction_with_wallet(send_tx.raw_hex(), None, None)?
-        .transaction()?;
+        .create_raw_transaction(&inputs, &send_tx_outputs)?
+        .into_model()?
+        .0;
+    let send_tx = rpc_client
+        .sign_raw_transaction_with_wallet(&send_tx)?
+        .into_model()?
+        .tx;
 
     // Create and sign the `undo_send_tx` transaction. This redirects funds back to the sender
     // address.
-    let undo_send_outputs = HashMap::from([(
-        sender_addr.to_string(),
-        selected_utxo.amount - UNDO_SEND_TX_FEE,
-    )]);
-    let undo_send_tx =
-        rpc_client.create_raw_transaction(&inputs, &undo_send_outputs, None, Some(true))?;
+    let undo_send_outputs = [Output::new(
+        sender_addr,
+        selected_utxo.amount.to_unsigned()? - UNDO_SEND_TX_FEE,
+    )];
     let undo_send_tx = rpc_client
-        .sign_raw_transaction_with_wallet(undo_send_tx.raw_hex(), None, None)?
-        .transaction()?;
+        .create_raw_transaction(&inputs, &undo_send_outputs)?
+        .into_model()?
+        .0;
+    let undo_send_tx = rpc_client
+        .sign_raw_transaction_with_wallet(&undo_send_tx)?
+        .into_model()?
+        .tx;
 
     // Sync after broadcasting the `send_tx`. Ensure that we detect and receive the `send_tx`.
-    let send_txid = env.rpc_client().send_raw_transaction(send_tx.raw_hex())?;
+    let send_txid = env.rpc_client().send_raw_transaction(&send_tx)?.txid()?;
     env.wait_until_electrum_sees_txid(send_txid, Duration::from_secs(6))?;
     let sync_request = SyncRequest::builder()
         .chain_tip(chain.tip())
@@ -111,7 +120,8 @@ pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
     // mempool.
     let undo_send_txid = env
         .rpc_client()
-        .send_raw_transaction(undo_send_tx.raw_hex())?;
+        .send_raw_transaction(&undo_send_tx)?
+        .txid()?;
     env.wait_until_electrum_sees_txid(undo_send_txid, Duration::from_secs(6))?;
     let sync_request = SyncRequest::builder()
         .chain_tip(chain.tip())
@@ -156,26 +166,16 @@ pub fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
     ];
 
     let _block_hashes = env.mine_blocks(101, None)?;
-    let txid1 = env.bitcoind.client.send_to_address(
-        &receive_address1,
-        Amount::from_sat(10000),
-        None,
-        None,
-        None,
-        None,
-        Some(1),
-        None,
-    )?;
-    let txid2 = env.bitcoind.client.send_to_address(
-        &receive_address0,
-        Amount::from_sat(20000),
-        None,
-        None,
-        None,
-        None,
-        Some(1),
-        None,
-    )?;
+    let txid1 = env
+        .bitcoind
+        .client
+        .send_to_address(&receive_address1, Amount::from_sat(10000))?
+        .txid()?;
+    let txid2 = env
+        .bitcoind
+        .client
+        .send_to_address(&receive_address0, Amount::from_sat(20000))?
+        .txid()?;
     let _block_hashes = env.mine_blocks(1, None)?;
     while client.get_height().unwrap() < 102 {
         sleep(Duration::from_millis(10))
@@ -224,16 +224,17 @@ pub fn test_update_tx_graph_without_keychain() -> anyhow::Result<()> {
         let tx_fee = env
             .bitcoind
             .client
-            .get_transaction(&tx.compute_txid(), None)
+            .get_transaction(tx.compute_txid())
             .expect("Tx must exist")
             .fee
             .expect("Fee must exist")
-            .abs()
-            .to_unsigned()
-            .expect("valid `Amount`");
+            .abs();
 
         // Check that the calculated fee matches the fee from the transaction data.
-        assert_eq!(fee, tx_fee);
+        assert_eq!(
+            fee,
+            Amount::from_float_in(tx_fee, bdk_core::bitcoin::Denomination::Bitcoin)?
+        );
     }
 
     assert_eq!(
@@ -280,16 +281,12 @@ pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
         .collect();
 
     // Then receive coins on the 4th address.
-    let txid_4th_addr = env.bitcoind.client.send_to_address(
-        &addresses[3],
-        Amount::from_sat(10000),
-        None,
-        None,
-        None,
-        None,
-        Some(1),
-        None,
-    )?;
+    let txid_4th_addr = env
+        .bitcoind
+        .client
+        .send_to_address(&addresses[3], Amount::from_sat(10000))?
+        .into_model()?
+        .txid;
     let _block_hashes = env.mine_blocks(1, None)?;
     while client.get_height().unwrap() < 103 {
         sleep(Duration::from_millis(10))
@@ -326,16 +323,11 @@ pub fn test_update_tx_graph_stop_gap() -> anyhow::Result<()> {
     assert_eq!(full_scan_update.last_active_indices[&0], 3);
 
     // Now receive a coin on the last address.
-    let txid_last_addr = env.bitcoind.client.send_to_address(
-        &addresses[addresses.len() - 1],
-        Amount::from_sat(10000),
-        None,
-        None,
-        None,
-        None,
-        Some(1),
-        None,
-    )?;
+    let txid_last_addr = env
+        .bitcoind
+        .client
+        .send_to_address(&addresses[addresses.len() - 1], Amount::from_sat(10000))?
+        .txid()?;
     let _block_hashes = env.mine_blocks(1, None)?;
     while client.get_height().unwrap() < 104 {
         sleep(Duration::from_millis(10))

--- a/crates/testenv/Cargo.toml
+++ b/crates/testenv/Cargo.toml
@@ -17,15 +17,16 @@ workspace = true
 
 [dependencies]
 bdk_chain = { path = "../chain", version = "0.23.1", default-features = false }
-electrsd = { version = "0.28.0", features = [ "legacy" ], default-features = false }
+electrsd = { version = "0.36.1", features = [ "legacy" ], default-features = false }
+bitcoin = { version = "0.32.0", default-features = false }
 
 [dev-dependencies]
 bdk_testenv = { path = "." }
 
 [features]
 default = ["std", "download"]
-download = ["electrsd/bitcoind_25_0", "electrsd/esplora_a33e97e1"]
-std = ["bdk_chain/std"]
+download = ["electrsd/corepc-node_28_2", "electrsd/esplora_a33e97e1"]
+std = ["bdk_chain/std", "bitcoin/rand-std"]
 serde = ["bdk_chain/serde"]
 
 [package.metadata.docs.rs]

--- a/crates/testenv/src/lib.rs
+++ b/crates/testenv/src/lib.rs
@@ -24,7 +24,7 @@ pub struct TestEnv {
 /// Configuration parameters.
 #[derive(Debug)]
 pub struct Config<'a> {
-    /// [`bitcoind::Conf`]
+    /// [`corepc_node::Conf`]
     pub bitcoind: corepc_node::Conf<'a>,
     /// [`electrsd::Conf`]
     pub electrsd: electrsd::Conf<'a>,
@@ -76,7 +76,7 @@ impl TestEnv {
         &self.electrsd.client
     }
 
-    /// Exposes the [`RpcApi`] calls from [`bitcoincore_rpc`].
+    /// Exposes the RPC calls from [`corepc_client`].
     pub fn rpc_client(&self) -> &corepc_node::Client {
         &self.bitcoind.client
     }


### PR DESCRIPTION
partially addresses #1949

### Description

Upgrades the `electrsd` version from `0.28.0` to `0.36.1`, migrating from old `bitcoind` to `corepc-node` and using the `corepc-node_28_2` feature.
 
Updates the `bitcoind` client type for `TestEnv`, and its internal methods. Also, updates: bdk_bitcoind_rpc, bdk_esplora, bdk_electrum usage of `bdk_testenv` and `TestEnv`.

### Notes to the reviewers

As we are upgrading to the latest `electrsd`, we can drop for now the pinning for `home` in the MSRV step.

### Changelog notice

```
### Added
- deps(bdk_testenv): introduces `bitcoin and it's `bitcoin/rand-std` feature under `bdk_testenv/std`.
- test(bdk_bitcoind_rpc): introcuce `ClientExt` trait to use custom testing RPC client with current `bitcoincore-rpc` one.

### Changed
- deps(bdk_testenv)!: bump `electrsd` to `0.36.1`.
- deps(bdk_testenv): updates `electrsd` feature to `corepc-node_28_2`.
- test(bdk_bitcoind_rpc): update all tests to use new `ClientExt` trait when building the `Emitter`.
- test(bdk_chain): update all tests to use new `bdk_testenv`, `electrsd` and `corepc-node` APIs.
- test(bdk_esplora, bdk_electrum): update all tests to use new `bdk_testenv`, `electrsd` and `corepc-node` APIs.
- build(testenv): feature gate `mine_empty_blocks`, `reorg_empty_blocks` behind `std` feature.

```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature