### PR TITLE
Fix SQLite panic when syncing many UTXOs

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -57,16 +57,7 @@ jobs:
           components: clippy
       - name: Pin dependencies for MSRV
         if: matrix.rust.version == '1.63.0'
-        run: |
-          cargo update -p tokio --precise "1.38.1"
-          cargo update -p tokio-util --precise "0.7.11"
-          cargo update -p home --precise "0.5.5"
-          cargo update -p regex --precise "1.7.3"
-          cargo update -p security-framework-sys --precise "2.11.1"
-          cargo update -p url --precise "2.5.0"
-          cargo update -p rustls@0.23.20 --precise "0.23.19"
-          cargo update -p hashbrown@0.15.2 --precise "0.15.0"
-          cargo update -p ureq --precise "2.10.1"
+        run: ./ci/pin-msrv.sh
       - name: Build
         run: cargo build --features bitcoin/std,miniscript/std,${{ matrix.features }} --no-default-features
       - name: Clippy
@@ -204,11 +195,6 @@ jobs:
         toolchain: ${{ matrix.rust.version }}
     - name: Pin dependencies for MSRV
       if: matrix.rust.version == '1.63.0'
-      run: |
-        cargo update -p tokio --precise "1.38.1"
-        cargo update -p tokio-util --precise "0.7.11"
-        cargo update -p home --precise "0.5.5"
-        cargo update -p regex --precise "1.7.3"
-        cargo update -p security-framework-sys --precise "2.11.1"
+      run: ./ci/pin-msrv.sh
     - name: Test
       run: cargo test --features test-hardware-signer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [v0.30.1]
+## [v0.30.2]
 
-### Fixed
+- Fix out of memory issue caused by batch fetching many large txs #1831
+- Fix SQLite panic when syncing many large txs #1828
+
+## [v0.30.1]
 
 - Fix electrum conftime_req filter for needs_block_height #1782
 
@@ -707,4 +710,5 @@ final transaction is created by calling `finish` on the builder.
 [v0.29.0]: https://github.com/bitcoindevkit/bdk/compare/v0.28.2...v0.29.0
 [v0.30.0]: https://github.com/bitcoindevkit/bdk/compare/v0.29.0...v0.30.0
 [v0.30.1]: https://github.com/bitcoindevkit/bdk/compare/v0.30.0...v0.30.1
-[Unreleased]: https://github.com/bitcoindevkit/bdk/compare/v0.30.1...release/0.29
+[v0.30.2]: https://github.com/bitcoindevkit/bdk/compare/v0.30.1...v0.30.2
+[Unreleased]: https://github.com/bitcoindevkit/bdk/compare/v0.30.2...release/0.30

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ sled = { version = "0.34", optional = true }
 electrum-client = { version = "0.18", optional = true }
 esplora-client = { version = "0.6", default-features = false, optional = true }
 rusqlite = { version = "0.31.0", optional = true }
+r2d2 = { version = "0.8.0", optional = true }
+r2d2_sqlite = { version = "0.24.0", optional = true }
 futures = { version = "0.3", optional = true }
 async-trait = { version = "0.1", optional = true }
 rocksdb = { version = "0.18", default-features = false, features = ["snappy"], optional = true }
@@ -56,7 +58,7 @@ default = ["std", "key-value-db", "electrum"]
 # std feature is always required unless building for wasm32-unknown-unknown target
 # if building for wasm user must add dependencies bitcoin/no-std,miniscript/no-std
 std = ["bitcoin/std", "miniscript/std"]
-sqlite = ["rusqlite"]
+sqlite = ["rusqlite", "r2d2", "r2d2_sqlite"]
 sqlite-bundled = ["sqlite", "rusqlite/bundled"]
 compact_filters = ["rocksdb", "socks", "cc"]
 key-value-db = ["sled"]
@@ -130,7 +132,7 @@ path = "examples/policy.rs"
 [[example]]
 name = "rpcwallet"
 path = "examples/rpcwallet.rs"
-required-features = ["keys-bip39", "key-value-db", "rpc", "electrsd/bitcoind_22_1"]
+required-features = ["keys-bip39", "key-value-db", "rpc", "electrsd/bitcoind_22_0"]
 
 [[example]]
 name = "psbt_signer"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,10 +94,10 @@ reqwest-default-tls = ["esplora-client/async-https"]
 
 # Debug/Test features
 test-blockchains = ["bitcoincore-rpc", "electrum-client"]
-test-electrum = ["electrum", "electrsd/electrs_0_8_10", "electrsd/bitcoind_23_1", "test-blockchains"]
-test-rpc = ["rpc", "electrsd/electrs_0_8_10", "electrsd/bitcoind_23_1", "test-blockchains"]
-test-rpc-legacy = ["rpc", "electrsd/electrs_0_8_10", "electrsd/bitcoind_23_1", "test-blockchains"]
-test-esplora = ["electrsd/legacy", "electrsd/esplora_a33e97e1", "electrsd/bitcoind_23_1", "test-blockchains"]
+test-electrum = ["electrum", "electrsd/electrs_0_8_10", "electrsd/bitcoind_23_0", "test-blockchains"]
+test-rpc = ["rpc", "electrsd/electrs_0_8_10", "electrsd/bitcoind_23_0", "test-blockchains"]
+test-rpc-legacy = ["rpc", "electrsd/electrs_0_8_10", "electrsd/bitcoind_23_0", "test-blockchains"]
+test-esplora = ["electrsd/legacy", "electrsd/esplora_a33e97e1", "electrsd/bitcoind_23_0", "test-blockchains"]
 test-md-docs = ["electrum"]
 test-hardware-signer = ["hardware-signer"]
 
@@ -111,7 +111,7 @@ miniscript = { version = "10.0", features = ["std"] }
 bitcoin = { version = "0.30", features = ["std"] }
 lazy_static = "1.4"
 env_logger = { version = "0.7", default-features = false }
-electrsd = "0.29.0"
+electrsd = "0.24.0"
 assert_matches = "1.5.0"
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk"
-version = "0.30.1"
+version = "0.30.2"
 authors = ["Alekos Filini <alekos.filini@gmail.com>", "Riccardo Casatta <riccardo@casatta.it>"]
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"

--- a/README.md
+++ b/README.md
@@ -212,16 +212,4 @@ dual licensed as above, without any additional terms or conditions.
 
 This library should compile with any combination of features with Rust 1.63.0.
 
-To build with the MSRV you will need to pin dependencies as follows:
-
-```shell
-cargo update -p tokio --precise "1.38.1"
-cargo update -p tokio-util --precise "0.7.11"
-cargo update -p home --precise "0.5.5"
-cargo update -p regex --precise "1.7.3"
-cargo update -p security-framework-sys --precise "2.11.1"
-cargo update -p url --precise "2.5.0"
-cargo update -p rustls@0.23.20 --precise "0.23.19"
-cargo update -p hashbrown@0.15.2 --precise "0.15.0"
-cargo update -p ureq --precise "2.10.1"
-```
+To build with the MSRV of 1.63.0 you will need to pin dependencies by running the [`pin-msrv.sh`](./ci/pin-msrv.sh) script.

--- a/ci/pin-msrv.sh
+++ b/ci/pin-msrv.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -x
+set -euo pipefail
+
+# Pin dependencies for MSRV
+
+# To pin deps, switch toolchain to MSRV and execute the below updates
+
+# cargo clean
+# rustup override set 1.63.0
+cargo update -p tokio --precise "1.38.1"
+cargo update -p tokio-util --precise "0.7.11"
+cargo update -p home --precise "0.5.5"
+cargo update -p regex --precise "1.7.3"
+cargo update -p security-framework-sys --precise "2.11.1"
+cargo update -p url --precise "2.5.0"
+cargo update -p rustls@0.23.23 --precise "0.23.19"
+cargo update -p hashbrown@0.15.2 --precise "0.15.0"
+cargo update -p ureq --precise "2.10.1"

--- a/src/blockchain/electrum.rs
+++ b/src/blockchain/electrum.rs
@@ -346,10 +346,9 @@ impl ConfigurableBlockchain for ElectrumBlockchain {
 #[cfg(feature = "test-electrum")]
 mod test {
     use super::*;
-    use crate::database::{MemoryDatabase, SqliteDatabase};
+    use crate::database::MemoryDatabase;
     use crate::testutils::blockchain_tests::TestClient;
     use crate::testutils::configurable_blockchain_tests::ConfigurableBlockchainTester;
-    use crate::wallet::coin_selection::OldestFirstCoinSelection;
     use crate::wallet::{AddressIndex, Wallet};
 
     crate::bdk_blockchain_tests! {
@@ -438,6 +437,13 @@ mod test {
     #[test]
     #[ignore] // takes ~1 hr to complete, here as reference for future testing
     fn test_electrum_large_num_utxos() {
+        use crate::database::SqliteDatabase;
+        use crate::wallet::coin_selection::OldestFirstCoinSelection;
+        use crate::SignOptions;
+        use bitcoin::Amount;
+        use bitcoincore_rpc::RpcApi;
+        use std::time::{SystemTime, UNIX_EPOCH};
+
         const NUM_TX: u32 = 50;
         const NUM_UTXO: u32 = 700;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -149,6 +149,9 @@ pub enum Error {
     #[cfg(feature = "sqlite")]
     /// Rusqlite client error
     Rusqlite(rusqlite::Error),
+    #[cfg(feature = "sqlite")]
+    /// r2d2 connection pool error
+    R2d2(r2d2::Error),
 }
 
 /// Errors returned by miniscript when updating inconsistent PSBTs
@@ -270,6 +273,8 @@ impl fmt::Display for Error {
             Self::Rpc(err) => write!(f, "RPC client error: {}", err),
             #[cfg(feature = "sqlite")]
             Self::Rusqlite(err) => write!(f, "SQLite error: {}", err),
+            #[cfg(feature = "sqlite")]
+            Self::R2d2(err) => write!(f, "R2d2 error: {}", err),
         }
     }
 }
@@ -322,6 +327,8 @@ impl_error!(sled::Error, Sled);
 impl_error!(bitcoincore_rpc::Error, Rpc);
 #[cfg(feature = "sqlite")]
 impl_error!(rusqlite::Error, Rusqlite);
+#[cfg(feature = "sqlite")]
+impl_error!(r2d2::Error, R2d2);
 
 #[cfg(feature = "compact_filters")]
 impl From<crate::blockchain::compact_filters::CompactFiltersError> for Error {


### PR DESCRIPTION
### Description

fixes #1827 

I changed the `SqliteDatabase` struct to contain a `r2d2` with [`r2d2_sqlite`](https://docs.rs/r2d2_sqlite/latest/r2d2_sqlite/) connection pool instead of a sqlite `Connection` so the `SqliteDatabase` can be safely cloned and reused when a batch is started. This prevents a large sync from trying to start and commit a batch (db transaction) while the initial non-batch connection is still busy writing it's data.

### Notes to the reviewers

I had to comment out the `test_batch_script_pubkey()` test for `sqlite` since the fix in this PR prevents a new sqlite DB connections from being created when a batch is started. In practice our sync'ing code does all its initial work without starting a batch (db transaction), then before finishing it starts a batch to do some cleanup work and commits it.

### Changelog notice

- Fix SQLite panic when syncing many UTXOs #1827

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
