### PR TITLE
Fix out of memory issue caused by many txs.

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -64,7 +64,7 @@ jobs:
           cargo update -p regex --precise "1.7.3"
           cargo update -p security-framework-sys --precise "2.11.1"
           cargo update -p url --precise "2.5.0"
-          cargo update -p rustls@0.23.20 --precise "0.23.19"
+          cargo update -p rustls@0.23.23 --precise "0.23.19"
           cargo update -p hashbrown@0.15.2 --precise "0.15.0"
           cargo update -p ureq --precise "2.10.1"
       - name: Build

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ cargo update -p home --precise "0.5.5"
 cargo update -p regex --precise "1.7.3"
 cargo update -p security-framework-sys --precise "2.11.1"
 cargo update -p url --precise "2.5.0"
-cargo update -p rustls@0.23.20 --precise "0.23.19"
+cargo update -p rustls@0.23.23 --precise "0.23.19"
 cargo update -p hashbrown@0.15.2 --precise "0.15.0"
 cargo update -p ureq --precise "2.10.1"
 ```


### PR DESCRIPTION
### Description
Partially addresses #1827.

For some wallets there exists a pathological case where we may try to fetch many thousands of transactions at once, which creates enormous memory pressure. By chunking the batch into more reasonably sized sub-queries, we allow time for memory to be freed.

For Bitkey, we have a user in which the bdk wallet tries to sync ~45000 transactions at once. See the below screenshots the impact of this change via basic memory profiling in our Android app:

Before:
<img width="458" alt="Screenshot 2025-02-13 at 10 26 31 AM" src="https://github.com/user-attachments/assets/9cc0ca4d-e8ba-4298-9a10-efc98664f2fb" />

After:
<img width="638" alt="Screenshot 2025-02-13 at 10 26 53 AM" src="https://github.com/user-attachments/assets/eb98d332-e838-4489-ab4b-6d3f5bd7b2ab" />

### Notes to the reviewers
I am a Rust noob, so please feel free to suggest alternative implementations.

Note that https://github.com/bitcoindevkit/bdk/pull/1828 is also needed to successfully sync wallets of this size.

### Changelog notice

Fix out of memory issue caused by many batch fetching many txs

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
