### PR TITLE
wallet: unnecessary coinbase chain position assert

### DIFF
--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -2073,10 +2073,6 @@ impl Wallet {
                     return false;
                 }
                 if tx.is_coinbase() {
-                    debug_assert!(
-                        chain_position.is_confirmed(),
-                        "coinbase must always be confirmed"
-                    );
                     if let Some(current_height) = current_height {
                         match chain_position {
                             ChainPosition::Confirmed(a) => {


### PR DESCRIPTION
### Description

Removes an unneeded assertion from `preselect_utxos`. I'm not precisely sure how I triggered this, but I encountered this while syncing a rather large signet wallet containing lots of freshly generated UTXOs. 

This assertion is not needed, as unconfirmed coinbase TXs get filtered away in the branch below anyways.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
