### PR TITLE
Generalize `add_recipient` to accept `Address`

### DIFF
--- a/crates/wallet/src/wallet/tx_builder.rs
+++ b/crates/wallet/src/wallet/tx_builder.rs
@@ -602,8 +602,12 @@ impl<'a, Cs> TxBuilder<'a, Cs> {
     }
 
     /// Add a recipient to the internal list
-    pub fn add_recipient(&mut self, script_pubkey: ScriptBuf, amount: Amount) -> &mut Self {
-        self.params.recipients.push((script_pubkey, amount));
+    pub fn add_recipient(
+        &mut self,
+        script_pubkey: impl Into<ScriptBuf>,
+        amount: Amount,
+    ) -> &mut Self {
+        self.params.recipients.push((script_pubkey.into(), amount));
         self
     }
 


### PR DESCRIPTION
### Description

I would imagine many users would be handling a `Address<NetworkChecked>` when building a transaction. They may pass this structure directly with this patch, or continue to use `ScriptBuf`.

### Notes to the reviewers

To my knowledge this is non-breaking, but it is a change in the function signature so I am not sure.

### Changelog notice

Accept any type that is convertible to a `ScriptBuf` in `TxBuilder::add_recipient`

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
