### PR TITLE
feat(wallet): Introduce `TxAmountSpend` trait for improved spend calculation

### DIFF
--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -80,7 +80,7 @@ pub use bdk_chain::Balance;
 pub use changeset::ChangeSet;
 pub use params::*;
 pub use persisted::*;
-pub use utils::IsDust;
+pub use utils::{IsDust, TxAmountSpend};
 
 /// A Bitcoin wallet
 ///

--- a/crates/wallet/src/wallet/utils.rs
+++ b/crates/wallet/src/wallet/utils.rs
@@ -152,8 +152,8 @@ mod test {
     // otherwise it's time-based
     pub(crate) const SEQUENCE_LOCKTIME_TYPE_FLAG: u32 = 1 << 22;
 
-    use super::{check_nsequence_rbf, shuffle_slice, IsDust};
-    use crate::bitcoin::{Address, Network, Sequence};
+    use super::{check_nsequence_rbf, shuffle_slice, IsDust, TxAmountSpend};
+    use crate::bitcoin::{Address, Amount, Network, Sequence};
     use alloc::vec::Vec;
     use core::str::FromStr;
     use rand::{rngs::StdRng, thread_rng, SeedableRng};
@@ -259,5 +259,13 @@ mod test {
         let mut test: Vec<u8> = vec![0, 1, 2, 4, 5];
         shuffle_slice(&mut test, &mut rng);
         assert_eq!(test, &[0, 4, 1, 2, 5]);
+    }
+    #[test]
+    fn test_txamountspend() {
+        let sent: Amount = Amount::from_sat(30);
+        let received: Amount = Amount::from_sat(30);
+        let fee: Amount = Amount::from_sat(30);
+        let result = (sent, received, fee).spend();
+        assert_eq!(result, Amount::from_sat(30));
     }
 }

--- a/crates/wallet/src/wallet/utils.rs
+++ b/crates/wallet/src/wallet/utils.rs
@@ -117,6 +117,19 @@ impl<Pk: MiniscriptKey + ToPublicKey> Satisfier<Pk> for Older {
         }
     }
 }
+/// Trait to perform the calculation of the transaction amount spent.
+/// Use the spend() method pass the three tuples of`Amount` values to perform the calc of total.
+pub trait TxAmountSpend {
+    /// Perfome the calc to get total of the transaction
+    fn spend(&self) -> Amount;
+}
+impl TxAmountSpend for (Amount, Amount, Amount) {
+    fn spend(&self) -> Amount {
+        // Pass the tree tuples of `Amount` to performe calculate
+        let (sent, received, fee) = *self;
+        sent - received + fee
+    }
+}
 
 // The Knuth shuffling algorithm based on the original [Fisher-Yates method](https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle)
 pub(crate) fn shuffle_slice<T>(list: &mut [T], rng: &mut impl RngCore) {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

This PR adds the new trait `TxAmountSpend` and a method `spend()` to improve the spend calculation. See [#1815](https://github.com/bitcoindevkit/bdk_wallet/issues/31) for more context.
<!-- Describe the purpose of this PR, what's being added, and/or fixed -->

### Notes to Reviewers
This PR adds `TxAmountSpend` in `utils.rs` and calls it in `mod.rs`. There are no breaking changes.
<!-- In this section, you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog Notice

- Added trait `TxAmountSpend`
- Added method `TxAmountSpend::spend()`

### Checklists

#### All Submissions:

* [x] I've signed all my commits.
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md).
* [x] I ran `cargo fmt` and `cargo clippy` before committing.

#### New Features:

* [x] I've added tests for the new feature.
* [x] I've added docs for the new feature.
