### PR TITLE
Use destination groups instead of coins in coin_select to improve privacy

### DIFF
--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -19,6 +19,7 @@ use alloc::{
     sync::Arc,
     vec::Vec,
 };
+use coin_selection::CoinSelectionParams;
 use core::{cmp::Ordering, fmt, mem, ops::Deref};
 
 use bdk_chain::{
@@ -1451,14 +1452,15 @@ impl Wallet {
             coin_selection::filter_duplicates(required_utxos, optional_utxos);
 
         let coin_selection = coin_selection
-            .coin_select(
+            .coin_select(CoinSelectionParams {
                 required_utxos,
                 optional_utxos,
                 fee_rate,
-                outgoing + fee_amount,
-                &drain_script,
-                rng,
-            )
+                target_amount: outgoing + fee_amount,
+                drain_script: &drain_script,
+                rand: rng,
+                avoid_partial_spends: params.avoid_partial_spends,
+            })
             .map_err(CreateTxError::CoinSelection)?;
 
         let excess = &coin_selection.excess;

--- a/crates/wallet/src/wallet/tx_builder.rs
+++ b/crates/wallet/src/wallet/tx_builder.rs
@@ -140,6 +140,7 @@ pub(crate) struct TxParams {
     pub(crate) bumping_fee: Option<PreviousFee>,
     pub(crate) current_height: Option<absolute::LockTime>,
     pub(crate) allow_dust: bool,
+    pub(crate) avoid_partial_spends: bool,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -572,6 +573,19 @@ impl<'a, Cs> TxBuilder<'a, Cs> {
     /// **Note**: by avoiding a dust limit check you may end up with a transaction that is non-standard.
     pub fn allow_dust(&mut self, allow_dust: bool) -> &mut Self {
         self.params.allow_dust = allow_dust;
+        self
+    }
+
+    /// Avoid partial spends.
+    ///
+    /// Group outputs by address, selecting many (possibly all) or none,
+    /// instead of selecting on a per-output basis. Privacy is improved as
+    /// addresses are mostly swept with fewer transactions and outputs are
+    /// aggregated in clean change addresses. It may result in higher fees
+    /// due to less optimal coin selection caused by this added limitation
+    /// and possibly a larger-than-necessary number of inputs being used
+    pub fn avoid_partial_spends(&mut self) -> &mut Self {
+        self.params.avoid_partial_spends = true;
         self
     }
 


### PR DESCRIPTION
In https://github.com/bitcoindevkit/bdk_wallet/issues/28 this PR from Bitcoin Core was mentioned https://github.com/bitcoin/bitcoin/pull/12257

This PR adds a param when building the tx called avoid_partial_spends. When true, it changes coin select to use output groups rather than outputs, where each output group corresponds to all outputs with the same destination.

It is a privacy improvement, as each time you spend some output, any other output that is publicly associated with the destination (address) will also be spent at the same time, at the cost of fee increase for cases where coin select without group restriction would find a more optimal set of coins (see example below).

For regular use without address reuse, this PR should have no effect on the user experience whatsoever; it only affects users who, for some reason, have multiple outputs with the same destination (i.e. address reuse).

Example: a node has four outputs linked to two addresses A and B:

- 1.0 btc to A
- 0.5 btc to A
- 1.0 btc to B
- 0.5 btc to B

The node sends 0.2 btc to C. Without -avoidpartialspends, the following coin selection will occur:

- 0.5 btc to A or B is picked
- 0.2 btc is output to C
- 0.3 - fee is output to (unique change address)

With -avoidpartialspends, the following will instead happen:

- Both of (0.5, 1.0) btc to A or B is picked (one or the other pair)
- 0.2 btc is output to C
- 1.3 - fee is output to (unique change address)

Assuming nobody sends to the address after you spend from it, you will only ever use one address once. The con is that the transaction becomes slightly larger in this case, because it is overpicking outputs to adhere to the no partial spending rule.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:
* [x] I'm linking the issue being fixed by this PR
