### PR TITLE
fix: typos in documentation files

### DIFF
--- a/crates/chain/src/canonical_iter.rs
+++ b/crates/chain/src/canonical_iter.rs
@@ -223,7 +223,7 @@ impl<A: Clone> CanonicalReason<A> {
         }
     }
 
-    /// Contruct a new [`CanonicalReason`] from the original which is transitive to `descendant`.
+    /// Construct a new [`CanonicalReason`] from the original which is transitive to `descendant`.
     ///
     /// This signals that either the [`ObservedIn`] or [`Anchor`] value belongs to the transaction's
     /// descendant, but is transitively relevant.

--- a/docs/adr/0001_persist.md
+++ b/docs/adr/0001_persist.md
@@ -26,7 +26,7 @@ The first approach was to create another trait `PersistBackendAsync` that was es
 
 #### Option 2: Return futures from persistence backend functions
 
-Another idea that was offered was to return something implementing `Future` from methods like `commit`. The idea was that it would minimize added dependencies and increase flexiblity by allowing the caller to `await` the result. In the end it seems less of an effort was put toward executing this idea.
+Another idea that was offered was to return something implementing `Future` from methods like `commit`. The idea was that it would minimize added dependencies and increase flexibility by allowing the caller to `await` the result. In the end it seems less of an effort was put toward executing this idea.
 
 ## Decision
 


### PR DESCRIPTION
**Description correction:**
Corrected `Contruct` to `Construct`
Corrected `flexiblity` to `flexibility`