### PR TITLE
wallet: Bump bitcoin dependency to v0.32.4

### DIFF
--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 [dependencies]
 rand_core = { version = "0.6.0" }
 miniscript = { version = "12.0.0", features = [ "serde" ], default-features = false }
-bitcoin = { version = "0.32.0", features = [ "serde", "base64" ], default-features = false }
+bitcoin = { version = "0.32.4", features = [ "serde", "base64" ], default-features = false }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
 bdk_chain = { path = "../chain", version = "0.21.1", features = [ "miniscript", "serde" ], default-features = false }


### PR DESCRIPTION
This is required since we are using Network::Testnet4


### Changelog notice

bdk_wallet:

- deps: Bump `bitcoin` to 0.32.4


### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

