### PR TITLE
wallet: Add ConfirmationSpendPolicy to spend only [un]confirmed outputs

### DIFF
--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -2026,6 +2026,8 @@ impl Wallet {
                     self.keychains().count() == 1
                         || params.change_policy.is_satisfied_by(local_output)
                 })
+                // only add utxos that match the confirmation policy
+                .filter(|local_output| params.confirmation_policy.is_satisfied_by(local_output))
                 // only add to optional UTxOs those marked as spendable
                 .filter(|local_output| !params.unspendable.contains(&local_output.outpoint))
                 // if bumping fees only add to optional UTxOs those confirmed

--- a/crates/wallet/src/wallet/tx_builder.rs
+++ b/crates/wallet/src/wallet/tx_builder.rs
@@ -543,7 +543,10 @@ impl<'a, Cs> TxBuilder<'a, Cs> {
 
     /// Set a specific [`ConfirmationSpendPolicy`]. See [`TxBuilder::only_spend_confirmed`] and
     /// [`TxBuilder::only_spend_unconfirmed`] for some shortcuts.
-    pub fn confirmation_policy(&mut self, confirmation_policy: ConfirmationSpendPolicy) -> &mut Self {
+    pub fn confirmation_policy(
+        &mut self,
+        confirmation_policy: ConfirmationSpendPolicy,
+    ) -> &mut Self {
         self.params.confirmation_policy = confirmation_policy;
         self
     }
@@ -895,11 +898,11 @@ impl ConfirmationSpendPolicy {
         match self {
             ConfirmationSpendPolicy::UnconfirmedAllowed => true,
             ConfirmationSpendPolicy::OnlyConfirmed => utxo.chain_position.is_confirmed(),
-            ConfirmationSpendPolicy::OnlyConfirmedSince { height } => {
-                utxo.chain_position.confirmation_height_upper_bound().map(|h| {
-                    h <= *height
-                }).unwrap_or(false)
-            },
+            ConfirmationSpendPolicy::OnlyConfirmedSince { height } => utxo
+                .chain_position
+                .confirmation_height_upper_bound()
+                .map(|h| h <= *height)
+                .unwrap_or(false),
             ConfirmationSpendPolicy::OnlyUnconfirmed => !utxo.chain_position.is_confirmed(),
         }
     }

--- a/crates/wallet/tests/wallet.rs
+++ b/crates/wallet/tests/wallet.rs
@@ -818,8 +818,16 @@ fn test_create_tx_confirmation_policy() {
         .only_spend_confirmed();
     let ret = builder.finish().unwrap();
     assert_eq!(ret.unsigned_tx.input.len(), 2);
-    assert!(ret.unsigned_tx.input.iter().any(|i| i.previous_output.txid == funding_txid));
-    assert!(ret.unsigned_tx.input.iter().any(|i| i.previous_output.txid == confirmed_txid));
+    assert!(ret
+        .unsigned_tx
+        .input
+        .iter()
+        .any(|i| i.previous_output.txid == funding_txid));
+    assert!(ret
+        .unsigned_tx
+        .input
+        .iter()
+        .any(|i| i.previous_output.txid == confirmed_txid));
 
     let mut builder = wallet.build_tx();
     builder
@@ -827,8 +835,16 @@ fn test_create_tx_confirmation_policy() {
         .only_spend_confirmed_since(3_000);
     let ret = builder.finish().unwrap();
     assert_eq!(ret.unsigned_tx.input.len(), 2);
-    assert!(ret.unsigned_tx.input.iter().any(|i| i.previous_output.txid == funding_txid));
-    assert!(ret.unsigned_tx.input.iter().any(|i| i.previous_output.txid == confirmed_txid));
+    assert!(ret
+        .unsigned_tx
+        .input
+        .iter()
+        .any(|i| i.previous_output.txid == funding_txid));
+    assert!(ret
+        .unsigned_tx
+        .input
+        .iter()
+        .any(|i| i.previous_output.txid == confirmed_txid));
 
     let mut builder = wallet.build_tx();
     builder
@@ -836,7 +852,11 @@ fn test_create_tx_confirmation_policy() {
         .only_spend_confirmed_since(2_500);
     let ret = builder.finish().unwrap();
     assert_eq!(ret.unsigned_tx.input.len(), 1);
-    assert!(ret.unsigned_tx.input.iter().any(|i| i.previous_output.txid == funding_txid));
+    assert!(ret
+        .unsigned_tx
+        .input
+        .iter()
+        .any(|i| i.previous_output.txid == funding_txid));
 
     let mut builder = wallet.build_tx();
     builder
@@ -844,7 +864,11 @@ fn test_create_tx_confirmation_policy() {
         .only_spend_unconfirmed();
     let ret = builder.finish().unwrap();
     assert_eq!(ret.unsigned_tx.input.len(), 1);
-    assert!(ret.unsigned_tx.input.iter().any(|i| i.previous_output.txid == unconfirmed_txid));
+    assert!(ret
+        .unsigned_tx
+        .input
+        .iter()
+        .any(|i| i.previous_output.txid == unconfirmed_txid));
 
     let mut builder = wallet.build_tx();
     builder


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

fixes bitcoindevkit/bdk_wallet#42

### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [ ] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [ ] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
