### PR TITLE
ci: pin idna_adapter dep to fix reqest with MSRV 1.75

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           cargo update -p home --precise "0.5.9"
           cargo update -p native-tls --precise "0.2.13"
+          cargo update -p idna_adapter --precise "1.1.0"
       - name: Pin dependencies for MSRV
         if: matrix.rust.version == '1.63.0'
         run: ./ci/pin-msrv.sh


### PR DESCRIPTION
### Description

The `bdk_esplora` crate depends on `reqwest` which now pins it's `idna_adapter` version to  support newer versions of the `url` crate when testing with it's MSRV. I fixed our CI 1.75 MSRV build by also pinning the `idna_adapter`.

### Notes to the reviewers

The MSRV break was fixed by the `reqwest` team with seanmonstar/reqwest#2470.

This change was made 2 mo ago, I'm not sure why our CI only broke now.

### Changelog notice

- Pin idna_adapter dep to fix reqwest with MSRV 1.75. 

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
