### PR TITLE
`bdk_wallet`: Pin `bdk_chain` version to latest release

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -29,7 +29,7 @@ jobs:
           - version: 1.63.0 # Overall MSRV
           - version: 1.75.0 # Specific MSRV for `bdk_electrum`
         features:
-          - --no-default-features --features miniscript/no-std
+          - --no-default-features --features miniscript/no-std,bdk_chain/hashbrown
           - --all-features
     steps:
       - name: checkout

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -21,8 +21,8 @@ miniscript = { version = "12.0.0", features = [ "serde" ], default-features = fa
 bitcoin = { version = "0.32.4", features = [ "serde", "base64" ], default-features = false }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }
-bdk_chain = { path = "../chain", version = "0.21.1", features = [ "miniscript", "serde" ], default-features = false }
-bdk_file_store = { path = "../file_store", version = "0.18.1", optional = true }
+bdk_chain = { version = "0.21.1", features = [ "miniscript", "serde" ], default-features = false }
+bdk_file_store = { version = "0.18.1", optional = true }
 
 # Optional dependencies
 bip39 = { version = "2.0", optional = true }
@@ -41,9 +41,9 @@ test-utils = ["std"]
 lazy_static = "1.4"
 assert_matches = "1.5.0"
 tempfile = "3"
-bdk_chain = { path = "../chain", features = ["rusqlite"] }
+bdk_chain = { version = "0.21.1", features = ["rusqlite"] }
 bdk_wallet = { path = ".", features = ["rusqlite", "file_store", "test-utils"] }
-bdk_file_store = { path = "../file_store" }
+bdk_file_store = { version = "0.18.1" }
 anyhow = "1"
 rand = "^0.8"
 

--- a/example-crates/example_wallet_electrum/Cargo.toml
+++ b/example-crates/example_wallet_electrum/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 bdk_wallet = { path = "../../crates/wallet", features = ["file_store"] }
-bdk_electrum = { path = "../../crates/electrum" }
+bdk_electrum = { version = "0.21" }
 anyhow = "1"

--- a/example-crates/example_wallet_esplora_async/Cargo.toml
+++ b/example-crates/example_wallet_esplora_async/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2021"
 
 [dependencies]
 bdk_wallet = { path = "../../crates/wallet", features = ["rusqlite"] }
-bdk_esplora = { path = "../../crates/esplora", features = ["async-https", "tokio"] }
+bdk_esplora = { version = "0.20", features = ["async-https", "tokio"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 anyhow = "1"

--- a/example-crates/example_wallet_esplora_blocking/Cargo.toml
+++ b/example-crates/example_wallet_esplora_blocking/Cargo.toml
@@ -8,5 +8,5 @@ publish = false
 
 [dependencies]
 bdk_wallet = { path = "../../crates/wallet", features = ["file_store"] }
-bdk_esplora = { path = "../../crates/esplora", features = ["blocking"] }
+bdk_esplora = { version = "0.20", features = ["blocking"] }
 anyhow = "1"

--- a/example-crates/example_wallet_rpc/Cargo.toml
+++ b/example-crates/example_wallet_rpc/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 bdk_wallet = { path = "../../crates/wallet", features = ["file_store"] }
-bdk_bitcoind_rpc = { path = "../../crates/bitcoind_rpc" }
+bdk_bitcoind_rpc = { version = "0.18" }
 
 anyhow = "1"
 clap = { version = "4.5.17", features = ["derive", "env"] }


### PR DESCRIPTION
### Description

As discussed here: https://discord.com/channels/753336465005608961/753336465005608965/1344807550217883688

Remove the use of Cargo `path` ref for the `bdk_chain` and `bdk_file_store` dependencies. This is the first step to move `bdk_wallet` into a new workspace.

Also fixed CI failures as we were testing no-std without hashbrown.

### Changelog notice

Remove the use of Cargo `path` ref for the `bdk_chain` and `bdk_file_store` dependencies. This is the first step to move `bdk_wallet` into a new workspace.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
