### PR TITLE
Delegate rustqlite connection persister to transaction persister

### DIFF
--- a/crates/wallet/src/wallet/persisted.rs
+++ b/crates/wallet/src/wallet/persisted.rs
@@ -272,16 +272,15 @@ impl WalletPersister for bdk_chain::rusqlite::Connection {
     type Error = bdk_chain::rusqlite::Error;
 
     fn initialize(persister: &mut Self) -> Result<ChangeSet, Self::Error> {
-        let db_tx = persister.transaction()?;
-        ChangeSet::init_sqlite_tables(&db_tx)?;
-        let changeset = ChangeSet::from_sqlite(&db_tx)?;
+        let mut db_tx = persister.transaction()?;
+        let changeset = WalletPersister::initialize(&mut db_tx)?;
         db_tx.commit()?;
         Ok(changeset)
     }
 
     fn persist(persister: &mut Self, changeset: &ChangeSet) -> Result<(), Self::Error> {
-        let db_tx = persister.transaction()?;
-        changeset.persist_to_sqlite(&db_tx)?;
+        let mut db_tx = persister.transaction()?;
+        WalletPersister::persist(&mut db_tx, changeset)?;
         db_tx.commit()
     }
 }


### PR DESCRIPTION
This is a small refactor that hopefully improves readability slightly.

Currently, the rusqlite connection persister and transaction persister are entirely different implementations, even though the connection persister just creates a new transaction, does what the transaction persister does, and then commits.

This makes the relationship a little clearly by explicitly delegating the connection persister implementation to the transaction persister implementation, so the reader doesn't need to manually compare the two implementations to see how they're related.