### PR TITLE
chore(examples): make change descriptor optional on example_wallet_rpc

### DIFF
--- a/example-crates/example_wallet_rpc/README.md
+++ b/example-crates/example_wallet_rpc/README.md
@@ -5,11 +5,11 @@ $ cargo run --bin example_wallet_rpc -- --help
 
 Bitcoind RPC example using `bdk_wallet::Wallet`
 
-Usage: example_wallet_rpc [OPTIONS] <DESCRIPTOR> <CHANGE_DESCRIPTOR>
+Usage: example_wallet_rpc [OPTIONS] <DESCRIPTOR> [CHANGE_DESCRIPTOR]
 
 Arguments:
   <DESCRIPTOR>         Wallet descriptor [env: DESCRIPTOR=]
-  <CHANGE_DESCRIPTOR>  Wallet change descriptor [env: CHANGE_DESCRIPTOR=]
+  [CHANGE_DESCRIPTOR]  Wallet change descriptor [env: CHANGE_DESCRIPTOR=]
 
 Options:
       --start-height <START_HEIGHT>  Earliest block height to start sync from [env: START_HEIGHT=] [default: 0]


### PR DESCRIPTION
### Description

This PR makes passing a `CHANGE_DESCRIPTOR` optional on `example_wallet_rpc`, as per #1533.

### Notes to the reviewers

Before instantiating a `Wallet` it checks if `args.change_descriptor` is Some. If true calls `Wallet::create`, else calls `Wallet::create_single`.

#### All Submissions:

* [X] I've signed all my commits
* [X] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [X] I ran `cargo fmt` and `cargo clippy` before committing