### PR TITLE
fix(examples): make regtest default on wallet_example_rpc

### DIFF
--- a/example-crates/example_wallet_rpc/README.md
+++ b/example-crates/example_wallet_rpc/README.md
@@ -3,43 +3,32 @@
 ```
 $ cargo run --bin example_wallet_rpc -- --help
 
-example_wallet_rpc 0.1.0
 Bitcoind RPC example using `bdk_wallet::Wallet`
 
-USAGE:
-    example_wallet_rpc [OPTIONS] <DESCRIPTOR> [CHANGE_DESCRIPTOR]
+Usage: example_wallet_rpc [OPTIONS] <DESCRIPTOR> <CHANGE_DESCRIPTOR>
 
-ARGS:
-    <DESCRIPTOR>           Wallet descriptor [env: DESCRIPTOR=]
-    <CHANGE_DESCRIPTOR>    Wallet change descriptor [env: CHANGE_DESCRIPTOR=]
+Arguments:
+  <DESCRIPTOR>         Wallet descriptor [env: DESCRIPTOR=]
+  <CHANGE_DESCRIPTOR>  Wallet change descriptor [env: CHANGE_DESCRIPTOR=]
 
-OPTIONS:
-        --db-path <DB_PATH>
-            Where to store wallet data [env: BDK_DB_PATH=] [default: .bdk_wallet_rpc_example.db]
+Options:
+      --start-height <START_HEIGHT>  Earliest block height to start sync from [env: START_HEIGHT=] [default: 0]
 
-    -h, --help
-            Print help information
+      --network <NETWORK>            Bitcoin network to connect to [env: BITCOIN_NETWORK=] [default: regtest]
 
-        --network <NETWORK>
-            Bitcoin network to connect to [env: BITCOIN_NETWORK=] [default: testnet]
+      --db-path <DB_PATH>            Where to store wallet data [env: BDK_DB_PATH=] [default: .bdk_wallet_rpc_example.db]
 
-        --rpc-cookie <RPC_COOKIE>
-            RPC auth cookie file [env: RPC_COOKIE=]
+      --url <URL>                    RPC URL [env: RPC_URL=] [default: 127.0.0.1:18443]
 
-        --rpc-pass <RPC_PASS>
-            RPC auth password [env: RPC_PASS=]
+      --rpc-cookie <RPC_COOKIE>      RPC auth cookie file [env: RPC_COOKIE=]
 
-        --rpc-user <RPC_USER>
-            RPC auth username [env: RPC_USER=]
+      --rpc-user <RPC_USER>          RPC auth username [env: RPC_USER=]
 
-        --start-height <START_HEIGHT>
-            Earliest block height to start sync from [env: START_HEIGHT=] [default: 481824]
+      --rpc-pass <RPC_PASS>          RPC auth password [env: RPC_PASS=]
 
-        --url <URL>
-            RPC URL [env: RPC_URL=] [default: 127.0.0.1:8332]
-
-    -V, --version
-            Print version information
+  -h, --help                         Print help
+  
+  -V, --version                      Print version
 
 ```
 

--- a/example-crates/example_wallet_rpc/src/main.rs
+++ b/example-crates/example_wallet_rpc/src/main.rs
@@ -27,10 +27,10 @@ pub struct Args {
     #[clap(env = "CHANGE_DESCRIPTOR")]
     pub change_descriptor: String,
     /// Earliest block height to start sync from
-    #[clap(env = "START_HEIGHT", long, default_value = "481824")]
+    #[clap(env = "START_HEIGHT", long, default_value = "0")]
     pub start_height: u32,
     /// Bitcoin network to connect to
-    #[clap(env = "BITCOIN_NETWORK", long, default_value = "testnet")]
+    #[clap(env = "BITCOIN_NETWORK", long, default_value = "regtest")]
     pub network: Network,
     /// Where to store wallet data
     #[clap(
@@ -41,7 +41,7 @@ pub struct Args {
     pub db_path: PathBuf,
 
     /// RPC URL
-    #[clap(env = "RPC_URL", long, default_value = "127.0.0.1:8332")]
+    #[clap(env = "RPC_URL", long, default_value = "127.0.0.1:18443")]
     pub url: String,
     /// RPC auth cookie file
     #[clap(env = "RPC_COOKIE", long)]


### PR DESCRIPTION
### Description

This PR makes `Regtest` the default network on `wallet_example_rpc` and updates the README accordingly.

### Notes to the reviewers

It had `Testnet` as the default network, `8332` as the default port and `481824` as the starting height; now everything is `Regtest`.

### Checklists

#### All Submissions:

* [X] I've signed all my commits
* [X] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [X] I ran `cargo fmt` and `cargo clippy` before committing