### PR TITLE
fix(wallet): allow PersistedWallet to be Send + Sync

### DIFF
--- a/crates/wallet/src/wallet/persisted.rs
+++ b/crates/wallet/src/wallet/persisted.rs
@@ -120,7 +120,7 @@ pub trait AsyncWalletPersister {
 #[derive(Debug)]
 pub struct PersistedWallet<P> {
     inner: Wallet,
-    marker: PhantomData<P>,
+    _marker: PhantomData<fn(&mut P)>,
 }
 
 impl<P> Deref for PersistedWallet<P> {
@@ -155,7 +155,7 @@ impl<P: WalletPersister> PersistedWallet<P> {
         }
         Ok(Self {
             inner,
-            marker: PhantomData,
+            _marker: PhantomData,
         })
     }
 
@@ -169,7 +169,7 @@ impl<P: WalletPersister> PersistedWallet<P> {
             .map(|opt| {
                 opt.map(|inner| PersistedWallet {
                     inner,
-                    marker: PhantomData,
+                    _marker: PhantomData,
                 })
             })
             .map_err(LoadWithPersistError::InvalidChangeSet)
@@ -214,7 +214,7 @@ impl<P: AsyncWalletPersister> PersistedWallet<P> {
         }
         Ok(Self {
             inner,
-            marker: PhantomData,
+            _marker: PhantomData,
         })
     }
 
@@ -230,7 +230,7 @@ impl<P: AsyncWalletPersister> PersistedWallet<P> {
             .map(|opt| {
                 opt.map(|inner| PersistedWallet {
                     inner,
-                    marker: PhantomData,
+                    _marker: PhantomData,
                 })
             })
             .map_err(LoadWithPersistError::InvalidChangeSet)

--- a/crates/wallet/tests/wallet.rs
+++ b/crates/wallet/tests/wallet.rs
@@ -12,7 +12,9 @@ use bdk_wallet::psbt::PsbtUtils;
 use bdk_wallet::signer::{SignOptions, SignerError};
 use bdk_wallet::test_utils::*;
 use bdk_wallet::tx_builder::AddForeignUtxoError;
-use bdk_wallet::{AddressInfo, Balance, ChangeSet, Update, Wallet, WalletPersister, WalletTx};
+use bdk_wallet::{
+    AddressInfo, Balance, ChangeSet, PersistedWallet, Update, Wallet, WalletPersister, WalletTx,
+};
 use bdk_wallet::{KeychainKind, LoadError, LoadMismatch, LoadWithPersistError};
 use bitcoin::constants::{ChainHash, COINBASE_MATURITY};
 use bitcoin::hashes::Hash;
@@ -4209,6 +4211,7 @@ fn test_tx_cancellation() {
 fn test_thread_safety() {
     fn thread_safe<T: Send + Sync>() {}
     thread_safe::<Wallet>(); // compiles only if true
+    thread_safe::<PersistedWallet<bdk_chain::rusqlite::Connection>>();
 }
 
 #[test]


### PR DESCRIPTION
### Description

fixes #1873 based on solution proposed by @praveenperera . 

### Notes to the reviewers

This is not a breaking change since it's only changing the internal `_marker` field's type.

### Changelog notice

- Fix PersistedWallet to be Send + Sync, even when used with a !Sync persister type such as rusqlite::Connection.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
