### PR TITLE
chore: Fix typo in error message

### DIFF
--- a/crates/esplora/src/async_ext.rs
+++ b/crates/esplora/src/async_ext.rs
@@ -204,7 +204,7 @@ async fn fetch_block<S: Sleeper>(
     let &tip_height = latest_blocks
         .keys()
         .last()
-        .expect("must have atleast one entry");
+        .expect("must have at least one entry");
     if height > tip_height {
         return Ok(None);
     }


### PR DESCRIPTION
### Description

I noticed a typo in the error message where "atleast" was written as one word. This corrects it to "at least" for better readability and accuracy.

---

Here’s the corrected code snippet:

```rust
let &tip_height = latest_blocks
    .keys()
    .last()
    .expect("must have at least one entry");
```

### Notes to the reviewers


### Changelog notice

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
