### PR TITLE
ci: add the ubuntu-24.04-arm as os for build-test

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -20,9 +20,12 @@ jobs:
   build-test:
     needs: prepare
     name: Build & Test
-    runs-on: ubuntu-latest
+    runs-on: ${{matrix.os}}
     strategy:
       matrix:
+        os: 
+          - ubuntu-latest
+          - ubuntu-24.04-arm
         rust:
           - version: ${{ needs.prepare.outputs.rust_version }}
             clippy: true


### PR DESCRIPTION
### Description
Resolves the issue bitcoindevkit/bdk_wallet#23 

### Notes to the reviewers
Here bitcoindevkit/bdk_wallet#23 we have to add ubuntu-24.04-arm as os for build-test. 



### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
