### PR TITLE
feat(wallet): `create_single` accepts a multipath descriptor

### DIFF
--- a/crates/wallet/src/descriptor/error.rs
+++ b/crates/wallet/src/descriptor/error.rs
@@ -68,7 +68,7 @@ impl fmt::Display for Error {
             ),
             Self::MultiPath => write!(
                 f,
-                "The descriptor contains multipath keys, which are not supported yet"
+                "The descriptor contains multipath keys when none were expected"
             ),
             Self::Key(err) => write!(f, "Key error: {}", err),
             Self::Policy(err) => write!(f, "Policy error: {}", err),

--- a/crates/wallet/src/test_utils.rs
+++ b/crates/wallet/src/test_utils.rs
@@ -145,6 +145,11 @@ pub fn get_test_wpkh_and_change_desc() -> (&'static str, &'static str) {
     "wpkh(tprv8ZgxMBicQKsPdy6LMhUtFHAgpocR8GC6QmwMSFpZs7h6Eziw3SpThFfczTDh5rW2krkqffa11UpX3XkeTTB2FvzZKWXqPY54Y6Rq4AQ5R8L/84'/1'/0'/1/*)")
 }
 
+/// `wpkh` multipath tpub
+pub fn get_test_wpkh_multipath() -> &'static str {
+    "wpkh([e273fe42/84'/1'/0']tpubDCmr3Luq75npLaYmRqqW1rLfSbfpnBXwLwAmUbR333fp95wjCHar3zoc9zSWovZFwrWr53mm3NTVqt6d1Pt6G26uf4etQjc3Pr5Hxe9QEQ2/<0;1>/*)"
+}
+
 /// `wsh` descriptor with policy `and(pk(A),older(6))`
 pub fn get_test_single_sig_csv() -> &'static str {
     "wsh(and_v(v:pk(cVpPVruEDdmutPzisEsYvtST1usBR3ntr8pXSyt6D2YYqXRyPcFW),older(6)))"

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -367,7 +367,7 @@ impl Wallet {
     ///
     /// If you have previously created a wallet, use [`load`](Self::load) instead.
     ///
-    /// This should be used when the parsed `descriptor` and `change_desctiptor` are either
+    /// This should be used when the parsed `descriptor` and `change_descriptor` are either
     /// a [`Single`] key or [`XPub`]. If creating a wallet from a [multipath] descriptor,
     /// use [`create_single`] instead.
     ///

--- a/crates/wallet/src/wallet/params.rs
+++ b/crates/wallet/src/wallet/params.rs
@@ -22,7 +22,7 @@ type DescriptorToExtract = Box<
         + 'static,
 >;
 
-fn make_descriptor_to_extract<D>(descriptor: D) -> DescriptorToExtract
+pub(crate) fn make_descriptor_to_extract<D>(descriptor: D) -> DescriptorToExtract
 where
     D: IntoWalletDescriptor + Send + 'static,
 {


### PR DESCRIPTION
### Notes to the reviewers

We reuse `Wallet::create_single` to accommodate a wallet descriptor that parses as a MultiXPub. The documentation is updated to clarify the distinction between the single vs. dual-keychain use cases.

The logical change happens in `create_with_params` where we now look for whether the external descriptor `is_multipath` and if so, use the parsed single descriptors to update the `descriptor` and `change_descriptor` and everything proceeds as normal. This means that the wallet change set still consists of the individually split descriptors.

An alternative that was discussed was to make a new dedicated function such as `create_from_multipath` that enforces the provided input to be a multipath descriptor. However we arrived at the approach in this PR in order to promote `create_single` as a more central API long term.

This is based on bitcoindevkit/bdk#1902 as that seemed to be relatively non controversial.

fixes bitcoindevkit/bdk_wallet#11 

Follow ups: Consider whether it might be needed to parse a multipath descriptor at load time https://github.com/bitcoindevkit/bdk_wallet/issues/11


### Changelog notice

Changed:

`Wallet::create_single` can be used to create a Wallet from a BIP389 multipath descriptor

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

