### PR TITLE
fix(wallet): added the validation of previous tx outputs for get_psbt_input

### DIFF
--- a/crates/wallet/src/wallet/error.rs
+++ b/crates/wallet/src/wallet/error.rs
@@ -102,6 +102,8 @@ pub enum CreateTxError {
     UnknownUtxo,
     /// Missing non_witness_utxo on foreign utxo for given `OutPoint`
     MissingNonWitnessUtxo(OutPoint),
+    /// Invalid vout index in transaction
+    InvalidVoutIndex(OutPoint),
     /// Miniscript PSBT error
     MiniscriptPsbt(MiniscriptPsbtError),
 }
@@ -167,6 +169,9 @@ impl fmt::Display for CreateTxError {
             }
             CreateTxError::MissingNonWitnessUtxo(outpoint) => {
                 write!(f, "Missing non_witness_utxo on foreign utxo {}", outpoint)
+            }
+            CreateTxError::InvalidVoutIndex(outpoint) => {
+                write!(f, "Invalid vout index in transaction: {}", outpoint)
             }
             CreateTxError::MiniscriptPsbt(err) => {
                 write!(f, "Miniscript PSBT error: {}", err)

--- a/crates/wallet/src/wallet/error.rs
+++ b/crates/wallet/src/wallet/error.rs
@@ -102,8 +102,6 @@ pub enum CreateTxError {
     UnknownUtxo,
     /// Missing non_witness_utxo on foreign utxo for given `OutPoint`
     MissingNonWitnessUtxo(OutPoint),
-    /// Invalid vout index in transaction
-    InvalidVoutIndex(OutPoint),
     /// Miniscript PSBT error
     MiniscriptPsbt(MiniscriptPsbtError),
 }
@@ -169,9 +167,6 @@ impl fmt::Display for CreateTxError {
             }
             CreateTxError::MissingNonWitnessUtxo(outpoint) => {
                 write!(f, "Missing non_witness_utxo on foreign utxo {}", outpoint)
-            }
-            CreateTxError::InvalidVoutIndex(outpoint) => {
-                write!(f, "Invalid vout index in transaction: {}", outpoint)
             }
             CreateTxError::MiniscriptPsbt(err) => {
                 write!(f, "Miniscript PSBT error: {}", err)

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -2167,7 +2167,7 @@ impl Wallet {
             } else {
                 // Use the existing UtxoUpdateError::IndexOutOfBounds variant
                 return Err(MiniscriptPsbtError::UtxoUpdate(
-                    miniscript::psbt::UtxoUpdateError::UtxoCheck
+                    miniscript::psbt::UtxoUpdateError::UtxoCheck,
                 )
                 .into());
             }

--- a/crates/wallet/src/wallet/mod.rs
+++ b/crates/wallet/src/wallet/mod.rs
@@ -2167,7 +2167,7 @@ impl Wallet {
             } else {
                 // Use the existing UtxoUpdateError::IndexOutOfBounds variant
                 return Err(MiniscriptPsbtError::UtxoUpdate(
-                    miniscript::psbt::UtxoUpdateError::IndexOutOfBounds(vout_index, outputs_len),
+                    miniscript::psbt::UtxoUpdateError::UtxoCheck
                 )
                 .into());
             }


### PR DESCRIPTION
### Description
It is fixing the issue bitcoindevkit/bdk_wallet#50 . This PR is adding validation of previous tx outputs. we would be checking the size of the prev_tx.output vector.


### Notes to the reviewers
Here  i have checked the size of the prev_tx.output vector. I have also added an error type of "InvalidVoutIndex"

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing


#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
