### PR TITLE
fix(wallet): added the validation of UTXO data for build_fee_bump

### DIFF
--- a/crates/wallet/src/wallet/error.rs
+++ b/crates/wallet/src/wallet/error.rs
@@ -223,6 +223,8 @@ pub enum BuildFeeBumpError {
     IrreplaceableTransaction(Txid),
     /// Node doesn't have data to estimate a fee rate
     FeeRateUnavailable,
+    /// Input references an invalid output index in the previous transaction
+    InvalidOutputIndex(OutPoint),
 }
 
 impl fmt::Display for BuildFeeBumpError {
@@ -247,6 +249,11 @@ impl fmt::Display for BuildFeeBumpError {
                 write!(f, "Transaction can't be replaced with txid: {}", txid)
             }
             Self::FeeRateUnavailable => write!(f, "Fee rate unavailable"),
+            Self::InvalidOutputIndex(outpoint) => write!(
+                f,
+                "Input references an invalid output index {} in transaction {}",
+                outpoint.vout, outpoint.txid
+            ),
         }
     }
 }


### PR DESCRIPTION
### Description
It fixes the Issue bitcoindevkit/bdk_wallet#51 . In this PR we are checking the size of the prev_tx.output list for ensuring that it contains the output referred by each input of the transaction to be bumped. 

### Notes to the reviewers
here prev_tx.output size is checked. Also changed the .map form .and_then for proper handling of Result.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
