### PR TITLE
Add an alternative storage back-end implementation using redb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/esplora",
     "crates/bitcoind_rpc",
     "crates/testenv",
+    "crates/redb",
     "example-crates/example_cli",
     "example-crates/example_electrum",
     "example-crates/example_esplora",

--- a/crates/redb/Cargo.toml
+++ b/crates/redb/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Bitcoin Dev Kit Developers"]
 [dependencies]
 bdk_wallet = { path = "../wallet", version = "1.1.0" }
 bdk_chain = { path = "../chain", version = "0.21.1", default-features = false }
-redb = "1.0.0"
+redb = "0.8.0"
 serde = { version = "1.0", features = ["derive"] }
 bincode = "1.3"
 

--- a/crates/redb/Cargo.toml
+++ b/crates/redb/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "bdk_redb"
+version = "0.1.0"
+edition = "2021"
+description = "Redb storage backend for Bitcoin Dev Kit"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/bitcoindevkit/bdk"
+authors = ["Bitcoin Dev Kit Developers"]
+
+[dependencies]
+bdk_wallet = { path = "../wallet", version = "1.1.0" }
+bdk_chain = { path = "../chain", version = "0.21.1", default-features = false }
+redb = "1.0.0"
+serde = { version = "1.0", features = ["derive"] }
+bincode = "1.3"
+
+[dev-dependencies]
+tempfile = "3.0"
+bitcoin = { version = "0.32.4", features = ["serde"] }

--- a/crates/redb/src/lib.rs
+++ b/crates/redb/src/lib.rs
@@ -1,0 +1,344 @@
+//! redb storage backend for Bitcoin Devlopment Kit
+//!
+//! This crate provides redb based implementation of `Wallet Persister`
+//! from the `bdk_wallet` crate.
+
+use std::path::Path;
+use std::fmt;
+use std::error::Error as StdError;
+
+use redb::{
+    Database, ReadableTable, TableDefinition,
+    DatabaseError, TransactionError, TableError, CommitError, StorageError
+};
+use bdk_wallet::{ChangeSet, WalletPersister};
+use bincode::{DefaultOptions, Options};
+
+// using single table with string keys for simplicity
+const WALLET_TABLE: TableDefinition<&str, &[u8]> = TableDefinition::new("wallet_data");
+
+// keys for different components fo changeset
+const DESCRIPTOR_KEY: &str = "descriptor";
+const CHANGE_DESCRIPTOR_KEY: &str = "change_descriptor";
+const NETWORK_KEY: &str = "network";
+const LOCAL_CHAIN_KEY: &str = "local_chain";
+const TX_GRAPH_KEY: &str = "tx_graph";
+const INDEXER_KEY: &str = "indexer";
+
+/// error type for redb wallet persister
+#[derive(Debug)]
+pub enum RedbStoreError {
+    /// database error
+    Database(redb::DatabaseError),
+    /// transaction error
+    Transaction(redb::TransactionError),
+    /// table error
+    Table(redb::TableError),
+    /// commit error
+    Commit(redb::CommitError),
+    /// storage error
+    Storage(redb::StorageError),
+    /// redb error
+    Redb(redb::Error),
+    /// serialization error
+    Serialization(bincode::Error),
+}
+
+impl fmt::Display for RedbStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RedbStoreError::Database(e) => write!(f, "Database error: {}", e),
+            RedbStoreError::Transaction(e) => write!(f, "Transaction error: {}", e),
+            RedbStoreError::Table(e) => write!(f, "Table error: {}", e),
+            RedbStoreError::Commit(e) => write!(f, "Commit error: {}", e),
+            RedbStoreError::Storage(e) => write!(f, "Storage error: {}", e),
+            RedbStoreError::Redb(e) => write!(f, "Redb error: {}", e),
+            RedbStoreError::Serialization(e) => write!(f, "Serialization error: {}", e),
+        }
+    }
+}
+
+impl StdError for RedbStoreError {}
+
+impl From<DatabaseError> for RedbStoreError {
+    fn from(e: DatabaseError) -> Self {
+        RedbStoreError::Database(e)
+    }
+}
+
+impl From<TransactionError> for RedbStoreError {
+    fn from(e: TransactionError) -> Self {
+        RedbStoreError::Transaction(e)
+    }
+}
+
+impl From<TableError> for RedbStoreError {
+    fn from(e: TableError) -> Self {
+        RedbStoreError::Table(e)
+    }
+}
+
+impl From<CommitError> for RedbStoreError {
+    fn from(e: CommitError) -> Self {
+        RedbStoreError::Commit(e)
+    }
+}
+
+impl From<StorageError> for RedbStoreError {
+    fn from(e: StorageError) -> Self {
+        RedbStoreError::Storage(e)
+    }
+}
+
+impl From<redb::Error> for RedbStoreError {
+    fn from(e: redb::Error) -> Self {
+        RedbStoreError::Redb(e)
+    }
+}
+
+impl From<bincode::Error> for RedbStoreError {
+    fn from(e: bincode::Error) -> Self {
+        RedbStoreError::Serialization(e)
+    }
+}
+
+/// redb based implementation of `WalletPersister`
+pub struct RedbStore {
+    db: Database,
+}
+
+fn bincode_options() -> impl bincode::Options {
+    DefaultOptions::new().with_varint_encoding()
+}
+
+impl RedbStore {
+    /// create new redb store at given path
+    pub fn create<P: AsRef<Path>>(path: P) -> Result<Self, RedbStoreError> {
+        let db = Database::create(path)?;
+
+        // initialize tables
+        let write_txn = db.begin_write()?;
+        {
+            // create wallet data table
+            write_txn.open_table(WALLET_TABLE)?;
+        }
+        write_txn.commit()?;
+
+        Ok(Self { db })
+    }
+
+    /// open existing redb store at given path
+    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, RedbStoreError> {
+        let db = Database::open(path)?;
+        Ok(Self { db })
+    }
+
+    /// creat a new redb store if it don;'t exist or open it if it exist
+    pub fn open_or_create<P: AsRef<Path>>(path: P) -> Result<Self, RedbStoreError> {
+        if path.as_ref().exists() {
+            Self::open(path)
+        } 
+        else {
+            Self::create(path)
+        }
+    }
+}
+
+impl WalletPersister for RedbStore {
+    type Error = RedbStoreError;
+
+    fn initialize(persister: &mut Self) -> Result<ChangeSet, Self::Error> {
+        // start read transaction
+        let read_txn = persister.db.begin_read()?;
+        
+        // open wallet data table
+        let table = read_txn.open_table(WALLET_TABLE)?;
+        
+        // create an empty changeset
+        let mut changeset = ChangeSet::default();
+        
+        // load each component of the changeset
+        // desc
+        if let Some(value) = table.get(DESCRIPTOR_KEY)? {
+            changeset.descriptor = Some(
+                bincode_options()
+                    .deserialize(value.value())
+                    .map_err(RedbStoreError::Serialization)?
+            );
+        }
+        
+        // change desc
+        if let Some(value) = table.get(CHANGE_DESCRIPTOR_KEY)? {
+            changeset.change_descriptor = Some(
+                bincode_options()
+                    .deserialize(value.value())
+                    .map_err(RedbStoreError::Serialization)?
+            );
+        }
+        
+        // network
+        if let Some(value) = table.get(NETWORK_KEY)? {
+            changeset.network = Some(
+                bincode_options()
+                    .deserialize(value.value())
+                    .map_err(RedbStoreError::Serialization)?
+            );
+        }
+        
+        // local chain
+        if let Some(value) = table.get(LOCAL_CHAIN_KEY)? {
+            changeset.local_chain = 
+                bincode_options()
+                    .deserialize(value.value())
+                    .map_err(RedbStoreError::Serialization)?;
+        }
+        
+        // Tx graph
+        if let Some(value) = table.get(TX_GRAPH_KEY)? {
+            changeset.tx_graph = 
+                bincode_options()
+                    .deserialize(value.value())
+                    .map_err(RedbStoreError::Serialization)?;
+        }
+        
+        // indxr
+        if let Some(value) = table.get(INDEXER_KEY)? {
+            changeset.indexer = 
+                bincode_options()
+                    .deserialize(value.value())
+                    .map_err(RedbStoreError::Serialization)?;
+        }
+        
+        Ok(changeset)
+    }
+
+    fn persist(persister: &mut Self, changeset: &ChangeSet) -> Result<(), Self::Error> {
+        // skip if the changeset is completely empty
+        if changeset.descriptor.is_none() &&
+           changeset.change_descriptor.is_none() &&
+           changeset.network.is_none() &&
+           changeset.local_chain.blocks.is_empty() &&
+           changeset.tx_graph.txs.is_empty() &&
+           changeset.tx_graph.txouts.is_empty() &&
+           changeset.indexer.last_revealed.is_empty() {
+            return Ok(());
+        }
+        
+        // start write transaction
+        let write_txn = persister.db.begin_write()?;
+
+        {
+            // open wallet data table
+            let mut table = write_txn.open_table(WALLET_TABLE)?;
+            
+            // store each component of the changeset if it's not empty
+            
+            // desc
+            if let Some(descriptor) = &changeset.descriptor {
+                let serialized = bincode_options()
+                    .serialize(descriptor)
+                    .map_err(RedbStoreError::Serialization)?;
+                table.insert(DESCRIPTOR_KEY, serialized.as_slice())?;
+            }
+            
+            // change desc
+            if let Some(change_descriptor) = &changeset.change_descriptor {
+                let serialized = bincode_options()
+                    .serialize(change_descriptor)
+                    .map_err(RedbStoreError::Serialization)?;
+                table.insert(CHANGE_DESCRIPTOR_KEY, serialized.as_slice())?;
+            }
+            
+            // network
+            if let Some(network) = &changeset.network {
+                let serialized = bincode_options()
+                    .serialize(network)
+                    .map_err(RedbStoreError::Serialization)?;
+                table.insert(NETWORK_KEY, serialized.as_slice())?;
+            }
+            
+            // local chain (check if it has any blocks)
+            if !changeset.local_chain.blocks.is_empty() {
+                let serialized = bincode_options()
+                    .serialize(&changeset.local_chain)
+                    .map_err(RedbStoreError::Serialization)?;
+                table.insert(LOCAL_CHAIN_KEY, serialized.as_slice())?;
+            }
+            
+            // Tx graph (check if it has any tx or outputs)
+            if !changeset.tx_graph.txs.is_empty() || 
+               !changeset.tx_graph.txouts.is_empty() ||
+               !changeset.tx_graph.anchors.is_empty() ||
+               !changeset.tx_graph.last_seen.is_empty() {
+                let serialized = bincode_options()
+                    .serialize(&changeset.tx_graph)
+                    .map_err(RedbStoreError::Serialization)?;
+                table.insert(TX_GRAPH_KEY, serialized.as_slice())?;
+            }
+            
+            // idxr (check if it has any revealed indices)
+            if !changeset.indexer.last_revealed.is_empty() {
+                let serialized = bincode_options()
+                    .serialize(&changeset.indexer)
+                    .map_err(RedbStoreError::Serialization)?;
+                table.insert(INDEXER_KEY, serialized.as_slice())?;
+            }
+        }
+        
+        // commit the Tx
+        write_txn.commit()?;
+        
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+    use bitcoin::Network;
+    
+    #[test]
+    fn test_empty_store() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("wallet.redb");
+        
+        let mut store = RedbStore::create(&db_path).unwrap();
+        
+        // initialize should return an empty changeset
+        let changeset = WalletPersister::initialize(&mut store).unwrap();
+        assert!(changeset.descriptor.is_none());
+        assert!(changeset.change_descriptor.is_none());
+        assert!(changeset.network.is_none());
+        assert!(changeset.local_chain.blocks.is_empty());
+        assert!(changeset.tx_graph.txs.is_empty());
+        assert!(changeset.indexer.last_revealed.is_empty());
+    }
+    
+    #[test]
+    fn test_persist_and_retrieve() {
+        let dir = tempdir().unwrap();
+        let db_path = dir.path().join("wallet.redb");
+        
+        // create a store and persist a changeset
+        {
+            let mut store = RedbStore::create(&db_path).unwrap();
+            
+            // creating simple changeset with just a network value
+            let mut changeset = ChangeSet::default();
+            changeset.network = Some(Network::Testnet);
+            
+            // persist the changeset
+            WalletPersister::persist(&mut store, &changeset).unwrap();
+        }
+        
+        // open store again and check if the changeset was persisted
+        {
+            let mut store = RedbStore::open(&db_path).unwrap();
+            
+            // initialized should return the persisted changeset
+            let changeset = WalletPersister::initialize(&mut store).unwrap();
+            assert_eq!(changeset.network, Some(Network::Testnet));
+        }
+    }
+}


### PR DESCRIPTION
### Description
Adds a new storage backend implementation for BDK wallet using [redb](https://docs.rs/redb/0.8.0/redb/index.html), a pure-Rust key-value store. This implementation provides an alternative to the existing SQLite and file_store backends, giving users more flexibility in how they store their wallet data. 
The implementation includes:
- new `bdk_redb` crate with an implementation of the `WalletPersister` trait
- basic tests to verify data is accurately stored and retrieved

### **Related to issue: bitcoindevkit/bdk_wallet#420, #691, bitcoindevkit/bdk_wallet#34**

### Notes to the reviewers
The implementation follows a similar pattern to the existing file_store backend. I chose to implement the redb backend in a separate crate to avoid adding direct dependencies to the wallet crate and to maintain separation of concerns.

The redb implementation stores each component of the ChangeSet separately, which allows for efficient updates and retrieval. I've added basic tests to verify the implementation works correctly, but would appreciate feedback on edge cases that should be tested.

### Changelog notice
**uses unsafe rust !!** [compulsory because redb v0.8.0 had marked some functions unsafe they are not unsafe in latest version of redb]
<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists
#### All Submissions:
* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:
* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Todo:
* [ ] add a feature flag for redb in the main wallet crate
* [ ] create a new example similar to example_wallet_esplora_blocking that demonstrates using the redb backend
* [ ] add more comprehensive tests
    * [ ] test edge cases and error handling
    * [ ] test with more complex wallet data
* [ ] add documentation for your new implementation
* [ ] update the project's README to mention the new storage backend