### PR TITLE
chore: bump `miniscript` to `12.3.1`

### DIFF
--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 bitcoin = { version = "0.32.0", default-features = false }
 bdk_core = { path = "../core", version = "0.4.1", default-features = false }
 serde = { version = "1", optional = true, features = ["derive", "rc"] }
-miniscript = { version = "12.0.0", optional = true, default-features = false }
+miniscript = { version = "12.3.1", optional = true, default-features = false }
 
 # Feature dependencies
 rusqlite = { version = "0.31.0", features = ["bundled"], optional = true }

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 
 [dependencies]
 rand_core = { version = "0.6.0" }
-miniscript = { version = "12.0.0", features = [ "serde" ], default-features = false }
+miniscript = { version = "12.3.1", features = [ "serde" ], default-features = false }
 bitcoin = { version = "0.32.4", features = [ "serde", "base64" ], default-features = false }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = { version = "^1.0" }


### PR DESCRIPTION
### Description

Bump `miniscript` dependency to `12.3.1`.

### Changelog notice

* Updated `miniscript` dependency to `12.3.1`.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
