### PR TITLE
chore: bump bdk_wallet to 1.2.0

### DIFF
--- a/crates/file_store/CHANGELOG.md
+++ b/crates/file_store/CHANGELOG.md
@@ -7,6 +7,26 @@ Contributors do not need to change this file but do need to add changelog detail
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [file_store-0.19.0]
+
+### Added:
+
+- `StoreError` enum, which includes `Io`, `Bincode` and `InvalidMagicBytes` #1684.
+- docs: add "not intended for production" note in `README`.
+
+### Changed:
+
+- `Store::create_new` to `Store::create`, with new return type: `Result<Self, StoreError>`
+- `Store::open` to `Store::load`, with new return type: `Result<(Self, Option<C>), StoreErrorWithDump<C>>`
+- `Store::open_or_create` to `Store::load_or_create`, with new return type: `Result<(Option<C>, Self), StoreErrorWithDump<C>>`
+- `Store::aggregate_changesets` to `Store::dump`, with new return type: `Result<Option<C>, StoreErrorWithDump<C>>`
+- `FileError` to `StoreError`
+- `AggregateChangesetsError` to `StoreErrorWithDump`, which now can include all the variants of `StoreError` in the error field.
+
+#### Removed:
+
+- `IterError` deleted.
+
 ## [file_store-0.18.1]
 
 ### Changed
@@ -14,3 +34,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Minor updates to fix new rustc 1.83.0 clippy warnings #1776
 
 [file_store-0.18.1]: https://github.com/bitcoindevkit/bdk/releases/tag/file_store-0.18.1
+[file_store-0.19.0]: https://github.com/bitcoindevkit/bdk/releases/tag/file_store-0.19.0

--- a/crates/file_store/Cargo.toml
+++ b/crates/file_store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_file_store"
-version = "0.18.1"
+version = "0.19.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bitcoindevkit/bdk"

--- a/crates/wallet/CHANGELOG.md
+++ b/crates/wallet/CHANGELOG.md
@@ -7,6 +7,22 @@ Contributors do not need to change this file but do need to add changelog detail
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [wallet-1.2.0]
+
+### Changed
+
+- Accept any type that is convertible to a `ScriptBuf` in `TxBuilder::add_recipient` #1841
+- Refactor/use iterators to preselect utxos #1798
+- Bump bitcoin dependency to v0.32.4 #1853
+- Pin bdk_chain version to latest release #1860
+- chore: bump `miniscript` to `12.3.1` #1924
+
+### Fixed
+
+- Fix off-by-one error checking coinbase maturity in optional UTxOs #1830
+- Fix PersistedWallet to be Send + Sync, even when used with a !Sync persister type such as rusqlite::Connection. #1874
+
+
 ## [wallet-1.1.0]
 
 ### Added
@@ -1255,3 +1271,4 @@ final transaction is created by calling `finish` on the builder.
 [v1.0.0-beta.6]: https://github.com/bitcoindevkit/bdk/releases/tag/v1.0.0-beta.6
 [wallet-1.0.0]: https://github.com/bitcoindevkit/bdk/releases/tag/wallet-1.0.0
 [wallet-1.1.0]: https://github.com/bitcoindevkit/bdk/releases/tag/wallet-1.1.0
+[wallet-1.2.0]: https://github.com/bitcoindevkit/bdk/releases/tag/wallet-1.2.0

--- a/crates/wallet/Cargo.toml
+++ b/crates/wallet/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bdk_wallet"
 homepage = "https://bitcoindevkit.org"
-version = "1.1.0"
+version = "1.2.0"
 repository = "https://github.com/bitcoindevkit/bdk"
 documentation = "https://docs.rs/bdk"
 description = "A modern, lightweight, descriptor-based wallet library"


### PR DESCRIPTION
Release `bdk_wallet` v1.2.0

- bdk_file_store to 0.19.0

fixes #1923 

