### PR TITLE
feat(chain): Add method for constructing TxGraph from a ChangeSet

### DIFF
--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -1216,6 +1216,13 @@ impl<A: Anchor> TxGraph<A> {
         self.try_list_expected_spk_txids(chain, chain_tip, indexer, spk_index_range)
             .map(|r| r.expect("infallible"))
     }
+
+    /// Construct a `TxGraph` from a `changeset`.
+    pub fn from_changeset(changeset: ChangeSet<A>) -> Self {
+        let mut graph = Self::default();
+        graph.apply_changeset(changeset);
+        graph
+    }
 }
 
 /// The [`ChangeSet`] represents changes to a [`TxGraph`].


### PR DESCRIPTION
### Description
* Added a `from_changeset()` function to `TxGraph` implementation
* This function initializes a new `TxGraph` and applies the given `ChangeSet`
* The method allows constructing a `TxGraph` directly from a `ChangeSet`,
  simplifying graph creation.

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature
