### PR TITLE
test: Add derivation index assertions in indexed_tx_graph tests

### DIFF
--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -160,21 +160,24 @@ fn test_list_owned_txouts() {
 
     {
         // we need to scope here to take immutable reference of the graph
-        for _ in 0..10 {
-            let ((_, script), _) = graph
+        for i in 0..10 {
+            let ((index, script), _) = graph
                 .index
                 .reveal_next_spk("keychain_1".to_string())
                 .unwrap();
-            // TODO Assert indexes
+            // Assert that index matches expected sequential derivation index
+            assert_eq!(index, i, "Failed asserting index {} equals expected {}", index, i);
             trusted_spks.push(script.to_owned());
         }
     }
     {
-        for _ in 0..10 {
-            let ((_, script), _) = graph
+        for i in 0..10 {
+            let ((index, script), _) = graph
                 .index
                 .reveal_next_spk("keychain_2".to_string())
                 .unwrap();
+            // Assert that index matches expected sequential derivation index
+            assert_eq!(index, i, "Failed asserting index {} equals expected {}", index, i);
             untrusted_spks.push(script.to_owned());
         }
     }


### PR DESCRIPTION
### Description

Added assertions to verify the derivation indexes in the test_indexed_tx_graph.rs test file. These assertions ensure that indexes increment correctly when revealing script public keys for both trusted and untrusted keychains.

### Notes to the reviewers

This is a simple test improvement that adds verification of a key component in the derivation process.

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
