### PR TITLE
feat!(chain): implement `first_seen` tracking

### DIFF
--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -632,7 +632,10 @@ fn test_get_chain_position() {
             },
             anchor: None,
             last_seen: Some(2),
-            exp_pos: Some(ChainPosition::Unconfirmed { last_seen: Some(2) }),
+            exp_pos: Some(ChainPosition::Unconfirmed {
+                last_seen: Some(2),
+                first_seen: Some(2),
+            }),
         },
         TestCase {
             name: "tx anchor in best chain - confirmed",
@@ -661,7 +664,10 @@ fn test_get_chain_position() {
             },
             anchor: Some(block_id!(2, "B'")),
             last_seen: Some(2),
-            exp_pos: Some(ChainPosition::Unconfirmed { last_seen: Some(2) }),
+            exp_pos: Some(ChainPosition::Unconfirmed {
+                last_seen: Some(2),
+                first_seen: Some(2),
+            }),
         },
         TestCase {
             name: "tx unknown anchor - unconfirmed",
@@ -674,7 +680,10 @@ fn test_get_chain_position() {
             },
             anchor: Some(block_id!(2, "B'")),
             last_seen: None,
-            exp_pos: Some(ChainPosition::Unconfirmed { last_seen: None }),
+            exp_pos: Some(ChainPosition::Unconfirmed {
+                last_seen: None,
+                first_seen: None,
+            }),
         },
     ]
     .into_iter()


### PR DESCRIPTION
### Description

This PR solves issue #1947 by implementing `first_seen` tracking.

* Added `first_seen` field to `TxGraph` and `ChangeSet` so that `first_seen` timestamp can be added when inserting a new seen-at using `insert_seen_at`. 

* `first_seen` added to `TxNode` as a way to retrieve the first-seen timestamp for a transaction.

* `first_seen` added to `ChainPosition::Unconfirmed` to order unconfirmed transactions by `first_seen`.

* New tests have been added for the above described functionalities. 


### Changelog notice

* Add tracking first-seen timestamps of transactions 

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

