### PR TITLE
core: allow serialization of SyncResponse

### DIFF
--- a/crates/core/src/checkpoint.rs
+++ b/crates/core/src/checkpoint.rs
@@ -10,10 +10,12 @@ use crate::BlockId;
 /// Checkpoints are cheaply cloneable and are useful to find the agreement point between two sparse
 /// block chains.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct CheckPoint(Arc<CPInner>);
 
 /// The internal contents of [`CheckPoint`].
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 struct CPInner {
     /// Block id (hash and height).
     block: BlockId,

--- a/crates/core/src/spk_client.rs
+++ b/crates/core/src/spk_client.rs
@@ -387,14 +387,14 @@ impl<I> SyncRequest<I> {
 /// See also [`SyncRequest`].
 #[must_use]
 #[derive(Debug)]
-pub struct SyncResponse<A = ConfirmationBlockTime> {
+pub struct SyncResponse<A: Ord = ConfirmationBlockTime> {
     /// Relevant transaction data discovered during the scan.
     pub tx_update: crate::TxUpdate<A>,
     /// Changes to the chain discovered during the scan.
     pub chain_update: Option<CheckPoint>,
 }
 
-impl<A> Default for SyncResponse<A> {
+impl<A: Ord> Default for SyncResponse<A> {
     fn default() -> Self {
         Self {
             tx_update: Default::default(),
@@ -540,7 +540,7 @@ impl<K: Ord + Clone> FullScanRequest<K> {
 /// See also [`FullScanRequest`].
 #[must_use]
 #[derive(Debug)]
-pub struct FullScanResponse<K, A = ConfirmationBlockTime> {
+pub struct FullScanResponse<K, A: Ord = ConfirmationBlockTime> {
     /// Relevant transaction data discovered during the scan.
     pub tx_update: crate::TxUpdate<A>,
     /// Last active indices for the corresponding keychains (`K`). An index is active if it had a
@@ -550,7 +550,7 @@ pub struct FullScanResponse<K, A = ConfirmationBlockTime> {
     pub chain_update: Option<CheckPoint>,
 }
 
-impl<K, A> Default for FullScanResponse<K, A> {
+impl<K, A: Ord> Default for FullScanResponse<K, A> {
     fn default() -> Self {
         Self {
             tx_update: Default::default(),

--- a/crates/core/src/tx_update.rs
+++ b/crates/core/src/tx_update.rs
@@ -19,8 +19,9 @@ use bitcoin::{OutPoint, Transaction, TxOut, Txid};
 /// tx_update.anchors.insert((anchor, txid));
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 #[non_exhaustive]
-pub struct TxUpdate<A = ()> {
+pub struct TxUpdate<A: Ord = ()> {
     /// Full transactions. These are transactions that were determined to be relevant to the wallet
     /// given the request.
     pub txs: Vec<Arc<Transaction>>,
@@ -52,7 +53,7 @@ pub struct TxUpdate<A = ()> {
     pub evicted_ats: HashSet<(Txid, u64)>,
 }
 
-impl<A> Default for TxUpdate<A> {
+impl<A: Ord> Default for TxUpdate<A> {
     fn default() -> Self {
         Self {
             txs: Default::default(),


### PR DESCRIPTION
### Description

The rationale behind this is to allow a separate instance of the same wallet be updated on a device that's not necessarily connected. Like a hardware wallet.

A connected device gets the response, serializes it with serde and passes the `Update` to the air-gapped one

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing