### PR TITLE
ci: pin grcov to v0.8.20 in coverage workflow

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.7.8
       - name: Install grcov
-        run: if [[ ! -e ~/.cargo/bin/grcov ]]; then cargo install grcov; fi
+        run: if [[ ! -e ~/.cargo/bin/grcov ]]; then cargo install grcov --version 0.8.20; fi
       - name: Test
         run: cargo test --all-features
       - name: Make coverage directory


### PR DESCRIPTION
### Description

The Code Coverage CI has started failing because `grcov v0.9.1` depends on `zip = "^2.6"`, and both `zip 2.6.0` and `2.6.1` have been yanked from crates.io (see: https://github.com/mozilla/grcov/issues/1351).

### Notes to the reviewers

This change will need to be reverted once upstream ships a `grcov` release that updates its `zip` dependency past the yanked versions.

### Changelog notice

* Pin `grcov` to `v0.8.20` in coverage workflow.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing
