### PR TITLE
[ft] SMT Replenish with > 1000 lastrevealed index

### DIFF
--- a/crates/chain/tests/test_keychain_txout_index.rs
+++ b/crates/chain/tests/test_keychain_txout_index.rs
@@ -542,10 +542,10 @@ fn lookahead_to_target() {
         },
         TestCase {
             lookahead: 13,
-            external_last_revealed: Some(100),
-            internal_last_revealed: Some(21),
-            internal_target: Some(120),
-            external_target: Some(130),
+            external_last_revealed: Some(1100),
+            internal_last_revealed: Some(1200),
+            internal_target: Some(1110),
+            external_target: Some(1120),
         },
     ];
 


### PR DESCRIPTION
Currently in BDK there is a pretty big problem when loading a wallet where the last revealed index is into the value of 1000+ for even decent hardware because of the need to utilize the CPU to generate SPKs for each index and add them to the graph.  The process will only use a single CPU core currently. Large wallets will cause timeouts and/or become a DoS vector.

This will if greater than 1000 last revealed use all available CPU cores to generate the SPKs,

Previous, ~3 minutes for 100000 SPKs 
![Screenshot from 2025-05-18 14-54-53](https://github.com/user-attachments/assets/17960572-6f7a-4b37-a550-97e3ab9c80c7)

Notice the CPU usage is only a single core at a time.

New, 28 Seconds for 100000 SPKs
![Screenshot from 2025-05-18 14-48-21](https://github.com/user-attachments/assets/71b2638f-cf45-4c7f-bcce-32bfd6eee56e)

All cores are being used!

**This speed up is linear to the number of CPU cores.** 


