### PR TITLE
Add `is_empty` methods to `TxUpdate` and `{}_Response` types

### DIFF
--- a/crates/core/src/spk_client.rs
+++ b/crates/core/src/spk_client.rs
@@ -403,6 +403,13 @@ impl<A> Default for SyncResponse<A> {
     }
 }
 
+impl<A> SyncResponse<A> {
+    /// Returns true if the `SyncResponse` is empty.
+    pub fn is_empty(&self) -> bool {
+        self.tx_update.is_empty() && self.chain_update.is_none()
+    }
+}
+
 /// Builds a [`FullScanRequest`].
 ///
 /// Construct with [`FullScanRequest::builder`].
@@ -557,6 +564,15 @@ impl<K, A> Default for FullScanResponse<K, A> {
             chain_update: Default::default(),
             last_active_indices: Default::default(),
         }
+    }
+}
+
+impl<K, A> FullScanResponse<K, A> {
+    /// Returns true if the `FullScanResponse` is empty.
+    pub fn is_empty(&self) -> bool {
+        self.tx_update.is_empty()
+            && self.last_active_indices.is_empty()
+            && self.chain_update.is_none()
     }
 }
 

--- a/crates/core/src/tx_update.rs
+++ b/crates/core/src/tx_update.rs
@@ -64,6 +64,17 @@ impl<A> Default for TxUpdate<A> {
     }
 }
 
+impl<A> TxUpdate<A> {
+    /// Returns true if the `TxUpdate` contains no elements in any of its fields.
+    pub fn is_empty(&self) -> bool {
+        self.txs.is_empty()
+            && self.txouts.is_empty()
+            && self.anchors.is_empty()
+            && self.seen_ats.is_empty()
+            && self.evicted_ats.is_empty()
+    }
+}
+
 impl<A: Ord> TxUpdate<A> {
     /// Transforms the [`TxUpdate`] to have `anchors` (`A`) of another type (`A2`).
     ///

--- a/crates/core/tests/test_spk_client.rs
+++ b/crates/core/tests/test_spk_client.rs
@@ -1,0 +1,13 @@
+use bdk_core::spk_client::{FullScanResponse, SyncResponse};
+
+#[test]
+fn test_empty() {
+    assert!(
+        FullScanResponse::<(), ()>::default().is_empty(),
+        "Default `FullScanResponse` must be empty"
+    );
+    assert!(
+        SyncResponse::<()>::default().is_empty(),
+        "Default `SyncResponse` must be empty"
+    );
+}

--- a/crates/core/tests/test_tx_update.rs
+++ b/crates/core/tests/test_tx_update.rs
@@ -1,0 +1,9 @@
+use bdk_core::TxUpdate;
+
+#[test]
+fn test_empty() {
+    assert!(
+        TxUpdate::<()>::default().is_empty(),
+        "Default `TxUpdate` must be empty"
+    );
+}


### PR DESCRIPTION
### Description

`is_empty` methods are helpful in various contexts so I added them.

### Changelog notice

```md
Added
  - `is_empty` methods to `TxUpdate`, `SyncResponse` and `FullScanResponse`
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo fmt` and `cargo clippy` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
