### PR TITLE
Persist spks derived from `KeychainTxOutIndex`

### DIFF
--- a/crates/bitcoind_rpc/examples/filter_iter.rs
+++ b/crates/bitcoind_rpc/examples/filter_iter.rs
@@ -33,9 +33,8 @@ fn main() -> anyhow::Result<()> {
     let (mut chain, _) = LocalChain::from_genesis_hash(genesis_block(NETWORK).block_hash());
     let mut graph = IndexedTxGraph::<ConfirmationBlockTime, KeychainTxOutIndex<&str>>::new({
         let mut index = KeychainTxOutIndex::default();
-        // TODO: Properly deal with these changesets.
-        let _ = index.insert_descriptor("external", descriptor.clone())?;
-        let _ = index.insert_descriptor("internal", change_descriptor.clone())?;
+        index.insert_descriptor("external", descriptor.clone())?;
+        index.insert_descriptor("internal", change_descriptor.clone())?;
         index
     });
 

--- a/crates/bitcoind_rpc/examples/filter_iter.rs
+++ b/crates/bitcoind_rpc/examples/filter_iter.rs
@@ -33,8 +33,9 @@ fn main() -> anyhow::Result<()> {
     let (mut chain, _) = LocalChain::from_genesis_hash(genesis_block(NETWORK).block_hash());
     let mut graph = IndexedTxGraph::<ConfirmationBlockTime, KeychainTxOutIndex<&str>>::new({
         let mut index = KeychainTxOutIndex::default();
-        index.insert_descriptor("external", descriptor.clone())?;
-        index.insert_descriptor("internal", change_descriptor.clone())?;
+        // TODO: Properly deal with these changesets.
+        let _ = index.insert_descriptor("external", descriptor.clone())?;
+        let _ = index.insert_descriptor("internal", change_descriptor.clone())?;
         index
     });
 

--- a/crates/bitcoind_rpc/examples/filter_iter.rs
+++ b/crates/bitcoind_rpc/examples/filter_iter.rs
@@ -31,6 +31,7 @@ fn main() -> anyhow::Result<()> {
     let (descriptor, _) = Descriptor::parse_descriptor(&secp, EXTERNAL)?;
     let (change_descriptor, _) = Descriptor::parse_descriptor(&secp, INTERNAL)?;
     let (mut chain, _) = LocalChain::from_genesis_hash(genesis_block(NETWORK).block_hash());
+
     let mut graph = IndexedTxGraph::<ConfirmationBlockTime, KeychainTxOutIndex<&str>>::new({
         let mut index = KeychainTxOutIndex::default();
         index.insert_descriptor("external", descriptor.clone())?;

--- a/crates/chain/benches/canonicalization.rs
+++ b/crates/chain/benches/canonicalization.rs
@@ -83,7 +83,7 @@ fn setup<F: Fn(&mut KeychainTxGraph, &LocalChain)>(f: F) -> (KeychainTxGraph, Lo
     let (desc, _) =
         <Descriptor<DescriptorPublicKey>>::parse_descriptor(&Secp256k1::new(), DESC).unwrap();
     let mut index = KeychainTxOutIndex::new(10);
-    index.insert_descriptor((), desc).unwrap();
+    let _ = index.insert_descriptor((), desc).unwrap();
     let mut tx_graph = KeychainTxGraph::new(index);
 
     f(&mut tx_graph, &chain);

--- a/crates/chain/benches/canonicalization.rs
+++ b/crates/chain/benches/canonicalization.rs
@@ -82,8 +82,8 @@ fn setup<F: Fn(&mut KeychainTxGraph, &LocalChain)>(f: F) -> (KeychainTxGraph, Lo
 
     let (desc, _) =
         <Descriptor<DescriptorPublicKey>>::parse_descriptor(&Secp256k1::new(), DESC).unwrap();
-    let mut index = KeychainTxOutIndex::new(10);
-    let _ = index.insert_descriptor((), desc).unwrap();
+    let mut index = KeychainTxOutIndex::new(10, true);
+    index.insert_descriptor((), desc).unwrap();
     let mut tx_graph = KeychainTxGraph::new(index);
 
     f(&mut tx_graph, &chain);

--- a/crates/chain/src/indexer/keychain_txout.rs
+++ b/crates/chain/src/indexer/keychain_txout.rs
@@ -236,6 +236,13 @@ impl<K> KeychainTxOutIndex<K> {
 
 /// Methods that are *re-exposed* from the internal [`SpkTxOutIndex`].
 impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
+    /// Construct `KeychainTxOutIndex<K>` from the given `changeset`.
+    pub fn from_changeset(changeset: ChangeSet) -> Self {
+        let mut out = Self::default();
+        out.apply_changeset(changeset);
+        out
+    }
+
     /// Get the set of indexed outpoints, corresponding to tracked keychains.
     pub fn outpoints(&self) -> &BTreeSet<KeychainIndexed<K, OutPoint>> {
         self.inner.outpoints()

--- a/crates/chain/src/rusqlite_impl.rs
+++ b/crates/chain/src/rusqlite_impl.rs
@@ -539,13 +539,12 @@ impl keychain_txout::ChangeSet {
     pub fn schema_v1() -> String {
         format!(
             "CREATE TABLE {} ( \
-            descriptor_id TEXT NOT NULL REFERENCES {}, \
+            descriptor_id TEXT NOT NULL, \
             spk_index INTEGER NOT NULL, \
             spk BLOB NOT NULL, \
-            PRIMARY KEY (descriptor_id, index) \
+            PRIMARY KEY (descriptor_id, spk_index) \
             ) STRICT",
             Self::DERIVED_SPKS_TABLE_NAME,
-            Self::LAST_REVEALED_TABLE_NAME,
         )
     }
 

--- a/crates/chain/src/spk_iter.rs
+++ b/crates/chain/src/spk_iter.rs
@@ -153,16 +153,16 @@ mod test {
         Descriptor<DescriptorPublicKey>,
         Descriptor<DescriptorPublicKey>,
     ) {
-        let mut txout_index = KeychainTxOutIndex::<TestKeychain>::new(0);
+        let mut txout_index = KeychainTxOutIndex::<TestKeychain>::new(0, true);
 
         let secp = Secp256k1::signing_only();
         let (external_descriptor,_) = Descriptor::<DescriptorPublicKey>::parse_descriptor(&secp, "tr([73c5da0a/86'/0'/0']xprv9xgqHN7yz9MwCkxsBPN5qetuNdQSUttZNKw1dcYTV4mkaAFiBVGQziHs3NRSWMkCzvgjEe3n9xV8oYywvM8at9yRqyaZVz6TYYhX98VjsUk/0/*)").unwrap();
         let (internal_descriptor,_) = Descriptor::<DescriptorPublicKey>::parse_descriptor(&secp, "tr([73c5da0a/86'/0'/0']xprv9xgqHN7yz9MwCkxsBPN5qetuNdQSUttZNKw1dcYTV4mkaAFiBVGQziHs3NRSWMkCzvgjEe3n9xV8oYywvM8at9yRqyaZVz6TYYhX98VjsUk/1/*)").unwrap();
 
-        let _ = txout_index
+        txout_index
             .insert_descriptor(TestKeychain::External, external_descriptor.clone())
             .unwrap();
-        let _ = txout_index
+        txout_index
             .insert_descriptor(TestKeychain::Internal, internal_descriptor.clone())
             .unwrap();
 

--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -35,14 +35,12 @@ fn insert_relevant_txs() {
     let spk_1 = descriptor.at_derivation_index(9).unwrap().script_pubkey();
     let lookahead = 10;
 
-    let mut graph = IndexedTxGraph::<ConfirmationBlockTime, KeychainTxOutIndex<()>>::new(
-        KeychainTxOutIndex::new(lookahead, true),
-    );
-    let is_inserted = graph
-        .index
-        .insert_descriptor((), descriptor.clone())
-        .unwrap();
-    assert!(is_inserted);
+    let mut graph = IndexedTxGraph::<ConfirmationBlockTime, KeychainTxOutIndex<()>>::new({
+        let mut indexer = KeychainTxOutIndex::new(lookahead, true);
+        let is_inserted = indexer.insert_descriptor((), descriptor.clone()).unwrap();
+        assert!(is_inserted);
+        indexer
+    });
 
     let tx_a = Transaction {
         output: vec![
@@ -160,18 +158,16 @@ fn test_list_owned_txouts() {
     let (desc_2, _) =
         Descriptor::parse_descriptor(&Secp256k1::signing_only(), DESCRIPTORS[3]).unwrap();
 
-    let mut graph = IndexedTxGraph::<ConfirmationBlockTime, KeychainTxOutIndex<String>>::new(
-        KeychainTxOutIndex::new(10, true),
-    );
-
-    assert!(graph
-        .index
-        .insert_descriptor("keychain_1".into(), desc_1)
-        .unwrap());
-    assert!(graph
-        .index
-        .insert_descriptor("keychain_2".into(), desc_2)
-        .unwrap());
+    let mut graph = IndexedTxGraph::<ConfirmationBlockTime, KeychainTxOutIndex<String>>::new({
+        let mut indexer = KeychainTxOutIndex::new(10, true);
+        assert!(indexer
+            .insert_descriptor("keychain_1".into(), desc_1)
+            .unwrap());
+        assert!(indexer
+            .insert_descriptor("keychain_2".into(), desc_2)
+            .unwrap());
+        indexer
+    });
 
     // Get trusted and untrusted addresses
 

--- a/crates/chain/tests/test_keychain_txout_index.rs
+++ b/crates/chain/tests/test_keychain_txout_index.rs
@@ -607,7 +607,7 @@ fn lookahead_to_target() {
                     }
                     None => target,
                 };
-                index.lookahead_to_target(keychain.clone(), target, &mut Vec::new());
+                let _ = index.lookahead_to_target(keychain.clone(), target);
                 let keys: Vec<_> = (0..)
                     .take_while(|&i| index.spk_at_index(keychain.clone(), i).is_some())
                     .collect();

--- a/examples/example_cli/src/lib.rs
+++ b/examples/example_cli/src/lib.rs
@@ -836,10 +836,13 @@ pub fn init_or_load<CS: clap::Subcommand, S: clap::Args>(
                 // insert descriptors and apply loaded changeset
                 let mut index = KeychainTxOutIndex::default();
                 if let Some(desc) = changeset.descriptor {
-                    index.insert_descriptor(Keychain::External, desc)?;
+                    // TODO: We should apply changeset to the graph before inserting descriptors.
+                    // TODO: Then persist the new _changesets returned to db.
+                    let (_, _changeset) = index.insert_descriptor(Keychain::External, desc)?;
                 }
                 if let Some(change_desc) = changeset.change_descriptor {
-                    index.insert_descriptor(Keychain::Internal, change_desc)?;
+                    let (_, _changeset) =
+                        index.insert_descriptor(Keychain::Internal, change_desc)?;
                 }
                 let mut graph = KeychainTxGraph::new(index);
                 graph.apply_changeset(indexed_tx_graph::ChangeSet {

--- a/examples/example_cli/src/lib.rs
+++ b/examples/example_cli/src/lib.rs
@@ -836,13 +836,10 @@ pub fn init_or_load<CS: clap::Subcommand, S: clap::Args>(
                 // insert descriptors and apply loaded changeset
                 let mut index = KeychainTxOutIndex::default();
                 if let Some(desc) = changeset.descriptor {
-                    // TODO: We should apply changeset to the graph before inserting descriptors.
-                    // TODO: Then persist the new _changesets returned to db.
-                    let (_, _changeset) = index.insert_descriptor(Keychain::External, desc)?;
+                    index.insert_descriptor(Keychain::External, desc)?;
                 }
                 if let Some(change_desc) = changeset.change_descriptor {
-                    let (_, _changeset) =
-                        index.insert_descriptor(Keychain::Internal, change_desc)?;
+                    index.insert_descriptor(Keychain::Internal, change_desc)?;
                 }
                 let mut graph = KeychainTxGraph::new(index);
                 graph.apply_changeset(indexed_tx_graph::ChangeSet {


### PR DESCRIPTION
Replaces #1960
Fixes #1953
Fixes #1964 

### Description

Users with large wallet and/or complex descriptors may experience slow startup of `KeychainTxOutIndex`. This PR addresses this problem by providing the option to persist derived spks so that they no longer need to be re-derived on startup.

The `IndexedTxGraph` API has been changed for better ergonomics.

Compared to #1960, this is a more longterm solution that does not depend on multi-threading logic.

### Changelog notice

```md
Changed
  - `KeychainTxOutIndex::new` to take in an additional parameter `persist_spks` to control whether derived spks are cached and persisted across restarts. The default of `persist_spks` is false.
  - `KeychainTxOutIndex` methods (`lookahead_to_target, `next_unused_spk`, `reveal_next_spk`) now return changesets as they may derive spks to be persisted.
  - The `InsertDescriptorError` type now wraps descriptors in `Box` to reduce enum size.

Added
  - `spk_cache` field to `indexer::keychain_txout::ChangeSet` which persists derived spks.
  - `IndexedTxGraph::from_changeset` - allows constructing from `indexed_tx_graph::ChangeSet` and only indexing when ready.
  - `IndexedTxGraph::reindex` method.

Fixed
  - `KeychainTxOutIndex::reveal_to_target` so that it actually returns `None` if the `keychain` does not exist.
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo +nightly fmt` and `cargo clippy` before committing

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature