### PR TITLE
chore: bump `bdk_chain` to 0.23.0

### DIFF
--- a/crates/bitcoind_rpc/CHANGELOG.md
+++ b/crates/bitcoind_rpc/CHANGELOG.md
@@ -7,9 +7,15 @@ Contributors do not need to change this file but do need to add changelog detail
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [bitcoind_rpc-0.20.0]
+
+### Changed
+
+- bump bdk_core to 0.6.0
+
 ## [bitcoind_rpc-0.19.0]
 
-## Changed
+### Changed
 
 - feat(rpc)!: Update Emitter::mempool to support evicted_at #1857
 - Change Emitter::mempool to return MempoolEvents which contain mempool-eviction data.
@@ -31,3 +37,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [bitcoind_rpc-0.17.1]: https://github.com/bitcoindevkit/bdk/releases/tag/bitcoind_rpc-0.17.1
 [bitcoind_rpc-0.18.0]: https://github.com/bitcoindevkit/bdk/releases/tag/bitcoind_rpc-0.18.0
 [bitcoind_rpc-0.19.0]: https://github.com/bitcoindevkit/bdk/releases/tag/bitcoind_rpc-0.19.0
+[bitcoind_rpc-0.20.0]: https://github.com/bitcoindevkit/bdk/releases/tag/bitcoind_rpc-0.20.0

--- a/crates/bitcoind_rpc/Cargo.toml
+++ b/crates/bitcoind_rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_bitcoind_rpc"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"
@@ -18,7 +18,7 @@ workspace = true
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false }
 bitcoincore-rpc = { version = "0.19.0" }
-bdk_core = { path = "../core", version = "0.5.0", default-features = false }
+bdk_core = { path = "../core", version = "0.6.0", default-features = false }
 
 [dev-dependencies]
 bdk_bitcoind_rpc = { path = "." }

--- a/crates/chain/CHANGELOG.md
+++ b/crates/chain/CHANGELOG.md
@@ -7,6 +7,21 @@ Contributors do not need to change this file but do need to add changelog detail
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [chain-0.23.0]
+
+### Added
+
+- feat!(chain): implement `first_seen` tracking #1950
+- fix(chain): persist `first_seen` #1966
+- Persist spks derived from KeychainTxOutIndex #1963
+
+### Changed
+
+- fix(docs): `merge_chains` outdated documentation #1806
+- chore: create and apply rustfmt.toml #1946
+- chore: Update rust-version to 1.86.0 #1955
+- bump bdk_core to 0.6.0
+
 ## [chain-0.22.0]
 
 ### Added
@@ -41,3 +56,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [chain-0.21.1]: https://github.com/bitcoindevkit/bdk/releases/tag/chain-0.21.1
 [chain-0.22.0]: https://github.com/bitcoindevkit/bdk/releases/tag/chain-0.22.0
+[chain-0.23.0]: https://github.com/bitcoindevkit/bdk/releases/tag/chain-0.23.0

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_chain"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"
@@ -17,7 +17,7 @@ workspace = true
 
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false }
-bdk_core = { path = "../core", version = "0.5.0", default-features = false }
+bdk_core = { path = "../core", version = "0.6.0", default-features = false }
 serde = { version = "1", optional = true, features = ["derive", "rc"] }
 miniscript = { version = "12.3.1", optional = true, default-features = false }
 

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [core-0.6.0]
+
+### Added
+
+- Add `is_empty` methods to `TxUpdate` and `{}_Response` types #1961
+
 ## [core-0.5.0]
 
 ### Added
@@ -36,3 +42,4 @@ This is because requests now have a `start_time`, instead of specifying a `seen_
 
 [core-0.4.1]: https://github.com/bitcoindevkit/bdk/releases/tag/core-0.4.1
 [core-0.5.0]: https://github.com/bitcoindevkit/bdk/releases/tag/core-0.5.0
+[core-0.6.0]: https://github.com/bitcoindevkit/bdk/releases/tag/core-0.6.0

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_core"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"

--- a/crates/electrum/CHANGELOG.md
+++ b/crates/electrum/CHANGELOG.md
@@ -7,6 +7,12 @@ Contributors do not need to change this file but do need to add changelog detail
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [electrum-0.23.0]
+
+### Changed
+
+- bump bdk_core to 0.6.0
+
 ## [electrum-0.22.0]
 
 ### Fixed
@@ -37,3 +43,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [electrum-0.20.1]: https://github.com/bitcoindevkit/bdk/releases/tag/electrum-0.20.1
 [electrum-0.21.0]: https://github.com/bitcoindevkit/bdk/releases/tag/electrum-0.21.0
 [electrum-0.22.0]: https://github.com/bitcoindevkit/bdk/releases/tag/electrum-0.22.0
+[electrum-0.23.0]: https://github.com/bitcoindevkit/bdk/releases/tag/electrum-0.23.0

--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_electrum"
-version = "0.22.0"
+version = "0.23.0"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -13,7 +13,7 @@ readme = "README.md"
 workspace = true
 
 [dependencies]
-bdk_core = { path = "../core", version = "0.5.0" }
+bdk_core = { path = "../core", version = "0.6.0" }
 electrum-client = { version = "0.23.1", features = [ "proxy" ], default-features = false }
 
 [dev-dependencies]

--- a/crates/esplora/CHANGELOG.md
+++ b/crates/esplora/CHANGELOG.md
@@ -7,6 +7,12 @@ Contributors do not need to change this file but do need to add changelog detail
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [esplora-0.22.0]
+
+### Changed
+
+- bump bdk_core to 0.6.0
+
 ## [esplora-0.21.0]
 
 ### Changed
@@ -25,3 +31,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [esplora-0.20.1]: https://github.com/bitcoindevkit/bdk/releases/tag/esplora-0.20.1
 [esplora-0.21.0]: https://github.com/bitcoindevkit/bdk/releases/tag/esplora-0.21.0
+[esplora-0.22.0]: https://github.com/bitcoindevkit/bdk/releases/tag/esplora-0.22.0

--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_esplora"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -15,7 +15,7 @@ readme = "README.md"
 workspace = true
 
 [dependencies]
-bdk_core = { path = "../core", version = "0.5.0", default-features = false }
+bdk_core = { path = "../core", version = "0.6.0", default-features = false }
 esplora-client = { version = "0.12.0", default-features = false }
 async-trait = { version = "0.1.66", optional = true }
 futures = { version = "0.3.26", optional = true }

--- a/crates/file_store/CHANGELOG.md
+++ b/crates/file_store/CHANGELOG.md
@@ -7,6 +7,12 @@ Contributors do not need to change this file but do need to add changelog detail
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [file_store-0.21.0]
+
+### Changed
+
+- bump bdk_core to 0.6.0
+
 ## [file_store-0.20.0]
 
 ### Changed
@@ -42,3 +48,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [file_store-0.18.1]: https://github.com/bitcoindevkit/bdk/releases/tag/file_store-0.18.1
 [file_store-0.19.0]: https://github.com/bitcoindevkit/bdk/releases/tag/file_store-0.19.0
 [file_store-0.20.0]: https://github.com/bitcoindevkit/bdk/releases/tag/file_store-0.20.0
+[file_store-0.21.0]: https://github.com/bitcoindevkit/bdk/releases/tag/file_store-0.21.0

--- a/crates/file_store/Cargo.toml
+++ b/crates/file_store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_file_store"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -14,7 +14,7 @@ readme = "README.md"
 workspace = true
 
 [dependencies]
-bdk_core = { path = "../core", version = "0.5.0", features = ["serde"]}
+bdk_core = { path = "../core", version = "0.6.0", features = ["serde"]}
 bincode = { version = "1" }
 serde = { version = "1", features = ["derive"] }
 

--- a/crates/testenv/CHANGELOG.md
+++ b/crates/testenv/CHANGELOG.md
@@ -7,7 +7,15 @@ Contributors do not need to change this file but do need to add changelog detail
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [testenv-0.13.0]
+
+### Changed
+
+- deps: bump `bdk_chain` to 0.23.0
+
 ## [testenv-0.12.0]
+
+### Changed
 
 - deps: bump `bdk_chain` to 0.22.0
 
@@ -19,3 +27,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [testenv-0.11.1]: https://github.com/bitcoindevkit/bdk/releases/tag/testenv-0.11.1
 [testenv-0.12.0]: https://github.com/bitcoindevkit/bdk/releases/tag/testenv-0.12.0
+[testenv-0.13.0]: https://github.com/bitcoindevkit/bdk/releases/tag/testenv-0.13.0

--- a/crates/testenv/Cargo.toml
+++ b/crates/testenv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_testenv"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"
@@ -16,7 +16,7 @@ readme = "README.md"
 workspace = true
 
 [dependencies]
-bdk_chain = { path = "../chain", version = "0.22.0", default-features = false }
+bdk_chain = { path = "../chain", version = "0.23.0", default-features = false }
 electrsd = { version = "0.28.0", features = [ "legacy" ], default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
core to 0.6.0
bitcoind_rpc to 0.20.0
electrum to 0.23.0
esplora to 0.22.0
file_store 0.21.0
testenv to 0.13.0

TODO

- [x] Update changelogs

fixes #1969 
