### PR TITLE
Add `TxGraph::get_last_evicted`

### DIFF
--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -410,6 +410,13 @@ impl<A> TxGraph<A> {
         })
     }
 
+    /// Get the `last_evicted` timestamp of the given `txid`.
+    ///
+    /// Ideally, this would be included in [`TxNode`], but that would be a breaking change.
+    pub fn get_last_evicted(&self, txid: Txid) -> Option<u64> {
+        self.last_evicted.get(&txid).copied()
+    }
+
     /// Calculates the fee of a given transaction. Returns [`Amount::ZERO`] if `tx` is a coinbase
     /// transaction. Returns `OK(_)` if we have all the [`TxOut`]s being spent by `tx` in the
     /// graph (either as the full transactions or individual txouts).


### PR DESCRIPTION
### Description

Ideally, this would be included as a field in `TxNode`, however that would be a breaking change.

### Changelog notice

```md
Added
- `TxGraph::get_last_evicted`
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo +nightly fmt` and `cargo clippy` before committing

#### New Features:

~* [ ] I've added tests for the new feature~
* [x] I've added docs for the new feature
