### PR TITLE
chore(bdk-electrum): use new `batch_transaction_get_merkle` API

### DIFF
--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -14,8 +14,7 @@ workspace = true
 
 [dependencies]
 bdk_core = { path = "../core", version = "0.6.0" }
-electrum-client = { version = "0.23.1", features = [ "proxy" ], default-features = false }
-serde_json = "1.0"
+electrum-client = { version = "0.24.0", features = [ "proxy" ], default-features = false }
 
 [dev-dependencies]
 bdk_testenv = { path = "../testenv" }

--- a/crates/electrum/src/bdk_electrum_client.rs
+++ b/crates/electrum/src/bdk_electrum_client.rs
@@ -506,23 +506,12 @@ impl<E: ElectrumApi> BdkElectrumClient<E> {
             }
         }
 
-        // Batch all get_merkle calls.
-        let mut batch = electrum_client::Batch::default();
-        for &(txid, height, _) in &to_fetch {
-            batch.raw(
-                "blockchain.transaction.get_merkle".into(),
-                vec![
-                    electrum_client::Param::String(format!("{txid:x}")),
-                    electrum_client::Param::Usize(height),
-                ],
-            );
-        }
-        let resps = self.inner.batch_call(&batch)?;
+        // Fetch merkle proofs.
+        let txids_and_heights = to_fetch.iter().map(|&(txid, height, _)| (txid, height));
+        let proofs = self.inner.batch_transaction_get_merkle(txids_and_heights)?;
 
         // Validate each proof, retrying once for each stale header.
-        for ((txid, height, hash), resp) in to_fetch.into_iter().zip(resps.into_iter()) {
-            let proof: electrum_client::GetMerkleRes = serde_json::from_value(resp)?;
-
+        for ((txid, height, hash), proof) in to_fetch.into_iter().zip(proofs.into_iter()) {
             let mut header = {
                 let cache = self.block_header_cache.lock().unwrap();
                 cache


### PR DESCRIPTION
fixes #1987
depends on https://github.com/bitcoindevkit/rust-electrum-client/pull/170

### Description

- update `batch_fetch_anchors` to use `batch_transaction_get_merkle` method instead of manually creating the batch call.

### Changelog notice

```md
### Changes
- deps: bump `electrum-client` to 0.24.0
- Use new `batch_transaction_get_merkle` method instead of batch raw calls
```

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `cargo +nightly fmt` and `cargo clippy` before committing
