### PR TITLE
chore: add metadata fields to issue templates for triage

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -17,10 +17,24 @@ assignees: ''
 <!-- A clear and concise description of what you expected to happen. -->
 
 **Build environment**  
- - BDK tag/commit: <!-- e.g. v0.13.0, 3a07614 --> 
- - OS+version: <!-- e.g. ubuntu 20.04.01, macOS 12.0.1, windows -->  
- - Rust/Cargo version: <!-- e.g. 1.56.0 --> 
- - Rust/Cargo target: <!-- e.g. x86_64-apple-darwin, x86_64-unknown-linux-gnu, etc. -->  
+- BDK tag/commit: <!-- e.g. v0.13.0, 3a07614 --> 
+- OS+version: <!-- e.g. ubuntu 20.04.01, macOS 12.0.1, windows -->  
+- Rust/Cargo version: <!-- e.g. 1.56.0 --> 
+- Rust/Cargo target: <!-- e.g. x86_64-apple-darwin, x86_64-unknown-linux-gnu, etc. -->  
+
+**Which backend(s) are relevant (if any)?**
+- [ ] Electrum
+- [ ] Esplora
+- [ ] Bitcoin Core RPC
+- [ ] None / not backend-related (e.g. `bdk_chain`, `bdk_core`)
+- [ ] Other (please specify): `____`
+
+**Is this blocking production use?**
+- [ ] Yes
+- [ ] No
+
+**Project or organization (optional)**  
+<!-- e.g. BitKey, LDK, personal wallet project, etc. -->
 
 **Additional context**  
-<!-- Add any other context about the problem here. --> 
+<!-- Add any other context, logs, or error messages here. -->

--- a/.github/ISSUE_TEMPLATE/enhancement_request.md
+++ b/.github/ISSUE_TEMPLATE/enhancement_request.md
@@ -4,14 +4,33 @@ about: Request a new feature or change to an existing feature
 title: ''
 labels: 'enhancement'
 assignees: ''
-
 ---
 
 **Describe the enhancement**  
 <!-- A clear and concise description of what you would like added or changed. -->
 
 **Use case**  
-<!-- Tell us how you or others will use this new feature or change to an existing feature. --> 
+<!-- Tell us how you or others will use this new feature or change to an existing feature. -->
+
+**Impact**
+- [ ] Blocking production usage
+- [ ] Nice-to-have / UX improvement
+- [ ] Developer experience / maintainability
+
+**Are you using BDK in a production project?**
+- [ ] Yes
+- [ ] No
+- [ ] Not yet, but planning to
+
+**Which backend(s) are relevant (if any)?**
+- [ ] Electrum
+- [ ] Esplora
+- [ ] Bitcoin Core RPC
+- [ ] None / not backend-related (e.g. `bdk_chain`, `bdk_core`)
+- [ ] Other (please specify): `____`
+
+**Project or organization (optional)**
+<!-- e.g. BitKey, LDK, personal wallet project, etc. -->
 
 **Additional context**
-<!-- Add any other context about the enhancement here. --> 
+<!-- Add any other context, links, or design thoughts here. -->


### PR DESCRIPTION
### Description

This PR updates the GitHub issue templates `bug_report.md` and `enhancement_request.md` to improve triage and prioritization. Specifically, it adds structured fields for:

* Production impact (e.g., blocking usage vs. nice-to-have)
* Backend in use (Electrum, Esplora, RPC, etc.)
* Project or organization (optional, helps identify high-priority users)

The goal is to make it easier for maintainers to gauge the urgency and relevance of issues, especially for production users or high-impact integrations.

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
