### PR TITLE
keychain_txout: `apply_changeset` restores spk cache before last revealed

### DIFF
--- a/crates/chain/src/indexer/keychain_txout.rs
+++ b/crates/chain/src/indexer/keychain_txout.rs
@@ -938,15 +938,15 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
 
     /// Applies the `ChangeSet<K>` to the [`KeychainTxOutIndex<K>`]
     pub fn apply_changeset(&mut self, changeset: ChangeSet) {
-        for (did, index) in changeset.last_revealed {
-            let v = self.last_revealed.entry(did).or_default();
-            *v = index.max(*v);
-            self.replenish_inner_index_did(did, self.lookahead);
-        }
         if self.persist_spks {
             for (did, spks) in changeset.spk_cache {
                 self.spk_cache.entry(did).or_default().extend(spks);
             }
+        }
+        for (did, index) in changeset.last_revealed {
+            let v = self.last_revealed.entry(did).or_default();
+            *v = index.max(*v);
+            self.replenish_inner_index_did(did, self.lookahead);
         }
     }
 }


### PR DESCRIPTION
This patch improves readability and maintains logical consistency with the use of `spk_cache` throughout the `keychain_txout` module.

While it might offer a performance benefit, the results are mostly comparable with the current benchmarks as far as I can tell. At least there's no indication that it would negatively impact performance.

fixes #1975

### Changelog notice


### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

