### PR TITLE
fix(core): Memory leak bugs in `CheckPoint::drop` impl

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -23,3 +23,9 @@ serde = ["dep:serde", "bitcoin/serde", "hashbrown?/serde"]
 [dev-dependencies]
 bdk_chain = { path = "../chain" }
 bdk_testenv = { path = "../testenv", default-features = false }
+
+[build-dependencies]
+version_check = "0.9"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(has_arc_into_inner)'] }

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    if version_check::is_min_version("1.70.0").unwrap_or(false) {
+        println!("cargo:rustc-cfg=has_arc_into_inner");
+    }
+}


### PR DESCRIPTION
### Description

* Fix memory leak bug in `CheckPoint::drop` by using `Arc::into_inner` if it is available (>= 1.70).
* Fix `CPInner::drop` logic so that if `CPInner::block` becomes generic and is of a type that required `drop`, it does not leak memory.
* Add tests for memory leak + stack overflow when dropping `CheckPoint`.

An alternative fix is to bump MSRV to >= 1.70 so we don't need to do conditional compilation based on version.

### Changelog notice

```md
Fix:
- Drop implementation of `CheckPoint` to avoid memory leaks for rust version >= 1.70.
```

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### Bugfixes:

* [x] I've added tests to reproduce the issue which are now passing

