### PR TITLE
`FilterIter` API redesign

### DIFF
--- a/crates/bitcoind_rpc/examples/filter_iter.rs
+++ b/crates/bitcoind_rpc/examples/filter_iter.rs
@@ -1,15 +1,14 @@
-#![allow(clippy::print_stdout)]
+#![allow(clippy::print_stdout, clippy::print_stderr)]
 use std::time::Instant;
 
 use anyhow::Context;
-use bdk_bitcoind_rpc::bip158::{Event, EventInner, FilterIter};
+use bdk_bitcoind_rpc::bip158::{Event, FilterIter};
 use bdk_chain::bitcoin::{constants::genesis_block, secp256k1::Secp256k1, Network};
 use bdk_chain::indexer::keychain_txout::KeychainTxOutIndex;
 use bdk_chain::local_chain::LocalChain;
 use bdk_chain::miniscript::Descriptor;
 use bdk_chain::{BlockId, ConfirmationBlockTime, IndexedTxGraph, SpkIterator};
 use bdk_testenv::anyhow;
-use bitcoin::Address;
 
 // This example shows how BDK chain and tx-graph structures are updated using compact
 // filters syncing. Assumes a connection can be made to a bitcoin node via environment
@@ -17,13 +16,13 @@ use bitcoin::Address;
 
 // Usage: `cargo run -p bdk_bitcoind_rpc --example filter_iter`
 
-const EXTERNAL: &str = "tr([7d94197e]tprv8ZgxMBicQKsPe1chHGzaa84k1inY2nAXUL8iPSyWESPrEst4E5oCFXhPATqj5fvw34LDknJz7rtXyEC4fKoXryUdc9q87pTTzfQyv61cKdE/86'/1'/0'/0/*)#uswl2jj7";
-const INTERNAL: &str = "tr([7d94197e]tprv8ZgxMBicQKsPe1chHGzaa84k1inY2nAXUL8iPSyWESPrEst4E5oCFXhPATqj5fvw34LDknJz7rtXyEC4fKoXryUdc9q87pTTzfQyv61cKdE/86'/1'/0'/1/*)#dyt7h8zx";
+const EXTERNAL: &str = "tr([83737d5e/86'/1'/0']tpubDDR5GgtoxS8fJyjjvdahN4VzV5DV6jtbcyvVXhEKq2XtpxjxBXmxH3r8QrNbQqHg4bJM1EGkxi7Pjfkgnui9jQWqS7kxHvX6rhUeriLDKxz/0/*)";
+const INTERNAL: &str = "tr([83737d5e/86'/1'/0']tpubDDR5GgtoxS8fJyjjvdahN4VzV5DV6jtbcyvVXhEKq2XtpxjxBXmxH3r8QrNbQqHg4bJM1EGkxi7Pjfkgnui9jQWqS7kxHvX6rhUeriLDKxz/1/*)";
 const SPK_COUNT: u32 = 25;
 const NETWORK: Network = Network::Signet;
 
-const START_HEIGHT: u32 = 170_000;
-const START_HASH: &str = "00000041c812a89f084f633e4cf47e819a2f6b1c0a15162355a930410522c99d";
+const START_HEIGHT: u32 = 205_000;
+const START_HASH: &str = "0000002bd0f82f8c0c0f1e19128f84c938763641dba85c44bdb6aed1678d16cb";
 
 fn main() -> anyhow::Result<()> {
     // Setup receiving chain and graph structures.
@@ -52,37 +51,22 @@ fn main() -> anyhow::Result<()> {
     let rpc_client =
         bitcoincore_rpc::Client::new(&url, bitcoincore_rpc::Auth::CookieFile(cookie.into()))?;
 
-    // Initialize block emitter
-    let cp = chain.tip();
-    let start_height = cp.height();
-    let mut emitter = FilterIter::new_with_checkpoint(&rpc_client, cp);
+    // Initialize `FilterIter`
+    let mut spks = vec![];
     for (_, desc) in graph.index.keychains() {
-        let spks = SpkIterator::new_with_range(desc, 0..SPK_COUNT).map(|(_, spk)| spk);
-        emitter.add_spks(spks);
+        spks.extend(SpkIterator::new_with_range(desc, 0..SPK_COUNT).map(|(_, s)| s));
     }
+    let iter = FilterIter::new(&rpc_client, chain.tip(), spks);
 
     let start = Instant::now();
 
-    // Sync
-    if let Some(tip) = emitter.get_tip()? {
-        let blocks_to_scan = tip.height - start_height;
-
-        for event in emitter.by_ref() {
-            let event = event?;
-            let curr = event.height();
-            // apply relevant blocks
-            if let Event::Block(EventInner { height, ref block }) = event {
-                let _ = graph.apply_block_relevant(block, height);
-                println!("Matched block {curr}");
-            }
-            if curr % 1000 == 0 {
-                let progress = (curr - start_height) as f32 / blocks_to_scan as f32;
-                println!("[{:.2}%]", progress * 100.0);
-            }
-        }
-        // update chain
-        if let Some(cp) = emitter.chain_update() {
-            let _ = chain.apply_update(cp)?;
+    for res in iter {
+        let Event { cp, block } = res?;
+        let height = cp.height();
+        let _ = chain.apply_update(cp)?;
+        if let Some(block) = block {
+            let _ = graph.apply_block_relevant(&block, height);
+            println!("Matched block {height}");
         }
     }
 
@@ -105,9 +89,18 @@ fn main() -> anyhow::Result<()> {
         }
     }
 
-    let unused_spk = graph.index.reveal_next_spk("external").unwrap().0 .1;
-    let unused_address = Address::from_script(&unused_spk, NETWORK)?;
-    println!("Next external address: {unused_address}");
+    for canon_tx in graph.graph().list_canonical_txs(
+        &chain,
+        chain.tip().block_id(),
+        bdk_chain::CanonicalizationParams::default(),
+    ) {
+        if !canon_tx.chain_position.is_confirmed() {
+            eprintln!(
+                "ERROR: canonical tx should be confirmed {}",
+                canon_tx.tx_node.txid
+            );
+        }
+    }
 
     Ok(())
 }

--- a/crates/bitcoind_rpc/src/bip158.rs
+++ b/crates/bitcoind_rpc/src/bip158.rs
@@ -13,7 +13,20 @@ use bitcoincore_rpc;
 use bitcoincore_rpc::{json::GetBlockHeaderResult, RpcApi};
 
 /// Type that returns Bitcoin blocks by matching a list of script pubkeys (SPKs) against a
-/// [`bip158::BlockFilter`].
+/// [`bip158::BlockFilter`](bitcoin::bip158::BlockFilter).
+///
+/// * `FilterIter` talks to bitcoind via JSON-RPC interface, which is handled by the
+///   [`bitcoincore_rpc::Client`].
+/// * Collect the script pubkeys (SPKs) you want to watch. These will usually correspond to wallet
+///   addresses that have been handed out for receiving payments.
+/// * Construct `FilterIter` with the RPC client, SPKs, and [`CheckPoint`]. The checkpoint tip
+///   informs `FilterIter` of the height to begin scanning from. An error is thrown if `FilterIter`
+///   is unable to find a common ancestor with the remote node.
+/// * Scan blocks by calling `next` in a loop and processing the [`Event`]s. If a filter matched any
+///   of the watched scripts, then the relevant [`Block`] is returned. Note that false positives may
+///   occur. `FilterIter` will continue to yield events until it reaches the latest chain tip.
+///   Events contain the updated checkpoint `cp` which may be incorporated into the local chain
+///   state to stay in sync with the tip.
 #[derive(Debug)]
 pub struct FilterIter<'a> {
     /// RPC client

--- a/crates/bitcoind_rpc/tests/test_filter_iter.rs
+++ b/crates/bitcoind_rpc/tests/test_filter_iter.rs
@@ -112,6 +112,16 @@ fn filter_iter_detects_reorgs() -> anyhow::Result<()> {
     assert_eq!(iter.next().unwrap()?.height(), MINE_TO);
     assert!(iter.next().is_none());
 
+    // Try 6-block-reorg
+    {
+        const REORG_COUNT: usize = 6;
+        let _ = env.reorg(REORG_COUNT)?;
+        for c in (0..REORG_COUNT).rev() {
+            assert_eq!(iter.next().unwrap()?.height(), MINE_TO - (c as u32));
+        }
+        assert!(iter.next().is_none());
+    }
+
     Ok(())
 }
 

--- a/crates/bitcoind_rpc/tests/test_filter_iter.rs
+++ b/crates/bitcoind_rpc/tests/test_filter_iter.rs
@@ -1,8 +1,7 @@
-use bitcoin::{constants, Address, Amount, Network, ScriptBuf};
-
-use bdk_bitcoind_rpc::bip158::FilterIter;
+use bdk_bitcoind_rpc::bip158::{Error, FilterIter};
 use bdk_core::{BlockId, CheckPoint};
-use bdk_testenv::{anyhow, bitcoind, block_id, TestEnv};
+use bdk_testenv::{anyhow, bitcoind, TestEnv};
+use bitcoin::{Address, Amount, Network, ScriptBuf};
 use bitcoincore_rpc::RpcApi;
 
 fn testenv() -> anyhow::Result<TestEnv> {
@@ -15,131 +14,42 @@ fn testenv() -> anyhow::Result<TestEnv> {
     })
 }
 
-// Test the result of `chain_update` given a local checkpoint.
-//
-// new blocks
-//       2--3--4--5--6--7--8--9--10--11
-//
-// case 1: base below new blocks
-// 0-
-// case 2: base overlaps with new blocks
-// 0--1--2--3--4
-// case 3: stale tip (with overlap)
-// 0--1--2--3--4--x
-// case 4: stale tip (no overlap)
-// 0--x
 #[test]
-fn get_tip_and_chain_update() -> anyhow::Result<()> {
+fn filter_iter_matches_blocks() -> anyhow::Result<()> {
     let env = testenv()?;
+    let addr = env
+        .rpc_client()
+        .get_new_address(None, None)?
+        .assume_checked();
 
-    let genesis_hash = constants::genesis_block(Network::Regtest).block_hash();
-    let genesis = BlockId {
-        height: 0,
-        hash: genesis_hash,
-    };
+    let _ = env.mine_blocks(100, Some(addr.clone()))?;
+    assert_eq!(env.rpc_client().get_block_count()?, 101);
 
-    let hash = env.rpc_client().get_best_block_hash()?;
-    let header = env.rpc_client().get_block_header_info(&hash)?;
-    assert_eq!(header.height, 1);
-    let block_1 = BlockId {
-        height: header.height as u32,
-        hash,
-    };
-
-    // `FilterIter` will try to return up to ten recent blocks
-    // so we keep them for reference
-    let new_blocks: Vec<BlockId> = (2..12)
-        .zip(env.mine_blocks(10, None)?)
-        .map(BlockId::from)
-        .collect();
-
-    let new_tip = *new_blocks.last().unwrap();
-
-    struct TestCase {
-        // name
-        name: &'static str,
-        // local blocks
-        chain: Vec<BlockId>,
-        // expected blocks
-        exp: Vec<BlockId>,
-    }
-
-    // For each test we create a new `FilterIter` with the checkpoint given
-    // by the blocks in the test chain. Then we sync to the remote tip and
-    // check the blocks that are returned in the chain update.
-    [
-        TestCase {
-            name: "point of agreement below new blocks, expect base + new",
-            chain: vec![genesis, block_1],
-            exp: [block_1].into_iter().chain(new_blocks.clone()).collect(),
-        },
-        TestCase {
-            name: "point of agreement genesis, expect base + new",
-            chain: vec![genesis],
-            exp: [genesis].into_iter().chain(new_blocks.clone()).collect(),
-        },
-        TestCase {
-            name: "point of agreement within new blocks, expect base + remaining",
-            chain: new_blocks[..=2].to_vec(),
-            exp: new_blocks[2..].to_vec(),
-        },
-        TestCase {
-            name: "stale tip within new blocks, expect base + corrected + remaining",
-            // base height: 4, stale height: 5
-            chain: vec![new_blocks[2], block_id!(5, "E")],
-            exp: new_blocks[2..].to_vec(),
-        },
-        TestCase {
-            name: "stale tip below new blocks, expect base + corrected + new",
-            chain: vec![genesis, block_id!(1, "A")],
-            exp: [genesis, block_1].into_iter().chain(new_blocks).collect(),
-        },
-    ]
-    .into_iter()
-    .for_each(|test| {
-        let cp = CheckPoint::from_block_ids(test.chain).unwrap();
-        let mut iter = FilterIter::new_with_checkpoint(env.rpc_client(), cp);
-        assert_eq!(iter.get_tip().unwrap(), Some(new_tip));
-        let update_cp = iter.chain_update().unwrap();
-        let mut update_blocks: Vec<_> = update_cp.iter().map(|cp| cp.block_id()).collect();
-        update_blocks.reverse();
-        assert_eq!(update_blocks, test.exp, "{}", test.name);
-    });
-
-    Ok(())
-}
-
-#[test]
-fn filter_iter_returns_matched_blocks() -> anyhow::Result<()> {
-    use bdk_bitcoind_rpc::bip158::{Event, EventInner};
-    let env = testenv()?;
-    let rpc = env.rpc_client();
-    while rpc.get_block_count()? < 101 {
-        let _ = env.mine_blocks(1, None)?;
-    }
-
-    // send tx
-    let spk = ScriptBuf::from_hex("0014446906a6560d8ad760db3156706e72e171f3a2aa")?;
-    let txid = env.send(
-        &Address::from_script(&spk, Network::Regtest)?,
+    // Send tx to external address to confirm at height = 102
+    let _txid = env.send(
+        &Address::from_script(
+            &ScriptBuf::from_hex("0014446906a6560d8ad760db3156706e72e171f3a2aa")?,
+            Network::Regtest,
+        )?,
         Amount::from_btc(0.42)?,
     )?;
     let _ = env.mine_blocks(1, None);
 
-    // match blocks
-    let mut iter = FilterIter::new_with_height(rpc, 1);
-    iter.add_spk(spk);
-    assert_eq!(iter.get_tip()?.unwrap().height, 102);
+    let genesis_hash = env.genesis_hash()?;
+    let cp = CheckPoint::new(BlockId {
+        height: 0,
+        hash: genesis_hash,
+    });
+
+    let iter = FilterIter::new(&env.bitcoind.client, cp, [addr.script_pubkey()]);
 
     for res in iter {
         let event = res?;
-        match event {
-            event if event.height() <= 101 => assert!(!event.is_match()),
-            Event::Block(EventInner { height, block }) => {
-                assert_eq!(height, 102);
-                assert!(block.txdata.iter().any(|tx| tx.compute_txid() == txid));
-            }
-            Event::NoMatch(_) => panic!("expected to match block 102"),
+        let height = event.height();
+        if (2..102).contains(&height) {
+            assert!(event.is_match(), "expected to match height {height}");
+        } else {
+            assert!(!event.is_match());
         }
     }
 
@@ -147,19 +57,101 @@ fn filter_iter_returns_matched_blocks() -> anyhow::Result<()> {
 }
 
 #[test]
-fn filter_iter_error_no_scripts() -> anyhow::Result<()> {
-    use bdk_bitcoind_rpc::bip158::Error;
+fn filter_iter_error_wrong_network() -> anyhow::Result<()> {
     let env = testenv()?;
-    let _ = env.mine_blocks(2, None)?;
+    let _ = env.mine_blocks(10, None)?;
 
-    let mut iter = FilterIter::new_with_height(env.rpc_client(), 1);
-    assert_eq!(iter.get_tip()?.unwrap().height, 3);
+    // Try to initialize FilterIter with a CP on the wrong network
+    let block_id = BlockId {
+        height: 0,
+        hash: bitcoin::hashes::Hash::hash(b"wrong-hash"),
+    };
+    let cp = CheckPoint::new(block_id);
+    let mut iter = FilterIter::new(&env.bitcoind.client, cp, [ScriptBuf::new()]);
+    assert!(matches!(iter.next(), Some(Err(Error::ReorgDepthExceeded))));
 
-    // iterator should return three errors
-    for _ in 0..3 {
-        assert!(matches!(iter.next().unwrap(), Err(Error::NoScripts)));
+    Ok(())
+}
+
+// Test that while a reorg is detected we delay incrementing the best height
+#[test]
+fn filter_iter_detects_reorgs() -> anyhow::Result<()> {
+    const MINE_TO: u32 = 16;
+
+    let env = testenv()?;
+    let rpc = env.rpc_client();
+    while rpc.get_block_count()? < MINE_TO as u64 {
+        let _ = env.mine_blocks(1, None)?;
     }
+
+    let genesis_hash = env.genesis_hash()?;
+    let cp = CheckPoint::new(BlockId {
+        height: 0,
+        hash: genesis_hash,
+    });
+
+    let spk = ScriptBuf::from_hex("0014446906a6560d8ad760db3156706e72e171f3a2aa")?;
+    let mut iter = FilterIter::new(&env.bitcoind.client, cp, [spk]);
+
+    // Process events to height (MINE_TO - 1)
+    loop {
+        if iter.next().unwrap()?.height() == MINE_TO - 1 {
+            break;
+        }
+    }
+
+    for _ in 0..3 {
+        // Invalidate and remine 1 block
+        let _ = env.reorg(1)?;
+
+        // Call next. If we detect a reorg, we'll see no change in the event height
+        assert_eq!(iter.next().unwrap()?.height(), MINE_TO - 1);
+    }
+
+    // If no reorg, then height should increment normally from here on
+    assert_eq!(iter.next().unwrap()?.height(), MINE_TO);
     assert!(iter.next().is_none());
+
+    Ok(())
+}
+
+#[test]
+fn event_checkpoint_connects_to_local_chain() -> anyhow::Result<()> {
+    use bitcoin::BlockHash;
+    use std::collections::BTreeMap;
+    let env = testenv()?;
+    let _ = env.mine_blocks(15, None)?;
+
+    let cp = env.make_checkpoint_tip();
+    let mut chain = bdk_chain::local_chain::LocalChain::from_tip(cp.clone())?;
+    assert_eq!(chain.tip().height(), 16);
+    let old_hashes: Vec<BlockHash> = [14, 15, 16]
+        .into_iter()
+        .map(|height| chain.get(height).unwrap().hash())
+        .collect();
+
+    // Construct iter
+    let mut iter = FilterIter::new(&env.bitcoind.client, cp, vec![ScriptBuf::new()]);
+
+    // Now reorg 3 blocks (14, 15, 16)
+    let new_hashes: BTreeMap<u32, BlockHash> = (14..=16).zip(env.reorg(3)?).collect();
+
+    // Expect events from height 14 on...
+    while let Some(event) = iter.next().transpose()? {
+        let _ = chain
+            .apply_update(event.cp)
+            .expect("chain update should connect");
+    }
+
+    for height in 14..=16 {
+        let hash = chain.get(height).unwrap().hash();
+        assert!(!old_hashes.contains(&hash), "Old hashes were reorged out");
+        assert_eq!(
+            new_hashes.get(&height),
+            Some(&hash),
+            "Chain must include new hashes"
+        );
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Previously `FilterIter` did not detect or handle reorgs between `next` calls, meaning that if a reorg occurred, we might process blocks from a stale fork potentially resulting in an invalid wallet state. This PR aims to fix that by adding logic to explicitly check for and respond to a reorg on every call to `next`.

### Notes to the reviewers

The old implementation required storing block IDs of scanned blocks before creating a checkpoint update, but because the interface was split across different methods, it introduced a timing risk between method calls which, when we consider the possibility of reorgs, made the implementation somewhat brittle.

To address this, we make sure that 1) Finding the start block and 2) Updating the internal checkpoint are directly tied to the logic of `next`. Since the checkpoint in practice is derived from a clone of the local chain, this ensures that the checkpoint returned by `next` can always find a connection point with the receiver. Additionally we now emit a checkpoint at every height to ensure that any "must-include" heights are not missing.

For example usage see `examples/filter_iter.rs`

fixes #1848 

### Changelog notice

    Fixed
    - `FilterIter` now handles reorgs to ensure consistency of the header chain.

    Changed
    - `Event` is now a struct instead of enum

    Added
    - `FilterIter::new` constructor that takes as input a reference to the RPC client, checkpoint, and a list of SPKs.
    - `Error::ReorgDepthExceeded` variant
    - `Error::TryFromInt` variant

    Removed
    - `FilterIter::new_with_height`
    - `FilterIter::new_with_checkpoint`
    - `EventInner` type
    - `FilterIter::get_tip`
    - `FilterIter::chain_update`
    - `Error::NoScripts` variant


### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [x] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
