### PR TITLE
bump(bdk_chain): rusqlite to 0.36.0

### DIFF
--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1", optional = true, features = ["derive", "rc"] }
 miniscript = { version = "12.3.1", optional = true, default-features = false }
 
 # Feature dependencies
-rusqlite = { version = "0.31.0", features = ["bundled"], optional = true }
+rusqlite = { version = "0.37.0", features = ["bundled"], optional = true }
 
 [dev-dependencies]
 rand = "0.8"

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1", optional = true, features = ["derive", "rc"] }
 miniscript = { version = "12.3.1", optional = true, default-features = false }
 
 # Feature dependencies
-rusqlite = { version = "0.37.0", features = ["bundled"], optional = true }
+rusqlite = { version = "0.36.0", features = ["bundled"], optional = true }
 
 [dev-dependencies]
 rand = "0.8"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

This PR bumps the chain crates feature dependency on rusqlite to the more recent version 0.36.0.


<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Notes to the reviewers

I submitted this PR because the "outdated" dependency breaks dependency resolution in my project.

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

See https://github.com/bitcoindevkit/bdk/pull/1766

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [X] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
