### PR TITLE
chore(release): bump bdk-chain to `0.23.1` and update `CHANGELOG`s

### DIFF
--- a/crates/bitcoind_rpc/CHANGELOG.md
+++ b/crates/bitcoind_rpc/CHANGELOG.md
@@ -7,6 +7,21 @@ Contributors do not need to change this file but do need to add changelog detail
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [bitcoind_rpc-0.21.0]
+
+### Added
+
+- Introduce usage of `cfg_attr(coverage_nightly)` in order to not consider tests under coverage. #1986
+
+### Changed
+
+- deps: bump bdk_core to 0.6.1
+
+### Fixed
+
+- Some mempool transactions not being emitted at all, it was fixed by simplifying the emitter, and replaced the avoid-re-emission-logic with a new one that emits all mempool transactions. #1988
+- Use the `getrawmempool` without verbose, as a more performant method. `Emitter::mempool` method now requires the `std` feature. A non-std version of this is added: `Emitter::mempool_at` #1988
+
 ## [bitcoind_rpc-0.20.0]
 
 ### Changed
@@ -38,3 +53,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [bitcoind_rpc-0.18.0]: https://github.com/bitcoindevkit/bdk/releases/tag/bitcoind_rpc-0.18.0
 [bitcoind_rpc-0.19.0]: https://github.com/bitcoindevkit/bdk/releases/tag/bitcoind_rpc-0.19.0
 [bitcoind_rpc-0.20.0]: https://github.com/bitcoindevkit/bdk/releases/tag/bitcoind_rpc-0.20.0
+[bitcoind_rpc-0.21.0]: https://github.com/bitcoindevkit/bdk/releases/tag/bitcoind_rpc-0.21.0

--- a/crates/bitcoind_rpc/Cargo.toml
+++ b/crates/bitcoind_rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_bitcoind_rpc"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"
@@ -18,7 +18,7 @@ workspace = true
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false }
 bitcoincore-rpc = { version = "0.19.0" }
-bdk_core = { path = "../core", version = "0.6.0", default-features = false }
+bdk_core = { path = "../core", version = "0.6.1", default-features = false }
 
 [dev-dependencies]
 bdk_bitcoind_rpc = { path = "." }

--- a/crates/chain/CHANGELOG.md
+++ b/crates/chain/CHANGELOG.md
@@ -7,6 +7,23 @@ Contributors do not need to change this file but do need to add changelog detail
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [chain-0.23.1]
+
+### Added
+
+- Add new tests covering excluded bounds and the `SpkTxOutIndex::outputs_in_range` #1897
+- Add new `reindex_tx_graph` benchmark, and unit test to cover `spk_cache` behavior #1968
+- Add new `TxGraph::get_last_evicted` method #1977
+
+### Changed
+
+- Improve API docs, fixed parameter names to match the function or struct definition, and correct some spelling mistakes. #1968
+- `KeychainTxOutIndex::apply_changeset` restores spk_cache before last revealed #1993
+- deps: bump bdk_core to 0.6.1
+
+### Fixed
+- During canonicalization, exclude coinbase transactions when considering txs that are anchored in stale blocks #1976
+
 ## [chain-0.23.0]
 
 ### Added
@@ -57,3 +74,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [chain-0.21.1]: https://github.com/bitcoindevkit/bdk/releases/tag/chain-0.21.1
 [chain-0.22.0]: https://github.com/bitcoindevkit/bdk/releases/tag/chain-0.22.0
 [chain-0.23.0]: https://github.com/bitcoindevkit/bdk/releases/tag/chain-0.23.0
+[chain-0.23.1]: https://github.com/bitcoindevkit/bdk/releases/tag/chain-0.23.1

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_chain"
-version = "0.23.0"
+version = "0.23.1"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"
@@ -17,7 +17,7 @@ workspace = true
 
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false }
-bdk_core = { path = "../core", version = "0.6.0", default-features = false }
+bdk_core = { path = "../core", version = "0.6.1", default-features = false }
 serde = { version = "1", optional = true, features = ["derive", "rc"] }
 miniscript = { version = "12.3.1", optional = true, default-features = false }
 

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [core-0.6.1]
+
+### Changed
+
+- Fix `clippy` warnings for `SpkItem` on `spk_client` #1990
+
 ## [core-0.6.0]
 
 ### Added
@@ -43,3 +49,4 @@ This is because requests now have a `start_time`, instead of specifying a `seen_
 [core-0.4.1]: https://github.com/bitcoindevkit/bdk/releases/tag/core-0.4.1
 [core-0.5.0]: https://github.com/bitcoindevkit/bdk/releases/tag/core-0.5.0
 [core-0.6.0]: https://github.com/bitcoindevkit/bdk/releases/tag/core-0.6.0
+[core-0.6.1]: https://github.com/bitcoindevkit/bdk/releases/tag/core-0.6.1

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_core"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"

--- a/crates/electrum/CHANGELOG.md
+++ b/crates/electrum/CHANGELOG.md
@@ -7,6 +7,22 @@ Contributors do not need to change this file but do need to add changelog detail
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [electrum-0.23.1]
+
+### Added
+- Introduce usage of `cfg_attr(coverage_nightly)` in order to not consider tests under coverage. #1986
+
+### Changed
+
+- Add transaction anchor cache to prevent redundant network calls. #1957
+- Batch Merkle Proof, script history, and header requests. #1957
+- Fix `clippy` warnings on electrum-client batch call #1990
+- deps: bump bdk_core to 0.6.1
+- deps: bump electrum-client to 0.24.0
+
+### Fixed
+- Removed all `unwrap()`s and `expect()`s from `bdk_electrum_client.rs` #1981
+
 ## [electrum-0.23.0]
 
 ### Changed
@@ -44,3 +60,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [electrum-0.21.0]: https://github.com/bitcoindevkit/bdk/releases/tag/electrum-0.21.0
 [electrum-0.22.0]: https://github.com/bitcoindevkit/bdk/releases/tag/electrum-0.22.0
 [electrum-0.23.0]: https://github.com/bitcoindevkit/bdk/releases/tag/electrum-0.23.0
+[electrum-0.23.1]: https://github.com/bitcoindevkit/bdk/releases/tag/electrum-0.23.1

--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_electrum"
-version = "0.23.0"
+version = "0.23.1"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -13,7 +13,7 @@ readme = "README.md"
 workspace = true
 
 [dependencies]
-bdk_core = { path = "../core", version = "0.6.0" }
+bdk_core = { path = "../core", version = "0.6.1" }
 electrum-client = { version = "0.24.0", features = [ "proxy" ], default-features = false }
 
 [dev-dependencies]

--- a/crates/esplora/CHANGELOG.md
+++ b/crates/esplora/CHANGELOG.md
@@ -7,6 +7,18 @@ Contributors do not need to change this file but do need to add changelog detail
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [esplora-0.22.1]
+
+### Added
+- Introduce usage of `cfg_attr(coverage_nightly)` in order to not consider tests under coverage. #1986
+
+### Changed
+- deps: bump `esplora-client` to 0.12.1
+- deps: bump `bdk_core` to 0.6.1
+
+### Fixed
+- Esplora `chain_update` returns early with `esplora_client::Error::HeaderHashNotFound` if no point of agreement is found in the local checkpoint #1971
+
 ## [esplora-0.22.0]
 
 ### Changed
@@ -32,3 +44,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [esplora-0.20.1]: https://github.com/bitcoindevkit/bdk/releases/tag/esplora-0.20.1
 [esplora-0.21.0]: https://github.com/bitcoindevkit/bdk/releases/tag/esplora-0.21.0
 [esplora-0.22.0]: https://github.com/bitcoindevkit/bdk/releases/tag/esplora-0.22.0
+[esplora-0.22.1]: https://github.com/bitcoindevkit/bdk/releases/tag/esplora-0.22.1

--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_esplora"
-version = "0.22.0"
+version = "0.22.1"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -15,8 +15,8 @@ readme = "README.md"
 workspace = true
 
 [dependencies]
-bdk_core = { path = "../core", version = "0.6.0", default-features = false }
-esplora-client = { version = "0.12.0", default-features = false }
+bdk_core = { path = "../core", version = "0.6.1", default-features = false }
+esplora-client = { version = "0.12.1", default-features = false }
 async-trait = { version = "0.1.66", optional = true }
 futures = { version = "0.3.26", optional = true }
 

--- a/crates/file_store/CHANGELOG.md
+++ b/crates/file_store/CHANGELOG.md
@@ -7,6 +7,17 @@ Contributors do not need to change this file but do need to add changelog detail
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [file_store-0.21.1]
+
+### Added
+
+- Introduce usage of `cfg_attr(coverage_nightly)` in order to not consider tests under coverage. #1986
+
+### Changed
+
+- Fix `clippy` formatting warnings for `StoreError` and test assertions #1990
+- Bump `bdk_core` to `0.6.1`
+
 ## [file_store-0.21.0]
 
 ### Changed
@@ -49,3 +60,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [file_store-0.19.0]: https://github.com/bitcoindevkit/bdk/releases/tag/file_store-0.19.0
 [file_store-0.20.0]: https://github.com/bitcoindevkit/bdk/releases/tag/file_store-0.20.0
 [file_store-0.21.0]: https://github.com/bitcoindevkit/bdk/releases/tag/file_store-0.21.0
+[file_store-0.21.1]: https://github.com/bitcoindevkit/bdk/releases/tag/file_store-0.21.1

--- a/crates/file_store/Cargo.toml
+++ b/crates/file_store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_file_store"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -14,7 +14,7 @@ readme = "README.md"
 workspace = true
 
 [dependencies]
-bdk_core = { path = "../core", version = "0.6.0", features = ["serde"]}
+bdk_core = { path = "../core", version = "0.6.1", features = ["serde"]}
 bincode = { version = "1" }
 serde = { version = "1", features = ["derive"] }
 

--- a/crates/testenv/CHANGELOG.md
+++ b/crates/testenv/CHANGELOG.md
@@ -7,6 +7,13 @@ Contributors do not need to change this file but do need to add changelog detail
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [testenv-0.13.1]
+
+### Changed
+
+- Introduce usage of `cfg_attr(coverage_nightly)` in order to not consider tests under coverage. #1986
+- deps: bump `bdk_chain` to 0.23.1
+
 ## [testenv-0.13.0]
 
 ### Changed
@@ -28,3 +35,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [testenv-0.11.1]: https://github.com/bitcoindevkit/bdk/releases/tag/testenv-0.11.1
 [testenv-0.12.0]: https://github.com/bitcoindevkit/bdk/releases/tag/testenv-0.12.0
 [testenv-0.13.0]: https://github.com/bitcoindevkit/bdk/releases/tag/testenv-0.13.0
+[testenv-0.13.1]: https://github.com/bitcoindevkit/bdk/releases/tag/testenv-0.13.1

--- a/crates/testenv/Cargo.toml
+++ b/crates/testenv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_testenv"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"
@@ -16,7 +16,7 @@ readme = "README.md"
 workspace = true
 
 [dependencies]
-bdk_chain = { path = "../chain", version = "0.23.0", default-features = false }
+bdk_chain = { path = "../chain", version = "0.23.1", default-features = false }
 electrsd = { version = "0.28.0", features = [ "legacy" ], default-features = false }
 
 [dev-dependencies]


### PR DESCRIPTION
fixes #2003 

### Description

It updates the crates CHANGELOGs, and bumps its newer versions.

### Notes to the reviewers

Let me know if you think I missed anything on the CHANGELOG's or the bumped versions are off.

### Changelog notice

- bump `bdk-chain` to `0.23.1 and other crates too.
- update all required CHANGELOGs

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

