### PR TITLE
Add populate_anchor_cache method to bdk

### DIFF
--- a/examples/example_electrum/src/main.rs
+++ b/examples/example_electrum/src/main.rs
@@ -126,16 +126,13 @@ fn main() -> anyhow::Result<()> {
 
     let client = BdkElectrumClient::new(electrum_cmd.electrum_args().client(network)?);
 
-    // Tell the electrum client about the txs we've already got locally so it doesn't re-download
-    // them
-    client.populate_tx_cache(
-        graph
-            .lock()
-            .unwrap()
-            .graph()
-            .full_txs()
-            .map(|tx_node| tx_node.tx),
-    );
+    // Tell the electrum client about the txs and anchors we've already got locally so it doesn't
+    // re-download .them
+    {
+        let graph = graph.lock().unwrap();
+        client.populate_tx_cache(graph.graph().full_txs().map(|tx_node| tx_node.tx));
+        client.populate_anchor_cache(graph.graph().all_anchors().clone());
+    }
 
     let (chain_update, tx_update, keychain_update) = match electrum_cmd.clone() {
         ElectrumCommands::Scan {


### PR DESCRIPTION
This PR addresses #1982
It introduces functionality to populate the anchor cache, improving how BDK handles stateful or performance-critical anchor data.

### Changes
- Add `populate_anchor_cache` method to `BdkElectrumClient `in `bdk-core`
- Improves sync speed by caching anchor transactions in advance
- Enables pre-caching of anchor transactions to reduce redundant network calls

Follow-up work will extend this functionality to `bdk-wallet`.