### PR TITLE
docs(chain): add doctest for min confirmation balance filtering

### DIFF
--- a/crates/core/src/checkpoint.rs
+++ b/crates/core/src/checkpoint.rs
@@ -192,6 +192,30 @@ impl CheckPoint {
             })
     }
 
+    /// Returns the checkpoint at `height` if one exists, otherwise the nearest checkpoint at a
+    /// lower height.
+    ///
+    /// This is equivalent to taking the "floor" of `height` over this checkpoint chain.
+    ///
+    /// Returns `None` if no checkpoint exists at or below the given height.
+    pub fn floor_at(&self, height: u32) -> Option<Self> {
+        self.range(..=height).next()
+    }
+
+    /// Returns the checkpoint located a number of heights below this one.
+    ///
+    /// This is a convenience wrapper for [`CheckPoint::floor_at`], subtracting `to_subtract` from
+    /// the current height.
+    ///
+    /// - If a checkpoint exists exactly `offset` heights below, it is returned.
+    /// - Otherwise, the nearest checkpoint *below that target height* is returned.
+    ///
+    /// Returns `None` if `to_subtract` is greater than the current height, or if there is no
+    /// checkpoint at or below the target height.
+    pub fn floor_below(&self, offset: u32) -> Option<Self> {
+        self.floor_at(self.height().checked_sub(offset)?)
+    }
+
     /// Inserts `block_id` at its height within the chain.
     ///
     /// The effect of `insert` depends on whether a height already exists. If it doesn't the


### PR DESCRIPTION
Implements #1942.

### Description

This PR adds a new doctest demonstrating how to simulate a minimum confirmation threshold for confirmed balance calculations by adjusting the `chain_tip` height passed to `TxGraph::balance`.

### Changelog notice

- Added a doctest illustrating how to filter confirmed balance results by simulating a minimum confirmation threshold via `chain_tip` height.

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
