### PR TITLE
`IndexedTxGraph`: Transactions that conflict with relevant txs are also relevant.

### DIFF
--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -27,7 +27,7 @@ rusqlite = { version = "0.31.0", features = ["bundled"], optional = true }
 [dev-dependencies]
 rand = "0.8"
 proptest = "1.2.0"
-bdk_testenv = { path = "../testenv", default-features = false }
+bdk_testenv = { path = "../testenv" }
 criterion = { version = "0.2" }
 
 [features]

--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -133,7 +133,7 @@ fn relevant_conflicts() -> anyhow::Result<()> {
             Ok(())
         }
 
-        /// Broadcast the original sending transcation.
+        /// Broadcast the original sending transaction.
         fn broadcast_send(&self) -> anyhow::Result<Txid> {
             let client = self.env.rpc_client();
             Ok(client.send_raw_transaction(&self.tx_send)?)


### PR DESCRIPTION
## Description

This PR changes the behavior of `IndexedTxGraph` insert-if-relevant methods to consider relevant-tx-conflicts as relevant.

Affected methods:
* `.apply_block_relevant`
* `.batch_insert_relevant`
* `.batch_insert_relevant_unconfirmed`

#### Rationale

It is useful to be able to determine:

* Why something is no longer part of the best history.
* Whether it is possible that something can reappear in the best history.

In order to do this, we need to track conflicts of spk-relevant transactions. 

For example, an incoming transaction may be evicted from the mempool due to insufficient fees or cancelled (a conflicting transaction is confirmed). The caller may want to handle these two possibilities differently:

* **Transaction has insufficient fees** - the caller may want to CPFP the transaction.
* **Transaction is cancelled/replaced** - The user may want to forget about this transaction once the conflict reaches x confirmations.

The `IntentTracker` will make use of these relevant-conflicts to help determine the course of action.

#### Side note about chain sources

For some chain sources, obtaining relevant-conflicts is extremely costly or downright impossible (i.e. Electrum, BIP-158 filters).

`bdk_bitcoind_rpc::Emitter` is still the most robust chain source to use.

### Changelog notice

```md
Changed:
- Behavior of `IndexedTxGraph` methods (`apply_block_relevant`, `batch_insert_relevant` and `batch_insert_relevant_unconfirmed`) to also consider conflicts of spk-relevant transactions as relevant.
```

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
