### PR TITLE
Add functions to test persistence

### DIFF
--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -29,6 +29,8 @@ rand = "0.8"
 proptest = "1.2.0"
 bdk_testenv = { path = "../testenv" }
 criterion = { version = "0.7" }
+tempfile = "3"
+anyhow = "1.0.102"
 
 [features]
 default = ["std", "miniscript"]

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -30,7 +30,7 @@ proptest = "1.2.0"
 bdk_testenv = { path = "../testenv" }
 criterion = { version = "0.7" }
 tempfile = "3"
-anyhow = "1.0.102"
+anyhow = "1"
 
 [features]
 default = ["std", "miniscript"]

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -27,7 +27,7 @@ rusqlite = { version = "0.31.0", features = ["bundled"], optional = true }
 [dev-dependencies]
 rand = "0.8"
 proptest = "1.2.0"
-bdk_testenv = { path = "../testenv" }
+bdk_testenv = { path = "../testenv" } # `miniscript` is active by default
 criterion = { version = "0.7" }
 tempfile = "3"
 anyhow = "1"

--- a/crates/chain/tests/test_rusqlite_impl.rs
+++ b/crates/chain/tests/test_rusqlite_impl.rs
@@ -1,0 +1,109 @@
+#![cfg(feature = "rusqlite")]
+use bdk_chain::{keychain_txout, local_chain, tx_graph, ConfirmationBlockTime};
+use bdk_testenv::persist_test_utils::{
+    persist_indexer_changeset, persist_local_chain_changeset, persist_txgraph_changeset,
+};
+
+fn tx_graph_changeset_init(
+    db: &mut rusqlite::Connection,
+) -> rusqlite::Result<tx_graph::ChangeSet<ConfirmationBlockTime>> {
+    let db_tx = db.transaction()?;
+    tx_graph::ChangeSet::<ConfirmationBlockTime>::init_sqlite_tables(&db_tx)?;
+    let changeset = tx_graph::ChangeSet::<ConfirmationBlockTime>::from_sqlite(&db_tx)?;
+    db_tx.commit()?;
+    Ok(changeset)
+}
+
+fn tx_graph_changeset_persist(
+    db: &mut rusqlite::Connection,
+    changeset: &tx_graph::ChangeSet<ConfirmationBlockTime>,
+) -> rusqlite::Result<()> {
+    let db_tx = db.transaction()?;
+    changeset.persist_to_sqlite(&db_tx)?;
+    db_tx.commit()
+}
+
+fn keychain_txout_changeset_init(
+    db: &mut rusqlite::Connection,
+) -> rusqlite::Result<keychain_txout::ChangeSet> {
+    let db_tx = db.transaction()?;
+    keychain_txout::ChangeSet::init_sqlite_tables(&db_tx)?;
+    let changeset = keychain_txout::ChangeSet::from_sqlite(&db_tx)?;
+    db_tx.commit()?;
+    Ok(changeset)
+}
+
+fn keychain_txout_changeset_persist(
+    db: &mut rusqlite::Connection,
+    changeset: &keychain_txout::ChangeSet,
+) -> rusqlite::Result<()> {
+    let db_tx = db.transaction()?;
+    changeset.persist_to_sqlite(&db_tx)?;
+    db_tx.commit()
+}
+
+fn local_chain_changeset_init(
+    db: &mut rusqlite::Connection,
+) -> rusqlite::Result<local_chain::ChangeSet> {
+    let db_tx = db.transaction()?;
+    local_chain::ChangeSet::init_sqlite_tables(&db_tx)?;
+    let changeset = local_chain::ChangeSet::from_sqlite(&db_tx)?;
+    db_tx.commit()?;
+    Ok(changeset)
+}
+
+fn local_chain_changeset_persist(
+    db: &mut rusqlite::Connection,
+    changeset: &local_chain::ChangeSet,
+) -> rusqlite::Result<()> {
+    let db_tx = db.transaction()?;
+    changeset.persist_to_sqlite(&db_tx)?;
+    db_tx.commit()
+}
+
+#[test]
+fn txgraph_is_persisted() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir().unwrap();
+    Ok(persist_txgraph_changeset::<rusqlite::Connection, _, _, _>(
+        || {
+            Ok(rusqlite::Connection::open(
+                temp_dir.path().join("wallet.sqlite"),
+            )?)
+        },
+        |db| Ok(tx_graph_changeset_init(db)?),
+        |db, changeset| Ok(tx_graph_changeset_persist(db, changeset)?),
+    )?)
+}
+
+#[test]
+fn indexer_is_persisted() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir().unwrap();
+    Ok(persist_indexer_changeset::<rusqlite::Connection, _, _, _>(
+        || {
+            Ok(rusqlite::Connection::open(
+                temp_dir.path().join("wallet.sqlite"),
+            )?)
+        },
+        |db| Ok(keychain_txout_changeset_init(db)?),
+        |db, changeset| Ok(keychain_txout_changeset_persist(db, changeset)?),
+    )?)
+}
+
+#[test]
+fn local_chain_is_persisted() -> anyhow::Result<()> {
+    let temp_dir = tempfile::tempdir().unwrap();
+    Ok(persist_local_chain_changeset::<
+        rusqlite::Connection,
+        _,
+        _,
+        _,
+    >(
+        || {
+            Ok(rusqlite::Connection::open(
+                temp_dir.path().join("wallet.sqlite"),
+            )?)
+        },
+        |db| Ok(local_chain_changeset_init(db)?),
+        |db, changeset| Ok(local_chain_changeset_persist(db, changeset)?),
+    )?)
+}

--- a/crates/chain/tests/test_rusqlite_impl.rs
+++ b/crates/chain/tests/test_rusqlite_impl.rs
@@ -1,109 +1,87 @@
 #![cfg(feature = "rusqlite")]
 use bdk_chain::{keychain_txout, local_chain, tx_graph, ConfirmationBlockTime};
 use bdk_testenv::persist_test_utils::{
-    persist_indexer_changeset, persist_local_chain_changeset, persist_txgraph_changeset,
+    assert_persist_changesets, keychain_txout_changesets, local_chain_changesets,
+    tx_graph_changesets,
 };
-
-fn tx_graph_changeset_init(
-    db: &mut rusqlite::Connection,
-) -> rusqlite::Result<tx_graph::ChangeSet<ConfirmationBlockTime>> {
-    let db_tx = db.transaction()?;
-    tx_graph::ChangeSet::<ConfirmationBlockTime>::init_sqlite_tables(&db_tx)?;
-    let changeset = tx_graph::ChangeSet::<ConfirmationBlockTime>::from_sqlite(&db_tx)?;
-    db_tx.commit()?;
-    Ok(changeset)
-}
-
-fn tx_graph_changeset_persist(
-    db: &mut rusqlite::Connection,
-    changeset: &tx_graph::ChangeSet<ConfirmationBlockTime>,
-) -> rusqlite::Result<()> {
-    let db_tx = db.transaction()?;
-    changeset.persist_to_sqlite(&db_tx)?;
-    db_tx.commit()
-}
-
-fn keychain_txout_changeset_init(
-    db: &mut rusqlite::Connection,
-) -> rusqlite::Result<keychain_txout::ChangeSet> {
-    let db_tx = db.transaction()?;
-    keychain_txout::ChangeSet::init_sqlite_tables(&db_tx)?;
-    let changeset = keychain_txout::ChangeSet::from_sqlite(&db_tx)?;
-    db_tx.commit()?;
-    Ok(changeset)
-}
-
-fn keychain_txout_changeset_persist(
-    db: &mut rusqlite::Connection,
-    changeset: &keychain_txout::ChangeSet,
-) -> rusqlite::Result<()> {
-    let db_tx = db.transaction()?;
-    changeset.persist_to_sqlite(&db_tx)?;
-    db_tx.commit()
-}
-
-fn local_chain_changeset_init(
-    db: &mut rusqlite::Connection,
-) -> rusqlite::Result<local_chain::ChangeSet> {
-    let db_tx = db.transaction()?;
-    local_chain::ChangeSet::init_sqlite_tables(&db_tx)?;
-    let changeset = local_chain::ChangeSet::from_sqlite(&db_tx)?;
-    db_tx.commit()?;
-    Ok(changeset)
-}
-
-fn local_chain_changeset_persist(
-    db: &mut rusqlite::Connection,
-    changeset: &local_chain::ChangeSet,
-) -> rusqlite::Result<()> {
-    let db_tx = db.transaction()?;
-    changeset.persist_to_sqlite(&db_tx)?;
-    db_tx.commit()
-}
 
 #[test]
 fn txgraph_is_persisted() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir().unwrap();
-    Ok(persist_txgraph_changeset::<rusqlite::Connection, _, _, _>(
+    let changesets = tx_graph_changesets();
+    Ok(assert_persist_changesets(
         || {
             Ok(rusqlite::Connection::open(
                 temp_dir.path().join("wallet.sqlite"),
             )?)
         },
-        |db| Ok(tx_graph_changeset_init(db)?),
-        |db, changeset| Ok(tx_graph_changeset_persist(db, changeset)?),
+        |db| {
+            let db_tx = db.transaction()?;
+            tx_graph::ChangeSet::<ConfirmationBlockTime>::init_sqlite_tables(&db_tx)?;
+            let changeset = tx_graph::ChangeSet::<ConfirmationBlockTime>::from_sqlite(&db_tx)?;
+            db_tx.commit()?;
+            Ok(changeset)
+        },
+        |db, changeset| {
+            let db_tx = db.transaction()?;
+            changeset.persist_to_sqlite(&db_tx)?;
+            db_tx.commit()?;
+            Ok(())
+        },
+        &changesets,
     )?)
 }
 
 #[test]
 fn indexer_is_persisted() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir().unwrap();
-    Ok(persist_indexer_changeset::<rusqlite::Connection, _, _, _>(
+    let changesets = keychain_txout_changesets();
+    Ok(assert_persist_changesets(
         || {
             Ok(rusqlite::Connection::open(
                 temp_dir.path().join("wallet.sqlite"),
             )?)
         },
-        |db| Ok(keychain_txout_changeset_init(db)?),
-        |db, changeset| Ok(keychain_txout_changeset_persist(db, changeset)?),
+        |db| {
+            let db_tx = db.transaction()?;
+            keychain_txout::ChangeSet::init_sqlite_tables(&db_tx)?;
+            let changeset = keychain_txout::ChangeSet::from_sqlite(&db_tx)?;
+            db_tx.commit()?;
+            Ok(changeset)
+        },
+        |db, changeset| {
+            let db_tx = db.transaction()?;
+            changeset.persist_to_sqlite(&db_tx)?;
+            db_tx.commit()?;
+            Ok(())
+        },
+        &changesets,
     )?)
 }
 
 #[test]
 fn local_chain_is_persisted() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir().unwrap();
-    Ok(persist_local_chain_changeset::<
-        rusqlite::Connection,
-        _,
-        _,
-        _,
-    >(
+    let changesets = local_chain_changesets();
+    Ok(assert_persist_changesets(
         || {
             Ok(rusqlite::Connection::open(
                 temp_dir.path().join("wallet.sqlite"),
             )?)
         },
-        |db| Ok(local_chain_changeset_init(db)?),
-        |db, changeset| Ok(local_chain_changeset_persist(db, changeset)?),
+        |db| {
+            let db_tx = db.transaction()?;
+            local_chain::ChangeSet::init_sqlite_tables(&db_tx)?;
+            let changeset = local_chain::ChangeSet::from_sqlite(&db_tx)?;
+            db_tx.commit()?;
+            Ok(changeset)
+        },
+        |db, changeset| {
+            let db_tx = db.transaction()?;
+            changeset.persist_to_sqlite(&db_tx)?;
+            db_tx.commit()?;
+            Ok(())
+        },
+        &changesets,
     )?)
 }

--- a/crates/chain/tests/test_rusqlite_impl.rs
+++ b/crates/chain/tests/test_rusqlite_impl.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "rusqlite")]
+use anyhow::anyhow;
 use bdk_chain::{keychain_txout, local_chain, tx_graph, ConfirmationBlockTime};
 use bdk_testenv::persist_test_utils::{
     assert_persist_changesets, keychain_txout_changesets, local_chain_changesets,
@@ -9,17 +10,17 @@ use bdk_testenv::persist_test_utils::{
 fn txgraph_is_persisted() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir().unwrap();
     let changesets = tx_graph_changesets();
-    Ok(assert_persist_changesets(
+    assert_persist_changesets(
         || {
-            Ok(rusqlite::Connection::open(
-                temp_dir.path().join("wallet.sqlite"),
-            )?)
+            let mut db = rusqlite::Connection::open(temp_dir.path().join("wallet.sqlite"))?;
+            let db_tx = db.transaction()?;
+            tx_graph::ChangeSet::<ConfirmationBlockTime>::init_sqlite_tables(&db_tx)?;
+            db_tx.commit()?;
+            Ok(db)
         },
         |db| {
             let db_tx = db.transaction()?;
-            tx_graph::ChangeSet::<ConfirmationBlockTime>::init_sqlite_tables(&db_tx)?;
             let changeset = tx_graph::ChangeSet::<ConfirmationBlockTime>::from_sqlite(&db_tx)?;
-            db_tx.commit()?;
             Ok(changeset)
         },
         |db, changeset| {
@@ -29,24 +30,25 @@ fn txgraph_is_persisted() -> anyhow::Result<()> {
             Ok(())
         },
         &changesets,
-    )?)
+    )
+    .map_err(|err| anyhow!(err))
 }
 
 #[test]
 fn indexer_is_persisted() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir().unwrap();
     let changesets = keychain_txout_changesets();
-    Ok(assert_persist_changesets(
+    assert_persist_changesets(
         || {
-            Ok(rusqlite::Connection::open(
-                temp_dir.path().join("wallet.sqlite"),
-            )?)
+            let mut db = rusqlite::Connection::open(temp_dir.path().join("wallet.sqlite"))?;
+            let db_tx = db.transaction()?;
+            keychain_txout::ChangeSet::init_sqlite_tables(&db_tx)?;
+            db_tx.commit()?;
+            Ok(db)
         },
         |db| {
             let db_tx = db.transaction()?;
-            keychain_txout::ChangeSet::init_sqlite_tables(&db_tx)?;
             let changeset = keychain_txout::ChangeSet::from_sqlite(&db_tx)?;
-            db_tx.commit()?;
             Ok(changeset)
         },
         |db, changeset| {
@@ -56,24 +58,25 @@ fn indexer_is_persisted() -> anyhow::Result<()> {
             Ok(())
         },
         &changesets,
-    )?)
+    )
+    .map_err(|err| anyhow!(err))
 }
 
 #[test]
 fn local_chain_is_persisted() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir().unwrap();
     let changesets = local_chain_changesets();
-    Ok(assert_persist_changesets(
+    assert_persist_changesets(
         || {
-            Ok(rusqlite::Connection::open(
-                temp_dir.path().join("wallet.sqlite"),
-            )?)
+            let mut db = rusqlite::Connection::open(temp_dir.path().join("wallet.sqlite"))?;
+            let db_tx = db.transaction()?;
+            local_chain::ChangeSet::init_sqlite_tables(&db_tx)?;
+            db_tx.commit()?;
+            Ok(db)
         },
         |db| {
             let db_tx = db.transaction()?;
-            local_chain::ChangeSet::init_sqlite_tables(&db_tx)?;
             let changeset = local_chain::ChangeSet::from_sqlite(&db_tx)?;
-            db_tx.commit()?;
             Ok(changeset)
         },
         |db, changeset| {
@@ -83,5 +86,6 @@ fn local_chain_is_persisted() -> anyhow::Result<()> {
             Ok(())
         },
         &changesets,
-    )?)
+    )
+    .map_err(|err| anyhow!(err))
 }

--- a/crates/chain/tests/test_rusqlite_impl.rs
+++ b/crates/chain/tests/test_rusqlite_impl.rs
@@ -1,10 +1,7 @@
 #![cfg(feature = "rusqlite")]
 use anyhow::anyhow;
 use bdk_chain::{keychain_txout, local_chain, tx_graph, ConfirmationBlockTime};
-use bdk_testenv::persist_test_utils::{
-    assert_persist_changesets, keychain_txout_changesets, local_chain_changesets,
-    tx_graph_changesets,
-};
+use bdk_testenv::persist_test_utils::*;
 
 #[test]
 fn txgraph_is_persisted() -> anyhow::Result<()> {
@@ -35,6 +32,7 @@ fn txgraph_is_persisted() -> anyhow::Result<()> {
 }
 
 #[test]
+#[cfg(feature = "miniscript")]
 fn indexer_is_persisted() -> anyhow::Result<()> {
     let temp_dir = tempfile::tempdir().unwrap();
     let changesets = keychain_txout_changesets();

--- a/crates/file_store/Cargo.toml
+++ b/crates/file_store/Cargo.toml
@@ -21,6 +21,6 @@ serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
 tempfile = "3"
-anyhow = { version = "1.0.102", default-features = false}
+anyhow = { version = "1", default-features = false}
 bdk_testenv = {path = "../testenv"}
 bdk_chain = { path = "../chain", version = "0.23.1", default-features = false, features = ["serde"]}

--- a/crates/file_store/Cargo.toml
+++ b/crates/file_store/Cargo.toml
@@ -21,3 +21,6 @@ serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
 tempfile = "3"
+anyhow = { version = "1.0.102", default-features = false}
+bdk_testenv = {path = "../testenv"}
+bdk_chain = { path = "../chain", version = "0.23.1", default-features = false, features = ["serde"]}

--- a/crates/file_store/Cargo.toml
+++ b/crates/file_store/Cargo.toml
@@ -22,5 +22,4 @@ serde = { version = "1", features = ["derive"] }
 [dev-dependencies]
 tempfile = "3"
 anyhow = { version = "1", default-features = false}
-bdk_testenv = {path = "../testenv"}
-bdk_chain = { path = "../chain", version = "0.23.1", default-features = false, features = ["serde"]}
+bdk_testenv = { path = "../testenv", features = ["serde"] } # `miniscript` is active by default.

--- a/crates/file_store/src/store.rs
+++ b/crates/file_store/src/store.rs
@@ -295,9 +295,9 @@ mod test {
     const TEST_MAGIC_BYTES: [u8; TEST_MAGIC_BYTES_LEN] =
         [98, 100, 107, 102, 115, 49, 49, 49, 49, 49, 49, 49];
 
-    use bdk_chain::{keychain_txout, local_chain, tx_graph, ConfirmationBlockTime};
     use bdk_testenv::persist_test_utils::{
-        persist_indexer_changeset, persist_local_chain_changeset, persist_txgraph_changeset,
+        assert_persist_changesets, keychain_txout_changesets, local_chain_changesets,
+        tx_graph_changesets,
     };
 
     type TestChangeSet = BTreeSet<String>;
@@ -608,12 +608,8 @@ mod test {
     #[test]
     fn txgraph_is_persisted() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir().unwrap();
-        Ok(persist_txgraph_changeset::<
-            Store<tx_graph::ChangeSet<ConfirmationBlockTime>>,
-            _,
-            _,
-            _,
-        >(
+        let changesets = tx_graph_changesets();
+        Ok(assert_persist_changesets(
             || {
                 Ok(Store::create(
                     &TEST_MAGIC_BYTES,
@@ -622,18 +618,15 @@ mod test {
             },
             |db| Ok(db.dump().map(Option::unwrap_or_default)?),
             |db, changeset| Ok(db.append(changeset)?),
+            &changesets,
         )?)
     }
 
     #[test]
     fn indexer_is_persisted() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir().unwrap();
-        Ok(persist_indexer_changeset::<
-            Store<keychain_txout::ChangeSet>,
-            _,
-            _,
-            _,
-        >(
+        let changesets = keychain_txout_changesets();
+        Ok(assert_persist_changesets(
             || {
                 Ok(Store::create(
                     &TEST_MAGIC_BYTES,
@@ -642,18 +635,15 @@ mod test {
             },
             |db| Ok(db.dump().map(Option::unwrap_or_default)?),
             |db, changeset| Ok(db.append(changeset)?),
+            &changesets,
         )?)
     }
 
     #[test]
     fn local_chain_is_persisted() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir().unwrap();
-        Ok(persist_local_chain_changeset::<
-            Store<local_chain::ChangeSet>,
-            _,
-            _,
-            _,
-        >(
+        let changesets = local_chain_changesets();
+        Ok(assert_persist_changesets(
             || {
                 Ok(Store::create(
                     &TEST_MAGIC_BYTES,
@@ -662,6 +652,7 @@ mod test {
             },
             |db| Ok(db.dump().map(Option::unwrap_or_default)?),
             |db, changeset| Ok(db.append(changeset)?),
+            &changesets,
         )?)
     }
 }

--- a/crates/file_store/src/store.rs
+++ b/crates/file_store/src/store.rs
@@ -291,6 +291,8 @@ mod test {
         io::{Seek, Write},
     };
 
+    use anyhow::anyhow;
+
     const TEST_MAGIC_BYTES_LEN: usize = 12;
     const TEST_MAGIC_BYTES: [u8; TEST_MAGIC_BYTES_LEN] =
         [98, 100, 107, 102, 115, 49, 49, 49, 49, 49, 49, 49];
@@ -609,50 +611,38 @@ mod test {
     fn txgraph_is_persisted() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir().unwrap();
         let changesets = tx_graph_changesets();
-        Ok(assert_persist_changesets(
-            || {
-                Ok(Store::create(
-                    &TEST_MAGIC_BYTES,
-                    temp_dir.path().join("store.db"),
-                )?)
-            },
+        assert_persist_changesets(
+            || Ok(Store::load_or_create(&TEST_MAGIC_BYTES, temp_dir.path().join("store.db"))?.0),
             |db| Ok(db.dump().map(Option::unwrap_or_default)?),
             |db, changeset| Ok(db.append(changeset)?),
             &changesets,
-        )?)
+        )
+        .map_err(|err| anyhow!(err))
     }
 
     #[test]
     fn indexer_is_persisted() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir().unwrap();
         let changesets = keychain_txout_changesets();
-        Ok(assert_persist_changesets(
-            || {
-                Ok(Store::create(
-                    &TEST_MAGIC_BYTES,
-                    temp_dir.path().join("store.db"),
-                )?)
-            },
+        assert_persist_changesets(
+            || Ok(Store::load_or_create(&TEST_MAGIC_BYTES, temp_dir.path().join("store.db"))?.0),
             |db| Ok(db.dump().map(Option::unwrap_or_default)?),
             |db, changeset| Ok(db.append(changeset)?),
             &changesets,
-        )?)
+        )
+        .map_err(|err| anyhow!(err))
     }
 
     #[test]
     fn local_chain_is_persisted() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir().unwrap();
         let changesets = local_chain_changesets();
-        Ok(assert_persist_changesets(
-            || {
-                Ok(Store::create(
-                    &TEST_MAGIC_BYTES,
-                    temp_dir.path().join("store.db"),
-                )?)
-            },
+        assert_persist_changesets(
+            || Ok(Store::load_or_create(&TEST_MAGIC_BYTES, temp_dir.path().join("store.db"))?.0),
             |db| Ok(db.dump().map(Option::unwrap_or_default)?),
             |db, changeset| Ok(db.append(changeset)?),
             &changesets,
-        )?)
+        )
+        .map_err(|err| anyhow!(err))
     }
 }

--- a/crates/file_store/src/store.rs
+++ b/crates/file_store/src/store.rs
@@ -295,6 +295,11 @@ mod test {
     const TEST_MAGIC_BYTES: [u8; TEST_MAGIC_BYTES_LEN] =
         [98, 100, 107, 102, 115, 49, 49, 49, 49, 49, 49, 49];
 
+    use bdk_chain::{keychain_txout, local_chain, tx_graph, ConfirmationBlockTime};
+    use bdk_testenv::persist_test_utils::{
+        persist_indexer_changeset, persist_local_chain_changeset, persist_txgraph_changeset,
+    };
+
     type TestChangeSet = BTreeSet<String>;
 
     /// Check behavior of [`Store::create`] and [`Store::load`].
@@ -598,5 +603,65 @@ mod test {
 
         // current position matches EOF
         assert_eq!(current_pointer, expected_pointer);
+    }
+
+    #[test]
+    fn txgraph_is_persisted() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir().unwrap();
+        Ok(persist_txgraph_changeset::<
+            Store<tx_graph::ChangeSet<ConfirmationBlockTime>>,
+            _,
+            _,
+            _,
+        >(
+            || {
+                Ok(Store::create(
+                    &TEST_MAGIC_BYTES,
+                    temp_dir.path().join("store.db"),
+                )?)
+            },
+            |db| Ok(db.dump().map(Option::unwrap_or_default)?),
+            |db, changeset| Ok(db.append(changeset)?),
+        )?)
+    }
+
+    #[test]
+    fn indexer_is_persisted() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir().unwrap();
+        Ok(persist_indexer_changeset::<
+            Store<keychain_txout::ChangeSet>,
+            _,
+            _,
+            _,
+        >(
+            || {
+                Ok(Store::create(
+                    &TEST_MAGIC_BYTES,
+                    temp_dir.path().join("store.db"),
+                )?)
+            },
+            |db| Ok(db.dump().map(Option::unwrap_or_default)?),
+            |db, changeset| Ok(db.append(changeset)?),
+        )?)
+    }
+
+    #[test]
+    fn local_chain_is_persisted() -> anyhow::Result<()> {
+        let temp_dir = tempfile::tempdir().unwrap();
+        Ok(persist_local_chain_changeset::<
+            Store<local_chain::ChangeSet>,
+            _,
+            _,
+            _,
+        >(
+            || {
+                Ok(Store::create(
+                    &TEST_MAGIC_BYTES,
+                    temp_dir.path().join("store.db"),
+                )?)
+            },
+            |db| Ok(db.dump().map(Option::unwrap_or_default)?),
+            |db, changeset| Ok(db.append(changeset)?),
+        )?)
     }
 }

--- a/crates/file_store/src/store.rs
+++ b/crates/file_store/src/store.rs
@@ -297,10 +297,7 @@ mod test {
     const TEST_MAGIC_BYTES: [u8; TEST_MAGIC_BYTES_LEN] =
         [98, 100, 107, 102, 115, 49, 49, 49, 49, 49, 49, 49];
 
-    use bdk_testenv::persist_test_utils::{
-        assert_persist_changesets, keychain_txout_changesets, local_chain_changesets,
-        tx_graph_changesets,
-    };
+    use bdk_testenv::persist_test_utils::*;
 
     type TestChangeSet = BTreeSet<String>;
 

--- a/crates/testenv/Cargo.toml
+++ b/crates/testenv/Cargo.toml
@@ -24,10 +24,10 @@ bitcoin = { version = "0.32.0", default-features = false }
 bdk_testenv = { path = "." }
 
 [features]
-default = ["std", "download"]
+default = ["std", "download", "miniscript"]
 download = ["electrsd/bitcoind_download", "electrsd/bitcoind_28_2", "electrsd/esplora_a33e97e1"]
 std = ["bdk_chain/std", "bitcoin/rand-std"]
 serde = ["bdk_chain/serde"]
-
+miniscript = ["bdk_chain/miniscript"]
 [package.metadata.docs.rs]
 no-default-features = true

--- a/crates/testenv/src/lib.rs
+++ b/crates/testenv/src/lib.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
+pub mod persist_test_utils;
 pub mod utils;
 
 use anyhow::Context;
@@ -13,6 +14,8 @@ use bitcoin::hex::HexToBytesError;
 use core::time::Duration;
 use electrsd::bitcoind::mtype::GetBlockTemplate;
 use electrsd::bitcoind::{TemplateRequest, TemplateRules};
+
+extern crate alloc;
 
 pub use electrsd;
 pub use electrsd::bitcoind;

--- a/crates/testenv/src/persist_test_utils.rs
+++ b/crates/testenv/src/persist_test_utils.rs
@@ -8,10 +8,7 @@ use bdk_chain::{
 
 #[cfg(feature = "miniscript")]
 use bdk_chain::{indexer::keychain_txout, DescriptorExt, SpkIterator};
-use core::{
-    cmp::PartialEq,
-    fmt::{Debug, Display},
-};
+use core::{cmp::PartialEq, fmt::Debug};
 
 use core::error::Error as Err;
 
@@ -25,83 +22,79 @@ const ADDRS: [&str; 2] = [
     "bcrt1q8an5jfmpq8w2hr648nn34ecf9zdtxk0qyqtrfl",
 ];
 
-/// Errors caused by a failed persister test.
-#[derive(Debug)]
-pub enum PersistErr<C: Debug> {
-    /// ChangeSet Mismatch
-    ChangeSetMismatch {
-        /// the resulting changeset
-        got: Box<C>,
-        /// the expected changeset
-        expected: Box<C>,
-    },
-    /// Errors thrown by underlying persistence backend.
-    Persister(Box<dyn Err + 'static + Send + Sync>),
-}
+/// A helper to check if a custom persistence backend persists `ChangeSet`s correctly.
+///
+/// This first tries to create a `Store` using `init`, `load`s from it and checks if
+/// the result is an empty `ChangeSet`.
+/// It then tries to `persist` each `ChangeSet` in `changesets` one by one, doing a `load`
+/// each time and checks that the aggregated `ChangeSet` matches the one loaded.
+///
+/// Finally it closes the `Store`, reopens it using `init`, `load`s from it and checks if the loaded
+/// `ChangeSet` matches the final aggregated `ChangeSet`.
+pub fn assert_persist_changesets<C, Store, Init, Load, Persist>(
+    init: Init,
+    load: Load,
+    persist: Persist,
+    changesets: &[C],
+) -> Result<(), String>
+where
+    C: Debug + PartialEq + Default + Merge + Clone,
+    Init: Fn() -> Result<Store, Box<dyn Err>>,
+    Load: Fn(&mut Store) -> Result<C, Box<dyn Err>>,
+    Persist: Fn(&mut Store, &C) -> Result<(), Box<dyn Err>>,
+{
+    let mut merged_changeset = C::default();
+    {
+        let mut store = init().map_err(|err| {
+            format!(
+                "Encountered an error from the persister while initializing the store.\nGot:\n{}",
+                err
+            )
+        })?;
 
-impl<C: Debug> From<Box<dyn Err + 'static + Send + Sync>> for PersistErr<C> {
-    fn from(value: Box<dyn Err + 'static + Send + Sync>) -> Self {
-        PersistErr::Persister(value)
-    }
-}
+        let init_changeset = load(&mut store).map_err(|err| format!("Encountered an error from the persister while loading from the new store.\nGot:\n{}",err))?;
 
-impl<C: Debug> Display for PersistErr<C> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        match self {
-            PersistErr::ChangeSetMismatch { got, expected } => write!(
-                f,
-                "ChangeSet mismatch! Got: {:?}, Expected: {:?}",
-                got, expected
-            ),
-            PersistErr::Persister(err) => write!(f, "{err}"),
+        if init_changeset != C::default() {
+            Err("Loading from a new store should return an empty changeset.")?;
+        }
+
+        for (i, changeset) in changesets.iter().enumerate() {
+            persist(&mut store, changeset).map_err(|err| format!("Persisting changeset no. {} failed. Got an error from the persister instead:\n{} ", i+1, err) )?;
+
+            merged_changeset.merge(changeset.clone());
+
+            let persisted_changeset = load(&mut store).map_err(|err| format!("Encountered an error from the persister while loading (after persisting changeset no. {}).\nGot:\n {}", i+1, err))?;
+
+            if persisted_changeset != merged_changeset {
+                Err(format!(
+                    "Persisting changeset no. {} failed.\nExpected:\n\n{:?}\n\n\nLoaded:\n\n{:?};",
+                    i + 1,
+                    merged_changeset,
+                    persisted_changeset
+                ))?;
+            }
         }
     }
-}
 
-impl<C: Debug> Err for PersistErr<C> {}
+    let mut store = init().map_err(|err| {
+        format!(
+            "Encountered an error while reopening the store.\nGot:\n{}",
+            err
+        )
+    })?;
 
-/// Tests if `ChangeSet` is being persisted correctly.
-///
-/// We create a dummy `ChangeSet`, persist it and check if loaded `ChangeSet` matches
-/// the persisted one. We then create another such dummy `ChangeSet`, persist it and load it to
-/// check if merged `ChangeSet` is returned.
-pub fn assert_persist_changesets<CS, Store, CreateStore, Initialize, Persist>(
-    create_store: CreateStore,
-    initialize: Initialize,
-    persist: Persist,
-    changesets: &[CS],
-) -> Result<(), PersistErr<CS>>
-where
-    CS: Debug + PartialEq + Default + Merge + Clone,
-    CreateStore: Fn() -> Result<Store, Box<dyn Err + 'static + Send + Sync>>,
-    Initialize: Fn(&mut Store) -> Result<CS, Box<dyn Err + 'static + Send + Sync>>,
-    Persist: Fn(&mut Store, &CS) -> Result<(), Box<dyn Err + 'static + Send + Sync>>,
-{
-    let mut store = create_store()?;
-
-    let init_changeset = initialize(&mut store)?;
-
-    if init_changeset != CS::default() {
-        return Err(PersistErr::ChangeSetMismatch {
-            expected: Box::new(CS::default()),
-            got: Box::new(init_changeset),
-        });
-    }
-
-    let mut merged_changeset = CS::default();
-
-    for changeset in changesets {
-        persist(&mut store, changeset)?;
-        merged_changeset.merge(changeset.clone());
-    }
-
-    let persisted_changeset = initialize(&mut store)?;
+    let persisted_changeset = load(&mut store).map_err(|err| {
+        format!(
+            "Unable to load the persisted changeset after reopening the store.\nGot an error from the persister:\n{}",
+            err
+        )
+    })?;
 
     if persisted_changeset != merged_changeset {
-        return Err(PersistErr::ChangeSetMismatch {
-            expected: Box::new(merged_changeset),
-            got: Box::new(persisted_changeset),
-        });
+        Err(format!(
+            "Did not get the expected changeset after reopening the store and loading.\nExpected:\n\n{:?}\n\n\nLoaded:\n\n{:?};",
+            merged_changeset, persisted_changeset
+        ))?;
     }
 
     Ok(())

--- a/crates/testenv/src/persist_test_utils.rs
+++ b/crates/testenv/src/persist_test_utils.rs
@@ -1,0 +1,308 @@
+//! This module provides utility functions for testing custom persistence backends.
+use crate::{block_id, hash};
+use alloc::sync::Arc;
+use bdk_chain::{
+    bitcoin::{self, OutPoint},
+    local_chain, tx_graph, ConfirmationBlockTime, Merge,
+};
+
+#[cfg(feature = "miniscript")]
+use bdk_chain::{indexer::keychain_txout, DescriptorExt, SpkIterator};
+use core::{
+    cmp::PartialEq,
+    fmt::{Debug, Display},
+};
+
+use core::error::Error as Err;
+
+use crate::utils::{create_test_tx, create_txout};
+
+#[cfg(feature = "miniscript")]
+use crate::utils::{parse_descriptor, spk_at_index};
+
+const ADDRS: [&str; 2] = [
+    "bcrt1q3qtze4ys45tgdvguj66zrk4fu6hq3a3v9pfly5",
+    "bcrt1q8an5jfmpq8w2hr648nn34ecf9zdtxk0qyqtrfl",
+];
+
+/// Errors caused by a failed persister test.
+#[derive(Debug)]
+pub enum PersistErr<C: Debug> {
+    /// ChangeSet Mismatch
+    ChangeSetMismatch {
+        /// the resulting changeset
+        got: Box<C>,
+        /// the expected changeset
+        expected: Box<C>,
+    },
+    /// Errors thrown by underlying persistence backend.
+    Persister(Box<dyn Err + 'static + Send + Sync>),
+}
+
+impl<C: Debug> From<Box<dyn Err + 'static + Send + Sync>> for PersistErr<C> {
+    fn from(value: Box<dyn Err + 'static + Send + Sync>) -> Self {
+        PersistErr::Persister(value)
+    }
+}
+
+impl<C: Debug> Display for PersistErr<C> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            PersistErr::ChangeSetMismatch { got, expected } => write!(
+                f,
+                "ChangeSet mismatch! Got: {:?}, Expected: {:?}",
+                got, expected
+            ),
+            PersistErr::Persister(err) => write!(f, "{err}"),
+        }
+    }
+}
+
+impl<C: Debug> Err for PersistErr<C> {}
+
+/// Tests if `ChangeSet` is being persisted correctly.
+///
+/// We create a dummy `ChangeSet`, persist it and check if loaded `ChangeSet` matches
+/// the persisted one. We then create another such dummy `ChangeSet`, persist it and load it to
+/// check if merged `ChangeSet` is returned.
+pub fn persist_changeset<CS, Store, CreateStore, Initialize, Persist>(
+    create_store: CreateStore,
+    initialize: Initialize,
+    persist: Persist,
+    changesets: &[CS],
+) -> Result<(), PersistErr<CS>>
+where
+    CS: Debug + PartialEq + Default + Merge + Clone,
+    CreateStore: Fn() -> Result<Store, Box<dyn Err + 'static + Send + Sync>>,
+    Initialize: Fn(&mut Store) -> Result<CS, Box<dyn Err + 'static + Send + Sync>>,
+    Persist: Fn(&mut Store, &CS) -> Result<(), Box<dyn Err + 'static + Send + Sync>>,
+{
+    let mut store = create_store()?;
+
+    let init_changeset = initialize(&mut store)?;
+
+    if init_changeset != CS::default() {
+        return Err(PersistErr::ChangeSetMismatch {
+            expected: Box::new(CS::default()),
+            got: Box::new(init_changeset),
+        });
+    }
+
+    let mut merged_changeset = CS::default();
+
+    for changeset in changesets {
+        persist(&mut store, changeset)?;
+        merged_changeset.merge(changeset.clone());
+    }
+
+    let persisted_changeset = initialize(&mut store)?;
+
+    if persisted_changeset != merged_changeset {
+        return Err(PersistErr::ChangeSetMismatch {
+            expected: Box::new(merged_changeset),
+            got: Box::new(persisted_changeset),
+        });
+    }
+
+    Ok(())
+}
+
+/// Tests if [`TxGraph`](tx_graph::TxGraph) is being persisted correctly.
+///
+/// We create a dummy [`tx_graph::ChangeSet`], persist it and check if loaded
+/// `ChangeSet` matches the persisted one. We then create another such dummy `ChangeSet`, persist it
+/// and load it to check if merged `ChangeSet` is returned.
+pub fn persist_txgraph_changeset<Store, CreateStore, Initialize, Persist>(
+    create_store: CreateStore,
+    initialize: Initialize,
+    persist: Persist,
+) -> Result<(), PersistErr<tx_graph::ChangeSet<ConfirmationBlockTime>>>
+where
+    CreateStore: Fn() -> Result<Store, Box<dyn Err + 'static + Send + Sync>>,
+    Initialize: Fn(
+        &mut Store,
+    ) -> Result<
+        tx_graph::ChangeSet<ConfirmationBlockTime>,
+        Box<dyn Err + 'static + Send + Sync>,
+    >,
+    Persist: Fn(
+        &mut Store,
+        &tx_graph::ChangeSet<ConfirmationBlockTime>,
+    ) -> Result<(), Box<dyn Err + 'static + Send + Sync>>,
+{
+    let changesets = tx_graph_changesets();
+    persist_changeset::<
+        tx_graph::ChangeSet<ConfirmationBlockTime>,
+        Store,
+        CreateStore,
+        Initialize,
+        Persist,
+    >(create_store, initialize, persist, &changesets)
+}
+
+/// Tests if [`KeychainTxOutIndex`](keychain_txout::KeychainTxOutIndex) is being persisted
+/// correctly.
+///
+/// See [`persist_txgraph_changeset`].
+#[cfg(feature = "miniscript")]
+pub fn persist_indexer_changeset<Store, CreateStore, Initialize, Persist>(
+    create_store: CreateStore,
+    initialize: Initialize,
+    persist: Persist,
+) -> Result<(), PersistErr<keychain_txout::ChangeSet>>
+where
+    CreateStore: Fn() -> Result<Store, Box<dyn Err + 'static + Send + Sync>>,
+    Initialize:
+        Fn(&mut Store) -> Result<keychain_txout::ChangeSet, Box<dyn Err + 'static + Send + Sync>>,
+    Persist: Fn(
+        &mut Store,
+        &keychain_txout::ChangeSet,
+    ) -> Result<(), Box<dyn Err + 'static + Send + Sync>>,
+{
+    let changesets = keychain_txout_changesets();
+    persist_changeset::<keychain_txout::ChangeSet, Store, CreateStore, Initialize, Persist>(
+        create_store,
+        initialize,
+        persist,
+        &changesets,
+    )
+}
+
+/// Tests if [`LocalChain`](local_chain::LocalChain) is being persisted correctly.
+///
+/// See [`persist_txgraph_changeset`].
+pub fn persist_local_chain_changeset<Store, CreateStore, Initialize, Persist>(
+    create_store: CreateStore,
+    initialize: Initialize,
+    persist: Persist,
+) -> Result<(), PersistErr<local_chain::ChangeSet>>
+where
+    CreateStore: Fn() -> Result<Store, Box<dyn Err + 'static + Send + Sync>>,
+    Initialize:
+        Fn(&mut Store) -> Result<local_chain::ChangeSet, Box<dyn Err + 'static + Send + Sync>>,
+    Persist:
+        Fn(&mut Store, &local_chain::ChangeSet) -> Result<(), Box<dyn Err + 'static + Send + Sync>>,
+{
+    let changesets = local_chain_changesets();
+    persist_changeset::<local_chain::ChangeSet, Store, CreateStore, Initialize, Persist>(
+        create_store,
+        initialize,
+        persist,
+        &changesets,
+    )
+}
+
+/// Get two [`tx_graph::ChangeSet`](tx_graph::ChangeSet)s.
+fn tx_graph_changesets() -> [tx_graph::ChangeSet<ConfirmationBlockTime>; 2] {
+    use tx_graph::ChangeSet;
+
+    let tx1 = Arc::new(create_test_tx(
+        [hash!("BTC")],
+        [0],
+        [30_000],
+        [ADDRS[0]],
+        1,
+        0,
+    ));
+
+    let conf_anchor: ConfirmationBlockTime = ConfirmationBlockTime {
+        block_id: block_id!(910425, "Rust"),
+        confirmation_time: 1755416660,
+    };
+
+    let tx_graph_changeset1 = ChangeSet::<ConfirmationBlockTime> {
+        txs: [tx1.clone()].into(),
+        txouts: [
+            (OutPoint::new(hash!("BDK"), 0), create_txout(1300, ADDRS[1])),
+            (
+                OutPoint::new(hash!("Bitcoin_fixes_things"), 0),
+                create_txout(1400, ADDRS[1]),
+            ),
+        ]
+        .into(),
+        anchors: [(conf_anchor, tx1.compute_txid())].into(),
+        last_seen: [(tx1.compute_txid(), 1755416650)].into(),
+        first_seen: [(tx1.compute_txid(), 1755416655)].into(),
+        last_evicted: [(tx1.compute_txid(), 1755416660)].into(),
+    };
+
+    let tx2 = Arc::new(create_test_tx(
+        [tx1.compute_txid()],
+        [0],
+        [20_000],
+        [ADDRS[0]],
+        1,
+        0,
+    ));
+
+    let conf_anchor: ConfirmationBlockTime = ConfirmationBlockTime {
+        block_id: block_id!(910426, "BOSS"),
+        confirmation_time: 1755416700,
+    };
+
+    let tx_graph_changeset2 = ChangeSet::<ConfirmationBlockTime> {
+        txs: [tx2.clone()].into(),
+        txouts: [(
+            OutPoint::new(hash!("Magical_Bitcoin"), 0),
+            create_txout(10000, ADDRS[1]),
+        )]
+        .into(),
+        anchors: [(conf_anchor, tx2.compute_txid())].into(),
+        last_seen: [(tx2.compute_txid(), 1755416700)].into(),
+        first_seen: [(tx2.compute_txid(), 1755416670)].into(),
+        last_evicted: [(tx2.compute_txid(), 1755416760)].into(),
+    };
+
+    [tx_graph_changeset1, tx_graph_changeset2]
+}
+
+/// Get two [`keychain_txout::ChangeSet`](keychain_txout::ChangeSet)s.
+#[cfg(feature = "miniscript")]
+fn keychain_txout_changesets() -> [keychain_txout::ChangeSet; 2] {
+    use crate::utils::DESCRIPTORS;
+    use keychain_txout::ChangeSet;
+
+    let descriptor_ids = DESCRIPTORS.map(|d| parse_descriptor(d).0.descriptor_id());
+    let descs = DESCRIPTORS.map(|desc| parse_descriptor(desc).0);
+
+    let changeset = ChangeSet {
+        last_revealed: [(descriptor_ids[0], 1), (descriptor_ids[1], 100)].into(),
+        spk_cache: [
+            (
+                descriptor_ids[0],
+                SpkIterator::new_with_range(&descs[0], 0..=26).collect(),
+            ),
+            (
+                descriptor_ids[1],
+                SpkIterator::new_with_range(&descs[1], 0..=125).collect(),
+            ),
+        ]
+        .into(),
+    };
+
+    let changeset_new = ChangeSet {
+        last_revealed: [(descriptor_ids[0], 2)].into(),
+        spk_cache: [(
+            descriptor_ids[0],
+            [(27, spk_at_index(&descs[0], 27))].into(),
+        )]
+        .into(),
+    };
+
+    [changeset, changeset_new]
+}
+
+/// Get two [`local_chain::ChangeSet`](local_chain::ChangeSet)s.
+fn local_chain_changesets() -> [local_chain::ChangeSet; 2] {
+    use local_chain::ChangeSet;
+
+    let changeset = ChangeSet {
+        blocks: [(910425, Some(hash!("B"))), (910426, Some(hash!("D")))].into(),
+    };
+
+    let changeset_new = ChangeSet {
+        blocks: [(910427, Some(hash!("K")))].into(),
+    };
+
+    [changeset, changeset_new]
+}

--- a/crates/testenv/src/persist_test_utils.rs
+++ b/crates/testenv/src/persist_test_utils.rs
@@ -65,7 +65,7 @@ impl<C: Debug> Err for PersistErr<C> {}
 /// We create a dummy `ChangeSet`, persist it and check if loaded `ChangeSet` matches
 /// the persisted one. We then create another such dummy `ChangeSet`, persist it and load it to
 /// check if merged `ChangeSet` is returned.
-pub fn persist_changeset<CS, Store, CreateStore, Initialize, Persist>(
+pub fn assert_persist_changesets<CS, Store, CreateStore, Initialize, Persist>(
     create_store: CreateStore,
     initialize: Initialize,
     persist: Persist,
@@ -107,93 +107,8 @@ where
     Ok(())
 }
 
-/// Tests if [`TxGraph`](tx_graph::TxGraph) is being persisted correctly.
-///
-/// We create a dummy [`tx_graph::ChangeSet`], persist it and check if loaded
-/// `ChangeSet` matches the persisted one. We then create another such dummy `ChangeSet`, persist it
-/// and load it to check if merged `ChangeSet` is returned.
-pub fn persist_txgraph_changeset<Store, CreateStore, Initialize, Persist>(
-    create_store: CreateStore,
-    initialize: Initialize,
-    persist: Persist,
-) -> Result<(), PersistErr<tx_graph::ChangeSet<ConfirmationBlockTime>>>
-where
-    CreateStore: Fn() -> Result<Store, Box<dyn Err + 'static + Send + Sync>>,
-    Initialize: Fn(
-        &mut Store,
-    ) -> Result<
-        tx_graph::ChangeSet<ConfirmationBlockTime>,
-        Box<dyn Err + 'static + Send + Sync>,
-    >,
-    Persist: Fn(
-        &mut Store,
-        &tx_graph::ChangeSet<ConfirmationBlockTime>,
-    ) -> Result<(), Box<dyn Err + 'static + Send + Sync>>,
-{
-    let changesets = tx_graph_changesets();
-    persist_changeset::<
-        tx_graph::ChangeSet<ConfirmationBlockTime>,
-        Store,
-        CreateStore,
-        Initialize,
-        Persist,
-    >(create_store, initialize, persist, &changesets)
-}
-
-/// Tests if [`KeychainTxOutIndex`](keychain_txout::KeychainTxOutIndex) is being persisted
-/// correctly.
-///
-/// See [`persist_txgraph_changeset`].
-#[cfg(feature = "miniscript")]
-pub fn persist_indexer_changeset<Store, CreateStore, Initialize, Persist>(
-    create_store: CreateStore,
-    initialize: Initialize,
-    persist: Persist,
-) -> Result<(), PersistErr<keychain_txout::ChangeSet>>
-where
-    CreateStore: Fn() -> Result<Store, Box<dyn Err + 'static + Send + Sync>>,
-    Initialize:
-        Fn(&mut Store) -> Result<keychain_txout::ChangeSet, Box<dyn Err + 'static + Send + Sync>>,
-    Persist: Fn(
-        &mut Store,
-        &keychain_txout::ChangeSet,
-    ) -> Result<(), Box<dyn Err + 'static + Send + Sync>>,
-{
-    let changesets = keychain_txout_changesets();
-    persist_changeset::<keychain_txout::ChangeSet, Store, CreateStore, Initialize, Persist>(
-        create_store,
-        initialize,
-        persist,
-        &changesets,
-    )
-}
-
-/// Tests if [`LocalChain`](local_chain::LocalChain) is being persisted correctly.
-///
-/// See [`persist_txgraph_changeset`].
-pub fn persist_local_chain_changeset<Store, CreateStore, Initialize, Persist>(
-    create_store: CreateStore,
-    initialize: Initialize,
-    persist: Persist,
-) -> Result<(), PersistErr<local_chain::ChangeSet>>
-where
-    CreateStore: Fn() -> Result<Store, Box<dyn Err + 'static + Send + Sync>>,
-    Initialize:
-        Fn(&mut Store) -> Result<local_chain::ChangeSet, Box<dyn Err + 'static + Send + Sync>>,
-    Persist:
-        Fn(&mut Store, &local_chain::ChangeSet) -> Result<(), Box<dyn Err + 'static + Send + Sync>>,
-{
-    let changesets = local_chain_changesets();
-    persist_changeset::<local_chain::ChangeSet, Store, CreateStore, Initialize, Persist>(
-        create_store,
-        initialize,
-        persist,
-        &changesets,
-    )
-}
-
-/// Get two [`tx_graph::ChangeSet`](tx_graph::ChangeSet)s.
-fn tx_graph_changesets() -> [tx_graph::ChangeSet<ConfirmationBlockTime>; 2] {
+/// Get two [`tx_graph::ChangeSet`]s.
+pub fn tx_graph_changesets() -> [tx_graph::ChangeSet<ConfirmationBlockTime>; 2] {
     use tx_graph::ChangeSet;
 
     let tx1 = Arc::new(create_test_tx(
@@ -256,9 +171,9 @@ fn tx_graph_changesets() -> [tx_graph::ChangeSet<ConfirmationBlockTime>; 2] {
     [tx_graph_changeset1, tx_graph_changeset2]
 }
 
-/// Get two [`keychain_txout::ChangeSet`](keychain_txout::ChangeSet)s.
+/// Get two [`keychain_txout::ChangeSet`]s.
 #[cfg(feature = "miniscript")]
-fn keychain_txout_changesets() -> [keychain_txout::ChangeSet; 2] {
+pub fn keychain_txout_changesets() -> [keychain_txout::ChangeSet; 2] {
     use crate::utils::DESCRIPTORS;
     use keychain_txout::ChangeSet;
 
@@ -292,8 +207,8 @@ fn keychain_txout_changesets() -> [keychain_txout::ChangeSet; 2] {
     [changeset, changeset_new]
 }
 
-/// Get two [`local_chain::ChangeSet`](local_chain::ChangeSet)s.
-fn local_chain_changesets() -> [local_chain::ChangeSet; 2] {
+/// Get two [`local_chain::ChangeSet`]s.
+pub fn local_chain_changesets() -> [local_chain::ChangeSet; 2] {
     use local_chain::ChangeSet;
 
     let changeset = ChangeSet {

--- a/crates/testenv/src/persist_test_utils.rs
+++ b/crates/testenv/src/persist_test_utils.rs
@@ -2,7 +2,7 @@
 use crate::{block_id, hash};
 use alloc::sync::Arc;
 use bdk_chain::{
-    bitcoin::{self, OutPoint},
+    bitcoin::{self, transaction::Version, OutPoint},
     local_chain, tx_graph, ConfirmationBlockTime, Merge,
 };
 
@@ -47,35 +47,44 @@ where
     Persist: Fn(&mut Store, &C) -> Result<(), Box<dyn Err>>,
 {
     let mut merged_changeset = C::default();
-    {
-        let mut store = init().map_err(|err| {
+    let mut store = init().map_err(|err| {
+        format!(
+            "Encountered an error from the persister while initializing the store.\nGot:\n{}",
+            err
+        )
+    })?;
+
+    let init_changeset = load(&mut store).map_err(|err| {
+        format!(
+            "Encountered an error from the persister while loading from the new store.\nGot:\n{}",
+            err
+        )
+    })?;
+
+    if init_changeset != C::default() {
+        Err("Loading from a new store should return an empty changeset.")?;
+    }
+
+    for (i, changeset) in changesets.iter().enumerate() {
+        persist(&mut store, changeset).map_err(|err| {
             format!(
-                "Encountered an error from the persister while initializing the store.\nGot:\n{}",
+                "Persisting changeset no. {} failed. Got an error from the persister instead:\n{} ",
+                i + 1,
                 err
             )
         })?;
 
-        let init_changeset = load(&mut store).map_err(|err| format!("Encountered an error from the persister while loading from the new store.\nGot:\n{}",err))?;
+        merged_changeset.merge(changeset.clone());
 
-        if init_changeset != C::default() {
-            Err("Loading from a new store should return an empty changeset.")?;
-        }
+        let persisted_changeset = load(&mut store).map_err(|err| format!("Encountered an error from the persister while loading (after persisting changeset no. {}).\nGot:\n {}", i+1, err))?;
 
-        for (i, changeset) in changesets.iter().enumerate() {
-            persist(&mut store, changeset).map_err(|err| format!("Persisting changeset no. {} failed. Got an error from the persister instead:\n{} ", i+1, err) )?;
-
-            merged_changeset.merge(changeset.clone());
-
-            let persisted_changeset = load(&mut store).map_err(|err| format!("Encountered an error from the persister while loading (after persisting changeset no. {}).\nGot:\n {}", i+1, err))?;
-
-            if persisted_changeset != merged_changeset {
-                Err(format!(
-                    "Persisting changeset no. {} failed.\nExpected:\n\n{:?}\n\n\nLoaded:\n\n{:?};",
-                    i + 1,
-                    merged_changeset,
-                    persisted_changeset
-                ))?;
-            }
+        if persisted_changeset != merged_changeset {
+            Err(format!(
+                "Persisting changeset no. {} failed.\nExpected:\n\n{:?}\n\n\nLoaded:\n\n{:?};",
+                i + 1,
+                merged_changeset,
+                persisted_changeset
+            ))?;
         }
     }
 
@@ -112,7 +121,7 @@ pub fn tx_graph_changesets() -> [tx_graph::ChangeSet<ConfirmationBlockTime>; 2] 
         [0],
         [30_000],
         [ADDRS[0]],
-        1,
+        Version::ONE,
         0,
     ));
 
@@ -142,7 +151,7 @@ pub fn tx_graph_changesets() -> [tx_graph::ChangeSet<ConfirmationBlockTime>; 2] 
         [0],
         [20_000],
         [ADDRS[0]],
-        1,
+        Version::ONE,
         0,
     ));
 

--- a/crates/testenv/src/persist_test_utils.rs
+++ b/crates/testenv/src/persist_test_utils.rs
@@ -22,15 +22,18 @@ const ADDRS: [&str; 2] = [
     "bcrt1q8an5jfmpq8w2hr648nn34ecf9zdtxk0qyqtrfl",
 ];
 
-/// A helper to check if a custom persistence backend persists `ChangeSet`s correctly.
+/// Asserts a persistence backend correctly stores and reloads a sequence of `ChangeSet`s.
 ///
-/// This first tries to create a `Store` using `init`, `load`s from it and checks if
-/// the result is an empty `ChangeSet`.
-/// It then tries to `persist` each `ChangeSet` in `changesets` one by one, doing a `load`
-/// each time and checks that the aggregated `ChangeSet` matches the one loaded.
+/// Checks that `load` always returns the merge of everything `persist`ed so far - including after
+/// the store is dropped and reopened. The backend is supplied as three closures:
 ///
-/// Finally it closes the `Store`, reopens it using `init`, `load`s from it and checks if the loaded
-/// `ChangeSet` matches the final aggregated `ChangeSet`.
+/// - `init`: open-or-create a handle. This must never wipe existing data.
+/// - `load`: return the full persisted changeset (`C::default()` on a fresh store).
+/// - `persist`: durably write one changeset on top of what's stored; must survive the handle being
+///   dropped.
+///
+/// Returns `Err` naming the failing step if a closure errors or a load doesn't match the expected
+/// merge.
 pub fn assert_persist_changesets<C, Store, Init, Load, Persist>(
     init: Init,
     load: Load,

--- a/crates/testenv/src/utils.rs
+++ b/crates/testenv/src/utils.rs
@@ -103,7 +103,7 @@ pub fn create_test_tx(
     vouts: impl IntoIterator<Item = u32>,
     amounts: impl IntoIterator<Item = u64>,
     addrs: impl IntoIterator<Item = &'static str>,
-    version: u32,
+    version: transaction::Version,
     locktime: u32,
 ) -> Transaction {
     let input_vec = core::iter::zip(txids, vouts)
@@ -115,8 +115,6 @@ pub fn create_test_tx(
     let output_vec = core::iter::zip(amounts, addrs)
         .map(|(amount, addr)| create_txout(amount, addr))
         .collect();
-    let version = transaction::Version::non_standard(version as i32);
-    assert!(version.is_standard());
     let lock_time = absolute::LockTime::from_consensus(locktime);
     assert_eq!(lock_time.to_consensus_u32(), locktime);
     Transaction {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Added a helper `assert_persist_changesets` to the testenv for testing custom persistence backends. Partially solves [bdk_wallet#14](https://github.com/bitcoindevkit/bdk_wallet/issues/14) and might help with [bdk_wallet#234](https://github.com/bitcoindevkit/bdk_wallet/issues/234).

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

``` 
Added
   - `miniscript` feature to testenv which depends on `bdk_chain/miniscript` .
    - `assert_persist_changesets` to testenv to check `ChangeSet`s are persisted properly.
    - `tx_graph_changesets`, `keychain_txout_changesets`, `local_chain_changesets` which provide changesets
    to be used as arguments to `assert_persist_changesets`.
    - `create_test_tx`, `spk_at_index`,`parse_descriptor`, `create_txout` helpers to testenv for creating changesets for testing.
 Changed
   - default feature of testenv to also activate `miniscript` feature.
```

### Todo
* [x] Add docs
* [x] Add tests to bdk_chain based on testenv utilities

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
