### PR TITLE
Waterfalls PoC

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# taken from https://fasterthanli.me/series/building-a-rust-service-with-nix/part-10 and updated the version
+
+if ! has nix_direnv_version || ! nix_direnv_version 3.0.4; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.4/direnvrc" "sha256-DzlYZ33mWF/Gs8DDeyjr8mnVmQGx7ASYqA5WlxwvBG4="
+fi
+
+watch_file rust-toolchain.toml
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ Cargo.lock
 *.sqlite*
 
 crates/electrum/target
+
+.direnv/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "examples/example_cli",
     "examples/example_electrum",
     "examples/example_esplora",
+    "examples/example_waterfalls",
     "examples/example_bitcoind_rpc_polling",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/esplora",
     "crates/bitcoind_rpc",
     "crates/testenv",
+    "crates/waterfalls",
     "examples/example_cli",
     "examples/example_electrum",
     "examples/example_esplora",
@@ -22,4 +23,6 @@ print_stdout = "deny"
 print_stderr = "deny"
 
 [workspace.lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage,coverage_nightly)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(coverage,coverage_nightly)',
+] }

--- a/crates/waterfalls/Cargo.toml
+++ b/crates/waterfalls/Cargo.toml
@@ -21,6 +21,9 @@ futures = { version = "0.3.26", optional = true }
 
 [dev-dependencies]
 waterfalls-client = { version = "0.1.0" }
+waterfalls = { version = "0.9", default-features = false, features = [
+    "test_env",
+] }
 bdk_chain = { path = "../chain" }
 bdk_testenv = { path = "../testenv" }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }

--- a/crates/waterfalls/Cargo.toml
+++ b/crates/waterfalls/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "bdk_waterfalls"
+version = "0.1.0"
+edition = "2021"
+authors = ["Riccardo Casatta <riccardo@casatta.it>"]
+homepage = "https://bitcoindevkit.org"
+repository = "https://github.com/bitcoindevkit/bdk"
+documentation = "https://docs.rs/bdk_waterfalls"
+description = "Fetch data from waterfalls in the form that bdk accepts"
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+
+[lints]
+workspace = true
+
+[dependencies]
+bdk_core = { path = "../core", version = "0.6.1", default-features = false }
+waterfalls-client = { version = "0.1.0", default-features = false }
+async-trait = { version = "0.1.66", optional = true }
+futures = { version = "0.3.26", optional = true }
+
+[dev-dependencies]
+waterfalls-client = { version = "0.1.0" }
+bdk_chain = { path = "../chain" }
+bdk_testenv = { path = "../testenv" }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
+
+[features]
+default = ["std", "async-https", "blocking-https"]
+std = ["bdk_core/std"]
+tokio = ["waterfalls-client/tokio"]
+async = ["async-trait", "futures", "waterfalls-client/async"]
+async-https = ["async", "waterfalls-client/async-https"]
+async-https-rustls = ["async", "waterfalls-client/async-https-rustls"]
+async-https-native = ["async", "waterfalls-client/async-https-native"]
+blocking = ["waterfalls-client/blocking"]
+blocking-https = ["blocking", "waterfalls-client/blocking-https"]
+blocking-https-rustls = ["blocking", "waterfalls-client/blocking-https-rustls"]
+blocking-https-native = ["blocking", "waterfalls-client/blocking-https-native"]

--- a/crates/waterfalls/Cargo.toml
+++ b/crates/waterfalls/Cargo.toml
@@ -15,14 +15,14 @@ workspace = true
 
 [dependencies]
 bdk_core = { path = "../core", version = "0.6.1", default-features = false }
-waterfalls-client = { version = "0.1.0", default-features = false }
+waterfalls-client = { version = "0.2.0", default-features = false }
 async-trait = { version = "0.1.66", optional = true }
 futures = { version = "0.3.26", optional = true }
 log = "0.4.20"
 
 [dev-dependencies]
-waterfalls-client = { version = "0.1.0" }
-waterfalls = { version = "0.9", default-features = false, features = [
+waterfalls-client = { version = "0.2.0" }
+waterfalls = { version = "0.9.6", default-features = false, features = [
     "test_env",
 ] }
 bdk_chain = { path = "../chain" }

--- a/crates/waterfalls/Cargo.toml
+++ b/crates/waterfalls/Cargo.toml
@@ -18,6 +18,7 @@ bdk_core = { path = "../core", version = "0.6.1", default-features = false }
 waterfalls-client = { version = "0.1.0", default-features = false }
 async-trait = { version = "0.1.66", optional = true }
 futures = { version = "0.3.26", optional = true }
+log = "0.4.20"
 
 [dev-dependencies]
 waterfalls-client = { version = "0.1.0" }

--- a/crates/waterfalls/Cargo.toml
+++ b/crates/waterfalls/Cargo.toml
@@ -27,6 +27,7 @@ waterfalls = { version = "0.9", default-features = false, features = [
 bdk_chain = { path = "../chain" }
 bdk_testenv = { path = "../testenv" }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
+env_logger = "0.11.8"
 
 [features]
 default = ["std", "async-https", "blocking-https"]

--- a/crates/waterfalls/src/lib.rs
+++ b/crates/waterfalls/src/lib.rs
@@ -1,0 +1,133 @@
+use std::collections::BTreeMap;
+
+use bdk_core::{
+    bitcoin::{address::FromScriptError, Address, Network},
+    spk_client::{FullScanRequest, FullScanResponse},
+    TxUpdate,
+};
+use waterfalls_client::{BlockingClient, Builder};
+
+pub type Error = Box<dyn std::error::Error + Send + Sync>;
+
+struct Client {
+    client: BlockingClient,
+    network: Network,
+}
+
+impl Client {
+    pub fn new(network: Network, base_url: &str) -> Result<Self, Error> {
+        Ok(Self {
+            client: Builder::new(base_url).build_blocking(),
+            network,
+        })
+    }
+
+    fn full_scan<K: Ord + Clone, R: Into<FullScanRequest<K>>>(
+        &self,
+        request: R,
+        _stop_gap: usize,
+        _parallel_requests: usize,
+    ) -> Result<FullScanResponse<K>, Error> {
+        let mut request: FullScanRequest<K> = request.into();
+
+        let keychain_addresses =
+            get_addesses_from_request(&mut request, self.network).map_err(|e| Box::new(e))?;
+
+        let chain_update = None;
+        let tx_update = TxUpdate::default();
+        let last_active_indices = BTreeMap::new();
+
+        for (_keychain, addresses) in keychain_addresses {
+            // TODO: we can do a single call for multiple keychains
+            let _result = self
+                .client
+                .waterfalls_addresses(&addresses)
+                .map_err(|e| Box::new(e))?;
+        }
+
+        Ok(FullScanResponse {
+            chain_update,
+            tx_update,
+            last_active_indices,
+        })
+    }
+}
+
+fn get_addesses_from_request<K: Ord + Clone>(
+    request: &mut FullScanRequest<K>,
+    network: Network,
+) -> Result<Vec<(K, Vec<Address>)>, FromScriptError> {
+    let mut result = Vec::new();
+    for (i, keychain) in request.keychains().iter().enumerate() {
+        let mut addresses = Vec::new();
+        let keychain_spks = request.iter_spks(keychain.clone());
+        for (_, spk) in keychain_spks {
+            addresses.push(Address::from_script(&spk, network)?);
+        }
+        println!("keychain_{}: addresses: {:?}", i, addresses);
+        result.push((keychain.clone(), addresses));
+    }
+    Ok(result)
+}
+
+#[cfg(test)]
+mod test {
+    use std::str::FromStr;
+
+    use bdk_core::{
+        bitcoin::{Address, Network},
+        spk_client::FullScanRequest,
+    };
+    use bdk_testenv::anyhow;
+
+    use crate::Client;
+
+    #[test]
+    pub fn test_full_scan() -> anyhow::Result<()> {
+        // Initialize a waterfalls TestEnv
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let test_env = rt.block_on(async {
+            let exe = std::env::var("BITCOIND_EXEC").expect("BITCOIND_EXEC must be set");
+            waterfalls::test_env::launch(exe, waterfalls::be::Family::Bitcoin).await
+        });
+        let url = test_env.base_url();
+
+        let client = Client::new(Network::Regtest, &url).map_err(|e| anyhow::anyhow!("{}", e))?;
+
+        // Now let's test the gap limit. First of all get a chain of 10 addresses.
+        let addresses = [
+            "bcrt1qj9f7r8r3p2y0sqf4r3r62qysmkuh0fzep473d2ar7rcz64wqvhssjgf0z4",
+            "bcrt1qmm5t0ch7vh2hryx9ctq3mswexcugqe4atkpkl2tetm8merqkthas3w7q30",
+            "bcrt1qut9p7ej7l7lhyvekj28xknn8gnugtym4d5qvnp5shrsr4nksmfqsmyn87g",
+            "bcrt1qqz0xtn3m235p2k96f5wa2dqukg6shxn9n3txe8arlrhjh5p744hsd957ww",
+            "bcrt1q9c0t62a8l6wfytmf2t9lfj35avadk3mm8g4p3l84tp6rl66m48sqrme7wu",
+            "bcrt1qkmh8yrk2v47cklt8dytk8f3ammcwa4q7dzattedzfhqzvfwwgyzsg59zrh",
+            "bcrt1qvgrsrzy07gjkkfr5luplt0azxtfwmwq5t62gum5jr7zwcvep2acs8hhnp2",
+            "bcrt1qw57edarcg50ansq8mk3guyrk78rk0fwvrds5xvqeupteu848zayq549av8",
+            "bcrt1qvtve5ekf6e5kzs68knvnt2phfw6a0yjqrlgat392m6zt9jsvyxhqfx67ef",
+            "bcrt1qw03ddumfs9z0kcu76ln7jrjfdwam20qtffmkcral3qtza90sp9kqm787uk",
+        ];
+        let addresses: Vec<_> = addresses
+            .into_iter()
+            .map(|s| Address::from_str(s).unwrap().assume_checked())
+            .collect();
+        let spks: Vec<_> = addresses
+            .iter()
+            .enumerate()
+            .map(|(i, addr)| (i as u32, addr.script_pubkey()))
+            .collect();
+
+        // Then send coins on one of the addresses.
+
+        let _full_scan_update = {
+            let request = FullScanRequest::builder().spks_for_keychain(0, spks.clone());
+            client
+                .full_scan(request, 0, 0)
+                .map_err(|e| anyhow::anyhow!("{}", e))?
+        };
+
+        rt.block_on(test_env.shutdown());
+
+        Ok(())
+    }
+}

--- a/crates/waterfalls/src/lib.rs
+++ b/crates/waterfalls/src/lib.rs
@@ -140,7 +140,7 @@ fn get_addesses_from_request<K: Ord + Clone>(
     for (i, keychain) in request.keychains().iter().enumerate() {
         let mut addresses = Vec::new();
         let keychain_spks = request.iter_spks(keychain.clone());
-        for (j, spk) in keychain_spks {
+        for (_, spk) in keychain_spks {
             addresses.push(Address::from_script(&spk, network)?);
 
             if addresses.len() == 50 {

--- a/crates/waterfalls/src/main.rs
+++ b/crates/waterfalls/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/crates/waterfalls/src/main.rs
+++ b/crates/waterfalls/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}

--- a/examples/example_waterfalls/Cargo.toml
+++ b/examples/example_waterfalls/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "example_waterfalls"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bdk_chain = { path = "../../crates/chain", features = ["serde"] }
+bdk_waterfalls = { path = "../../crates/waterfalls", features = ["blocking"] }
+example_cli = { path = "../example_cli" }
+env_logger = "0.11"

--- a/examples/example_waterfalls/src/main.rs
+++ b/examples/example_waterfalls/src/main.rs
@@ -1,0 +1,179 @@
+use core::f32;
+use std::{
+    collections::BTreeSet,
+    io::{self, Write},
+};
+
+use bdk_chain::{
+    bitcoin::Network,
+    keychain_txout::FullScanRequestBuilderExt,
+    spk_client::{FullScanRequest, SyncRequest},
+    CanonicalizationParams, Merge,
+};
+use bdk_waterfalls::waterfalls_client;
+use example_cli::{
+    anyhow::{self, Context},
+    clap::{self, Parser, Subcommand},
+    ChangeSet, Keychain,
+};
+
+const DB_MAGIC: &[u8] = b"bdk_example_waterfalls";
+const DB_PATH: &str = ".bdk_example_waterfalls.db";
+
+#[derive(Subcommand, Debug, Clone)]
+enum WaterfallsCommands {
+    /// Scans the addresses in the wallet using the waterfalls API.
+    Scan {
+        #[clap(flatten)]
+        waterfalls_args: WaterfallsArgs,
+
+        #[clap(flatten)]
+        scan_options: ScanOptions,
+    },
+}
+
+impl WaterfallsCommands {
+    fn waterfalls_args(&self) -> WaterfallsArgs {
+        match self {
+            WaterfallsCommands::Scan {
+                waterfalls_args, ..
+            } => waterfalls_args.clone(),
+        }
+    }
+}
+
+#[derive(clap::Args, Debug, Clone)]
+pub struct WaterfallsArgs {
+    /// The esplora url endpoint to connect to.
+    #[clap(long, short = 'u', env = "WATERFALLS_SERVER")]
+    waterfalls_url: Option<String>,
+}
+
+#[derive(Parser, Debug, Clone, PartialEq)]
+pub struct ScanOptions {
+    /// Max number of concurrent esplora server requests.
+    #[clap(long, default_value = "2")]
+    pub parallel_requests: usize,
+}
+
+impl WaterfallsArgs {
+    pub fn client(&self, network: Network) -> anyhow::Result<bdk_waterfalls::Client> {
+        let waterfalls_url = self.waterfalls_url.as_deref().unwrap_or(match network {
+            Network::Bitcoin => "https://waterfalls.liquidwebwallet.org/bitcoin/api",
+            Network::Regtest => "http://localhost:3002",
+            Network::Signet => "https://waterfalls.liquidwebwallet.org/bitcoinsignet/api",
+            _ => panic!("unsupported network"),
+        });
+
+        let client = bdk_waterfalls::Client::new(network, waterfalls_url).unwrap(); // TODO: handle error
+        Ok(client)
+    }
+}
+
+fn main() -> anyhow::Result<()> {
+    env_logger::init();
+    let example_cli::Init {
+        args,
+        graph,
+        chain,
+        db,
+        network,
+    } = match example_cli::init_or_load::<WaterfallsCommands, WaterfallsArgs>(DB_MAGIC, DB_PATH)? {
+        Some(init) => init,
+        None => return Ok(()),
+    };
+
+    let waterfalls_cmd = match &args.command {
+        // These are commands that are handled by this example (sync, scan).
+        example_cli::Commands::ChainSpecific(esplora_cmd) => esplora_cmd,
+        // These are general commands handled by example_cli. Execute the cmd and return.
+        general_cmd => {
+            return example_cli::handle_commands(
+                &graph,
+                &chain,
+                &db,
+                network,
+                |esplora_args, tx| {
+                    let client = esplora_args.client(network)?;
+                    client.broadcast(tx).unwrap(); // TODO: handle error
+                    Ok(())
+                },
+                general_cmd.clone(),
+            );
+        }
+    };
+
+    let client = waterfalls_cmd.waterfalls_args().client(network)?;
+    // Prepare the `IndexedTxGraph` and `LocalChain` updates based on whether we are scanning or
+    // syncing.
+    //
+    // Scanning: We are iterating through spks of all keychains and scanning for transactions for
+    //   each spk. We start with the lowest derivation index spk and stop scanning after `stop_gap`
+    //   number of consecutive spks have no transaction history. A Scan is done in situations of
+    //   wallet restoration. It is a special case. Applications should use "sync" style updates
+    //   after an initial scan.
+    //
+    // Syncing: We only check for specified spks, utxos and txids to update their confirmation
+    //   status or fetch missing transactions.
+    let (local_chain_changeset, indexed_tx_graph_changeset) = match &waterfalls_cmd {
+        WaterfallsCommands::Scan { scan_options, .. } => {
+            let request = {
+                let chain_tip = chain.lock().expect("mutex must not be poisoned").tip();
+                let indexed_graph = &*graph.lock().expect("mutex must not be poisoned");
+                FullScanRequest::builder()
+                    .chain_tip(chain_tip)
+                    .spks_from_indexer(&indexed_graph.index)
+                    .inspect({
+                        let mut once = BTreeSet::<Keychain>::new();
+                        move |keychain, spk_i, _| {
+                            if once.insert(keychain) {
+                                eprint!("\nscanning {keychain}: ");
+                            }
+                            eprint!("{spk_i} ");
+                            // Flush early to ensure we print at every iteration.
+                            let _ = io::stderr().flush();
+                        }
+                    })
+                    .build()
+            };
+
+            // The client scans keychain spks for transaction histories, stopping after `stop_gap`
+            // is reached. It returns a `TxGraph` update (`tx_update`) and a structure that
+            // represents the last active spk derivation indices of keychains
+            // (`keychain_indices_update`).
+            let update = client
+                .full_scan(request, 10, scan_options.parallel_requests)
+                .unwrap(); // TODO: handle error
+
+            let mut graph = graph.lock().expect("mutex must not be poisoned");
+            let mut chain = chain.lock().expect("mutex must not be poisoned");
+            // Because we did a stop gap based scan we are likely to have some updates to our
+            // deriviation indices. Usually before a scan you are on a fresh wallet with no
+            // addresses derived so we need to derive up to last active addresses the scan found
+            // before adding the transactions.
+            (
+                chain.apply_update(update.chain_update.expect("request included chain tip"))?,
+                {
+                    let index_changeset = graph
+                        .index
+                        .reveal_to_target_multi(&update.last_active_indices);
+                    let mut indexed_tx_graph_changeset = graph.apply_update(update.tx_update);
+                    indexed_tx_graph_changeset.merge(index_changeset.into());
+                    indexed_tx_graph_changeset
+                },
+            )
+        }
+    };
+
+    println!();
+
+    // We persist the changes
+    let mut db = db.lock().unwrap();
+    db.append(&ChangeSet {
+        local_chain: local_chain_changeset,
+        tx_graph: indexed_tx_graph_changeset.tx_graph,
+        indexer: indexed_tx_graph_changeset.indexer,
+        ..Default::default()
+    })?;
+    Ok(())
+}

--- a/examples/example_waterfalls/src/main.rs
+++ b/examples/example_waterfalls/src/main.rs
@@ -1,18 +1,13 @@
-use core::f32;
 use std::{
     collections::BTreeSet,
     io::{self, Write},
 };
 
 use bdk_chain::{
-    bitcoin::Network,
-    keychain_txout::FullScanRequestBuilderExt,
-    spk_client::{FullScanRequest, SyncRequest},
-    CanonicalizationParams, Merge,
+    bitcoin::Network, keychain_txout::FullScanRequestBuilderExt, spk_client::FullScanRequest, Merge,
 };
-use bdk_waterfalls::waterfalls_client;
 use example_cli::{
-    anyhow::{self, Context},
+    anyhow::{self},
     clap::{self, Parser, Subcommand},
     ChangeSet, Keychain,
 };

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1755615617,
+        "narHash": "sha256-HMwfAJBdrr8wXAkbGhtcby1zGFvs+StOp19xNsbqdOg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "20075955deac2583bb12f07151c2df830ef346b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1755743804,
+        "narHash": "sha256-M6qT02voARH5e9eTXQBzpYIE/hAp6jPgBCyxLmw5uBM=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "80322e975e27d834451d6b66e63f8abae9d74bf2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,42 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs = {
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          overlays = [ (import rust-overlay) ];
+          pkgs = import nixpkgs {
+            inherit system overlays;
+          };
+          inherit (pkgs) lib;
+
+          # Read rust version from rust-version file
+          rustVersion = lib.strings.removeSuffix "\n" (builtins.readFile ./rust-version);
+
+          rustToolchain = pkgs.rust-bin.stable.${rustVersion}.default.override {
+            extensions = [ "rust-src" "clippy" ];
+          };
+
+          nativeBuildInputs = with pkgs; [ rustToolchain pkg-config ];
+          buildInputs = with pkgs; [ openssl ];
+
+        in
+        {
+          devShells.default = pkgs.mkShell {
+            inherit buildInputs nativeBuildInputs;
+
+            RUST_VERSION = rustVersion;
+          };
+        }
+      );
+} 

--- a/flake.nix
+++ b/flake.nix
@@ -28,7 +28,7 @@
           };
 
           nativeBuildInputs = with pkgs; [ rustToolchain pkg-config ];
-          buildInputs = with pkgs; [ openssl ];
+          buildInputs = with pkgs; [ openssl bitcoind ];
 
         in
         {
@@ -36,6 +36,9 @@
             inherit buildInputs nativeBuildInputs;
 
             RUST_VERSION = rustVersion;
+
+            # Environment variables for integration tests
+            BITCOIND_EXEC = "${pkgs.bitcoind}/bin/bitcoind";
           };
         }
       );


### PR DESCRIPTION


[Waterfalls](https://github.com/RCasatta/waterfalls) is a new blockchain indexer which is optimized to be queried by descriptor or batch addresses. 
Waterfalls started with liquid (it is serving https://liquidwebwallet.org/) and recently added support for bitcoin. 

This is a proof of concept to integrate the waterfalls backend in bdk.

There are *many* open-points, shortcuts and bugs. But this is an end-to-end balance computation at least for 1 signet descriptor is the same as the electrum example 

```
/git/bdk/examples/example_waterfalls$ cargo run -- init "tr(tpubDDh1wUM29wsoJnHomNYrEwhGainWHUSzErfNrsZKiCjQWWUjFLwhtAqWvGUKc4oESXqcGKdbPDv7fBDsPHPYitNuGNrJ9BKrW1GPxUyiUUb/0/*)" --change-descriptor 'tr(tpubDDh1wUM29wsoJnHomNYrEwhGainWHUSzErfNrsZKiCjQWWUjFLwhtAqWvGUKc4oESXqcGKdbPDv7fBDsPHPYitNuGNrJ9BKrW1GPxUyiUUb/1/*)' -n signet

$ cargo run -- scan
...
$ cargo run -- balance
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.15s
     Running `/home/casatta/git/bdk/target/debug/example_electrum balance`
confirmed:
    total             79690 sats
    spendable         79690 sats
    immature              0 sats
unconfirmed:
    total                 0 sats
    trusted               0 sats
    untrusted             0 sats

```

The purpose of this PR is to gather feedback and if there are no show-stopper work to make this mergeable in steps
