### PR TITLE
chore(release): bump `bdk-chain` to `0.23.2`

### DIFF
--- a/crates/bitcoind_rpc/CHANGELOG.md
+++ b/crates/bitcoind_rpc/CHANGELOG.md
@@ -7,6 +7,27 @@ Contributors do not need to change this file but do need to add changelog detail
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [bitcoind_rpc-0.22.0]
+
+### Fixed
+- `FilterIter` now handles reorgs to ensure consistency of the header chain. #2000
+
+### Changed
+- `Event` is now a struct instead of enum #2000
+
+### Added
+- `FilterIter::new` constructor that takes as input a reference to the RPC client, checkpoint, and a list of SPKs. #2000
+- `Error::ReorgDepthExceeded` variant. #2000
+- `Error::TryFromInt` variant. #2000
+
+### Removed
+- `FilterIter::new_with_height` method #2000
+- `FilterIter::new_with_checkpoint` method #2000
+- `EventInner` type #2000
+- `FilterIter::get_tip` method #2000
+- `FilterIter::chain_update` method #2000
+- `Error::NoScripts` variant #2000
+
 ## [bitcoind_rpc-0.21.0]
 
 ### Added
@@ -54,3 +75,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [bitcoind_rpc-0.19.0]: https://github.com/bitcoindevkit/bdk/releases/tag/bitcoind_rpc-0.19.0
 [bitcoind_rpc-0.20.0]: https://github.com/bitcoindevkit/bdk/releases/tag/bitcoind_rpc-0.20.0
 [bitcoind_rpc-0.21.0]: https://github.com/bitcoindevkit/bdk/releases/tag/bitcoind_rpc-0.21.0
+[bitcoind_rpc-0.22.0]: https://github.com/bitcoindevkit/bdk/releases/tag/bitcoind_rpc-0.22.0

--- a/crates/bitcoind_rpc/Cargo.toml
+++ b/crates/bitcoind_rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_bitcoind_rpc"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"

--- a/crates/chain/CHANGELOG.md
+++ b/crates/chain/CHANGELOG.md
@@ -7,6 +7,16 @@ Contributors do not need to change this file but do need to add changelog detail
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [chain-0.23.2]
+
+### Added
+
+- Added a doctest illustrating how to filter confirmed balance results by simulating a minimum confirmation threshold via `chain_tip` height. #2007
+
+### Fixed
+
+- Behavior of `IndexedTxGraph` methods (`apply_block_relevant`, `batch_insert_relevant` and `batch_insert_relevant_unconfirmed`) to also consider conflicts of spk-relevant transactions as relevant. #2008
+
 ## [chain-0.23.1]
 
 ### Added
@@ -75,3 +85,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [chain-0.22.0]: https://github.com/bitcoindevkit/bdk/releases/tag/chain-0.22.0
 [chain-0.23.0]: https://github.com/bitcoindevkit/bdk/releases/tag/chain-0.23.0
 [chain-0.23.1]: https://github.com/bitcoindevkit/bdk/releases/tag/chain-0.23.1
+[chain-0.23.2]: https://github.com/bitcoindevkit/bdk/releases/tag/chain-0.23.2

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_chain"
-version = "0.23.1"
+version = "0.23.2"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"
@@ -17,7 +17,7 @@ workspace = true
 
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false }
-bdk_core = { path = "../core", version = "0.6.1", default-features = false }
+bdk_core = { path = "../core", version = "0.6.2", default-features = false }
 serde = { version = "1", optional = true, features = ["derive", "rc"] }
 miniscript = { version = "12.3.1", optional = true, default-features = false }
 

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [core-0.6.2]
+
+### Added
+
+- Added two new convenience methods: `floor_at` and `floor_below` for getting the checkpoint at a floored height or by an offset from the tip. #2007
+
 ## [core-0.6.1]
 
 ### Changed
@@ -50,3 +56,4 @@ This is because requests now have a `start_time`, instead of specifying a `seen_
 [core-0.5.0]: https://github.com/bitcoindevkit/bdk/releases/tag/core-0.5.0
 [core-0.6.0]: https://github.com/bitcoindevkit/bdk/releases/tag/core-0.6.0
 [core-0.6.1]: https://github.com/bitcoindevkit/bdk/releases/tag/core-0.6.1
+[core-0.6.2]: https://github.com/bitcoindevkit/bdk/releases/tag/core-0.6.2

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_core"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"

--- a/crates/electrum/CHANGELOG.md
+++ b/crates/electrum/CHANGELOG.md
@@ -7,6 +7,20 @@ Contributors do not need to change this file but do need to add changelog detail
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [electrum-0.23.2]
+
+### Added
+
+- Add a new `populate_anchor_cache` method. #2005
+
+### Changed
+
+- Update the `populate_tx_cache` method documentation. #2005
+
+### Fixed
+
+- Update the `batch_fetch_anchors` to no longer uses a potentially stale hash as the anchor. #2011
+
 ## [electrum-0.23.1]
 
 ### Added
@@ -61,3 +75,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [electrum-0.22.0]: https://github.com/bitcoindevkit/bdk/releases/tag/electrum-0.22.0
 [electrum-0.23.0]: https://github.com/bitcoindevkit/bdk/releases/tag/electrum-0.23.0
 [electrum-0.23.1]: https://github.com/bitcoindevkit/bdk/releases/tag/electrum-0.23.1
+[electrum-0.23.2]: https://github.com/bitcoindevkit/bdk/releases/tag/electrum-0.23.2

--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_electrum"
-version = "0.23.1"
+version = "0.23.2"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"

--- a/crates/file_store/CHANGELOG.md
+++ b/crates/file_store/CHANGELOG.md
@@ -7,6 +7,11 @@ Contributors do not need to change this file but do need to add changelog detail
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [file_store-0.22.0]
+
+### Changed
+- `Changeset` field of `StoreErrorWithDump` is now of type `Option<Box<C>>` #1998
+
 ## [file_store-0.21.1]
 
 ### Added
@@ -61,3 +66,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [file_store-0.20.0]: https://github.com/bitcoindevkit/bdk/releases/tag/file_store-0.20.0
 [file_store-0.21.0]: https://github.com/bitcoindevkit/bdk/releases/tag/file_store-0.21.0
 [file_store-0.21.1]: https://github.com/bitcoindevkit/bdk/releases/tag/file_store-0.21.1
+[file_store-0.22.0]: https://github.com/bitcoindevkit/bdk/releases/tag/file_store-0.22.0

--- a/crates/file_store/Cargo.toml
+++ b/crates/file_store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_file_store"
-version = "0.21.1"
+version = "0.22.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/bitcoindevkit/bdk"


### PR DESCRIPTION
fixes #2022
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

It bumps the required versions for the next releases and also each CHANGELOG.md

- bump `bdk_core` to `0.6.2`
- bump `bitcoind_rpc` to `0.22.0`
- bump `file_store` to `0.22.0`.
- bump `bdk_electrum` to `0.23.2`

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
