### PR TITLE
Add `last_evicted` field to `TxNode`

### DIFF
--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -220,6 +220,8 @@ pub struct TxNode<'a, T, A> {
     pub first_seen: Option<u64>,
     /// The last-seen unix timestamp of the transaction as unconfirmed.
     pub last_seen: Option<u64>,
+    /// The last-evicted-from-mempool unix timestamp of the transaction.
+    pub last_evicted: Option<u64>,
 }
 
 impl<T, A> Deref for TxNode<'_, T, A> {
@@ -342,6 +344,7 @@ impl<A> TxGraph<A> {
                 anchors: self.anchors.get(&txid).unwrap_or(&self.empty_anchors),
                 first_seen: self.first_seen.get(&txid).copied(),
                 last_seen: self.last_seen.get(&txid).copied(),
+                last_evicted: self.last_evicted.get(&txid).copied(),
             }),
             TxNodeInternal::Partial(_) => None,
         })
@@ -378,6 +381,7 @@ impl<A> TxGraph<A> {
                 anchors: self.anchors.get(&txid).unwrap_or(&self.empty_anchors),
                 first_seen: self.first_seen.get(&txid).copied(),
                 last_seen: self.last_seen.get(&txid).copied(),
+                last_evicted: self.last_evicted.get(&txid).copied(),
             }),
             _ => None,
         }
@@ -408,13 +412,6 @@ impl<A> TxGraph<A> {
                 .map(|(vout, txout)| (*vout, txout))
                 .collect::<BTreeMap<_, _>>(),
         })
-    }
-
-    /// Get the `last_evicted` timestamp of the given `txid`.
-    ///
-    /// Ideally, this would be included in [`TxNode`], but that would be a breaking change.
-    pub fn get_last_evicted(&self, txid: Txid) -> Option<u64> {
-        self.last_evicted.get(&txid).copied()
     }
 
     /// Calculates the fee of a given transaction. Returns [`Amount::ZERO`] if `tx` is a coinbase


### PR DESCRIPTION

### Description

All `last_evicted` field to `TxNode` and remove `TxGraph::get_last_evicted` method.

### Notes to the reviewers

`get_last_evicted` was added as adding fields to `TxNode` is a breaking change. However, we are going to break `bdk_chain` in the next release so a breaking change now is okay.

### Changelog notice

```md
Added:
- `last_evicted` field is added to `TxNode`.

Removed:
- `TxGraph::get_last_evicted` method is removed.
```

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### New Features:

~* [ ] I've added tests for the new feature~
* [x] I've added docs for the new feature
