### PR TITLE
`CanonicalView`

### DIFF
--- a/crates/bitcoind_rpc/examples/filter_iter.rs
+++ b/crates/bitcoind_rpc/examples/filter_iter.rs
@@ -68,8 +68,10 @@ fn main() -> anyhow::Result<()> {
 
     println!("\ntook: {}s", start.elapsed().as_secs());
     println!("Local tip: {}", chain.tip().height());
-    let unspent: Vec<_> = graph
-        .canonical_view(&chain, chain.tip().block_id(), Default::default())
+
+    let canonical_view = graph.canonical_view(&chain, chain.tip().block_id(), Default::default());
+
+    let unspent: Vec<_> = canonical_view
         .filter_unspent_outpoints(graph.index.outpoints().clone())
         .collect();
     if !unspent.is_empty() {
@@ -80,14 +82,7 @@ fn main() -> anyhow::Result<()> {
         }
     }
 
-    for canon_tx in graph
-        .canonical_view(
-            &chain,
-            chain.tip().block_id(),
-            bdk_chain::CanonicalizationParams::default(),
-        )
-        .txs()
-    {
+    for canon_tx in canonical_view.txs() {
         if !canon_tx.pos.is_confirmed() {
             eprintln!("ERROR: canonical tx should be confirmed {}", canon_tx.txid);
         }

--- a/crates/bitcoind_rpc/tests/test_emitter.rs
+++ b/crates/bitcoind_rpc/tests/test_emitter.rs
@@ -312,7 +312,7 @@ fn get_balance(
     let outpoints = recv_graph.index.outpoints().clone();
     let balance = recv_graph
         .canonical_view(recv_chain, chain_tip, CanonicalizationParams::default())
-        .balance(outpoints, |_, _| true);
+        .balance(outpoints, |_, _| true, 1);
     Ok(balance)
 }
 

--- a/crates/chain/benches/canonicalization.rs
+++ b/crates/chain/benches/canonicalization.rs
@@ -95,31 +95,32 @@ fn setup<F: Fn(&mut KeychainTxGraph, &LocalChain)>(f: F) -> (KeychainTxGraph, Lo
 }
 
 fn run_list_canonical_txs(tx_graph: &KeychainTxGraph, chain: &LocalChain, exp_txs: usize) {
-    let txs = tx_graph.graph().list_canonical_txs(
+    let view = tx_graph.canonical_view(
         chain,
         chain.tip().block_id(),
         CanonicalizationParams::default(),
     );
+    let txs = view.txs();
     assert_eq!(txs.count(), exp_txs);
 }
 
 fn run_filter_chain_txouts(tx_graph: &KeychainTxGraph, chain: &LocalChain, exp_txos: usize) {
-    let utxos = tx_graph.graph().filter_chain_txouts(
+    let view = tx_graph.canonical_view(
         chain,
         chain.tip().block_id(),
         CanonicalizationParams::default(),
-        tx_graph.index.outpoints().clone(),
     );
+    let utxos = view.filter_outpoints(tx_graph.index.outpoints().clone());
     assert_eq!(utxos.count(), exp_txos);
 }
 
 fn run_filter_chain_unspents(tx_graph: &KeychainTxGraph, chain: &LocalChain, exp_utxos: usize) {
-    let utxos = tx_graph.graph().filter_chain_unspents(
+    let view = tx_graph.canonical_view(
         chain,
         chain.tip().block_id(),
         CanonicalizationParams::default(),
-        tx_graph.index.outpoints().clone(),
     );
+    let utxos = view.filter_unspent_outpoints(tx_graph.index.outpoints().clone());
     assert_eq!(utxos.count(), exp_utxos);
 }
 

--- a/crates/chain/benches/indexer.rs
+++ b/crates/chain/benches/indexer.rs
@@ -86,7 +86,7 @@ fn do_bench(indexed_tx_graph: &KeychainTxGraph, chain: &LocalChain) {
     let op = graph.index.outpoints().clone();
     let bal = graph
         .canonical_view(chain, chain_tip, CanonicalizationParams::default())
-        .balance(op, |_, _| false);
+        .balance(op, |_, _| false, 1);
     assert_eq!(bal.total(), AMOUNT * TX_CT as u64);
 }
 

--- a/crates/chain/benches/indexer.rs
+++ b/crates/chain/benches/indexer.rs
@@ -84,13 +84,9 @@ fn do_bench(indexed_tx_graph: &KeychainTxGraph, chain: &LocalChain) {
     // Check balance
     let chain_tip = chain.tip().block_id();
     let op = graph.index.outpoints().clone();
-    let bal = graph.graph().balance(
-        chain,
-        chain_tip,
-        CanonicalizationParams::default(),
-        op,
-        |_, _| false,
-    );
+    let bal = graph
+        .canonical_view(chain, chain_tip, CanonicalizationParams::default())
+        .balance(op, |_, _| false);
     assert_eq!(bal.total(), AMOUNT * TX_CT as u64);
 }
 

--- a/crates/chain/src/canonical_view.rs
+++ b/crates/chain/src/canonical_view.rs
@@ -41,7 +41,7 @@ use crate::{
 /// conflicted). It includes the transaction itself along with its position in the chain (confirmed
 /// or unconfirmed).
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct CanonicalViewTx<A> {
+pub struct CanonicalTx<A> {
     /// The position of this transaction in the chain.
     ///
     /// This indicates whether the transaction is confirmed (and at what height) or
@@ -228,11 +228,11 @@ impl<A: Anchor> CanonicalView<A> {
     ///     println!("Found tx {} at position {:?}", canonical_tx.txid, canonical_tx.pos);
     /// }
     /// ```
-    pub fn tx(&self, txid: Txid) -> Option<CanonicalViewTx<A>> {
+    pub fn tx(&self, txid: Txid) -> Option<CanonicalTx<A>> {
         self.txs
             .get(&txid)
             .cloned()
-            .map(|(tx, pos)| CanonicalViewTx { pos, txid, tx })
+            .map(|(tx, pos)| CanonicalTx { pos, txid, tx })
     }
 
     /// Get a single canonical transaction output.
@@ -302,12 +302,10 @@ impl<A: Anchor> CanonicalView<A> {
     /// // Get the total number of canonical transactions
     /// println!("Total canonical transactions: {}", view.txs().len());
     /// ```
-    pub fn txs(
-        &self,
-    ) -> impl ExactSizeIterator<Item = CanonicalViewTx<A>> + DoubleEndedIterator + '_ {
+    pub fn txs(&self) -> impl ExactSizeIterator<Item = CanonicalTx<A>> + DoubleEndedIterator + '_ {
         self.order.iter().map(|&txid| {
             let (tx, pos) = self.txs[&txid].clone();
-            CanonicalViewTx { pos, txid, tx }
+            CanonicalTx { pos, txid, tx }
         })
     }
 

--- a/crates/chain/src/canonical_view.rs
+++ b/crates/chain/src/canonical_view.rs
@@ -1,0 +1,275 @@
+//! Canonical view.
+
+use crate::collections::HashMap;
+use alloc::sync::Arc;
+use core::{fmt, ops::RangeBounds};
+
+use alloc::vec::Vec;
+
+use bdk_core::BlockId;
+use bitcoin::{Amount, OutPoint, ScriptBuf, Transaction, Txid};
+
+use crate::{
+    spk_txout::SpkTxOutIndex, tx_graph::TxNode, Anchor, Balance, CanonicalIter, CanonicalReason,
+    CanonicalizationParams, ChainOracle, ChainPosition, FullTxOut, ObservedIn, TxGraph,
+};
+
+/// A single canonical transaction.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct CanonicalViewTx<A> {
+    /// Chain position.
+    pub pos: ChainPosition<A>,
+    /// Transaction ID.
+    pub txid: Txid,
+    /// The actual transaction.
+    pub tx: Arc<Transaction>,
+}
+
+/// A view of canonical transactions.
+#[derive(Debug)]
+pub struct CanonicalView<A> {
+    order: Vec<Txid>,
+    txs: HashMap<Txid, (Arc<Transaction>, ChainPosition<A>)>,
+    spends: HashMap<OutPoint, Txid>,
+    tip: BlockId,
+}
+
+impl<A: Anchor> CanonicalView<A> {
+    /// Create a canonical view.
+    pub fn new<'g, C>(
+        tx_graph: &'g TxGraph<A>,
+        chain: &'g C,
+        chain_tip: BlockId,
+        params: CanonicalizationParams,
+    ) -> Result<Self, C::Error>
+    where
+        C: ChainOracle,
+    {
+        fn find_direct_anchor<'g, A: Anchor, C: ChainOracle>(
+            tx_node: &TxNode<'g, Arc<Transaction>, A>,
+            chain: &C,
+            chain_tip: BlockId,
+        ) -> Result<Option<A>, C::Error> {
+            tx_node
+                .anchors
+                .iter()
+                .find_map(|a| -> Option<Result<A, C::Error>> {
+                    match chain.is_block_in_chain(a.anchor_block(), chain_tip) {
+                        Ok(Some(true)) => Some(Ok(a.clone())),
+                        Ok(Some(false)) | Ok(None) => None,
+                        Err(err) => Some(Err(err)),
+                    }
+                })
+                .transpose()
+        }
+
+        let mut view = Self {
+            tip: chain_tip,
+            order: vec![],
+            txs: HashMap::new(),
+            spends: HashMap::new(),
+        };
+
+        for r in CanonicalIter::new(tx_graph, chain, chain_tip, params) {
+            let (txid, tx, why) = r?;
+
+            let tx_node = match tx_graph.get_tx_node(txid) {
+                Some(tx_node) => tx_node,
+                None => {
+                    // TODO: Have the `CanonicalIter` return `TxNode`s.
+                    debug_assert!(false, "tx node must exist!");
+                    continue;
+                }
+            };
+
+            view.order.push(txid);
+
+            if !tx.is_coinbase() {
+                view.spends
+                    .extend(tx.input.iter().map(|txin| (txin.previous_output, txid)));
+            }
+
+            let pos = match why {
+                CanonicalReason::Assumed { descendant } => match descendant {
+                    Some(_) => match find_direct_anchor(&tx_node, chain, chain_tip)? {
+                        Some(anchor) => ChainPosition::Confirmed {
+                            anchor,
+                            transitively: None,
+                        },
+                        None => ChainPosition::Unconfirmed {
+                            first_seen: tx_node.first_seen,
+                            last_seen: tx_node.last_seen,
+                        },
+                    },
+                    None => ChainPosition::Unconfirmed {
+                        first_seen: tx_node.first_seen,
+                        last_seen: tx_node.last_seen,
+                    },
+                },
+                CanonicalReason::Anchor { anchor, descendant } => match descendant {
+                    Some(_) => match find_direct_anchor(&tx_node, chain, chain_tip)? {
+                        Some(anchor) => ChainPosition::Confirmed {
+                            anchor,
+                            transitively: None,
+                        },
+                        None => ChainPosition::Confirmed {
+                            anchor,
+                            transitively: descendant,
+                        },
+                    },
+                    None => ChainPosition::Confirmed {
+                        anchor,
+                        transitively: None,
+                    },
+                },
+                CanonicalReason::ObservedIn { observed_in, .. } => match observed_in {
+                    ObservedIn::Mempool(last_seen) => ChainPosition::Unconfirmed {
+                        first_seen: tx_node.first_seen,
+                        last_seen: Some(last_seen),
+                    },
+                    ObservedIn::Block(_) => ChainPosition::Unconfirmed {
+                        first_seen: tx_node.first_seen,
+                        last_seen: None,
+                    },
+                },
+            };
+            view.txs.insert(txid, (tx_node.tx, pos));
+        }
+
+        Ok(view)
+    }
+
+    /// Get a single canonical transaction.
+    pub fn tx(&self, txid: Txid) -> Option<CanonicalViewTx<A>> {
+        self.txs
+            .get(&txid)
+            .cloned()
+            .map(|(tx, pos)| CanonicalViewTx { pos, txid, tx })
+    }
+
+    /// Get a single canonical txout.
+    pub fn txout(&self, op: OutPoint) -> Option<FullTxOut<A>> {
+        let (tx, pos) = self.txs.get(&op.txid)?;
+        let vout: usize = op.vout.try_into().ok()?;
+        let txout = tx.output.get(vout)?;
+        let spent_by = self.spends.get(&op).map(|spent_by_txid| {
+            let (_, spent_by_pos) = &self.txs[spent_by_txid];
+            (spent_by_pos.clone(), *spent_by_txid)
+        });
+        Some(FullTxOut {
+            chain_position: pos.clone(),
+            outpoint: op,
+            txout: txout.clone(),
+            spent_by,
+            is_on_coinbase: tx.is_coinbase(),
+        })
+    }
+
+    /// Ordered transactions.
+    pub fn txs(
+        &self,
+    ) -> impl ExactSizeIterator<Item = CanonicalViewTx<A>> + DoubleEndedIterator + '_ {
+        self.order.iter().map(|&txid| {
+            let (tx, pos) = self.txs[&txid].clone();
+            CanonicalViewTx { pos, txid, tx }
+        })
+    }
+
+    /// Get a filtered list of outputs from the given `outpoints`.
+    ///
+    /// `outpoints` is a list of outpoints we are interested in, coupled with an outpoint identifier
+    /// (`O`) for convenience. If `O` is not necessary, the caller can use `()`, or
+    /// [`Iterator::enumerate`] over a list of [`OutPoint`]s.
+    pub fn filter_outpoints<'v, O: Clone + 'v>(
+        &'v self,
+        outpoints: impl IntoIterator<Item = (O, OutPoint)> + 'v,
+    ) -> impl Iterator<Item = (O, FullTxOut<A>)> + 'v {
+        outpoints
+            .into_iter()
+            .filter_map(|(op_i, op)| Some((op_i, self.txout(op)?)))
+    }
+
+    /// Get a filtered list of unspent outputs (UTXOs) from the given `outpoints`
+    ///
+    /// `outpoints` is a list of outpoints we are interested in, coupled with an outpoint identifier
+    /// (`O`) for convenience. If `O` is not necessary, the caller can use `()`, or
+    /// [`Iterator::enumerate`] over a list of [`OutPoint`]s.
+    pub fn filter_unspent_outpoints<'v, O: Clone + 'v>(
+        &'v self,
+        outpoints: impl IntoIterator<Item = (O, OutPoint)> + 'v,
+    ) -> impl Iterator<Item = (O, FullTxOut<A>)> + 'v {
+        self.filter_outpoints(outpoints)
+            .filter(|(_, txo)| txo.spent_by.is_none())
+    }
+
+    /// Get the total balance of `outpoints`.
+    ///
+    /// The output of `trust_predicate` should return `true` for scripts that we trust.
+    ///
+    /// `outpoints` is a list of outpoints we are interested in, coupled with an outpoint identifier
+    /// (`O`) for convenience. If `O` is not necessary, the caller can use `()`, or
+    /// [`Iterator::enumerate`] over a list of [`OutPoint`]s.
+    pub fn balance<'v, O: Clone + 'v>(
+        &'v self,
+        outpoints: impl IntoIterator<Item = (O, OutPoint)> + 'v,
+        mut trust_predicate: impl FnMut(&O, ScriptBuf) -> bool,
+    ) -> Balance {
+        let mut immature = Amount::ZERO;
+        let mut trusted_pending = Amount::ZERO;
+        let mut untrusted_pending = Amount::ZERO;
+        let mut confirmed = Amount::ZERO;
+
+        for (spk_i, txout) in self.filter_unspent_outpoints(outpoints) {
+            match &txout.chain_position {
+                ChainPosition::Confirmed { .. } => {
+                    if txout.is_confirmed_and_spendable(self.tip.height) {
+                        confirmed += txout.txout.value;
+                    } else if !txout.is_mature(self.tip.height) {
+                        immature += txout.txout.value;
+                    }
+                }
+                ChainPosition::Unconfirmed { .. } => {
+                    if trust_predicate(&spk_i, txout.txout.script_pubkey) {
+                        trusted_pending += txout.txout.value;
+                    } else {
+                        untrusted_pending += txout.txout.value;
+                    }
+                }
+            }
+        }
+
+        Balance {
+            immature,
+            trusted_pending,
+            untrusted_pending,
+            confirmed,
+        }
+    }
+
+    /// List txids that are expected to exist under the given spks.
+    ///
+    /// This is used to fill
+    /// [`SyncRequestBuilder::expected_spk_txids`](bdk_core::spk_client::SyncRequestBuilder::expected_spk_txids).
+    ///
+    ///
+    /// The spk index range can be constrained with `range`.
+    pub fn list_expected_spk_txids<'v, I>(
+        &'v self,
+        indexer: &'v impl AsRef<SpkTxOutIndex<I>>,
+        spk_index_range: impl RangeBounds<I> + 'v,
+    ) -> impl Iterator<Item = (ScriptBuf, Txid)> + 'v
+    where
+        I: fmt::Debug + Clone + Ord + 'v,
+    {
+        let indexer = indexer.as_ref();
+        self.txs().flat_map(move |c_tx| -> Vec<_> {
+            let range = &spk_index_range;
+            let relevant_spks = indexer.relevant_spks_of_tx(&c_tx.tx);
+            relevant_spks
+                .into_iter()
+                .filter(|(i, _)| range.contains(i))
+                .map(|(_, spk)| (spk, c_tx.txid))
+                .collect()
+        })
+    }
+}

--- a/crates/chain/src/lib.rs
+++ b/crates/chain/src/lib.rs
@@ -46,6 +46,8 @@ mod chain_oracle;
 pub use chain_oracle::*;
 mod canonical_iter;
 pub use canonical_iter::*;
+mod canonical_view;
+pub use canonical_view::*;
 
 #[doc(hidden)]
 pub mod example_utils;

--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -124,7 +124,7 @@ use crate::BlockId;
 use crate::CanonicalIter;
 use crate::CanonicalView;
 use crate::CanonicalizationParams;
-use crate::{Anchor, ChainOracle, ChainPosition, Merge};
+use crate::{Anchor, ChainOracle, Merge};
 use alloc::collections::vec_deque::VecDeque;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
@@ -242,27 +242,6 @@ enum TxNodeInternal {
 impl Default for TxNodeInternal {
     fn default() -> Self {
         Self::Partial(BTreeMap::new())
-    }
-}
-
-/// A transaction that is deemed to be part of the canonical history.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
-pub struct CanonicalTx<'a, T, A> {
-    /// How the transaction is observed in the canonical chain (confirmed or unconfirmed).
-    pub chain_position: ChainPosition<A>,
-    /// The transaction node (as part of the graph).
-    pub tx_node: TxNode<'a, T, A>,
-}
-
-impl<'a, T, A> From<CanonicalTx<'a, T, A>> for Txid {
-    fn from(tx: CanonicalTx<'a, T, A>) -> Self {
-        tx.tx_node.txid
-    }
-}
-
-impl<'a, A> From<CanonicalTx<'a, Arc<Transaction>, A>> for Arc<Transaction> {
-    fn from(tx: CanonicalTx<'a, Arc<Transaction>, A>) -> Self {
-        tx.tx_node.tx
     }
 }
 

--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -120,21 +120,18 @@
 //! [`insert_txout`]: TxGraph::insert_txout
 
 use crate::collections::*;
-use crate::spk_txout::SpkTxOutIndex;
 use crate::BlockId;
 use crate::CanonicalIter;
-use crate::CanonicalReason;
+use crate::CanonicalView;
 use crate::CanonicalizationParams;
-use crate::ObservedIn;
-use crate::{Anchor, Balance, ChainOracle, ChainPosition, FullTxOut, Merge};
+use crate::{Anchor, ChainOracle, ChainPosition, Merge};
 use alloc::collections::vec_deque::VecDeque;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use bdk_core::ConfirmationBlockTime;
 pub use bdk_core::TxUpdate;
-use bitcoin::{Amount, OutPoint, ScriptBuf, SignedAmount, Transaction, TxOut, Txid};
+use bitcoin::{Amount, OutPoint, SignedAmount, Transaction, TxOut, Txid};
 use core::fmt::{self, Formatter};
-use core::ops::RangeBounds;
 use core::{
     convert::Infallible,
     ops::{Deref, RangeInclusive},
@@ -980,183 +977,6 @@ impl<A: Anchor> TxGraph<A> {
 }
 
 impl<A: Anchor> TxGraph<A> {
-    /// List graph transactions that are in `chain` with `chain_tip`.
-    ///
-    /// Each transaction is represented as a [`CanonicalTx`] that contains where the transaction is
-    /// observed in-chain, and the [`TxNode`].
-    ///
-    /// # Error
-    ///
-    /// If the [`ChainOracle`] implementation (`chain`) fails, an error will be returned with the
-    /// returned item.
-    ///
-    /// If the [`ChainOracle`] is infallible, [`list_canonical_txs`] can be used instead.
-    ///
-    /// [`list_canonical_txs`]: Self::list_canonical_txs
-    pub fn try_list_canonical_txs<'a, C: ChainOracle + 'a>(
-        &'a self,
-        chain: &'a C,
-        chain_tip: BlockId,
-        params: CanonicalizationParams,
-    ) -> impl Iterator<Item = Result<CanonicalTx<'a, Arc<Transaction>, A>, C::Error>> {
-        fn find_direct_anchor<A: Anchor, C: ChainOracle>(
-            tx_node: &TxNode<'_, Arc<Transaction>, A>,
-            chain: &C,
-            chain_tip: BlockId,
-        ) -> Result<Option<A>, C::Error> {
-            tx_node
-                .anchors
-                .iter()
-                .find_map(|a| -> Option<Result<A, C::Error>> {
-                    match chain.is_block_in_chain(a.anchor_block(), chain_tip) {
-                        Ok(Some(true)) => Some(Ok(a.clone())),
-                        Ok(Some(false)) | Ok(None) => None,
-                        Err(err) => Some(Err(err)),
-                    }
-                })
-                .transpose()
-        }
-        self.canonical_iter(chain, chain_tip, params)
-            .flat_map(move |res| {
-                res.map(|(txid, _, canonical_reason)| {
-                    let tx_node = self.get_tx_node(txid).expect("must contain tx");
-                    let chain_position = match canonical_reason {
-                        CanonicalReason::Assumed { descendant } => match descendant {
-                            Some(_) => match find_direct_anchor(&tx_node, chain, chain_tip)? {
-                                Some(anchor) => ChainPosition::Confirmed {
-                                    anchor,
-                                    transitively: None,
-                                },
-                                None => ChainPosition::Unconfirmed {
-                                    first_seen: tx_node.first_seen,
-                                    last_seen: tx_node.last_seen,
-                                },
-                            },
-                            None => ChainPosition::Unconfirmed {
-                                first_seen: tx_node.first_seen,
-                                last_seen: tx_node.last_seen,
-                            },
-                        },
-                        CanonicalReason::Anchor { anchor, descendant } => match descendant {
-                            Some(_) => match find_direct_anchor(&tx_node, chain, chain_tip)? {
-                                Some(anchor) => ChainPosition::Confirmed {
-                                    anchor,
-                                    transitively: None,
-                                },
-                                None => ChainPosition::Confirmed {
-                                    anchor,
-                                    transitively: descendant,
-                                },
-                            },
-                            None => ChainPosition::Confirmed {
-                                anchor,
-                                transitively: None,
-                            },
-                        },
-                        CanonicalReason::ObservedIn { observed_in, .. } => match observed_in {
-                            ObservedIn::Mempool(last_seen) => ChainPosition::Unconfirmed {
-                                first_seen: tx_node.first_seen,
-                                last_seen: Some(last_seen),
-                            },
-                            ObservedIn::Block(_) => ChainPosition::Unconfirmed {
-                                first_seen: tx_node.first_seen,
-                                last_seen: None,
-                            },
-                        },
-                    };
-                    Ok(CanonicalTx {
-                        chain_position,
-                        tx_node,
-                    })
-                })
-            })
-    }
-
-    /// List graph transactions that are in `chain` with `chain_tip`.
-    ///
-    /// This is the infallible version of [`try_list_canonical_txs`].
-    ///
-    /// [`try_list_canonical_txs`]: Self::try_list_canonical_txs
-    pub fn list_canonical_txs<'a, C: ChainOracle<Error = Infallible> + 'a>(
-        &'a self,
-        chain: &'a C,
-        chain_tip: BlockId,
-        params: CanonicalizationParams,
-    ) -> impl Iterator<Item = CanonicalTx<'a, Arc<Transaction>, A>> {
-        self.try_list_canonical_txs(chain, chain_tip, params)
-            .map(|res| res.expect("infallible"))
-    }
-
-    /// Get a filtered list of outputs from the given `outpoints` that are in `chain` with
-    /// `chain_tip`.
-    ///
-    /// `outpoints` is a list of outpoints we are interested in, coupled with an outpoint identifier
-    /// (`OI`) for convenience. If `OI` is not necessary, the caller can use `()`, or
-    /// [`Iterator::enumerate`] over a list of [`OutPoint`]s.
-    ///
-    /// Floating outputs (i.e., outputs for which we don't have the full transaction in the graph)
-    /// are ignored.
-    ///
-    /// # Error
-    ///
-    /// An [`Iterator::Item`] can be an [`Err`] if the [`ChainOracle`] implementation (`chain`)
-    /// fails.
-    ///
-    /// If the [`ChainOracle`] implementation is infallible, [`filter_chain_txouts`] can be used
-    /// instead.
-    ///
-    /// [`filter_chain_txouts`]: Self::filter_chain_txouts
-    pub fn try_filter_chain_txouts<'a, C: ChainOracle + 'a, OI: Clone + 'a>(
-        &'a self,
-        chain: &'a C,
-        chain_tip: BlockId,
-        params: CanonicalizationParams,
-        outpoints: impl IntoIterator<Item = (OI, OutPoint)> + 'a,
-    ) -> Result<impl Iterator<Item = (OI, FullTxOut<A>)> + 'a, C::Error> {
-        let mut canon_txs = HashMap::<Txid, CanonicalTx<Arc<Transaction>, A>>::new();
-        let mut canon_spends = HashMap::<OutPoint, Txid>::new();
-        for r in self.try_list_canonical_txs(chain, chain_tip, params) {
-            let canonical_tx = r?;
-            let txid = canonical_tx.tx_node.txid;
-
-            if !canonical_tx.tx_node.tx.is_coinbase() {
-                for txin in &canonical_tx.tx_node.tx.input {
-                    let _res = canon_spends.insert(txin.previous_output, txid);
-                    assert!(_res.is_none(), "tried to replace {_res:?} with {txid:?}",);
-                }
-            }
-            canon_txs.insert(txid, canonical_tx);
-        }
-        Ok(outpoints.into_iter().filter_map(move |(spk_i, outpoint)| {
-            let canon_tx = canon_txs.get(&outpoint.txid)?;
-            let txout = canon_tx
-                .tx_node
-                .tx
-                .output
-                .get(outpoint.vout as usize)
-                .cloned()?;
-            let chain_position = canon_tx.chain_position.clone();
-            let spent_by = canon_spends.get(&outpoint).map(|spend_txid| {
-                let spend_tx = canon_txs
-                    .get(spend_txid)
-                    .cloned()
-                    .expect("must be canonical");
-                (spend_tx.chain_position, *spend_txid)
-            });
-            let is_on_coinbase = canon_tx.tx_node.is_coinbase();
-            Some((
-                spk_i,
-                FullTxOut {
-                    outpoint,
-                    txout,
-                    chain_position,
-                    spent_by,
-                    is_on_coinbase,
-                },
-            ))
-        }))
-    }
-
     /// List txids by descending anchor height order.
     ///
     /// If multiple anchors exist for a txid, the highest anchor height will be used. Transactions
@@ -1192,262 +1012,24 @@ impl<A: Anchor> TxGraph<A> {
         CanonicalIter::new(self, chain, chain_tip, params)
     }
 
-    /// Get a filtered list of outputs from the given `outpoints` that are in `chain` with
-    /// `chain_tip`.
-    ///
-    /// This is the infallible version of [`try_filter_chain_txouts`].
-    ///
-    /// [`try_filter_chain_txouts`]: Self::try_filter_chain_txouts
-    pub fn filter_chain_txouts<'a, C: ChainOracle<Error = Infallible> + 'a, OI: Clone + 'a>(
+    /// Returns a [`CanonicalView`].
+    pub fn try_canonical_view<'a, C: ChainOracle>(
         &'a self,
         chain: &'a C,
         chain_tip: BlockId,
         params: CanonicalizationParams,
-        outpoints: impl IntoIterator<Item = (OI, OutPoint)> + 'a,
-    ) -> impl Iterator<Item = (OI, FullTxOut<A>)> + 'a {
-        self.try_filter_chain_txouts(chain, chain_tip, params, outpoints)
-            .expect("oracle is infallible")
+    ) -> Result<CanonicalView<A>, C::Error> {
+        CanonicalView::new(self, chain, chain_tip, params)
     }
 
-    /// Get a filtered list of unspent outputs (UTXOs) from the given `outpoints` that are in
-    /// `chain` with `chain_tip`.
-    ///
-    /// `outpoints` is a list of outpoints we are interested in, coupled with an outpoint identifier
-    /// (`OI`) for convenience. If `OI` is not necessary, the caller can use `()`, or
-    /// [`Iterator::enumerate`] over a list of [`OutPoint`]s.
-    ///
-    /// Floating outputs are ignored.
-    ///
-    /// # Error
-    ///
-    /// An [`Iterator::Item`] can be an [`Err`] if the [`ChainOracle`] implementation (`chain`)
-    /// fails.
-    ///
-    /// If the [`ChainOracle`] implementation is infallible, [`filter_chain_unspents`] can be used
-    /// instead.
-    ///
-    /// [`filter_chain_unspents`]: Self::filter_chain_unspents
-    pub fn try_filter_chain_unspents<'a, C: ChainOracle + 'a, OI: Clone + 'a>(
+    /// Returns a [`CanonicalView`].
+    pub fn canonical_view<'a, C: ChainOracle<Error = Infallible>>(
         &'a self,
         chain: &'a C,
         chain_tip: BlockId,
         params: CanonicalizationParams,
-        outpoints: impl IntoIterator<Item = (OI, OutPoint)> + 'a,
-    ) -> Result<impl Iterator<Item = (OI, FullTxOut<A>)> + 'a, C::Error> {
-        Ok(self
-            .try_filter_chain_txouts(chain, chain_tip, params, outpoints)?
-            .filter(|(_, full_txo)| full_txo.spent_by.is_none()))
-    }
-
-    /// Get a filtered list of unspent outputs (UTXOs) from the given `outpoints` that are in
-    /// `chain` with `chain_tip`.
-    ///
-    /// This is the infallible version of [`try_filter_chain_unspents`].
-    ///
-    /// [`try_filter_chain_unspents`]: Self::try_filter_chain_unspents
-    pub fn filter_chain_unspents<'a, C: ChainOracle<Error = Infallible> + 'a, OI: Clone + 'a>(
-        &'a self,
-        chain: &'a C,
-        chain_tip: BlockId,
-        params: CanonicalizationParams,
-        txouts: impl IntoIterator<Item = (OI, OutPoint)> + 'a,
-    ) -> impl Iterator<Item = (OI, FullTxOut<A>)> + 'a {
-        self.try_filter_chain_unspents(chain, chain_tip, params, txouts)
-            .expect("oracle is infallible")
-    }
-
-    /// Get the total balance of `outpoints` that are in `chain` of `chain_tip`.
-    ///
-    /// The output of `trust_predicate` should return `true` for scripts that we trust.
-    ///
-    /// `outpoints` is a list of outpoints we are interested in, coupled with an outpoint identifier
-    /// (`OI`) for convenience. If `OI` is not necessary, the caller can use `()`, or
-    /// [`Iterator::enumerate`] over a list of [`OutPoint`]s.
-    ///
-    /// If the provided [`ChainOracle`] implementation (`chain`) is infallible, [`balance`] can be
-    /// used instead.
-    ///
-    /// [`balance`]: Self::balance
-    pub fn try_balance<C: ChainOracle, OI: Clone>(
-        &self,
-        chain: &C,
-        chain_tip: BlockId,
-        params: CanonicalizationParams,
-        outpoints: impl IntoIterator<Item = (OI, OutPoint)>,
-        mut trust_predicate: impl FnMut(&OI, ScriptBuf) -> bool,
-    ) -> Result<Balance, C::Error> {
-        let mut immature = Amount::ZERO;
-        let mut trusted_pending = Amount::ZERO;
-        let mut untrusted_pending = Amount::ZERO;
-        let mut confirmed = Amount::ZERO;
-
-        for (spk_i, txout) in self.try_filter_chain_unspents(chain, chain_tip, params, outpoints)? {
-            match &txout.chain_position {
-                ChainPosition::Confirmed { .. } => {
-                    if txout.is_confirmed_and_spendable(chain_tip.height) {
-                        confirmed += txout.txout.value;
-                    } else if !txout.is_mature(chain_tip.height) {
-                        immature += txout.txout.value;
-                    }
-                }
-                ChainPosition::Unconfirmed { .. } => {
-                    if trust_predicate(&spk_i, txout.txout.script_pubkey) {
-                        trusted_pending += txout.txout.value;
-                    } else {
-                        untrusted_pending += txout.txout.value;
-                    }
-                }
-            }
-        }
-
-        Ok(Balance {
-            immature,
-            trusted_pending,
-            untrusted_pending,
-            confirmed,
-        })
-    }
-
-    /// Get the total balance of `outpoints` that are in `chain` of `chain_tip`.
-    ///
-    /// This is the infallible version of [`try_balance`].
-    ///
-    /// ### Minimum confirmations
-    ///
-    /// To filter for transactions with at least `N` confirmations, pass a `chain_tip` that is
-    /// `N - 1` blocks below the actual tip. This ensures that only transactions with at least `N`
-    /// confirmations are counted as confirmed in the returned [`Balance`].
-    ///
-    /// ```
-    /// # use bdk_chain::tx_graph::TxGraph;
-    /// # use bdk_chain::{local_chain::LocalChain, CanonicalizationParams, ConfirmationBlockTime};
-    /// # use bdk_testenv::{hash, utils::new_tx};
-    /// # use bitcoin::{Amount, BlockHash, OutPoint, ScriptBuf, Transaction, TxIn, TxOut};
-    ///
-    /// # let spk = ScriptBuf::from_hex("0014c692ecf13534982a9a2834565cbd37add8027140").unwrap();
-    /// # let chain =
-    /// #     LocalChain::<BlockHash>::from_blocks((0..=15).map(|i| (i as u32, hash!("h"))).collect()).unwrap();
-    /// # let mut graph: TxGraph = TxGraph::default();
-    /// # let coinbase_tx = Transaction {
-    /// #     input: vec![TxIn {
-    /// #         previous_output: OutPoint::null(),
-    /// #         ..Default::default()
-    /// #     }],
-    /// #     output: vec![TxOut {
-    /// #         value: Amount::from_sat(70000),
-    /// #         script_pubkey: spk.clone(),
-    /// #     }],
-    /// #     ..new_tx(0)
-    /// # };
-    /// # let tx = Transaction {
-    /// #     input: vec![TxIn {
-    /// #         previous_output: OutPoint::new(coinbase_tx.compute_txid(), 0),
-    /// #         ..Default::default()
-    /// #     }],
-    /// #     output: vec![TxOut {
-    /// #         value: Amount::from_sat(42_000),
-    /// #         script_pubkey: spk.clone(),
-    /// #     }],
-    /// #     ..new_tx(1)
-    /// # };
-    /// # let txid = tx.compute_txid();
-    /// # let _ = graph.insert_tx(tx.clone());
-    /// # let _ = graph.insert_anchor(
-    /// #     txid,
-    /// #     ConfirmationBlockTime {
-    /// #         block_id: chain.get(10).unwrap().block_id(),
-    /// #         confirmation_time: 123456,
-    /// #     },
-    /// # );
-    ///
-    /// let minimum_confirmations = 6;
-    /// let target_tip = chain
-    ///     .tip()
-    ///     .floor_below(minimum_confirmations - 1)
-    ///     .expect("checkpoint from local chain must have genesis");
-    /// let balance = graph.balance(
-    ///     &chain,
-    ///     target_tip.block_id(),
-    ///     CanonicalizationParams::default(),
-    ///     std::iter::once(((), OutPoint::new(txid, 0))),
-    ///     |_: &(), _| true,
-    /// );
-    /// assert_eq!(balance.confirmed, Amount::from_sat(42_000));
-    /// ```
-    ///
-    /// [`try_balance`]: Self::try_balance
-    pub fn balance<C: ChainOracle<Error = Infallible>, OI: Clone>(
-        &self,
-        chain: &C,
-        chain_tip: BlockId,
-        params: CanonicalizationParams,
-        outpoints: impl IntoIterator<Item = (OI, OutPoint)>,
-        trust_predicate: impl FnMut(&OI, ScriptBuf) -> bool,
-    ) -> Balance {
-        self.try_balance(chain, chain_tip, params, outpoints, trust_predicate)
-            .expect("oracle is infallible")
-    }
-
-    /// List txids that are expected to exist under the given spks.
-    ///
-    /// This is used to fill
-    /// [`SyncRequestBuilder::expected_spk_txids`](bdk_core::spk_client::SyncRequestBuilder::expected_spk_txids).
-    ///
-    ///
-    /// The spk index range can be constrained with `range`.
-    ///
-    /// # Error
-    ///
-    /// If the [`ChainOracle`] implementation (`chain`) fails, an error will be returned with the
-    /// returned item.
-    ///
-    /// If the [`ChainOracle`] is infallible,
-    /// [`list_expected_spk_txids`](Self::list_expected_spk_txids) can be used instead.
-    pub fn try_list_expected_spk_txids<'a, C, I>(
-        &'a self,
-        chain: &'a C,
-        chain_tip: BlockId,
-        indexer: &'a impl AsRef<SpkTxOutIndex<I>>,
-        spk_index_range: impl RangeBounds<I> + 'a,
-    ) -> impl Iterator<Item = Result<(ScriptBuf, Txid), C::Error>> + 'a
-    where
-        C: ChainOracle,
-        I: fmt::Debug + Clone + Ord + 'a,
-    {
-        let indexer = indexer.as_ref();
-        self.try_list_canonical_txs(chain, chain_tip, CanonicalizationParams::default())
-            .flat_map(move |res| -> Vec<Result<(ScriptBuf, Txid), C::Error>> {
-                let range = &spk_index_range;
-                let c_tx = match res {
-                    Ok(c_tx) => c_tx,
-                    Err(err) => return vec![Err(err)],
-                };
-                let relevant_spks = indexer.relevant_spks_of_tx(&c_tx.tx_node);
-                relevant_spks
-                    .into_iter()
-                    .filter(|(i, _)| range.contains(i))
-                    .map(|(_, spk)| Ok((spk, c_tx.tx_node.txid)))
-                    .collect()
-            })
-    }
-
-    /// List txids that are expected to exist under the given spks.
-    ///
-    /// This is the infallible version of
-    /// [`try_list_expected_spk_txids`](Self::try_list_expected_spk_txids).
-    pub fn list_expected_spk_txids<'a, C, I>(
-        &'a self,
-        chain: &'a C,
-        chain_tip: BlockId,
-        indexer: &'a impl AsRef<SpkTxOutIndex<I>>,
-        spk_index_range: impl RangeBounds<I> + 'a,
-    ) -> impl Iterator<Item = (ScriptBuf, Txid)> + 'a
-    where
-        C: ChainOracle<Error = Infallible>,
-        I: fmt::Debug + Clone + Ord + 'a,
-    {
-        self.try_list_expected_spk_txids(chain, chain_tip, indexer, spk_index_range)
-            .map(|r| r.expect("infallible"))
+    ) -> CanonicalView<A> {
+        CanonicalView::new(self, chain, chain_tip, params).expect("infallible")
     }
 
     /// Construct a `TxGraph` from a `changeset`.

--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -21,15 +21,14 @@
 //! Conflicting transactions are allowed to coexist within a [`TxGraph`]. A process called
 //! canonicalization is required to get a conflict-free view of transactions.
 //!
-//! * [`list_canonical_txs`](TxGraph::list_canonical_txs) lists canonical transactions.
-//! * [`filter_chain_txouts`](TxGraph::filter_chain_txouts) filters out canonical outputs from a
-//!   list of outpoints.
-//! * [`filter_chain_unspents`](TxGraph::filter_chain_unspents) filters out canonical unspent
-//!   outputs from a list of outpoints.
-//! * [`balance`](TxGraph::balance) gets the total sum of unspent outputs filtered from a list of
-//!   outpoints.
-//! * [`canonical_iter`](TxGraph::canonical_iter) returns the [`CanonicalIter`] which contains all
-//!   of the canonicalization logic.
+//! * [`canonical_iter`](TxGraph::canonical_iter) returns a [`CanonicalIter`] which performs
+//!   incremental canonicalization. This is useful when you only need to check specific transactions
+//!   (e.g., verifying whether a few unconfirmed transactions are canonical) without computing the
+//!   entire canonical view.
+//! * [`canonical_view`](TxGraph::canonical_view) returns a [`CanonicalView`] which provides a
+//!   complete canonical view of the graph. This is required for typical wallet operations like
+//!   querying balances, listing outputs, transactions, and UTXOs. You must construct this first
+//!   before performing these operations.
 //!
 //! All these methods require a `chain` and `chain_tip` argument. The `chain` must be a
 //! [`ChainOracle`] implementation (such as [`LocalChain`](crate::local_chain::LocalChain)) which

--- a/crates/chain/tests/test_canonical_view.rs
+++ b/crates/chain/tests/test_canonical_view.rs
@@ -1,0 +1,304 @@
+#![cfg(feature = "miniscript")]
+
+use bdk_chain::{local_chain::LocalChain, CanonicalizationParams, ConfirmationBlockTime, TxGraph};
+use bdk_testenv::{hash, utils::new_tx};
+use bitcoin::{Amount, OutPoint, ScriptBuf, Transaction, TxIn, TxOut};
+
+#[test]
+fn test_min_confirmations_parameter() {
+    // Create a local chain with several blocks
+    let chain = LocalChain::from_blocks(
+        [
+            (0, hash!("block0")),
+            (1, hash!("block1")),
+            (2, hash!("block2")),
+            (3, hash!("block3")),
+            (4, hash!("block4")),
+            (5, hash!("block5")),
+            (6, hash!("block6")),
+            (7, hash!("block7")),
+            (8, hash!("block8")),
+            (9, hash!("block9")),
+            (10, hash!("block10")),
+        ]
+        .into(),
+    )
+    .unwrap();
+
+    let mut tx_graph = TxGraph::default();
+
+    // Create a non-coinbase transaction
+    let tx = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(hash!("parent"), 0),
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(50_000),
+            script_pubkey: ScriptBuf::new(),
+        }],
+        ..new_tx(1)
+    };
+    let txid = tx.compute_txid();
+    let outpoint = OutPoint::new(txid, 0);
+
+    // Insert transaction into graph
+    let _ = tx_graph.insert_tx(tx.clone());
+
+    // Test 1: Transaction confirmed at height 5, tip at height 10 (6 confirmations)
+    let anchor_height_5 = ConfirmationBlockTime {
+        block_id: chain.get(5).unwrap().block_id(),
+        confirmation_time: 123456,
+    };
+    let _ = tx_graph.insert_anchor(txid, anchor_height_5);
+
+    let chain_tip = chain.tip().block_id();
+    let canonical_view =
+        tx_graph.canonical_view(&chain, chain_tip, CanonicalizationParams::default());
+
+    // Test min_confirmations = 1: Should be confirmed (has 6 confirmations)
+    let balance_1_conf = canonical_view.balance(
+        [((), outpoint)],
+        |_, _| true, // trust all
+        1,
+    );
+
+    assert_eq!(balance_1_conf.confirmed, Amount::from_sat(50_000));
+    assert_eq!(balance_1_conf.trusted_pending, Amount::ZERO);
+
+    // Test min_confirmations = 6: Should be confirmed (has exactly 6 confirmations)
+    let balance_6_conf = canonical_view.balance(
+        [((), outpoint)],
+        |_, _| true, // trust all
+        6,
+    );
+    assert_eq!(balance_6_conf.confirmed, Amount::from_sat(50_000));
+    assert_eq!(balance_6_conf.trusted_pending, Amount::ZERO);
+
+    // Test min_confirmations = 7: Should be trusted pending (only has 6 confirmations)
+    let balance_7_conf = canonical_view.balance(
+        [((), outpoint)],
+        |_, _| true, // trust all
+        7,
+    );
+    assert_eq!(balance_7_conf.confirmed, Amount::ZERO);
+    assert_eq!(balance_7_conf.trusted_pending, Amount::from_sat(50_000));
+
+    // Test min_confirmations = 0: Should behave same as 1 (confirmed)
+    let balance_0_conf = canonical_view.balance(
+        [((), outpoint)],
+        |_, _| true, // trust all
+        0,
+    );
+    assert_eq!(balance_0_conf.confirmed, Amount::from_sat(50_000));
+    assert_eq!(balance_0_conf.trusted_pending, Amount::ZERO);
+    assert_eq!(balance_0_conf, balance_1_conf);
+}
+
+#[test]
+fn test_min_confirmations_with_untrusted_tx() {
+    // Create a local chain
+    let chain = LocalChain::from_blocks(
+        [
+            (0, hash!("genesis")),
+            (1, hash!("b1")),
+            (2, hash!("b2")),
+            (3, hash!("b3")),
+            (4, hash!("b4")),
+            (5, hash!("b5")),
+            (6, hash!("b6")),
+            (7, hash!("b7")),
+            (8, hash!("b8")),
+            (9, hash!("b9")),
+            (10, hash!("tip")),
+        ]
+        .into(),
+    )
+    .unwrap();
+
+    let mut tx_graph = TxGraph::default();
+
+    // Create a transaction
+    let tx = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(hash!("parent"), 0),
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(25_000),
+            script_pubkey: ScriptBuf::new(),
+        }],
+        ..new_tx(1)
+    };
+    let txid = tx.compute_txid();
+    let outpoint = OutPoint::new(txid, 0);
+
+    let _ = tx_graph.insert_tx(tx.clone());
+
+    // Anchor at height 8, tip at height 10 (3 confirmations)
+    let anchor = ConfirmationBlockTime {
+        block_id: chain.get(8).unwrap().block_id(),
+        confirmation_time: 123456,
+    };
+    let _ = tx_graph.insert_anchor(txid, anchor);
+
+    let canonical_view = tx_graph.canonical_view(
+        &chain,
+        chain.tip().block_id(),
+        CanonicalizationParams::default(),
+    );
+
+    // Test with min_confirmations = 5 and untrusted predicate
+    let balance = canonical_view.balance(
+        [((), outpoint)],
+        |_, _| false, // don't trust
+        5,
+    );
+
+    // Should be untrusted pending (not enough confirmations and not trusted)
+    assert_eq!(balance.confirmed, Amount::ZERO);
+    assert_eq!(balance.trusted_pending, Amount::ZERO);
+    assert_eq!(balance.untrusted_pending, Amount::from_sat(25_000));
+}
+
+#[test]
+fn test_min_confirmations_multiple_transactions() {
+    // Create a local chain
+    let chain = LocalChain::from_blocks(
+        [
+            (0, hash!("genesis")),
+            (1, hash!("b1")),
+            (2, hash!("b2")),
+            (3, hash!("b3")),
+            (4, hash!("b4")),
+            (5, hash!("b5")),
+            (6, hash!("b6")),
+            (7, hash!("b7")),
+            (8, hash!("b8")),
+            (9, hash!("b9")),
+            (10, hash!("b10")),
+            (11, hash!("b11")),
+            (12, hash!("b12")),
+            (13, hash!("b13")),
+            (14, hash!("b14")),
+            (15, hash!("tip")),
+        ]
+        .into(),
+    )
+    .unwrap();
+
+    let mut tx_graph = TxGraph::default();
+
+    // Create multiple transactions at different heights
+    let mut outpoints = vec![];
+
+    // Transaction 0: anchored at height 5, has 11 confirmations (tip-5+1 = 15-5+1 = 11)
+    let tx0 = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(hash!("parent0"), 0),
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(10_000),
+            script_pubkey: ScriptBuf::new(),
+        }],
+        ..new_tx(1)
+    };
+    let txid0 = tx0.compute_txid();
+    let outpoint0 = OutPoint::new(txid0, 0);
+    let _ = tx_graph.insert_tx(tx0);
+    let _ = tx_graph.insert_anchor(
+        txid0,
+        ConfirmationBlockTime {
+            block_id: chain.get(5).unwrap().block_id(),
+            confirmation_time: 123456,
+        },
+    );
+    outpoints.push(((), outpoint0));
+
+    // Transaction 1: anchored at height 10, has 6 confirmations (15-10+1 = 6)
+    let tx1 = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(hash!("parent1"), 0),
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(20_000),
+            script_pubkey: ScriptBuf::new(),
+        }],
+        ..new_tx(2)
+    };
+    let txid1 = tx1.compute_txid();
+    let outpoint1 = OutPoint::new(txid1, 0);
+    let _ = tx_graph.insert_tx(tx1);
+    let _ = tx_graph.insert_anchor(
+        txid1,
+        ConfirmationBlockTime {
+            block_id: chain.get(10).unwrap().block_id(),
+            confirmation_time: 123457,
+        },
+    );
+    outpoints.push(((), outpoint1));
+
+    // Transaction 2: anchored at height 13, has 3 confirmations (15-13+1 = 3)
+    let tx2 = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(hash!("parent2"), 0),
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(30_000),
+            script_pubkey: ScriptBuf::new(),
+        }],
+        ..new_tx(3)
+    };
+    let txid2 = tx2.compute_txid();
+    let outpoint2 = OutPoint::new(txid2, 0);
+    let _ = tx_graph.insert_tx(tx2);
+    let _ = tx_graph.insert_anchor(
+        txid2,
+        ConfirmationBlockTime {
+            block_id: chain.get(13).unwrap().block_id(),
+            confirmation_time: 123458,
+        },
+    );
+    outpoints.push(((), outpoint2));
+
+    let canonical_view = tx_graph.canonical_view(
+        &chain,
+        chain.tip().block_id(),
+        CanonicalizationParams::default(),
+    );
+
+    // Test with min_confirmations = 5
+    // tx0: 11 confirmations -> confirmed
+    // tx1: 6 confirmations -> confirmed
+    // tx2: 3 confirmations -> trusted pending
+    let balance = canonical_view.balance(outpoints.clone(), |_, _| true, 5);
+
+    assert_eq!(
+        balance.confirmed,
+        Amount::from_sat(10_000 + 20_000) // tx0 + tx1
+    );
+    assert_eq!(
+        balance.trusted_pending,
+        Amount::from_sat(30_000) // tx2
+    );
+    assert_eq!(balance.untrusted_pending, Amount::ZERO);
+
+    // Test with min_confirmations = 10
+    // tx0: 11 confirmations -> confirmed
+    // tx1: 6 confirmations -> trusted pending
+    // tx2: 3 confirmations -> trusted pending
+    let balance_high = canonical_view.balance(outpoints, |_, _| true, 10);
+
+    assert_eq!(
+        balance_high.confirmed,
+        Amount::from_sat(10_000) // only tx0
+    );
+    assert_eq!(
+        balance_high.trusted_pending,
+        Amount::from_sat(20_000 + 30_000) // tx1 + tx2
+    );
+    assert_eq!(balance_high.untrusted_pending, Amount::ZERO);
+}

--- a/crates/chain/tests/test_canonical_view.rs
+++ b/crates/chain/tests/test_canonical_view.rs
@@ -1,29 +1,30 @@
 #![cfg(feature = "miniscript")]
 
+use std::collections::BTreeMap;
+
 use bdk_chain::{local_chain::LocalChain, CanonicalizationParams, ConfirmationBlockTime, TxGraph};
 use bdk_testenv::{hash, utils::new_tx};
-use bitcoin::{Amount, OutPoint, ScriptBuf, Transaction, TxIn, TxOut};
+use bitcoin::{Amount, BlockHash, OutPoint, ScriptBuf, Transaction, TxIn, TxOut};
 
 #[test]
 fn test_min_confirmations_parameter() {
     // Create a local chain with several blocks
-    let chain = LocalChain::from_blocks(
-        [
-            (0, hash!("block0")),
-            (1, hash!("block1")),
-            (2, hash!("block2")),
-            (3, hash!("block3")),
-            (4, hash!("block4")),
-            (5, hash!("block5")),
-            (6, hash!("block6")),
-            (7, hash!("block7")),
-            (8, hash!("block8")),
-            (9, hash!("block9")),
-            (10, hash!("block10")),
-        ]
-        .into(),
-    )
-    .unwrap();
+    let blocks: BTreeMap<u32, BlockHash> = [
+        (0, hash!("block0")),
+        (1, hash!("block1")),
+        (2, hash!("block2")),
+        (3, hash!("block3")),
+        (4, hash!("block4")),
+        (5, hash!("block5")),
+        (6, hash!("block6")),
+        (7, hash!("block7")),
+        (8, hash!("block8")),
+        (9, hash!("block9")),
+        (10, hash!("block10")),
+    ]
+    .into_iter()
+    .collect();
+    let chain = LocalChain::from_blocks(blocks).unwrap();
 
     let mut tx_graph = TxGraph::default();
 
@@ -98,23 +99,22 @@ fn test_min_confirmations_parameter() {
 #[test]
 fn test_min_confirmations_with_untrusted_tx() {
     // Create a local chain
-    let chain = LocalChain::from_blocks(
-        [
-            (0, hash!("genesis")),
-            (1, hash!("b1")),
-            (2, hash!("b2")),
-            (3, hash!("b3")),
-            (4, hash!("b4")),
-            (5, hash!("b5")),
-            (6, hash!("b6")),
-            (7, hash!("b7")),
-            (8, hash!("b8")),
-            (9, hash!("b9")),
-            (10, hash!("tip")),
-        ]
-        .into(),
-    )
-    .unwrap();
+    let blocks: BTreeMap<u32, BlockHash> = [
+        (0, hash!("genesis")),
+        (1, hash!("b1")),
+        (2, hash!("b2")),
+        (3, hash!("b3")),
+        (4, hash!("b4")),
+        (5, hash!("b5")),
+        (6, hash!("b6")),
+        (7, hash!("b7")),
+        (8, hash!("b8")),
+        (9, hash!("b9")),
+        (10, hash!("tip")),
+    ]
+    .into_iter()
+    .collect();
+    let chain = LocalChain::from_blocks(blocks).unwrap();
 
     let mut tx_graph = TxGraph::default();
 
@@ -164,28 +164,27 @@ fn test_min_confirmations_with_untrusted_tx() {
 #[test]
 fn test_min_confirmations_multiple_transactions() {
     // Create a local chain
-    let chain = LocalChain::from_blocks(
-        [
-            (0, hash!("genesis")),
-            (1, hash!("b1")),
-            (2, hash!("b2")),
-            (3, hash!("b3")),
-            (4, hash!("b4")),
-            (5, hash!("b5")),
-            (6, hash!("b6")),
-            (7, hash!("b7")),
-            (8, hash!("b8")),
-            (9, hash!("b9")),
-            (10, hash!("b10")),
-            (11, hash!("b11")),
-            (12, hash!("b12")),
-            (13, hash!("b13")),
-            (14, hash!("b14")),
-            (15, hash!("tip")),
-        ]
-        .into(),
-    )
-    .unwrap();
+    let blocks: BTreeMap<u32, BlockHash> = [
+        (0, hash!("genesis")),
+        (1, hash!("b1")),
+        (2, hash!("b2")),
+        (3, hash!("b3")),
+        (4, hash!("b4")),
+        (5, hash!("b5")),
+        (6, hash!("b6")),
+        (7, hash!("b7")),
+        (8, hash!("b8")),
+        (9, hash!("b9")),
+        (10, hash!("b10")),
+        (11, hash!("b11")),
+        (12, hash!("b12")),
+        (13, hash!("b13")),
+        (14, hash!("b14")),
+        (15, hash!("tip")),
+    ]
+    .into_iter()
+    .collect();
+    let chain = LocalChain::from_blocks(blocks).unwrap();
 
     let mut tx_graph = TxGraph::default();
 

--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -460,32 +460,21 @@ fn test_list_owned_txouts() {
                 .map(|cp| cp.block_id())
                 .unwrap_or_else(|| panic!("block must exist at {height}"));
             let txouts = graph
-                .graph()
-                .filter_chain_txouts(
-                    &local_chain,
-                    chain_tip,
-                    CanonicalizationParams::default(),
-                    graph.index.outpoints().iter().cloned(),
-                )
+                .canonical_view(&local_chain, chain_tip, CanonicalizationParams::default())
+                .filter_outpoints(graph.index.outpoints().iter().cloned())
                 .collect::<Vec<_>>();
 
             let utxos = graph
-                .graph()
-                .filter_chain_unspents(
-                    &local_chain,
-                    chain_tip,
-                    CanonicalizationParams::default(),
-                    graph.index.outpoints().iter().cloned(),
-                )
+                .canonical_view(&local_chain, chain_tip, CanonicalizationParams::default())
+                .filter_unspent_outpoints(graph.index.outpoints().iter().cloned())
                 .collect::<Vec<_>>();
 
-            let balance = graph.graph().balance(
-                &local_chain,
-                chain_tip,
-                CanonicalizationParams::default(),
-                graph.index.outpoints().iter().cloned(),
-                |_, spk: ScriptBuf| trusted_spks.contains(&spk),
-            );
+            let balance = graph
+                .canonical_view(&local_chain, chain_tip, CanonicalizationParams::default())
+                .balance(
+                    graph.index.outpoints().iter().cloned(),
+                    |_, spk: ScriptBuf| trusted_spks.contains(&spk),
+                );
 
             let confirmed_txouts_txid = txouts
                 .iter()
@@ -789,15 +778,15 @@ fn test_get_chain_position() {
 
         // check chain position
         let chain_pos = graph
-            .graph()
-            .list_canonical_txs(
+            .canonical_view(
                 chain,
                 chain.tip().block_id(),
                 CanonicalizationParams::default(),
             )
+            .txs()
             .find_map(|canon_tx| {
-                if canon_tx.tx_node.txid == txid {
-                    Some(canon_tx.chain_position)
+                if canon_tx.txid == txid {
+                    Some(canon_tx.pos)
                 } else {
                     None
                 }

--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -474,6 +474,7 @@ fn test_list_owned_txouts() {
                 .balance(
                     graph.index.outpoints().iter().cloned(),
                     |_, spk: ScriptBuf| trusted_spks.contains(&spk),
+                    1,
                 );
 
             let confirmed_txouts_txid = txouts

--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -473,7 +473,7 @@ fn test_list_owned_txouts() {
                 .canonical_view(&local_chain, chain_tip, CanonicalizationParams::default())
                 .balance(
                     graph.index.outpoints().iter().cloned(),
-                    |_, spk: ScriptBuf| trusted_spks.contains(&spk),
+                    |_, txout| trusted_spks.contains(&txout.txout.script_pubkey),
                     1,
                 );
 

--- a/crates/chain/tests/test_tx_graph_conflicts.rs
+++ b/crates/chain/tests/test_tx_graph_conflicts.rs
@@ -1033,6 +1033,7 @@ fn test_tx_conflict_handling() {
             .balance(
                 env.indexer.outpoints().iter().cloned(),
                 |_, spk: ScriptBuf| env.indexer.index_of_spk(spk).is_some(),
+                1,
             );
         assert_eq!(
             balance, scenario.exp_balance,

--- a/crates/chain/tests/test_tx_graph_conflicts.rs
+++ b/crates/chain/tests/test_tx_graph_conflicts.rs
@@ -5,7 +5,7 @@ mod common;
 
 use bdk_chain::{local_chain::LocalChain, Balance, BlockId};
 use bdk_testenv::{block_id, hash, local_chain};
-use bitcoin::{Amount, BlockHash, OutPoint, ScriptBuf};
+use bitcoin::{Amount, BlockHash, OutPoint};
 use common::*;
 use std::collections::{BTreeSet, HashSet};
 
@@ -1032,8 +1032,12 @@ fn test_tx_conflict_handling() {
             .canonical_view(&local_chain, chain_tip, env.canonicalization_params.clone())
             .balance(
                 env.indexer.outpoints().iter().cloned(),
-                |_, spk: ScriptBuf| env.indexer.index_of_spk(spk).is_some(),
-                1,
+                |_, txout| {
+                    env.indexer
+                        .index_of_spk(txout.txout.script_pubkey.clone())
+                        .is_some()
+                },
+                0,
             );
         assert_eq!(
             balance, scenario.exp_balance,

--- a/crates/chain/tests/test_tx_graph_conflicts.rs
+++ b/crates/chain/tests/test_tx_graph_conflicts.rs
@@ -972,8 +972,9 @@ fn test_tx_conflict_handling() {
 
         let txs = env
             .tx_graph
-            .list_canonical_txs(&local_chain, chain_tip, env.canonicalization_params.clone())
-            .map(|tx| tx.tx_node.txid)
+            .canonical_view(&local_chain, chain_tip, env.canonicalization_params.clone())
+            .txs()
+            .map(|tx| tx.txid)
             .collect::<BTreeSet<_>>();
         let exp_txs = scenario
             .exp_chain_txs
@@ -988,12 +989,8 @@ fn test_tx_conflict_handling() {
 
         let txouts = env
             .tx_graph
-            .filter_chain_txouts(
-                &local_chain,
-                chain_tip,
-                env.canonicalization_params.clone(),
-                env.indexer.outpoints().iter().cloned(),
-            )
+            .canonical_view(&local_chain, chain_tip, env.canonicalization_params.clone())
+            .filter_outpoints(env.indexer.outpoints().iter().cloned())
             .map(|(_, full_txout)| full_txout.outpoint)
             .collect::<BTreeSet<_>>();
         let exp_txouts = scenario
@@ -1012,12 +1009,8 @@ fn test_tx_conflict_handling() {
 
         let utxos = env
             .tx_graph
-            .filter_chain_unspents(
-                &local_chain,
-                chain_tip,
-                env.canonicalization_params.clone(),
-                env.indexer.outpoints().iter().cloned(),
-            )
+            .canonical_view(&local_chain, chain_tip, env.canonicalization_params.clone())
+            .filter_unspent_outpoints(env.indexer.outpoints().iter().cloned())
             .map(|(_, full_txout)| full_txout.outpoint)
             .collect::<BTreeSet<_>>();
         let exp_utxos = scenario
@@ -1034,13 +1027,13 @@ fn test_tx_conflict_handling() {
             scenario.name
         );
 
-        let balance = env.tx_graph.balance(
-            &local_chain,
-            chain_tip,
-            env.canonicalization_params.clone(),
-            env.indexer.outpoints().iter().cloned(),
-            |_, spk: ScriptBuf| env.indexer.index_of_spk(spk).is_some(),
-        );
+        let balance = env
+            .tx_graph
+            .canonical_view(&local_chain, chain_tip, env.canonicalization_params.clone())
+            .balance(
+                env.indexer.outpoints().iter().cloned(),
+                |_, spk: ScriptBuf| env.indexer.index_of_spk(spk).is_some(),
+            );
         assert_eq!(
             balance, scenario.exp_balance,
             "\n[{}] 'balance' failed",

--- a/crates/electrum/tests/test_electrum.rs
+++ b/crates/electrum/tests/test_electrum.rs
@@ -42,7 +42,7 @@ fn get_balance(
     let outpoints = recv_graph.index.outpoints().clone();
     let balance = recv_graph
         .canonical_view(recv_chain, chain_tip, CanonicalizationParams::default())
-        .balance(outpoints, |_, _| true);
+        .balance(outpoints, |_, _| true, 1);
     Ok(balance)
 }
 

--- a/crates/electrum/tests/test_electrum.rs
+++ b/crates/electrum/tests/test_electrum.rs
@@ -40,13 +40,9 @@ fn get_balance(
 ) -> anyhow::Result<Balance> {
     let chain_tip = recv_chain.tip().block_id();
     let outpoints = recv_graph.index.outpoints().clone();
-    let balance = recv_graph.graph().balance(
-        recv_chain,
-        chain_tip,
-        CanonicalizationParams::default(),
-        outpoints,
-        |_, _| true,
-    );
+    let balance = recv_graph
+        .canonical_view(recv_chain, chain_tip, CanonicalizationParams::default())
+        .balance(outpoints, |_, _| true);
     Ok(balance)
 }
 
@@ -150,7 +146,11 @@ pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
     let sync_request = SyncRequest::builder()
         .chain_tip(chain.tip())
         .spks_with_indexes(graph.index.all_spks().clone())
-        .expected_spk_txids(graph.list_expected_spk_txids(&chain, chain.tip().block_id(), ..));
+        .expected_spk_txids(
+            graph
+                .canonical_view(&chain, chain.tip().block_id(), Default::default())
+                .list_expected_spk_txids(&graph.index, ..),
+        );
     let sync_response = client.sync(sync_request, BATCH_SIZE, true)?;
     assert!(
         sync_response
@@ -175,7 +175,11 @@ pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
     let sync_request = SyncRequest::builder()
         .chain_tip(chain.tip())
         .spks_with_indexes(graph.index.all_spks().clone())
-        .expected_spk_txids(graph.list_expected_spk_txids(&chain, chain.tip().block_id(), ..));
+        .expected_spk_txids(
+            graph
+                .canonical_view(&chain, chain.tip().block_id(), Default::default())
+                .list_expected_spk_txids(&graph.index, ..),
+        );
     let sync_response = client.sync(sync_request, BATCH_SIZE, true)?;
     assert!(
         sync_response

--- a/crates/esplora/tests/async_ext.rs
+++ b/crates/esplora/tests/async_ext.rs
@@ -87,7 +87,11 @@ pub async fn detect_receive_tx_cancel() -> anyhow::Result<()> {
     let sync_request = SyncRequest::builder()
         .chain_tip(chain.tip())
         .spks_with_indexes(graph.index.all_spks().clone())
-        .expected_spk_txids(graph.list_expected_spk_txids(&chain, chain.tip().block_id(), ..));
+        .expected_spk_txids(
+            graph
+                .canonical_view(&chain, chain.tip().block_id(), Default::default())
+                .list_expected_spk_txids(&graph.index, ..),
+        );
     let sync_response = client.sync(sync_request, 1).await?;
     assert!(
         sync_response
@@ -112,7 +116,11 @@ pub async fn detect_receive_tx_cancel() -> anyhow::Result<()> {
     let sync_request = SyncRequest::builder()
         .chain_tip(chain.tip())
         .spks_with_indexes(graph.index.all_spks().clone())
-        .expected_spk_txids(graph.list_expected_spk_txids(&chain, chain.tip().block_id(), ..));
+        .expected_spk_txids(
+            graph
+                .canonical_view(&chain, chain.tip().block_id(), Default::default())
+                .list_expected_spk_txids(&graph.index, ..),
+        );
     let sync_response = client.sync(sync_request, 1).await?;
     assert!(
         sync_response

--- a/crates/esplora/tests/blocking_ext.rs
+++ b/crates/esplora/tests/blocking_ext.rs
@@ -87,7 +87,11 @@ pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
     let sync_request = SyncRequest::builder()
         .chain_tip(chain.tip())
         .spks_with_indexes(graph.index.all_spks().clone())
-        .expected_spk_txids(graph.list_expected_spk_txids(&chain, chain.tip().block_id(), ..));
+        .expected_spk_txids(
+            graph
+                .canonical_view(&chain, chain.tip().block_id(), Default::default())
+                .list_expected_spk_txids(&graph.index, ..),
+        );
     let sync_response = client.sync(sync_request, 1)?;
     assert!(
         sync_response
@@ -112,7 +116,11 @@ pub fn detect_receive_tx_cancel() -> anyhow::Result<()> {
     let sync_request = SyncRequest::builder()
         .chain_tip(chain.tip())
         .spks_with_indexes(graph.index.all_spks().clone())
-        .expected_spk_txids(graph.list_expected_spk_txids(&chain, chain.tip().block_id(), ..));
+        .expected_spk_txids(
+            graph
+                .canonical_view(&chain, chain.tip().block_id(), Default::default())
+                .list_expected_spk_txids(&graph.index, ..),
+        );
     let sync_response = client.sync(sync_request, 1)?;
     assert!(
         sync_response

--- a/examples/example_bitcoind_rpc_polling/src/main.rs
+++ b/examples/example_bitcoind_rpc_polling/src/main.rs
@@ -145,13 +145,14 @@ fn main() -> anyhow::Result<()> {
                     chain.tip(),
                     fallback_height,
                     graph
-                        .graph()
-                        .list_canonical_txs(
+                        .canonical_view(
                             &*chain,
                             chain.tip().block_id(),
                             CanonicalizationParams::default(),
                         )
-                        .filter(|tx| tx.chain_position.is_unconfirmed()),
+                        .txs()
+                        .filter(|tx| tx.pos.is_unconfirmed())
+                        .map(|tx| tx.tx),
                 )
             };
             let mut db_stage = ChangeSet::default();
@@ -195,13 +196,15 @@ fn main() -> anyhow::Result<()> {
                     last_print = Instant::now();
                     let synced_to = chain.tip();
                     let balance = {
-                        graph.graph().balance(
-                            &*chain,
-                            synced_to.block_id(),
-                            CanonicalizationParams::default(),
-                            graph.index.outpoints().iter().cloned(),
-                            |(k, _), _| k == &Keychain::Internal,
-                        )
+                        graph
+                            .canonical_view(
+                                &*chain,
+                                synced_to.block_id(),
+                                CanonicalizationParams::default(),
+                            )
+                            .balance(graph.index.outpoints().iter().cloned(), |(k, _), _| {
+                                k == &Keychain::Internal
+                            })
                     };
                     println!(
                         "[{:>10}s] synced to {} @ {} | total: {}",
@@ -245,13 +248,14 @@ fn main() -> anyhow::Result<()> {
                     chain.tip(),
                     fallback_height,
                     graph
-                        .graph()
-                        .list_canonical_txs(
+                        .canonical_view(
                             &*chain,
                             chain.tip().block_id(),
                             CanonicalizationParams::default(),
                         )
-                        .filter(|tx| tx.chain_position.is_unconfirmed()),
+                        .txs()
+                        .filter(|tx| tx.pos.is_unconfirmed())
+                        .map(|tx| tx.tx),
                 )
             };
 
@@ -350,13 +354,15 @@ fn main() -> anyhow::Result<()> {
                     last_print = Some(Instant::now());
                     let synced_to = chain.tip();
                     let balance = {
-                        graph.graph().balance(
-                            &*chain,
-                            synced_to.block_id(),
-                            CanonicalizationParams::default(),
-                            graph.index.outpoints().iter().cloned(),
-                            |(k, _), _| k == &Keychain::Internal,
-                        )
+                        graph
+                            .canonical_view(
+                                &*chain,
+                                synced_to.block_id(),
+                                CanonicalizationParams::default(),
+                            )
+                            .balance(graph.index.outpoints().iter().cloned(), |(k, _), _| {
+                                k == &Keychain::Internal
+                            })
                     };
                     println!(
                         "[{:>10}s] synced to {} @ {} / {} | total: {}",

--- a/examples/example_bitcoind_rpc_polling/src/main.rs
+++ b/examples/example_bitcoind_rpc_polling/src/main.rs
@@ -202,9 +202,11 @@ fn main() -> anyhow::Result<()> {
                                 synced_to.block_id(),
                                 CanonicalizationParams::default(),
                             )
-                            .balance(graph.index.outpoints().iter().cloned(), |(k, _), _| {
-                                k == &Keychain::Internal
-                            })
+                            .balance(
+                                graph.index.outpoints().iter().cloned(),
+                                |(k, _), _| k == &Keychain::Internal,
+                                1,
+                            )
                     };
                     println!(
                         "[{:>10}s] synced to {} @ {} | total: {}",
@@ -360,9 +362,11 @@ fn main() -> anyhow::Result<()> {
                                 synced_to.block_id(),
                                 CanonicalizationParams::default(),
                             )
-                            .balance(graph.index.outpoints().iter().cloned(), |(k, _), _| {
-                                k == &Keychain::Internal
-                            })
+                            .balance(
+                                graph.index.outpoints().iter().cloned(),
+                                |(k, _), _| k == &Keychain::Internal,
+                                1,
+                            )
                     };
                     println!(
                         "[{:>10}s] synced to {} @ {} / {} | total: {}",

--- a/examples/example_cli/src/lib.rs
+++ b/examples/example_cli/src/lib.rs
@@ -530,9 +530,11 @@ pub fn handle_commands<CS: clap::Subcommand, S: clap::Args>(
                     chain.get_chain_tip()?,
                     CanonicalizationParams::default(),
                 )?
-                .balance(graph.index.outpoints().iter().cloned(), |(k, _), _| {
-                    k == &Keychain::Internal
-                });
+                .balance(
+                    graph.index.outpoints().iter().cloned(),
+                    |(k, _), _| k == &Keychain::Internal,
+                    1,
+                );
 
             let confirmed_total = balance.confirmed + balance.immature;
             let unconfirmed_total = balance.untrusted_pending + balance.trusted_pending;


### PR DESCRIPTION
### Description

`CanonicalView` allows us to canonicalize upfront, reducing our API surface and improving performance by reducing canonicalizations we need to do.

This is also the first step to achieving many of our goals.

* Event notifications.
* Intent tracker.
* Getting rid of `CanonicalUnspents` structure in `bdk_tx`.

### Changelog notice

```md
Added
- Introduce `CanonicalView` which allows us to canonicalize once upfront.
- Added `TxGraph::canonical_view` which constructs a `CanonicalView`.

Changed
- `TxGraph` methods which require canonicalization now have `CanonicalView` equivalents.

Removed
- `TxGraph` methods which take in a fallible `ChainOracle` implementations are now removed. 

```

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
