### PR TITLE
fix(ci): pin coverallsapp to v0.6.15

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -36,6 +36,7 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          coverage-reporter-version: v0.6.15
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
### Description

It's noticeable that coveralls CI step has been flaky for the past couple of days, you can notice on their status page: https://status.coveralls.io/ that they're facing some incidents.

As mentioned in their status page and on the following issue: https://github.com/coverallsapp/coverage-reporter/issues/180, a possible fix is to pin it to v0.6.15 version.

### Notes to the reviewers


### Changelog notice


### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

