### PR TITLE
fix(ci): remove retry/retry-delay

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -36,8 +36,6 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-        retry: 3
-        retry-delay: 30
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
### Description

It looks like that the retry approach introduced on #2032 does not really work, as the github  workflow syntax does not have those fields.

I've opened this PR to revert the changes, and make sure that CI is working again. Though I still think we can implement a manual retry logic on our side, probably using gh cli inside of the CI job.

### Notes to the reviewers

It needs to be merged in order to coverage CI to work properly again.

### Changelog notice

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
