### PR TITLE
feat(core): add skiplist to CheckPoint for faster traversal

### DIFF
--- a/crates/chain/src/indexer/keychain_txout.rs
+++ b/crates/chain/src/indexer/keychain_txout.rs
@@ -953,8 +953,8 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
     /// a [`TxOut`] with it's script pubkey.
     pub fn last_used_indices(&self) -> BTreeMap<K, u32> {
         self.keychain_to_descriptor_id
-            .iter()
-            .filter_map(|(keychain, _)| {
+            .keys()
+            .filter_map(|keychain| {
                 self.last_used_index(keychain.clone())
                     .map(|index| (keychain.clone(), index))
             })

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -23,3 +23,8 @@ serde = ["dep:serde", "bitcoin/serde", "hashbrown?/serde"]
 [dev-dependencies]
 bdk_chain = { path = "../chain" }
 bdk_testenv = { path = "../testenv", default-features = false }
+criterion = { version = "0.2" }
+
+[[bench]]
+name = "checkpoint_skiplist"
+harness = false

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -23,3 +23,9 @@ serde = ["dep:serde", "bitcoin/serde", "hashbrown?/serde"]
 [dev-dependencies]
 bdk_chain = { path = "../chain" }
 bdk_testenv = { path = "../testenv", default-features = false }
+criterion = { version = "0.7" }
+proptest = "1.2.0"
+
+[[bench]]
+name = "checkpoint_skiplist"
+harness = false

--- a/crates/core/benches/checkpoint_skiplist.rs
+++ b/crates/core/benches/checkpoint_skiplist.rs
@@ -1,0 +1,235 @@
+use bdk_core::CheckPoint;
+use bitcoin::hashes::Hash;
+use bitcoin::BlockHash;
+use criterion::{black_box, criterion_group, criterion_main, Bencher, Criterion};
+
+/// Create a checkpoint chain with the given length
+fn create_checkpoint_chain(length: u32) -> CheckPoint<BlockHash> {
+    let mut cp = CheckPoint::new(0, BlockHash::all_zeros());
+    for height in 1..=length {
+        let hash = BlockHash::from_byte_array([(height % 256) as u8; 32]);
+        cp = cp.push(height, hash).unwrap();
+    }
+    cp
+}
+
+/// Benchmark get() operations at various depths
+fn bench_checkpoint_get(c: &mut Criterion) {
+    // Small chain - get near start
+    c.bench_function("get_100_near_start", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(100);
+        let target = 10;
+        b.iter(|| {
+            black_box(cp.get(target));
+        });
+    });
+
+    // Medium chain - get middle
+    c.bench_function("get_1000_middle", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(1000);
+        let target = 500;
+        b.iter(|| {
+            black_box(cp.get(target));
+        });
+    });
+
+    // Large chain - get near end
+    c.bench_function("get_10000_near_end", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(10000);
+        let target = 9000;
+        b.iter(|| {
+            black_box(cp.get(target));
+        });
+    });
+
+    // Large chain - get near start (best case for skiplist)
+    c.bench_function("get_10000_near_start", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(10000);
+        let target = 100;
+        b.iter(|| {
+            black_box(cp.get(target));
+        });
+    });
+}
+
+/// Benchmark floor_at() operations
+fn bench_checkpoint_floor_at(c: &mut Criterion) {
+    c.bench_function("floor_at_1000", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(1000);
+        let target = 750; // Target that might not exist exactly
+        b.iter(|| {
+            black_box(cp.floor_at(target));
+        });
+    });
+
+    c.bench_function("floor_at_10000", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(10000);
+        let target = 7500;
+        b.iter(|| {
+            black_box(cp.floor_at(target));
+        });
+    });
+}
+
+/// Benchmark range() iteration
+fn bench_checkpoint_range(c: &mut Criterion) {
+    // Small range in middle (tests skip pointer efficiency)
+    c.bench_function("range_1000_middle_10pct", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(1000);
+        b.iter(|| {
+            let range: Vec<_> = cp.range(450..=550).collect();
+            black_box(range);
+        });
+    });
+
+    // Large range (tests iteration performance)
+    c.bench_function("range_10000_large_50pct", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(10000);
+        b.iter(|| {
+            let range: Vec<_> = cp.range(2500..=7500).collect();
+            black_box(range);
+        });
+    });
+
+    // Range from start (tests early termination)
+    c.bench_function("range_10000_from_start", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(10000);
+        b.iter(|| {
+            let range: Vec<_> = cp.range(..=100).collect();
+            black_box(range);
+        });
+    });
+
+    // Range near tip (minimal skip pointer usage)
+    c.bench_function("range_10000_near_tip", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(10000);
+        b.iter(|| {
+            let range: Vec<_> = cp.range(9900..).collect();
+            black_box(range);
+        });
+    });
+
+    // Single element range (edge case)
+    c.bench_function("range_single_element", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(10000);
+        b.iter(|| {
+            let range: Vec<_> = cp.range(5000..=5000).collect();
+            black_box(range);
+        });
+    });
+}
+
+/// Benchmark insert() operations
+fn bench_checkpoint_insert(c: &mut Criterion) {
+    c.bench_function("insert_sparse_1000", |b: &mut Bencher| {
+        // Create a sparse chain
+        let mut cp = CheckPoint::new(0, BlockHash::all_zeros());
+        for i in 1..=100 {
+            let height = i * 10;
+            let hash = BlockHash::from_byte_array([(height % 256) as u8; 32]);
+            cp = cp.push(height, hash).unwrap();
+        }
+
+        let insert_height = 505;
+        let insert_hash = BlockHash::from_byte_array([255; 32]);
+
+        b.iter(|| {
+            let result = cp.clone().insert(insert_height, insert_hash);
+            black_box(result);
+        });
+    });
+}
+
+/// Compare linear traversal vs skiplist-enhanced get()
+fn bench_traversal_comparison(c: &mut Criterion) {
+    // Linear traversal benchmark
+    c.bench_function("linear_traversal_10000", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(10000);
+        let target = 100; // Near the beginning
+
+        b.iter(|| {
+            let mut current = cp.clone();
+            while current.height() > target {
+                if let Some(prev) = current.prev() {
+                    current = prev;
+                } else {
+                    break;
+                }
+            }
+            black_box(current);
+        });
+    });
+
+    // Skiplist-enhanced get() for comparison
+    c.bench_function("skiplist_get_10000", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(10000);
+        let target = 100; // Same target
+
+        b.iter(|| {
+            black_box(cp.get(target));
+        });
+    });
+}
+
+/// Analyze skip pointer distribution and usage
+fn bench_skip_pointer_analysis(c: &mut Criterion) {
+    c.bench_function("count_skip_pointers_10000", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(10000);
+
+        b.iter(|| {
+            let mut count = 0;
+            let mut current = cp.clone();
+            loop {
+                if current.skip().is_some() {
+                    count += 1;
+                }
+                if let Some(prev) = current.prev() {
+                    current = prev;
+                } else {
+                    break;
+                }
+            }
+            black_box(count);
+        });
+    });
+
+    // Measure actual skip pointer usage during traversal
+    c.bench_function("skip_usage_in_traversal", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(10000);
+        let target = 100;
+
+        b.iter(|| {
+            let mut current = cp.clone();
+            let mut skips_used = 0;
+
+            while current.height() > target {
+                if let Some(skip_cp) = current.skip() {
+                    if skip_cp.height() >= target {
+                        current = skip_cp;
+                        skips_used += 1;
+                        continue;
+                    }
+                }
+
+                if let Some(prev) = current.prev() {
+                    current = prev;
+                } else {
+                    break;
+                }
+            }
+            black_box((current, skips_used));
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_checkpoint_get,
+    bench_checkpoint_floor_at,
+    bench_checkpoint_range,
+    bench_checkpoint_insert,
+    bench_traversal_comparison,
+    bench_skip_pointer_analysis
+);
+
+criterion_main!(benches);

--- a/crates/core/benches/checkpoint_skiplist.rs
+++ b/crates/core/benches/checkpoint_skiplist.rs
@@ -16,15 +16,6 @@ fn create_checkpoint_chain(length: u32) -> CheckPoint<BlockHash> {
 
 /// Benchmark get() operations at various depths
 fn bench_checkpoint_get(c: &mut Criterion) {
-    // Small chain - get near start
-    c.bench_function("get_100_near_start", |b: &mut Bencher| {
-        let cp = create_checkpoint_chain(100);
-        let target = 10;
-        b.iter(|| {
-            black_box(cp.get(target));
-        });
-    });
-
     // Medium chain - get middle
     c.bench_function("get_1000_middle", |b: &mut Bencher| {
         let cp = create_checkpoint_chain(1000);
@@ -34,10 +25,12 @@ fn bench_checkpoint_get(c: &mut Criterion) {
         });
     });
 
-    // Large chain - get near end
+    // Large chain - get near end. Target is deliberately not a power of two or a multiple of
+    // common skiplist intervals (e.g. 1000), so neither pskip nor a fixed-stride scheme gets a
+    // free 1-hop hit on a "lucky" alignment.
     c.bench_function("get_10000_near_end", |b: &mut Bencher| {
         let cp = create_checkpoint_chain(10000);
-        let target = 9000;
+        let target = 9123;
         b.iter(|| {
             black_box(cp.get(target));
         });
@@ -100,24 +93,6 @@ fn bench_checkpoint_range(c: &mut Criterion) {
             black_box(range);
         });
     });
-
-    // Range near tip (minimal skip pointer usage)
-    c.bench_function("range_10000_near_tip", |b: &mut Bencher| {
-        let cp = create_checkpoint_chain(10000);
-        b.iter(|| {
-            let range: Vec<_> = cp.range(9900..).collect();
-            black_box(range);
-        });
-    });
-
-    // Single element range (edge case)
-    c.bench_function("range_single_element", |b: &mut Bencher| {
-        let cp = create_checkpoint_chain(10000);
-        b.iter(|| {
-            let range: Vec<_> = cp.range(5000..=5000).collect();
-            black_box(range);
-        });
-    });
 }
 
 /// Benchmark insert() operations
@@ -141,84 +116,56 @@ fn bench_checkpoint_insert(c: &mut Criterion) {
     });
 }
 
-/// Compare linear traversal vs skiplist-enhanced get()
-fn bench_traversal_comparison(c: &mut Criterion) {
-    // Linear traversal benchmark
-    c.bench_function("linear_traversal_10000", |b: &mut Bencher| {
-        let cp = create_checkpoint_chain(10000);
-        let target = 100; // Near the beginning
+/// Random-access lookups over a realistic-size chain, comparing skiplist-enhanced
+/// `get()` against a plain linear walk. Targets are drawn from a deterministic
+/// xorshift sequence so the same query stream is used for both benches.
+///
+/// Chain length is sized to the order of a full Bitcoin chain (~1M blocks) so the log-scale
+/// advantage of pskip is visible.
+fn bench_random_access(c: &mut Criterion) {
+    const CHAIN_LEN: u32 = 1_000_000;
+    const QUERIES: usize = 256;
 
+    let cp = create_checkpoint_chain(CHAIN_LEN);
+
+    // Deterministic xorshift64* over the height range.
+    let mut state: u64 = 0x9E37_79B9_7F4A_7C15;
+    let targets: Vec<u32> = (0..QUERIES)
+        .map(|_| {
+            state ^= state << 13;
+            state ^= state >> 7;
+            state ^= state << 17;
+            (state % (CHAIN_LEN as u64 + 1)) as u32
+        })
+        .collect();
+
+    {
+        let cp = cp.clone();
+        let targets = targets.clone();
+        c.bench_function("random_access_skiplist_1m", move |b: &mut Bencher| {
+            let mut i = 0usize;
+            b.iter(|| {
+                let target = targets[i % QUERIES];
+                i = i.wrapping_add(1);
+                black_box(cp.get(target));
+            });
+        });
+    }
+
+    c.bench_function("random_access_linear_1m", move |b: &mut Bencher| {
+        let mut i = 0usize;
         b.iter(|| {
+            let target = targets[i % QUERIES];
+            i = i.wrapping_add(1);
+
             let mut current = cp.clone();
             while current.height() > target {
-                if let Some(prev) = current.prev() {
-                    current = prev;
-                } else {
-                    break;
+                match current.prev() {
+                    Some(prev) => current = prev,
+                    None => break,
                 }
             }
             black_box(current);
-        });
-    });
-
-    // Skiplist-enhanced get() for comparison
-    c.bench_function("skiplist_get_10000", |b: &mut Bencher| {
-        let cp = create_checkpoint_chain(10000);
-        let target = 100; // Same target
-
-        b.iter(|| {
-            black_box(cp.get(target));
-        });
-    });
-}
-
-/// Analyze skip pointer distribution and usage
-fn bench_skip_pointer_analysis(c: &mut Criterion) {
-    c.bench_function("count_skip_pointers_10000", |b: &mut Bencher| {
-        let cp = create_checkpoint_chain(10000);
-
-        b.iter(|| {
-            let mut count = 0;
-            let mut current = cp.clone();
-            loop {
-                if current.skip().is_some() {
-                    count += 1;
-                }
-                if let Some(prev) = current.prev() {
-                    current = prev;
-                } else {
-                    break;
-                }
-            }
-            black_box(count);
-        });
-    });
-
-    // Measure actual skip pointer usage during traversal
-    c.bench_function("skip_usage_in_traversal", |b: &mut Bencher| {
-        let cp = create_checkpoint_chain(10000);
-        let target = 100;
-
-        b.iter(|| {
-            let mut current = cp.clone();
-            let mut skips_used = 0;
-
-            while current.height() > target {
-                if let Some(skip_cp) = current.skip() {
-                    if skip_cp.height() >= target {
-                        current = skip_cp;
-                        skips_used += 1;
-                        continue;
-                    }
-                }
-
-                if let Some(prev) = current.prev() {
-                    current = prev;
-                } else {
-                    break;
-                }
-            }
-            black_box((current, skips_used));
         });
     });
 }
@@ -229,8 +176,7 @@ criterion_group!(
     bench_checkpoint_floor_at,
     bench_checkpoint_range,
     bench_checkpoint_insert,
-    bench_traversal_comparison,
-    bench_skip_pointer_analysis
+    bench_random_access
 );
 
 criterion_main!(benches);

--- a/crates/core/benches/checkpoint_skiplist.rs
+++ b/crates/core/benches/checkpoint_skiplist.rs
@@ -1,0 +1,236 @@
+use bdk_core::CheckPoint;
+use bitcoin::hashes::Hash;
+use bitcoin::BlockHash;
+use core::hint::black_box;
+use criterion::{criterion_group, criterion_main, Bencher, Criterion};
+
+/// Create a checkpoint chain with the given length
+fn create_checkpoint_chain(length: u32) -> CheckPoint<BlockHash> {
+    let mut cp = CheckPoint::new(0, BlockHash::all_zeros());
+    for height in 1..=length {
+        let hash = BlockHash::from_byte_array([(height % 256) as u8; 32]);
+        cp = cp.push(height, hash).unwrap();
+    }
+    cp
+}
+
+/// Benchmark get() operations at various depths
+fn bench_checkpoint_get(c: &mut Criterion) {
+    // Small chain - get near start
+    c.bench_function("get_100_near_start", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(100);
+        let target = 10;
+        b.iter(|| {
+            black_box(cp.get(target));
+        });
+    });
+
+    // Medium chain - get middle
+    c.bench_function("get_1000_middle", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(1000);
+        let target = 500;
+        b.iter(|| {
+            black_box(cp.get(target));
+        });
+    });
+
+    // Large chain - get near end
+    c.bench_function("get_10000_near_end", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(10000);
+        let target = 9000;
+        b.iter(|| {
+            black_box(cp.get(target));
+        });
+    });
+
+    // Large chain - get near start (best case for skiplist)
+    c.bench_function("get_10000_near_start", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(10000);
+        let target = 100;
+        b.iter(|| {
+            black_box(cp.get(target));
+        });
+    });
+}
+
+/// Benchmark floor_at() operations
+fn bench_checkpoint_floor_at(c: &mut Criterion) {
+    c.bench_function("floor_at_1000", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(1000);
+        let target = 750; // Target that might not exist exactly
+        b.iter(|| {
+            black_box(cp.floor_at(target));
+        });
+    });
+
+    c.bench_function("floor_at_10000", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(10000);
+        let target = 7500;
+        b.iter(|| {
+            black_box(cp.floor_at(target));
+        });
+    });
+}
+
+/// Benchmark range() iteration
+fn bench_checkpoint_range(c: &mut Criterion) {
+    // Small range in middle (tests skip pointer efficiency)
+    c.bench_function("range_1000_middle_10pct", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(1000);
+        b.iter(|| {
+            let range: Vec<_> = cp.range(450..=550).collect();
+            black_box(range);
+        });
+    });
+
+    // Large range (tests iteration performance)
+    c.bench_function("range_10000_large_50pct", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(10000);
+        b.iter(|| {
+            let range: Vec<_> = cp.range(2500..=7500).collect();
+            black_box(range);
+        });
+    });
+
+    // Range from start (tests early termination)
+    c.bench_function("range_10000_from_start", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(10000);
+        b.iter(|| {
+            let range: Vec<_> = cp.range(..=100).collect();
+            black_box(range);
+        });
+    });
+
+    // Range near tip (minimal skip pointer usage)
+    c.bench_function("range_10000_near_tip", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(10000);
+        b.iter(|| {
+            let range: Vec<_> = cp.range(9900..).collect();
+            black_box(range);
+        });
+    });
+
+    // Single element range (edge case)
+    c.bench_function("range_single_element", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(10000);
+        b.iter(|| {
+            let range: Vec<_> = cp.range(5000..=5000).collect();
+            black_box(range);
+        });
+    });
+}
+
+/// Benchmark insert() operations
+fn bench_checkpoint_insert(c: &mut Criterion) {
+    c.bench_function("insert_sparse_1000", |b: &mut Bencher| {
+        // Create a sparse chain
+        let mut cp = CheckPoint::new(0, BlockHash::all_zeros());
+        for i in 1..=100 {
+            let height = i * 10;
+            let hash = BlockHash::from_byte_array([(height % 256) as u8; 32]);
+            cp = cp.push(height, hash).unwrap();
+        }
+
+        let insert_height = 505;
+        let insert_hash = BlockHash::from_byte_array([255; 32]);
+
+        b.iter(|| {
+            let result = cp.clone().insert(insert_height, insert_hash);
+            black_box(result);
+        });
+    });
+}
+
+/// Compare linear traversal vs skiplist-enhanced get()
+fn bench_traversal_comparison(c: &mut Criterion) {
+    // Linear traversal benchmark
+    c.bench_function("linear_traversal_10000", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(10000);
+        let target = 100; // Near the beginning
+
+        b.iter(|| {
+            let mut current = cp.clone();
+            while current.height() > target {
+                if let Some(prev) = current.prev() {
+                    current = prev;
+                } else {
+                    break;
+                }
+            }
+            black_box(current);
+        });
+    });
+
+    // Skiplist-enhanced get() for comparison
+    c.bench_function("skiplist_get_10000", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(10000);
+        let target = 100; // Same target
+
+        b.iter(|| {
+            black_box(cp.get(target));
+        });
+    });
+}
+
+/// Analyze skip pointer distribution and usage
+fn bench_skip_pointer_analysis(c: &mut Criterion) {
+    c.bench_function("count_skip_pointers_10000", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(10000);
+
+        b.iter(|| {
+            let mut count = 0;
+            let mut current = cp.clone();
+            loop {
+                if current.skip().is_some() {
+                    count += 1;
+                }
+                if let Some(prev) = current.prev() {
+                    current = prev;
+                } else {
+                    break;
+                }
+            }
+            black_box(count);
+        });
+    });
+
+    // Measure actual skip pointer usage during traversal
+    c.bench_function("skip_usage_in_traversal", |b: &mut Bencher| {
+        let cp = create_checkpoint_chain(10000);
+        let target = 100;
+
+        b.iter(|| {
+            let mut current = cp.clone();
+            let mut skips_used = 0;
+
+            while current.height() > target {
+                if let Some(skip_cp) = current.skip() {
+                    if skip_cp.height() >= target {
+                        current = skip_cp;
+                        skips_used += 1;
+                        continue;
+                    }
+                }
+
+                if let Some(prev) = current.prev() {
+                    current = prev;
+                } else {
+                    break;
+                }
+            }
+            black_box((current, skips_used));
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_checkpoint_get,
+    bench_checkpoint_floor_at,
+    bench_checkpoint_range,
+    bench_checkpoint_insert,
+    bench_traversal_comparison,
+    bench_skip_pointer_analysis
+);
+
+criterion_main!(benches);

--- a/crates/core/src/checkpoint.rs
+++ b/crates/core/src/checkpoint.rs
@@ -6,6 +6,9 @@ use core::ops::RangeBounds;
 
 use crate::{BlockId, CheckPointEntry, CheckPointEntryIter};
 
+/// Interval for skiplist pointers based on checkpoint index.
+const CHECKPOINT_SKIP_INTERVAL: u32 = 100;
+
 /// A checkpoint is a node of a reference-counted linked list of [`BlockId`]s.
 ///
 /// Checkpoints are cheaply cloneable and are useful to find the agreement point between two sparse
@@ -28,6 +31,10 @@ struct CPInner<D> {
     data: D,
     /// Previous checkpoint (if any).
     prev: Option<Arc<CPInner<D>>>,
+    /// Skip pointer for fast traversals.
+    skip: Option<Arc<CPInner<D>>>,
+    /// Index of this checkpoint (number of checkpoints from the first).
+    index: u32,
 }
 
 /// When a `CPInner` is dropped we need to go back down the chain and manually remove any
@@ -144,6 +151,16 @@ impl<D> CheckPoint<D> {
         self.0.prev.clone().map(CheckPoint)
     }
 
+    /// Get the index of this checkpoint (number of checkpoints from the first).
+    pub fn index(&self) -> u32 {
+        self.0.index
+    }
+
+    /// Get the skip pointer checkpoint if it exists.
+    pub fn skip(&self) -> Option<CheckPoint<D>> {
+        self.0.skip.clone().map(CheckPoint)
+    }
+
     /// Iterate from this checkpoint in descending height.
     pub fn iter(&self) -> CheckPointIter<D> {
         self.clone().into_iter()
@@ -153,7 +170,37 @@ impl<D> CheckPoint<D> {
     ///
     /// Returns `None` if checkpoint at `height` does not exist`.
     pub fn get(&self, height: u32) -> Option<Self> {
-        self.range(height..=height).next()
+        let mut current = self.clone();
+
+        if current.height() == height {
+            return Some(current);
+        }
+
+        // Use skip pointers to jump close to target
+        while current.height() > height {
+            match current.skip() {
+                Some(skip_cp) => match skip_cp.height().cmp(&height) {
+                    core::cmp::Ordering::Greater => current = skip_cp,
+                    core::cmp::Ordering::Equal => return Some(skip_cp),
+                    core::cmp::Ordering::Less => break, // Skip would undershoot
+                },
+                None => break, // No more skip pointers
+            }
+        }
+
+        // Linear search for exact height
+        while current.height() > height {
+            match current.prev() {
+                Some(prev_cp) => match prev_cp.height().cmp(&height) {
+                    core::cmp::Ordering::Greater => current = prev_cp,
+                    core::cmp::Ordering::Equal => return Some(prev_cp),
+                    core::cmp::Ordering::Less => break, // Height doesn't exist
+                },
+                None => break, // End of chain
+            }
+        }
+
+        None
     }
 
     /// Iterate checkpoints over a height range.
@@ -166,17 +213,39 @@ impl<D> CheckPoint<D> {
     {
         let start_bound = range.start_bound().cloned();
         let end_bound = range.end_bound().cloned();
-        self.iter()
-            .skip_while(move |cp| match end_bound {
-                core::ops::Bound::Included(inc_bound) => cp.height() > inc_bound,
-                core::ops::Bound::Excluded(exc_bound) => cp.height() >= exc_bound,
-                core::ops::Bound::Unbounded => false,
-            })
-            .take_while(move |cp| match start_bound {
-                core::ops::Bound::Included(inc_bound) => cp.height() >= inc_bound,
-                core::ops::Bound::Excluded(exc_bound) => cp.height() > exc_bound,
-                core::ops::Bound::Unbounded => true,
-            })
+
+        let is_above_bound = |height: u32| match end_bound {
+            core::ops::Bound::Included(inc_bound) => height > inc_bound,
+            core::ops::Bound::Excluded(exc_bound) => height >= exc_bound,
+            core::ops::Bound::Unbounded => false,
+        };
+
+        let mut current = self.clone();
+
+        // Use skip pointers to jump close to target
+        while is_above_bound(current.height()) {
+            match current.skip() {
+                Some(skip_cp) if is_above_bound(skip_cp.height()) => {
+                    current = skip_cp;
+                }
+                _ => break, // Skip would undershoot or doesn't exist
+            }
+        }
+
+        // Linear search to exact position
+        while is_above_bound(current.height()) {
+            match current.prev() {
+                Some(prev) => current = prev,
+                None => break,
+            }
+        }
+
+        // Iterate from start point
+        current.into_iter().take_while(move |cp| match start_bound {
+            core::ops::Bound::Included(inc_bound) => cp.height() >= inc_bound,
+            core::ops::Bound::Excluded(exc_bound) => cp.height() > exc_bound,
+            core::ops::Bound::Unbounded => true,
+        })
     }
 
     /// Returns the checkpoint at `height` if one exists, otherwise the nearest checkpoint at a
@@ -246,6 +315,8 @@ where
             },
             data,
             prev: None,
+            skip: None,
+            index: 0,
         }))
     }
 
@@ -408,6 +479,28 @@ where
             }
         }
 
+        let new_index = self.0.index + 1;
+
+        // Skip pointers are added every CHECKPOINT_SKIP_INTERVAL (100) checkpoints
+        // e.g., checkpoints at index 100, 200, 300, etc. have skip pointers
+        let needs_skip_pointer =
+            new_index >= CHECKPOINT_SKIP_INTERVAL && new_index % CHECKPOINT_SKIP_INTERVAL == 0;
+
+        let skip = if needs_skip_pointer {
+            // Skip pointer points back CHECKPOINT_SKIP_INTERVAL positions
+            // e.g., checkpoint at index 200 points to checkpoint at index 100
+            // We walk back CHECKPOINT_SKIP_INTERVAL - 1 steps since we start from self (index
+            // new_index - 1)
+            let mut current = self.0.clone();
+            for _ in 0..(CHECKPOINT_SKIP_INTERVAL - 1) {
+                // This is safe: if we're at index >= 100, we must have at least 99 predecessors
+                current = current.prev.clone().expect("chain has enough checkpoints");
+            }
+            Some(current)
+        } else {
+            None
+        };
+
         Ok(Self(Arc::new(CPInner {
             block_id: BlockId {
                 height,
@@ -415,6 +508,8 @@ where
             },
             data,
             prev: Some(self.0),
+            skip,
+            index: new_index,
         })))
     }
 }
@@ -481,12 +576,15 @@ mod tests {
         let genesis = cp.get(0).expect("genesis exists");
         let weak = Arc::downgrade(&genesis.0);
 
-        // At this point there should be exactly two strong references to the
-        // genesis checkpoint: the variable `genesis` and the chain `cp`.
+        // At this point there should be exactly three strong references to the
+        // genesis checkpoint:
+        // 1. The variable `genesis`
+        // 2. The chain `cp` through checkpoint 1's prev pointer
+        // 3. Checkpoint at index 100's skip pointer (points to index 0)
         assert_eq!(
             Arc::strong_count(&genesis.0),
-            2,
-            "`cp` and `genesis` should be the only strong references",
+            3,
+            "`cp`, `genesis`, and checkpoint 100's skip pointer should be the only strong references",
         );
 
         // Dropping the chain should remove one strong reference.

--- a/crates/core/src/checkpoint.rs
+++ b/crates/core/src/checkpoint.rs
@@ -6,8 +6,20 @@ use core::ops::RangeBounds;
 
 use crate::{BlockId, CheckPointEntry, CheckPointEntryIter};
 
-/// Interval for skiplist pointers based on checkpoint index.
-const CHECKPOINT_SKIP_INTERVAL: u32 = 100;
+/// Spacing (in checkpoint indices) between skip pointers in the single-level skiplist.
+///
+/// A single skip pointer exists on every node whose index is a nonzero multiple of this value,
+/// and points `CHECKPOINT_SKIP_INTERVAL` positions further back. Traversal cost with a fixed
+/// interval `k` is `O(n/k + k)`, which is minimized when `k ≈ √n`.
+///
+/// `1000` is chosen to match the dense server workload that motivates this skiplist: a full
+/// Bitcoin chain has ~1M blocks, and `√1_000_000 ≈ 1000`. At that size a traversal takes on the
+/// order of 1–2k hops instead of ~1M.
+///
+/// This is deliberately tuned for *large* chains. For small chains (`n ≲ 1000`) no skip pointers
+/// get created and traversal is linear — but at that size linear is already microseconds and not
+/// worth optimizing for.
+const CHECKPOINT_SKIP_INTERVAL: u32 = 1000;
 
 /// A checkpoint is a node of a reference-counted linked list of [`BlockId`]s.
 ///
@@ -481,19 +493,21 @@ where
 
         let new_index = self.0.index + 1;
 
-        // Skip pointers are added every CHECKPOINT_SKIP_INTERVAL (100) checkpoints
-        // e.g., checkpoints at index 100, 200, 300, etc. have skip pointers
+        // Skip pointers are added every CHECKPOINT_SKIP_INTERVAL checkpoints
+        // e.g., checkpoints at index 1000, 2000, 3000, etc. have skip pointers
         let needs_skip_pointer =
             new_index >= CHECKPOINT_SKIP_INTERVAL && new_index % CHECKPOINT_SKIP_INTERVAL == 0;
 
         let skip = if needs_skip_pointer {
             // Skip pointer points back CHECKPOINT_SKIP_INTERVAL positions
-            // e.g., checkpoint at index 200 points to checkpoint at index 100
+            // e.g., checkpoint at index 2000 points to checkpoint at index 1000
             // We walk back CHECKPOINT_SKIP_INTERVAL - 1 steps since we start from self (index
             // new_index - 1)
             let mut current = self.0.clone();
             for _ in 0..(CHECKPOINT_SKIP_INTERVAL - 1) {
-                // This is safe: if we're at index >= 100, we must have at least 99 predecessors
+                // Safe: new_index is a nonzero multiple of CHECKPOINT_SKIP_INTERVAL, so `self`
+                // sits at index new_index - 1 and has at least CHECKPOINT_SKIP_INTERVAL - 1
+                // predecessors.
                 current = current.prev.clone().expect("chain has enough checkpoints");
             }
             Some(current)

--- a/crates/core/src/checkpoint.rs
+++ b/crates/core/src/checkpoint.rs
@@ -6,6 +6,93 @@ use core::ops::RangeBounds;
 
 use crate::{BlockId, CheckPointEntry, CheckPointEntryIter};
 
+/// Returns the checkpoint index that index `i` should hold a skip pointer to.
+///
+/// Mirrors Bitcoin Core's `GetSkipHeight` (operating on checkpoint indices rather than block
+/// heights, so sparse chains work). The chosen targets give skip distances that grow
+/// exponentially as you walk back, yielding `O(log n)` traversal.
+///
+/// For `i < 2` returns `0` — `prev` already covers those distances trivially.
+fn skip_index(i: u32) -> u32 {
+    // Clears the lowest set bit of `n`. This is what unlocks the exponential skip range:
+    // each call strips one trailing 1-bit, so the result lands at a power-of-two-aligned
+    // index below `n`.
+    fn invert_lowest_one(n: u32) -> u32 {
+        // Wrapping sub so that `invert_lowest_one(0) == 0` (matches Bitcoin Core's signed-int
+        // `n & (n-1)` semantics). The odd-i branch below relies on `invert_lowest_one(0) == 0`
+        // when `i == 3`.
+        n & n.wrapping_sub(1)
+    }
+    if i < 2 {
+        return 0;
+    }
+    if i & 1 == 0 {
+        return invert_lowest_one(i);
+    }
+    invert_lowest_one(invert_lowest_one(i - 1)) + 1
+}
+
+/// Walks back from `start` to the ancestor at `target` index, riding skip pointers in `O(log n)`.
+///
+/// Equivalent to Bitcoin Core's `CBlockIndex::GetAncestor`.
+fn ancestor_by_index<D>(start: &Arc<CPInner<D>>, target: u32) -> Arc<CPInner<D>> {
+    debug_assert!(target <= start.index);
+    let mut curr = start.clone();
+    while curr.index > target {
+        let skip_i = skip_index(curr.index);
+        let skip_i_prev = skip_index(curr.index.saturating_sub(1));
+
+        // Prev's skip is "strictly better" when it lands more than 2 indices below current's
+        // skip AND still reaches `target`. In that case we'd rather take one step back via
+        // `prev` and ride its longer skip next iteration.
+        let prev_skip_strictly_better =
+            skip_i > skip_i_prev.saturating_add(2) && skip_i_prev >= target;
+        let use_skip = curr.skip.is_some()
+            && (skip_i == target || (skip_i > target && !prev_skip_strictly_better));
+
+        curr = if use_skip {
+            curr.skip.clone().expect("checked above")
+        } else {
+            curr.prev
+                .clone()
+                .expect("walking toward smaller target requires prev")
+        };
+    }
+
+    curr
+}
+
+/// Walks back from `current` to the highest checkpoint at or below `target_height`.
+///
+/// Internally rides skip pointers using Bitcoin Core's `GetAncestor` skip-vs-prev heuristic,
+/// adapted to operate on heights so it works on sparse checkpoint chains.
+///
+/// Returns `None` only when the chain's base is itself above `target_height` (no ancestor exists
+/// at or below the target).
+fn walk_to_floor<D>(current: &CheckPoint<D>, target_height: u32) -> Option<CheckPoint<D>> {
+    let mut curr = current.clone();
+    while curr.height() > target_height {
+        let skip = curr.skip();
+        let take_skip = match &skip {
+            Some(skip_cp) if skip_cp.height() < target_height => false,
+            Some(skip_cp) if skip_cp.height() == target_height => true,
+            // Skip lands above target. Prefer prev's skip if it's a strictly bigger jump (lands
+            // more than 2 heights lower than current's skip) that still reaches target.
+            Some(skip_cp) => match curr.prev().and_then(|p| p.skip()) {
+                Some(prev_skip_cp) => {
+                    let prev_skip_h = prev_skip_cp.height();
+                    let skip_gap = skip_cp.height().saturating_sub(prev_skip_h);
+                    !(skip_gap > 2 && prev_skip_h >= target_height)
+                }
+                None => true,
+            },
+            None => false,
+        };
+        curr = if take_skip { skip? } else { curr.prev()? };
+    }
+    Some(curr)
+}
+
 /// A checkpoint is a node of a reference-counted linked list of [`BlockId`]s.
 ///
 /// Checkpoints are cheaply cloneable and are useful to find the agreement point between two sparse
@@ -28,6 +115,10 @@ struct CPInner<D> {
     data: D,
     /// Previous checkpoint (if any).
     prev: Option<Arc<CPInner<D>>>,
+    /// Skip pointer for fast traversals.
+    skip: Option<Arc<CPInner<D>>>,
+    /// Index of this checkpoint (number of checkpoints from the first).
+    index: u32,
 }
 
 /// When a `CPInner` is dropped we need to go back down the chain and manually remove any
@@ -46,8 +137,10 @@ impl<D> Drop for CPInner<D> {
             let arc_inner = Arc::into_inner(arc_node);
 
             match arc_inner {
-                // Keep going backwards.
-                Some(mut node) => current = node.prev.take(),
+                Some(mut node) => {
+                    node.skip.take(); // We don't want to recursively drop `node.skip`.
+                    current = node.prev.take();
+                }
                 None => break,
             }
         }
@@ -144,6 +237,25 @@ impl<D> CheckPoint<D> {
         self.0.prev.clone().map(CheckPoint)
     }
 
+    /// Get the index of this checkpoint (number of checkpoints from the first).
+    pub fn index(&self) -> u32 {
+        self.0.index
+    }
+
+    /// Get this checkpoint's pskip ancestor, if one exists.
+    ///
+    /// Returns the ancestor at the [skip index](Self::index) — a deterministically chosen
+    /// checkpoint that lets traversals cover exponentially-growing distances per hop. Returns
+    /// `None` for the genesis checkpoint (index `0`); for index `1`, the skip ancestor is the same
+    /// checkpoint as `prev`.
+    ///
+    /// This accessor exposes the internal pskip topology and is intended for diagnostics and
+    /// benchmarks, not for general-purpose traversal — use [`get`](Self::get),
+    /// [`range`](Self::range), or [`floor_at`](Self::floor_at) instead.
+    pub fn skip(&self) -> Option<CheckPoint<D>> {
+        self.0.skip.clone().map(CheckPoint)
+    }
+
     /// Iterate from this checkpoint in descending height.
     pub fn iter(&self) -> CheckPointIter<D> {
         self.clone().into_iter()
@@ -153,7 +265,15 @@ impl<D> CheckPoint<D> {
     ///
     /// Returns `None` if checkpoint at `height` does not exist`.
     pub fn get(&self, height: u32) -> Option<Self> {
-        self.range(height..=height).next()
+        if self.height() < height {
+            return None;
+        }
+        let floor = walk_to_floor(self, height)?;
+        if floor.height() == height {
+            Some(floor)
+        } else {
+            None
+        }
     }
 
     /// Iterate checkpoints over a height range.
@@ -166,12 +286,18 @@ impl<D> CheckPoint<D> {
     {
         let start_bound = range.start_bound().cloned();
         let end_bound = range.end_bound().cloned();
-        self.iter()
-            .skip_while(move |cp| match end_bound {
-                core::ops::Bound::Included(inc_bound) => cp.height() > inc_bound,
-                core::ops::Bound::Excluded(exc_bound) => cp.height() >= exc_bound,
-                core::ops::Bound::Unbounded => false,
-            })
+
+        // Find the highest checkpoint at or below the upper bound in `O(log n)`. For unbounded
+        // upper, start at `self`; for an excluded `0`, the range is empty.
+        let start = match end_bound {
+            core::ops::Bound::Included(b) => walk_to_floor(self, b),
+            core::ops::Bound::Excluded(b) => b.checked_sub(1).and_then(|b| walk_to_floor(self, b)),
+            core::ops::Bound::Unbounded => Some(self.clone()),
+        };
+
+        start
+            .into_iter()
+            .flat_map(IntoIterator::into_iter)
             .take_while(move |cp| match start_bound {
                 core::ops::Bound::Included(inc_bound) => cp.height() >= inc_bound,
                 core::ops::Bound::Excluded(exc_bound) => cp.height() > exc_bound,
@@ -246,6 +372,8 @@ where
             },
             data,
             prev: None,
+            skip: None,
+            index: 0,
         }))
     }
 
@@ -408,6 +536,13 @@ where
             }
         }
 
+        let new_index = self.0.index + 1;
+
+        // Wire the pskip pointer to the ancestor at skip_index(new_index). This is what makes
+        // traversal O(log n): each checkpoint carries one skip Arc to a deterministically chosen
+        // ancestor, and the chosen distances grow exponentially as you walk back.
+        let skip = Some(ancestor_by_index(&self.0, skip_index(new_index)));
+
         Ok(Self(Arc::new(CPInner {
             block_id: BlockId {
                 height,
@@ -415,6 +550,8 @@ where
             },
             data,
             prev: Some(self.0),
+            skip,
+            index: new_index,
         })))
     }
 }
@@ -471,9 +608,11 @@ mod tests {
 
     #[test]
     fn checkpoint_does_not_leak() {
+        const CHAIN_LEN: u32 = 1000;
+
         let mut cp = CheckPoint::new(0, bitcoin::hashes::Hash::hash(b"genesis"));
 
-        for height in 1u32..=1000 {
+        for height in 1u32..=CHAIN_LEN {
             let hash: BlockHash = bitcoin::hashes::Hash::hash(height.to_be_bytes().as_slice());
             cp = cp.push(height, hash).unwrap();
         }
@@ -481,15 +620,22 @@ mod tests {
         let genesis = cp.get(0).expect("genesis exists");
         let weak = Arc::downgrade(&genesis.0);
 
-        // At this point there should be exactly two strong references to the
-        // genesis checkpoint: the variable `genesis` and the chain `cp`.
+        // Expected strong references to genesis:
+        //  - the `genesis` local variable
+        //  - the chain `cp` via index 1's prev pointer
+        //  - one skip Arc per node `i` in `1..=CHAIN_LEN` where `skip_index(i) == 0` (under pskip,
+        //    those are i=1 and every power of 2 in [2, CHAIN_LEN]).
+        let expected_skips_to_genesis = (1..=CHAIN_LEN).filter(|&i| skip_index(i) == 0).count();
+        let expected_strong = 2 + expected_skips_to_genesis;
+
         assert_eq!(
             Arc::strong_count(&genesis.0),
-            2,
-            "`cp` and `genesis` should be the only strong references",
+            expected_strong,
+            "`genesis`, the chain's prev to genesis, and every pskip ancestor pointing to genesis \
+             should be the only strong references",
         );
 
-        // Dropping the chain should remove one strong reference.
+        // Dropping the chain should leave `genesis` as the only remaining strong reference.
         drop(cp);
         assert_eq!(
             Arc::strong_count(&genesis.0),
@@ -504,5 +650,49 @@ mod tests {
             weak.upgrade().is_none(),
             "the checkpoint node should be freed when all strong references are dropped",
         );
+    }
+
+    #[test]
+    fn skip_index_formula_table() {
+        // Hand-computed table of skip_index(i) for i in 0..=32, matching Bitcoin Core's
+        // GetSkipHeight. This locks the bit-twiddling formula against silent breakage.
+        let expected: [u32; 33] = [
+            0,  // 0
+            0,  // 1
+            0,  // 2  -> 010 & 001 = 000
+            1,  // 3  odd: ilo(ilo(2))+1 = ilo(0)+1 = 1
+            0,  // 4  -> 100 & 011 = 000
+            1,  // 5  odd: ilo(ilo(4))+1 = 1
+            4,  // 6  -> 110 & 101 = 100
+            1,  // 7  odd: ilo(ilo(6))+1 = ilo(4)+1 = 1
+            0,  // 8
+            1,  // 9
+            8,  // 10 -> 1010 & 1001 = 1000
+            1,  // 11
+            8,  // 12 -> 1100 & 1011 = 1000
+            1,  // 13
+            12, // 14 -> 1110 & 1101 = 1100
+            9,  // 15 odd: ilo(ilo(14))+1 = ilo(12)+1 = 8+1 = 9
+            0,  // 16
+            1,  // 17
+            16, // 18
+            1,  // 19
+            16, // 20
+            1,  // 21
+            20, // 22 -> 10110 & 10101 = 10100
+            17, // 23 odd: ilo(ilo(22))+1 = ilo(20)+1 = 16+1 = 17
+            16, // 24
+            1,  // 25
+            24, // 26 -> 11010 & 11001 = 11000
+            17, // 27 odd: ilo(ilo(26))+1 = ilo(24)+1 = 16+1 = 17
+            24, // 28 -> 11100 & 11011 = 11000
+            17, // 29 odd: ilo(ilo(28))+1 = ilo(24)+1 = 17
+            28, // 30 -> 11110 & 11101 = 11100
+            25, // 31 odd: ilo(ilo(30))+1 = ilo(28)+1 = 24+1 = 25
+            0,  // 32
+        ];
+        for (i, want) in expected.iter().enumerate() {
+            assert_eq!(skip_index(i as u32), *want, "skip_index({i}) mismatch");
+        }
     }
 }

--- a/crates/core/src/checkpoint.rs
+++ b/crates/core/src/checkpoint.rs
@@ -569,7 +569,45 @@ impl<D> Iterator for CheckPointIter<D> {
         self.next.clone_from(&current.prev);
         Some(CheckPoint(current))
     }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        // Take `self.next` since if the `n`th is not found, `.next` should return `None`.
+        let current = self.next.take()?;
+
+        let target_index = current.index.checked_sub(n.try_into().ok()?)?;
+        let inner = ancestor_by_index(&current, target_index);
+
+        // Advance `self.next`.
+        self.next.clone_from(&inner.prev);
+
+        Some(CheckPoint(inner))
+    }
+
+    fn last(self) -> Option<Self::Item>
+    where
+        Self: Sized,
+    {
+        Some(CheckPoint(ancestor_by_index(&self.next?, 0)))
+    }
+
+    fn count(self) -> usize
+    where
+        Self: Sized,
+    {
+        self.next
+            .map_or(0, |cp_inner| (cp_inner.index as usize).saturating_add(1))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let n = self
+            .next
+            .as_ref()
+            .map_or(0, |cp_inner| (cp_inner.index as usize).saturating_add(1));
+        (n, Some(n))
+    }
 }
+
+impl<D> ExactSizeIterator for CheckPointIter<D> {}
 
 impl<D> IntoIterator for CheckPoint<D> {
     type Item = CheckPoint<D>;

--- a/crates/core/src/checkpoint_entry.rs
+++ b/crates/core/src/checkpoint_entry.rs
@@ -11,8 +11,6 @@
 //! Use [`CheckPoint::entry_iter`] to iterate over entries, which yields placeholders for any
 //! gaps where `prev_blockhash` implies a block.
 
-use core::ops::RangeBounds;
-
 use bitcoin::BlockHash;
 
 use crate::{BlockId, CheckPoint, ToBlockHash};
@@ -137,62 +135,6 @@ impl<D: ToBlockHash> CheckPointEntry<D> {
             },
             checkpoint_above: checkpoint.clone(),
         })
-    }
-
-    /// Iterate over checkpoint entries backwards.
-    pub fn iter(&self) -> CheckPointEntryIter<D>
-    where
-        D: Clone,
-    {
-        self.clone().into_iter()
-    }
-
-    /// Get checkpoint entry at `height`.
-    ///
-    /// Returns `None` if checkpoint at `height` does not exist.
-    pub fn get(&self, height: u32) -> Option<Self>
-    where
-        D: Clone,
-    {
-        self.range(height..=height).next()
-    }
-
-    /// Iterate checkpoints over a height range.
-    pub fn range<R>(&self, range: R) -> impl Iterator<Item = CheckPointEntry<D>>
-    where
-        D: Clone,
-        R: RangeBounds<u32>,
-    {
-        let start_bound = range.start_bound().cloned();
-        let end_bound = range.end_bound().cloned();
-        self.iter()
-            .skip_while(move |cp_entry| match end_bound {
-                core::ops::Bound::Included(inc_bound) => cp_entry.height() > inc_bound,
-                core::ops::Bound::Excluded(exc_bound) => cp_entry.height() >= exc_bound,
-                core::ops::Bound::Unbounded => false,
-            })
-            .take_while(move |cp_entry| match start_bound {
-                core::ops::Bound::Included(inc_bound) => cp_entry.height() >= inc_bound,
-                core::ops::Bound::Excluded(exc_bound) => cp_entry.height() > exc_bound,
-                core::ops::Bound::Unbounded => true,
-            })
-    }
-
-    /// Returns the entry at `height` if one exists, otherwise the nearest checkpoint at a lower
-    /// height.
-    pub fn floor_at(&self, height: u32) -> Option<Self>
-    where
-        D: Clone,
-    {
-        self.range(..=height).next()
-    }
-
-    /// Returns the entry located a number of heights below this one.
-    pub fn floor_below(&self, offset: u32) -> Option<Self>
-    where
-        D: Clone,
-    {
-        self.floor_at(self.height().checked_sub(offset)?)
     }
 }
 

--- a/crates/core/tests/test_checkpoint_skiplist.rs
+++ b/crates/core/tests/test_checkpoint_skiplist.rs
@@ -1,0 +1,245 @@
+use bdk_core::CheckPoint;
+use bitcoin::hashes::Hash;
+use bitcoin::BlockHash;
+
+#[test]
+fn test_skiplist_indices() {
+    // Create a long chain to test skiplist
+    let mut cp = CheckPoint::new(0, BlockHash::all_zeros());
+    assert_eq!(cp.index(), 0);
+
+    for height in 1..=500 {
+        let hash = BlockHash::from_byte_array([height as u8; 32]);
+        cp = cp.push(height, hash).unwrap();
+        assert_eq!(cp.index(), height);
+    }
+
+    // Test that skip pointers are set correctly
+    // At index 100, 200, 300, 400, 500 we should have skip pointers
+    assert_eq!(cp.index(), 500);
+
+    // Navigate to index 400 and check skip pointer
+    let mut current = cp.clone();
+    for _ in 0..100 {
+        current = current.prev().unwrap();
+    }
+    assert_eq!(current.index(), 400);
+
+    // Check that skip pointer exists at index 400
+    if let Some(skip) = current.skip() {
+        assert_eq!(skip.index(), 300);
+    } else {
+        panic!("Expected skip pointer at index 400");
+    }
+
+    // Navigate to index 300 and check skip pointer
+    for _ in 0..100 {
+        current = current.prev().unwrap();
+    }
+    assert_eq!(current.index(), 300);
+
+    if let Some(skip) = current.skip() {
+        assert_eq!(skip.index(), 200);
+    } else {
+        panic!("Expected skip pointer at index 300");
+    }
+
+    // Navigate to index 100 and check skip pointer
+    for _ in 0..200 {
+        current = current.prev().unwrap();
+    }
+    assert_eq!(current.index(), 100);
+
+    if let Some(skip) = current.skip() {
+        assert_eq!(skip.index(), 0);
+    } else {
+        panic!("Expected skip pointer at index 100");
+    }
+}
+
+#[test]
+fn test_skiplist_get_performance() {
+    // Create a very long chain
+    let mut cp = CheckPoint::new(0, BlockHash::all_zeros());
+
+    for height in 1..=1000 {
+        let hash = BlockHash::from_byte_array([(height % 256) as u8; 32]);
+        cp = cp.push(height, hash).unwrap();
+    }
+
+    // Test that get() can find checkpoints efficiently
+    // This should use skip pointers to navigate quickly
+
+    // Verify the chain was built correctly
+    assert_eq!(cp.height(), 1000);
+    assert_eq!(cp.index(), 1000);
+
+    // Find checkpoint near the beginning
+    if let Some(found) = cp.get(50) {
+        assert_eq!(found.height(), 50);
+        assert_eq!(found.index(), 50);
+    } else {
+        // Debug: print the first few checkpoints
+        let mut current = cp.clone();
+        println!("First 10 checkpoints:");
+        for _ in 0..10 {
+            println!("Height: {}, Index: {}", current.height(), current.index());
+            if let Some(prev) = current.prev() {
+                current = prev;
+            } else {
+                break;
+            }
+        }
+        panic!("Could not find checkpoint at height 50");
+    }
+
+    // Find checkpoint in the middle
+    if let Some(found) = cp.get(500) {
+        assert_eq!(found.height(), 500);
+        assert_eq!(found.index(), 500);
+    } else {
+        panic!("Could not find checkpoint at height 500");
+    }
+
+    // Find checkpoint near the end
+    if let Some(found) = cp.get(950) {
+        assert_eq!(found.height(), 950);
+        assert_eq!(found.index(), 950);
+    } else {
+        panic!("Could not find checkpoint at height 950");
+    }
+
+    // Test non-existent checkpoint
+    assert!(cp.get(1001).is_none());
+}
+
+#[test]
+fn test_skiplist_floor_at() {
+    let mut cp = CheckPoint::new(0, BlockHash::all_zeros());
+
+    // Create sparse chain with gaps
+    for height in [10, 50, 100, 150, 200, 300, 400, 500] {
+        let hash = BlockHash::from_byte_array([height as u8; 32]);
+        cp = cp.push(height, hash).unwrap();
+    }
+
+    // Test floor_at with skip pointers
+    let floor = cp.floor_at(250).unwrap();
+    assert_eq!(floor.height(), 200);
+
+    let floor = cp.floor_at(99).unwrap();
+    assert_eq!(floor.height(), 50);
+
+    let floor = cp.floor_at(500).unwrap();
+    assert_eq!(floor.height(), 500);
+
+    let floor = cp.floor_at(600).unwrap();
+    assert_eq!(floor.height(), 500);
+}
+
+#[test]
+fn test_skiplist_insert_maintains_indices() {
+    let mut cp = CheckPoint::new(0, BlockHash::all_zeros());
+
+    // Build initial chain
+    for height in [10, 20, 30, 40, 50] {
+        let hash = BlockHash::from_byte_array([height as u8; 32]);
+        cp = cp.push(height, hash).unwrap();
+    }
+
+    // Insert a block in the middle
+    let hash = BlockHash::from_byte_array([25; 32]);
+    cp = cp.insert(25, hash);
+
+    // Check that indices are maintained correctly
+    let check = cp.get(50).unwrap();
+    assert_eq!(check.index(), 6); // 0, 10, 20, 25, 30, 40, 50
+
+    let check = cp.get(25).unwrap();
+    assert_eq!(check.index(), 3);
+
+    // Check the full chain has correct indices
+    let mut current = cp.clone();
+    let expected_heights = [50, 40, 30, 25, 20, 10, 0];
+    let expected_indices = [6, 5, 4, 3, 2, 1, 0];
+
+    for (expected_height, expected_index) in expected_heights.iter().zip(expected_indices.iter()) {
+        assert_eq!(current.height(), *expected_height);
+        assert_eq!(current.index(), *expected_index);
+        if *expected_height > 0 {
+            current = current.prev().unwrap();
+        }
+    }
+}
+
+#[test]
+fn test_skiplist_range_uses_skip_pointers() {
+    let mut cp = CheckPoint::new(0, BlockHash::all_zeros());
+
+    // Create a chain with 500 checkpoints
+    for height in 1..=500 {
+        let hash = BlockHash::from_byte_array([(height % 256) as u8; 32]);
+        cp = cp.push(height, hash).unwrap();
+    }
+
+    // Test range iteration
+    let range_items: Vec<_> = cp.range(100..=200).collect();
+    assert_eq!(range_items.len(), 101);
+    assert_eq!(range_items.first().unwrap().height(), 200);
+    assert_eq!(range_items.last().unwrap().height(), 100);
+
+    // Test open range
+    let range_items: Vec<_> = cp.range(450..).collect();
+    assert_eq!(range_items.len(), 51);
+    assert_eq!(range_items.first().unwrap().height(), 500);
+    assert_eq!(range_items.last().unwrap().height(), 450);
+}
+
+#[test]
+fn test_range_edge_cases() {
+    let mut cp = CheckPoint::new(0, BlockHash::all_zeros());
+
+    // Create sparse chain: 0, 100, 200, 300, 400, 500
+    for i in 1..=5 {
+        let height = i * 100;
+        let hash = BlockHash::from_byte_array([i as u8; 32]);
+        cp = cp.push(height, hash).unwrap();
+    }
+
+    // Empty range (start > end)
+    #[allow(clippy::reversed_empty_ranges)]
+    let empty: Vec<_> = cp.range(300..200).collect();
+    assert!(empty.is_empty());
+
+    // Single element range
+    let single: Vec<_> = cp.range(300..=300).collect();
+    assert_eq!(single.len(), 1);
+    assert_eq!(single[0].height(), 300);
+
+    // Range with non-existent bounds (150..250)
+    let partial: Vec<_> = cp.range(150..250).collect();
+    assert_eq!(partial.len(), 1);
+    assert_eq!(partial[0].height(), 200);
+
+    // Exclusive end bound (100..300 includes 100 and 200, but not 300)
+    let exclusive: Vec<_> = cp.range(100..300).collect();
+    assert_eq!(exclusive.len(), 2);
+    assert_eq!(exclusive[0].height(), 200);
+    assert_eq!(exclusive[1].height(), 100);
+
+    // Unbounded range (..)
+    let all: Vec<_> = cp.range(..).collect();
+    assert_eq!(all.len(), 6);
+    assert_eq!(all.first().unwrap().height(), 500);
+    assert_eq!(all.last().unwrap().height(), 0);
+
+    // Range beyond chain bounds
+    let beyond: Vec<_> = cp.range(600..700).collect();
+    assert!(beyond.is_empty());
+
+    // Range from genesis
+    let from_genesis: Vec<_> = cp.range(0..=200).collect();
+    assert_eq!(from_genesis.len(), 3);
+    assert_eq!(from_genesis[0].height(), 200);
+    assert_eq!(from_genesis[2].height(), 0);
+}

--- a/crates/core/tests/test_checkpoint_skiplist.rs
+++ b/crates/core/tests/test_checkpoint_skiplist.rs
@@ -4,56 +4,33 @@ use bitcoin::BlockHash;
 
 #[test]
 fn test_skiplist_indices() {
-    // Create a long chain to test skiplist
+    // Build a chain long enough to hold multiple skip pointers (indices 1000..=5000).
     let mut cp = CheckPoint::new(0, BlockHash::all_zeros());
     assert_eq!(cp.index(), 0);
 
-    for height in 1..=500 {
-        let hash = BlockHash::from_byte_array([height as u8; 32]);
+    for height in 1..=5000u32 {
+        let hash = BlockHash::from_byte_array([(height % 256) as u8; 32]);
         cp = cp.push(height, hash).unwrap();
         assert_eq!(cp.index(), height);
     }
+    assert_eq!(cp.index(), 5000);
 
-    // Test that skip pointers are set correctly
-    // At index 100, 200, 300, 400, 500 we should have skip pointers
-    assert_eq!(cp.index(), 500);
-
-    // Navigate to index 400 and check skip pointer
-    let mut current = cp.clone();
-    for _ in 0..100 {
-        current = current.prev().unwrap();
-    }
-    assert_eq!(current.index(), 400);
-
-    // Check that skip pointer exists at index 400
-    if let Some(skip) = current.skip() {
-        assert_eq!(skip.index(), 300);
-    } else {
-        panic!("Expected skip pointer at index 400");
+    // Skip pointers are expected at indices 1000, 2000, 3000, 4000, 5000, each pointing 1000 back.
+    // Intermediate indices should not have skip pointers.
+    for target_index in [5000u32, 4000, 3000, 2000, 1000] {
+        let node = cp.get(target_index).expect("checkpoint exists");
+        let skip = node
+            .skip()
+            .unwrap_or_else(|| panic!("expected skip pointer at index {target_index}"));
+        assert_eq!(skip.index(), target_index - 1000);
     }
 
-    // Navigate to index 300 and check skip pointer
-    for _ in 0..100 {
-        current = current.prev().unwrap();
-    }
-    assert_eq!(current.index(), 300);
-
-    if let Some(skip) = current.skip() {
-        assert_eq!(skip.index(), 200);
-    } else {
-        panic!("Expected skip pointer at index 300");
-    }
-
-    // Navigate to index 100 and check skip pointer
-    for _ in 0..200 {
-        current = current.prev().unwrap();
-    }
-    assert_eq!(current.index(), 100);
-
-    if let Some(skip) = current.skip() {
-        assert_eq!(skip.index(), 0);
-    } else {
-        panic!("Expected skip pointer at index 100");
+    for non_skip_index in [500u32, 1500, 2500, 4999] {
+        let node = cp.get(non_skip_index).expect("checkpoint exists");
+        assert!(
+            node.skip().is_none(),
+            "unexpected skip pointer at index {non_skip_index}"
+        );
     }
 }
 

--- a/crates/core/tests/test_checkpoint_skiplist.rs
+++ b/crates/core/tests/test_checkpoint_skiplist.rs
@@ -137,6 +137,35 @@ fn test_range_edge_cases() {
     assert_eq!(from_genesis[2].height(), 0);
 }
 
+#[test]
+fn test_iter_overrides() {
+    const N: u32 = 200;
+    let mut cp = CheckPoint::new(0, BlockHash::all_zeros());
+    for height in 1..=N {
+        let hash = BlockHash::from_byte_array([(height % 256) as u8; 32]);
+        cp = cp.push(height, hash).unwrap();
+    }
+    let len = (N + 1) as usize;
+
+    // Fresh iterator: count, last, size_hint, len.
+    // (nth correctness is covered by the `iter_nth_matches_collected` proptest).
+    assert_eq!(cp.iter().count(), len);
+    assert_eq!(cp.iter().last().unwrap().height(), 0);
+    assert_eq!(cp.iter().size_hint(), (len, Some(len)));
+    assert_eq!(cp.iter().len(), len);
+
+    // After nth(k), the iterator must resume from element k+1 and len shrinks accordingly.
+    let mut it = cp.iter();
+    assert_eq!(it.nth(3).unwrap().height(), N - 3);
+    assert_eq!(it.next().unwrap().height(), N - 4);
+    assert_eq!(it.len(), len - 5);
+
+    // Out-of-range nth drains the iterator.
+    let mut it = cp.iter();
+    assert!(it.nth(usize::MAX).is_none());
+    assert_eq!(it.len(), 0);
+}
+
 /// Build a sparse chain at the given heights (genesis at 0 is implicit; `heights` must be a
 /// strictly increasing sequence of positive heights).
 fn build_chain(heights: &[u32]) -> CheckPoint<BlockHash> {
@@ -203,6 +232,19 @@ proptest! {
         cases: 64,
         ..ProptestConfig::default()
     })]
+
+    /// `iter().nth(n)` matches indexing into the fully-collected chain for arbitrary n.
+    #[test]
+    fn iter_nth_matches_collected(
+        heights in arbitrary_sparse_heights(),
+        n in 0usize..=300,
+    ) {
+        let cp = build_chain(&heights);
+        let collected: Vec<u32> = cp.iter().map(|c| c.height()).collect();
+        let got = cp.iter().nth(n).map(|c| c.height());
+        let expected = collected.get(n).copied();
+        prop_assert_eq!(got, expected);
+    }
 
     /// `get(h)` matches a linear scan for any chain and any query height (existing, missing,
     /// genesis, beyond tip, etc.).

--- a/crates/core/tests/test_checkpoint_skiplist.rs
+++ b/crates/core/tests/test_checkpoint_skiplist.rs
@@ -1,0 +1,275 @@
+use bdk_core::CheckPoint;
+use bitcoin::hashes::Hash;
+use bitcoin::BlockHash;
+use proptest::prelude::*;
+
+/// Independent reference implementation of `bdk_core`'s private `skip_index` formula (mirrors
+/// Bitcoin Core's `GetSkipHeight`, operating on 0-based checkpoint indices). Reimplementing the
+/// formula in the test file keeps the structural-invariant assertion meaningful — if someone
+/// changes the library's `skip_index`, this test will catch it instead of vacuously agreeing with
+/// itself.
+fn expected_skip_index(i: u32) -> u32 {
+    if i < 2 {
+        return 0;
+    }
+    fn invert_lowest_one(n: u32) -> u32 {
+        n & n.wrapping_sub(1)
+    }
+    if i & 1 == 0 {
+        invert_lowest_one(i)
+    } else {
+        invert_lowest_one(invert_lowest_one(i - 1)) + 1
+    }
+}
+
+#[test]
+fn test_skiplist_indices() {
+    // Build a chain spanning multiple log levels and assert that each node carries the pskip
+    // pointer mandated by the formula.
+    let mut cp = CheckPoint::new(0, BlockHash::all_zeros());
+    assert_eq!(cp.index(), 0);
+    assert!(cp.skip().is_none(), "genesis must not have a skip pointer");
+
+    const N: u32 = 5000;
+    for height in 1..=N {
+        let hash = BlockHash::from_byte_array([(height % 256) as u8; 32]);
+        cp = cp.push(height, hash).unwrap();
+        assert_eq!(cp.index(), height);
+    }
+    assert_eq!(cp.index(), N);
+
+    // Walk the chain once and verify every non-genesis node skips to expected_skip_index(i).
+    let mut current = cp;
+    loop {
+        let i = current.index();
+        match current.skip() {
+            Some(skip) => {
+                let skip_index = skip.index();
+                let exp_skip_index = expected_skip_index(i);
+                assert_eq!(
+                    skip_index, exp_skip_index,
+                    "node at index {i} should skip to {exp_skip_index} but skips to {skip_index}",
+                )
+            }
+            None => assert_eq!(i, 0, "only the genesis node may have no skip pointer"),
+        }
+        match current.prev() {
+            Some(prev) => current = prev,
+            None => break,
+        }
+    }
+}
+
+#[test]
+fn test_skiplist_insert_maintains_indices() {
+    let mut cp = CheckPoint::new(0, BlockHash::all_zeros());
+
+    // Build initial chain
+    for height in [10, 20, 30, 40, 50] {
+        let hash = BlockHash::from_byte_array([height as u8; 32]);
+        cp = cp.push(height, hash).unwrap();
+    }
+
+    // Insert a block in the middle
+    let hash = BlockHash::from_byte_array([25; 32]);
+    cp = cp.insert(25, hash);
+
+    // Check the full chain has correct indices
+    let mut current = cp.clone();
+    let expected_heights = [50, 40, 30, 25, 20, 10, 0];
+    let expected_indices = [6, 5, 4, 3, 2, 1, 0];
+
+    for (expected_height, expected_index) in expected_heights.iter().zip(expected_indices.iter()) {
+        assert_eq!(current.height(), *expected_height);
+        assert_eq!(current.index(), *expected_index);
+        if *expected_height > 0 {
+            current = current.prev().unwrap();
+        }
+    }
+}
+
+#[test]
+fn test_range_edge_cases() {
+    let mut cp = CheckPoint::new(0, BlockHash::all_zeros());
+
+    // Create sparse chain: 0, 100, 200, 300, 400, 500
+    for i in 1..=5 {
+        let height = i * 100;
+        let hash = BlockHash::from_byte_array([i as u8; 32]);
+        cp = cp.push(height, hash).unwrap();
+    }
+
+    // Empty range (start > end)
+    #[allow(clippy::reversed_empty_ranges)]
+    let empty: Vec<_> = cp.range(300..200).collect();
+    assert!(empty.is_empty());
+
+    // Single element range
+    let single: Vec<_> = cp.range(300..=300).collect();
+    assert_eq!(single.len(), 1);
+    assert_eq!(single[0].height(), 300);
+
+    // Range with non-existent bounds (150..250)
+    let partial: Vec<_> = cp.range(150..250).collect();
+    assert_eq!(partial.len(), 1);
+    assert_eq!(partial[0].height(), 200);
+
+    // Exclusive end bound (100..300 includes 100 and 200, but not 300)
+    let exclusive: Vec<_> = cp.range(100..300).collect();
+    assert_eq!(exclusive.len(), 2);
+    assert_eq!(exclusive[0].height(), 200);
+    assert_eq!(exclusive[1].height(), 100);
+
+    // Unbounded range (..)
+    let all: Vec<_> = cp.range(..).collect();
+    assert_eq!(all.len(), 6);
+    assert_eq!(all.first().unwrap().height(), 500);
+    assert_eq!(all.last().unwrap().height(), 0);
+
+    // Range beyond chain bounds
+    let beyond: Vec<_> = cp.range(600..700).collect();
+    assert!(beyond.is_empty());
+
+    // Range from genesis
+    let from_genesis: Vec<_> = cp.range(0..=200).collect();
+    assert_eq!(from_genesis.len(), 3);
+    assert_eq!(from_genesis[0].height(), 200);
+    assert_eq!(from_genesis[2].height(), 0);
+}
+
+/// Build a sparse chain at the given heights (genesis at 0 is implicit; `heights` must be a
+/// strictly increasing sequence of positive heights).
+fn build_chain(heights: &[u32]) -> CheckPoint<BlockHash> {
+    let mut cp = CheckPoint::new(0, BlockHash::all_zeros());
+    for (i, &h) in heights.iter().enumerate() {
+        let hash = BlockHash::from_byte_array([((i + 1) & 0xff) as u8; 32]);
+        cp = cp.push(h, hash).unwrap();
+    }
+    cp
+}
+
+/// Linear-scan reference implementations against which the pskip-accelerated `get`/`range`/
+/// `floor_at` are compared. Walks the chain via `prev()` only.
+mod reference {
+    use super::*;
+    use core::ops::{Bound, RangeBounds};
+
+    pub(super) fn get(cp: &CheckPoint<BlockHash>, height: u32) -> Option<CheckPoint<BlockHash>> {
+        cp.iter().find(|c| c.height() == height)
+    }
+
+    pub(super) fn floor_at(
+        cp: &CheckPoint<BlockHash>,
+        height: u32,
+    ) -> Option<CheckPoint<BlockHash>> {
+        cp.iter().find(|c| c.height() <= height)
+    }
+
+    pub(super) fn range_heights<R: RangeBounds<u32>>(
+        cp: &CheckPoint<BlockHash>,
+        range: R,
+    ) -> Vec<u32> {
+        let lo = match range.start_bound() {
+            Bound::Included(&v) => v,
+            Bound::Excluded(&v) => v.saturating_add(1),
+            Bound::Unbounded => 0,
+        };
+        let hi = match range.end_bound() {
+            Bound::Included(&v) => v,
+            Bound::Excluded(&v) => v.saturating_sub(1),
+            Bound::Unbounded => u32::MAX,
+        };
+        if lo > hi {
+            return vec![];
+        }
+        cp.iter()
+            .filter(|c| c.height() >= lo && c.height() <= hi)
+            .map(|c| c.height())
+            .collect()
+    }
+}
+
+/// Strategy: pick a small, strictly-increasing set of positive heights up to a bound.
+fn arbitrary_sparse_heights() -> impl Strategy<Value = Vec<u32>> {
+    prop::collection::vec(1u32..=10_000, 0..200).prop_map(|mut v| {
+        v.sort_unstable();
+        v.dedup();
+        v
+    })
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 64,
+        ..ProptestConfig::default()
+    })]
+
+    /// `get(h)` matches a linear scan for any chain and any query height (existing, missing,
+    /// genesis, beyond tip, etc.).
+    #[test]
+    fn pskip_get_matches_linear(heights in arbitrary_sparse_heights(), q in 0u32..=10_500) {
+        let cp = build_chain(&heights);
+        let expected = reference::get(&cp, q).map(|c| c.height());
+        let got = cp.get(q).map(|c| c.height());
+        prop_assert_eq!(got, expected);
+    }
+
+    /// `floor_at(h)` matches a linear scan.
+    #[test]
+    fn pskip_floor_at_matches_linear(heights in arbitrary_sparse_heights(), q in 0u32..=10_500) {
+        let cp = build_chain(&heights);
+        let expected = reference::floor_at(&cp, q).map(|c| c.height());
+        let got = cp.floor_at(q).map(|c| c.height());
+        prop_assert_eq!(got, expected);
+    }
+
+    /// `range(a..=b)` (inclusive) matches a linear scan.
+    #[test]
+    fn pskip_range_inclusive_matches_linear(
+        heights in arbitrary_sparse_heights(),
+        a in 0u32..=10_500,
+        b in 0u32..=10_500,
+    ) {
+        let cp = build_chain(&heights);
+        let expected = reference::range_heights(&cp, a..=b);
+        let got: Vec<u32> = cp.range(a..=b).map(|c| c.height()).collect();
+        prop_assert_eq!(got, expected);
+    }
+
+    /// `range(a..b)` (exclusive end) matches a linear scan.
+    #[test]
+    fn pskip_range_exclusive_matches_linear(
+        heights in arbitrary_sparse_heights(),
+        a in 0u32..=10_500,
+        b in 0u32..=10_500,
+    ) {
+        let cp = build_chain(&heights);
+        let expected = reference::range_heights(&cp, a..b);
+        let got: Vec<u32> = cp.range(a..b).map(|c| c.height()).collect();
+        prop_assert_eq!(got, expected);
+    }
+
+    /// `range(..=b)` (unbounded start) matches a linear scan.
+    #[test]
+    fn pskip_range_unbounded_start_matches_linear(
+        heights in arbitrary_sparse_heights(),
+        b in 0u32..=10_500,
+    ) {
+        let cp = build_chain(&heights);
+        let expected = reference::range_heights(&cp, ..=b);
+        let got: Vec<u32> = cp.range(..=b).map(|c| c.height()).collect();
+        prop_assert_eq!(got, expected);
+    }
+
+    /// `range(a..)` (unbounded end) matches a linear scan.
+    #[test]
+    fn pskip_range_unbounded_end_matches_linear(
+        heights in arbitrary_sparse_heights(),
+        a in 0u32..=10_500,
+    ) {
+        let cp = build_chain(&heights);
+        let expected = reference::range_heights(&cp, a..);
+        let got: Vec<u32> = cp.range(a..).map(|c| c.height()).collect();
+        prop_assert_eq!(got, expected);
+    }
+}

--- a/crates/core/tests/test_merge.rs
+++ b/crates/core/tests/test_merge.rs
@@ -9,7 +9,7 @@ fn test_btree_map_merge() {
     let mut map2: BTreeMap<i32, &str> = BTreeMap::new();
     map2.insert(2, "b");
 
-    map1.merge(map2);
+    Merge::merge(&mut map1, map2);
 
     let expected: BTreeMap<i32, &str> = BTreeMap::from([(1, "a"), (2, "b")]);
     assert_eq!(map1, expected);
@@ -89,7 +89,7 @@ fn test_btree_map_merge_conflict() {
     let mut map2: BTreeMap<i32, &str> = BTreeMap::new();
     map2.insert(1, "b");
 
-    map1.merge(map2);
+    Merge::merge(&mut map1, map2);
 
     let expected: BTreeMap<i32, &str> = BTreeMap::from([(1, "b")]);
     assert_eq!(map1, expected);

--- a/crates/electrum/src/bdk_electrum_client.rs
+++ b/crates/electrum/src/bdk_electrum_client.rs
@@ -378,7 +378,7 @@ impl<E: ElectrumApi> BdkElectrumClient<E> {
             .inner
             .batch_script_get_history(unique_spks.iter().map(|spk| spk.as_script()))?;
         let mut spk_map = HashMap::new();
-        for (spk, history) in unique_spks.into_iter().zip(histories.into_iter()) {
+        for (spk, history) in unique_spks.into_iter().zip(histories) {
             spk_map.insert(spk, history);
         }
 
@@ -571,7 +571,7 @@ impl<E: ElectrumApi> BdkElectrumClient<E> {
         let proofs = self.inner.batch_transaction_get_merkle(to_fetch.iter())?;
 
         // Validate each proof, retrying once for each stale header.
-        for ((txid, height), proof) in to_fetch.into_iter().zip(proofs.into_iter()) {
+        for ((txid, height), proof) in to_fetch.into_iter().zip(proofs) {
             let mut header = {
                 let cache = self.block_header_cache.lock().unwrap();
                 cache


### PR DESCRIPTION
### Description

#### Summary

Add a skiplist to `CheckPoint` using Bitcoin Core's `CBlockIndex::pskip` pattern, adapted to operate on checkpoint indices rather than block heights. Result: O(log n) lookups for `get`, `floor_at`, and `range`, with no tuning constant. Per-node memory is unchanged — `Option<Arc<CPInner>>` is niche-optimized to 8 bytes whether or not it's populated.

The pskip approach was suggested by @ValuedMammal in https://github.com/bitcoindevkit/bdk/pull/2048#issuecomment-4328710770 and prototyped in https://github.com/ValuedMammal/block-graph/blob/master/block-graph/src/checkpoint.rs. Credit for the core idea goes there. This PR takes a different implementation path; the rationale is below.

#### Design

Every `CheckPoint` node carries one Arc skip pointer to a deterministically chosen ancestor at index `skip_index(i)`. The chosen targets give skip distances that grow exponentially as you walk back, yielding O(log n) traversal — ~17 hops at 1M blocks vs ~1M for a linear walk.

`get`, `floor_at`, and `range` all reduce to "walk back to the highest checkpoint at or below `target_height`", factored into one private `walk_to_floor` helper. Each public method is a thin wrapper.

#### Bench numbers (criterion)

Absolute pskip times, with a linear-walk baseline at 1M blocks for scale:

```
get_1000_middle             227 ns
get_10000_near_end          397 ns
floor_at_10000              565 ns
random_access_skiplist_1m   1.36 µs   (vs 3.84 ms linear walk over the same chain)
```

#### Caveats

- Insert is ~50 ns slower per push than a non-skiplist `CheckPoint` because every push wires its skip pointer via an O(log n) `ancestor_by_index` walk. For real-world per-block chain extension this is negligible (well under 1 µs/block), but bulk-rebuild paths (`insert_sparse_1000` → ~3.5 µs for 1000 sequential pushes) pay it linearly.

### Notes to the reviewers

#### History

This PR went through three design iterations. Including the rationale here so reviewers don't have to reconstruct it from the commit graph:

**1. Fixed-stride skiplist (initial proposal).** First version added a single skip pointer every `CHECKPOINT_SKIP_INTERVAL` indices, each pointing exactly that many positions back. `INTERVAL` was originally `100`, then bumped to `1000` after benchmarking — at mainnet-scale chains (~1M blocks) the cost-optimal stride for an O(n/k + k) walk is `k ≈ √n ≈ 1000`. This delivered ~50–80× speedups over linear walks but still left lookups at O(√n) (~2,000 hops at 1M blocks) and forced a tuning constant.

**2. Bitcoin Core's `pskip` (current).** @ValuedMammal pointed out that Bitcoin Core's `CBlockIndex::pskip` pattern achieves O(log n) lookups with no tuning constant by giving every node a single skip pointer to a *deterministically chosen* ancestor (computed from the index's bit pattern). Crucially, this comes at no extra per-node memory cost: `Option<Arc<CPInner>>` was already 8 bytes per node thanks to niche-optimization, so populating the field on every node uses the same space as populating it on every 1000th. Switched to this approach; the synthetic skiplist benches went from ~80% improvement to ~94% over linear, and the tuning constant disappeared.

**3. Reuse the pskip walker.** Once `ancestor_by_index` (the O(log n) walk underlying pskip) existed, it became natural to plug it into anywhere `CheckPoint`/`CheckPointIter` was advancing through the chain by a known amount. `get`, `range`, `floor_at`, `floor_below`, and `Iterator::nth` / `last` all use it now; `count` and `size_hint` derive from the `index` counter directly. Unused traversal methods on `CheckPointEntry` were removed in the same pass since they were duplicating `CheckPoint`'s own surface and had no callers in the workspace.

#### Diffs from @ValuedMammal's prototype

The [block-graph prototype](https://github.com/ValuedMammal/block-graph/blob/master/block-graph/src/checkpoint.rs) gets the high-level idea right (every node carries one deterministic skip pointer; index-based formula so sparse chains work) but has a few choices I wanted to address differently:

**1. `n & (n - 1)` underflow.** The prototype handles it by converting `u32 → i32 → u32` with `try_into().expect(...)`, relying on signed two's-complement to give `0 & -1 == 0`. This PR uses `n & n.wrapping_sub(1)` directly on `u32`, which produces the same `0 & u32::MAX == 0` result without the round-trip conversion.

**2. Traversal heuristic.** The prototype's `get` uses simple greedy ("take skip if it doesn't undershoot, else prev"). That's correct but **not genuinely O(log n)** — for targets near genesis on a long chain, it degrades to many small geometric descents stacked end-to-end. This PR uses Bitcoin Core's `GetAncestor` heuristic verbatim: take skip unless the *predecessor's* skip would have been a strictly bigger jump that still doesn't undershoot.

**3. Single internal helper for `get`/`range`/`floor_at`.** The public surface (`get`, `range`, `floor_at`) all reduces to "walk back to the highest checkpoint at or below `target_height`". This PR factors that into one private `walk_to_floor` function; each public method becomes a thin wrapper. The prototype duplicates the skip-walk logic.

**4. `Drop` cleanup.** With every node holding a skip Arc, the manual unwind loop in `Drop for CPInner` (existing fix for #1634) is extended with `node.skip.take()` so skip-pointer drops happen on the manual loop rather than triggering ancestor drops via the implicit recursive path.

### Changelog

```md
Added:
- `O(log n)` skiplist on `CheckPoint` (Bitcoin Core's pskip pattern). Speeds up `get`, `floor_at`, `range`, and full-chain iteration.
- `Iterator::nth` / `last` / `count` / `size_hint` overrides on `CheckPointIter` and `CheckPointEntryIter`, plus `ExactSizeIterator` impls. `nth` and `last` are now `O(log n)`; `count` and `size_hint` are `O(1)`.

Removed:
- Unused traversal methods on `CheckPointEntry`: `iter`, `get`, `range`, `floor_at`, `floor_below`. They had no callers in the workspace and duplicated `CheckPoint`'s own surface.
```

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
