### PR TITLE
chain: replace `ScriptBuf` with `&Script` in SPK index methods

### DIFF
--- a/crates/chain/src/indexer/keychain_txout.rs
+++ b/crates/chain/src/indexer/keychain_txout.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use alloc::{borrow::ToOwned, vec::Vec};
 use bitcoin::{
-    key::Secp256k1, Amount, OutPoint, ScriptBuf, SignedAmount, Transaction, TxOut, Txid,
+    key::Secp256k1, Amount, OutPoint, Script, ScriptBuf, SignedAmount, Transaction, TxOut, Txid,
 };
 use core::{
     fmt::Debug,
@@ -354,7 +354,10 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
     /// Returns the keychain and keychain index associated with the spk.
     ///
     /// This calls [`SpkTxOutIndex::index_of_spk`] internally.
-    pub fn index_of_spk(&self, script: ScriptBuf) -> Option<&(K, u32)> {
+    pub fn index_of_spk<T>(&self, script: T) -> Option<&(K, u32)>
+    where
+        T: AsRef<Script>,
+    {
         self.inner.index_of_spk(script)
     }
 

--- a/crates/chain/src/indexer/spk_txout.rs
+++ b/crates/chain/src/indexer/spk_txout.rs
@@ -7,7 +7,7 @@ use crate::{
     collections::{hash_map::Entry, BTreeMap, BTreeSet, HashMap},
     Indexer,
 };
-use bitcoin::{Amount, OutPoint, ScriptBuf, SignedAmount, Transaction, TxOut, Txid};
+use bitcoin::{Amount, OutPoint, Script, ScriptBuf, SignedAmount, Transaction, TxOut, Txid};
 
 /// An index storing [`TxOut`]s that have a script pubkey that matches those in a list.
 ///
@@ -280,8 +280,11 @@ impl<I: Clone + Ord + core::fmt::Debug> SpkTxOutIndex<I> {
     }
 
     /// Returns the index associated with the script pubkey.
-    pub fn index_of_spk(&self, script: ScriptBuf) -> Option<&I> {
-        self.spk_indices.get(script.as_script())
+    pub fn index_of_spk<T>(&self, script: T) -> Option<&I>
+    where
+        T: AsRef<Script>,
+    {
+        self.spk_indices.get(script.as_ref())
     }
 
     /// Computes the total value transfer effect `tx` has on the script pubkeys in `range`. Value is
@@ -305,7 +308,7 @@ impl<I: Clone + Ord + core::fmt::Debug> SpkTxOutIndex<I> {
             }
         }
         for txout in &tx.output {
-            if let Some(index) = self.index_of_spk(txout.script_pubkey.clone()) {
+            if let Some(index) = self.index_of_spk(txout.script_pubkey.as_script()) {
                 if range.contains(index) {
                     received += txout.value;
                 }

--- a/crates/chain/tests/test_tx_graph_conflicts.rs
+++ b/crates/chain/tests/test_tx_graph_conflicts.rs
@@ -64,7 +64,7 @@ fn test_tx_conflict_handling() {
                 TxTemplate {
                     tx_name: "unconfirmed_conflict",
                     inputs: &[
-                        TxInTemplate::PrevTx("confirmed_genesis", 0), 
+                        TxInTemplate::PrevTx("confirmed_genesis", 0),
                         TxInTemplate::PrevTx("unconfirmed_coinbase", 0)
                     ],
                     outputs: &[TxOutTemplate::new(20000, Some(2))],
@@ -1034,7 +1034,7 @@ fn test_tx_conflict_handling() {
                 env.indexer.outpoints().iter().cloned(),
                 |_, txout| {
                     env.indexer
-                        .index_of_spk(txout.txout.script_pubkey.clone())
+                        .index_of_spk(txout.txout.script_pubkey.as_script())
                         .is_some()
                 },
                 0,

--- a/examples/example_cli/src/lib.rs
+++ b/examples/example_cli/src/lib.rs
@@ -756,7 +756,7 @@ pub fn handle_commands<CS: clap::Subcommand, S: clap::Args>(
                                 .last()
                                 .expect("must have a keychain");
                             let change_index = tx.output.iter().find_map(|txout| {
-                                let spk = txout.script_pubkey.clone();
+                                let spk = txout.script_pubkey.as_script();
                                 match graph.index.index_of_spk(spk) {
                                     Some(&(keychain, index)) if keychain == change_keychain => {
                                         Some((keychain, index))


### PR DESCRIPTION
### Description

Replace `ScriptBuf` with `&Script` in `SpkTxOutIndex::index_of_spk` and `KeychainTxOutIndex::index_of_spk` methods, to avoid the need of cloning the `ScriptBuf` for a SPK index lookup.

### Changelog notice

Breaking changes:
- Change `SpkTxOutIndex::index_of_spk` and `KeychainTxOutIndex::index_of_spk` args from `ScriptBuf` to `&Script`.

### Checklists

#### All Submissions:

* [X] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [X] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
