### PR TITLE
Remove panic from stop gap scan loop

### DIFF
--- a/crates/esplora/src/blocking_ext.rs
+++ b/crates/esplora/src/blocking_ext.rs
@@ -170,9 +170,9 @@ fn fetch_latest_blocks(
     client: &esplora_client::BlockingClient,
 ) -> Result<BTreeMap<u32, BlockHash>, Error> {
     Ok(client
-        .get_blocks(None)?
+        .get_block_infos(None)?
         .into_iter()
-        .map(|b| (b.time.height, b.id))
+        .map(|b| (b.height, b.id))
         .collect())
 }
 
@@ -282,8 +282,11 @@ fn fetch_txs_with_keychain_spks<I: Iterator<Item = Indexed<SpkWithExpectedTxids>
     type TxsOfSpkIndex = (u32, Vec<esplora_client::Tx>, HashSet<Txid>);
 
     let mut update = TxUpdate::<ConfirmationBlockTime>::default();
-    let mut last_index = Option::<u32>::None;
     let mut last_active_index = Option::<u32>::None;
+    // Use consecutive_unused so unused count drives stop gap.
+    let mut consecutive_unused = 0usize;
+    // Treat stop_gap = 0 as 1 while preserving original semantics for other values.
+    let gap_limit = stop_gap.max(1);
 
     loop {
         let handles = keychain_spks
@@ -321,8 +324,10 @@ fn fetch_txs_with_keychain_spks<I: Iterator<Item = Indexed<SpkWithExpectedTxids>
 
         for handle in handles {
             let (index, txs, evicted) = handle.join().expect("thread must not panic")?;
-            last_index = Some(index);
-            if !txs.is_empty() {
+            if txs.is_empty() {
+                consecutive_unused = consecutive_unused.saturating_add(1);
+            } else {
+                consecutive_unused = 0;
                 last_active_index = Some(index);
             }
             for tx in txs {
@@ -337,13 +342,7 @@ fn fetch_txs_with_keychain_spks<I: Iterator<Item = Indexed<SpkWithExpectedTxids>
                 .extend(evicted.into_iter().map(|txid| (txid, start_time)));
         }
 
-        let last_index = last_index.expect("Must be set since handles wasn't empty.");
-        let gap_limit_reached = if let Some(i) = last_active_index {
-            last_index >= i.saturating_add(stop_gap as u32)
-        } else {
-            last_index + 1 >= stop_gap as u32
-        };
-        if gap_limit_reached {
+        if consecutive_unused >= gap_limit {
             break;
         }
     }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

This PR addresses a panic path in stop gap scan loop. Removes `expect` used to compute gap boundary and instead tracks `consecutive_unused` with `gap_limit = stop_gap.max(1)` to decide when to stop scanning.

Spurred by trying to address https://github.com/bitcoindevkit/bdk_wallet/issues/30 for Esplora

### Notes to the reviewers

Open to any and all feedback on this.

Behavior is unchanged for typical cases, it just avoids a panic in the control flow.

### Changelog notice

```
### Fix:
- Avoid a panic in the Esplora stop‑gap scan loop by tracking consecutive unused scripts to compute the gap boundary.
```

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
