### PR TITLE
fix(ci,test): update `chained_mempool_txs` to use 6 secs timeout

### DIFF
--- a/crates/electrum/tests/test_electrum.rs
+++ b/crates/electrum/tests/test_electrum.rs
@@ -240,7 +240,7 @@ pub fn chained_mempool_tx_sync() -> anyhow::Result<()> {
         .transaction()?;
     let txid2 = rpc_client.send_raw_transaction(signed_tx.raw_hex())?;
 
-    env.wait_until_electrum_sees_txid(signed_tx.compute_txid(), Duration::from_secs(5))?;
+    env.wait_until_electrum_sees_txid(signed_tx.compute_txid(), Duration::from_secs(6))?;
 
     let spk_history = electrum_client.script_get_history(&tracked_addr.script_pubkey())?;
     assert!(

--- a/crates/testenv/src/lib.rs
+++ b/crates/testenv/src/lib.rs
@@ -206,9 +206,10 @@ impl TestEnv {
             std::thread::sleep(delay);
         }
 
-        Err(anyhow::Error::msg(
-            "Timed out waiting for Electrsd to get block header",
-        ))
+        Err(anyhow::Error::msg(format!(
+            "Timed out waiting for Electrsd to get transaction, took: {:?}",
+            start.elapsed()
+        )))
     }
 
     /// This method waits for Electrsd to see a transaction with given `txid`. `timeout` is the
@@ -229,9 +230,10 @@ impl TestEnv {
             std::thread::sleep(delay);
         }
 
-        Err(anyhow::Error::msg(
-            "Timed out waiting for Electrsd to get transaction",
-        ))
+        Err(anyhow::Error::msg(format!(
+            "Timed out waiting for Electrsd to get transaction, took: {:?}",
+            start.elapsed()
+        )))
     }
 
     /// Invalidate a number of blocks of a given size `count`.


### PR DESCRIPTION
fixes #2045 

### Description

It's an initial attempt to solve the timeout failures we have been facing on CI when running electrum tests. It it's not solved at all, at least it now adds the total time elapsed so we can know how long it's taking in CI.

The PR updates the `chained_mempool_txs` test to use 6 seconds as timeout, instead of 5, it was the only spot using 5 instead of 6. Also updates the error message to show the total time elapsed, can help debug the CI if the timeout error persists.

### Notes to the reviewers


### Changelog notice

```
### Changed
- Update the `chained_mempool_txs` to use 6 seconds as timeout.
- Update the error message to show the time elapsed.
```

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
