### PR TITLE
ci: Pin `home` to 0.5.11

### DIFF
--- a/ci/pin-msrv.sh
+++ b/ci/pin-msrv.sh
@@ -9,3 +9,5 @@ set -euo pipefail
 
 # cargo clean
 # rustup override set 1.85.0
+
+cargo update -p home --precise "0.5.11"


### PR DESCRIPTION
### Description

PR pins `home` dependency in CI to `0.5.11` in order to build on rust 1.85.0.

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

