### PR TITLE
ci: Pin coverage toolchain to `nightly-2025-11-27`

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-            toolchain: nightly
+            toolchain: nightly-2025-11-27
             override: true
             cache: true
             components: llvm-tools-preview
@@ -27,7 +27,7 @@ jobs:
       - name: Make coverage directory
         run: mkdir coverage
       - name: Test and report coverage
-        run: cargo +nightly llvm-cov -q --doctests --branch --all --ignore-filename-regex "(example*|crates/testenv/*)" --all-features --lcov --output-path ./coverage/lcov.info
+        run: cargo llvm-cov -q --doctests --branch --all --ignore-filename-regex "(example*|crates/testenv/*)" --all-features --lcov --output-path ./coverage/lcov.info
       - name: Generate HTML coverage report
         run: genhtml -o coverage-report.html --ignore-errors unmapped ./coverage/lcov.info
       - name: Coveralls upload


### PR DESCRIPTION
### Description

`code_coverage.yml` started failing as can be seen in a [recent CI run](https://github.com/bitcoindevkit/bdk/actions/runs/19946035484/job/57195537541). As a workaround I set the toolchain in the coverage workflow to `nightly-2025-11-27` which is the version of the compiler in use the last time there was a successful coverage run.

The cause is unknown (to me) and likely doesn't originate from a crate in `bdk`. Assuming that a fix can be found, we can eventually revert this or otherwise keep the toolchain in `code_coverage.yml` up to date as needed.


### Changelog notice

```md
ci: Set code coverage toolchain to `nightly-2025-11-27`
```

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
