### PR TITLE
fix: no `Debug` on `Display` implementations

### DIFF
--- a/crates/chain/src/indexer/keychain_txout.rs
+++ b/crates/chain/src/indexer/keychain_txout.rs
@@ -973,25 +973,27 @@ pub enum InsertDescriptorError<K> {
     },
 }
 
-impl<K: core::fmt::Debug> core::fmt::Display for InsertDescriptorError<K> {
+impl<K: core::fmt::Display> core::fmt::Display for InsertDescriptorError<K> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             InsertDescriptorError::DescriptorAlreadyAssigned {
-                existing_assignment: existing,
+                existing_assignment,
                 descriptor,
             } => {
                 write!(
                     f,
-                    "attempt to re-assign descriptor {descriptor:?} already assigned to {existing:?}"
+                    "descriptor '{}' is already in use by another keychain '{}'",
+                    descriptor, existing_assignment
                 )
             }
             InsertDescriptorError::KeychainAlreadyAssigned {
-                existing_assignment: existing,
+                existing_assignment,
                 keychain,
             } => {
                 write!(
                     f,
-                    "attempt to re-assign keychain {keychain:?} already assigned to {existing:?}"
+                    "keychain '{}' is already associated with another descriptor '{}'",
+                    keychain, existing_assignment
                 )
             }
         }
@@ -999,7 +1001,7 @@ impl<K: core::fmt::Debug> core::fmt::Display for InsertDescriptorError<K> {
 }
 
 #[cfg(feature = "std")]
-impl<K: core::fmt::Debug> std::error::Error for InsertDescriptorError<K> {}
+impl<K: core::fmt::Display + core::fmt::Debug> std::error::Error for InsertDescriptorError<K> {}
 
 /// `ChangeSet` represents persistent updates to a [`KeychainTxOutIndex`].
 ///

--- a/crates/chain/tests/test_keychain_txout_index.rs
+++ b/crates/chain/tests/test_keychain_txout_index.rs
@@ -18,6 +18,15 @@ enum TestKeychain {
     Internal,
 }
 
+impl core::fmt::Display for TestKeychain {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            TestKeychain::External => write!(f, "External"),
+            TestKeychain::Internal => write!(f, "Internal"),
+        }
+    }
+}
+
 fn parse_descriptor(descriptor: &str) -> Descriptor<DescriptorPublicKey> {
     let secp = bdk_chain::bitcoin::secp256k1::Secp256k1::signing_only();
     Descriptor::<DescriptorPublicKey>::parse_descriptor(&secp, descriptor)

--- a/crates/file_store/src/lib.rs
+++ b/crates/file_store/src/lib.rs
@@ -25,13 +25,24 @@ pub enum StoreError {
 
 impl core::fmt::Display for StoreError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        fn fmt_hex_bytes(f: &mut core::fmt::Formatter<'_>, bytes: &[u8]) -> core::fmt::Result {
+            for &b in bytes {
+                write!(f, "{:02x}", b)?;
+            }
+            Ok(())
+        }
+
         match self {
-            Self::Io(e) => write!(f, "io error trying to read file: {e}"),
-            Self::InvalidMagicBytes { got, expected } => write!(
-                f,
-                "file has invalid magic bytes: expected={expected:?} got={got:?}",
-            ),
-            Self::Bincode(e) => write!(f, "bincode error while reading entry {e}"),
+            Self::Io(e) => write!(f, "io error while reading store file: {}", e),
+            Self::Bincode(e) => write!(f, "bincode error while decoding entry {}", e),
+            Self::InvalidMagicBytes { got, expected } => {
+                write!(f, "invalid magic bytes: ")?;
+                write!(f, "expected 0x")?;
+                fmt_hex_bytes(f, expected)?;
+                write!(f, ", got 0x")?;
+                fmt_hex_bytes(f, got)?;
+                Ok(())
+            }
         }
     }
 }

--- a/examples/example_electrum/src/main.rs
+++ b/examples/example_electrum/src/main.rs
@@ -210,9 +210,22 @@ fn main() -> anyhow::Result<()> {
                     .chain_tip(chain_tip.clone())
                     .inspect(|item, progress| {
                         let pc = (100 * progress.consumed()) as f32 / progress.total() as f32;
-                        eprintln!("[ SCANNING {pc:03.0}% ] {item}");
+                        match item {
+                            bdk_chain::spk_client::SyncItem::Spk((keychain, index), spk) => {
+                                eprintln!(
+                                    "[ SCANNING {pc:3.0}% ] script {} {} {}",
+                                    keychain, index, spk
+                                );
+                            }
+                            bdk_chain::spk_client::SyncItem::Txid(txid) => {
+                                eprintln!("[ SCANNING {pc:3.0}% ] txid {}", txid);
+                            }
+                            bdk_chain::spk_client::SyncItem::OutPoint(op) => {
+                                eprintln!("[ SCANNING {pc:3.0}% ] outpoint {}", op);
+                            }
+                        }
+                        let _ = io::stderr().flush();
                     });
-
             let canonical_view = graph.canonical_view(
                 &*chain,
                 chain_tip.block_id(),

--- a/examples/example_esplora/src/main.rs
+++ b/examples/example_esplora/src/main.rs
@@ -215,8 +215,20 @@ fn main() -> anyhow::Result<()> {
                     .chain_tip(local_tip.clone())
                     .inspect(|item, progress| {
                         let pc = (100 * progress.consumed()) as f32 / progress.total() as f32;
-                        eprintln!("[ SCANNING {pc:03.0}% ] {item}");
-                        // Flush early to ensure we print at every iteration.
+                        match item {
+                            bdk_chain::spk_client::SyncItem::Spk((keychain, index), spk) => {
+                                eprintln!(
+                                    "[ SCANNING {pc:3.0}% ] script {} {} {}",
+                                    keychain, index, spk
+                                );
+                            }
+                            bdk_chain::spk_client::SyncItem::Txid(txid) => {
+                                eprintln!("[ SCANNING {pc:3.0}% ] txid {}", txid);
+                            }
+                            bdk_chain::spk_client::SyncItem::OutPoint(op) => {
+                                eprintln!("[ SCANNING {pc:3.0}% ] outpoint {}", op);
+                            }
+                        }
                         let _ = io::stderr().flush();
                     });
 


### PR DESCRIPTION
### Description

Fixes https://github.com/bitcoindevkit/bdk/issues/1933, remove the usage of `Debug` on `Display` implemetations mentioned in https://github.com/bitcoindevkit/bdk/pull/1881#issuecomment-2718412512

### Changelog notice

- Replaced  `Debug` usage with `Display` messages for `InsertDescriptorError`, `CalculateFeeError` and `StoreError`.
- `InvalidMagicBytes` now displays expected and actual bytes in hexadecimal instead of using `Debug`.
- Added a new `short_descriptor` function to shorten descriptors for concise error output.
- Added detailed `SyncRequest` `Display` for Esplora and Electrum examples.

### Checklists

#### All Submissions:
* [x] I have signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just check`, `just fmt` and `just test` before committing
