### PR TITLE
ci: Swap `tibdex` for `actions/create-github-app-token` in `cron-update-rust.yml`

### DIFF
--- a/.github/workflows/cron-update-rust.yml
+++ b/.github/workflows/cron-update-rust.yml
@@ -15,11 +15,11 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
-      - uses: tibdex/github-app-token@v2
+      - uses: actions/create-github-app-token@v2
         id: generate-token
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: crazy-max/ghaction-import-gpg@v6
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}


### PR DESCRIPTION
### Description

Move away from the now archived `tibdex/github-app-token` in `cron-update-rust.yml` workflow in favor of official [`actions/create-github-app-token`](https://github.com/marketplace/actions/create-github-app-token).

fix #2072 

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
