### PR TITLE
Fix no-std compilation

### DIFF
--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -20,6 +20,7 @@ bdk_core = { path = "../core", version = "0.6.1", default-features = false }
 esplora-client = { version = "0.12.1", default-features = false }
 async-trait = { version = "0.1.66", optional = true }
 futures = { version = "0.3.26", optional = true }
+serde_json = { version = "1.0", features = ["alloc"] }
 
 [dev-dependencies]
 esplora-client = { version = "0.12.0" }

--- a/examples/example_cli/Cargo.toml
+++ b/examples/example_cli/Cargo.toml
@@ -15,4 +15,4 @@ anyhow = "1"
 clap = { version = "4.5.17", features = ["derive", "env"] }
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["alloc"] }


### PR DESCRIPTION
### Description

`serde_json` requires either `std` or `alloc` feature enabled. We just enable `alloc` as we don't need the features that `std` provides.

### Notes to the reviewers

`alloc` is just a subset of `std`. `json_serde` has `from_reader()` & `to_writer()` methods if `std` is enabled. We aren't using those methods so just having `alloc` is fine.

I'm also not sure why an explicit `alloc` cargo feature flag is needed in `serde_json`. They can just have an internal prelude based on whether the `std` feature is enabled.


### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
