### PR TITLE
Pin `home`, `time` & `time-core`

### DIFF
--- a/ci/pin-msrv.sh
+++ b/ci/pin-msrv.sh
@@ -11,3 +11,5 @@ set -euo pipefail
 # rustup override set 1.85.0
 
 cargo update -p home --precise "0.5.11"
+cargo update -p time --precise "0.3.45"
+cargo update -p time-core --precise "0.1.7"


### PR DESCRIPTION
### Description

Pin dependencies so we can still compile with rustc 1.85.0 (MSRV).

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
