### PR TITLE
Add request timeout to Esplora client in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,21 @@ Unless you explicitly state otherwise, any contribution intentionally
 submitted for inclusion in the work by you, as defined in the Apache-2.0
 license, shall be dual licensed as above, without any additional terms or
 conditions.
+
+## Esplora backend example
+
+BDK can be used with an Esplora backend to fetch blockchain data without running a full node.
+
+Below is a minimal example showing how to query the current blockchain height using `bdk_esplora`:
+
+```rust
+use bdk_esplora::EsploraClient;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let esplora = EsploraClient::new("https://blockstream.info/api")?;
+    let height = esplora.get_height()?;
+    println!("Current block height: {}", height);
+    Ok(())
+}
+```
+

--- a/examples/example_esplora/src/main.rs
+++ b/examples/example_esplora/src/main.rs
@@ -69,6 +69,7 @@ pub struct EsploraArgs {
     esplora_url: Option<String>,
 }
 
+use std::time::Duration;
 impl EsploraArgs {
     pub fn client(&self, network: Network) -> anyhow::Result<esplora_client::BlockingClient> {
         let esplora_url = self.esplora_url.as_deref().unwrap_or(match network {
@@ -79,10 +80,14 @@ impl EsploraArgs {
             _ => panic!("unsupported network"),
         });
 
-        let client = esplora_client::Builder::new(esplora_url).build_blocking();
+        let client = esplora_client::Builder::new(esplora_url)
+            .timeout(60)
+            .build_blocking();
+
         Ok(client)
     }
 }
+
 
 #[derive(Parser, Debug, Clone, PartialEq)]
 pub struct ScanOptions {


### PR DESCRIPTION
This PR adds a request timeout to the Esplora client used by the example application. Configuring a timeout helps avoid hanging network requests and makes the example more robust for real world usage.


