### PR TITLE
fix(esplora): deduplicate missing txids in fetch_txs_with_outpoints

### DIFF
--- a/crates/esplora/src/async_ext.rs
+++ b/crates/esplora/src/async_ext.rs
@@ -501,7 +501,7 @@ where
 
     // get outpoint spend-statuses
     let mut outpoints = outpoints.into_iter();
-    let mut missing_txs = Vec::<Txid>::with_capacity(outpoints.len());
+    let mut missing_txs = HashSet::<Txid>::with_capacity(outpoints.len());
     loop {
         let handles = outpoints
             .by_ref()
@@ -522,7 +522,7 @@ where
                 None => continue,
             };
             if !inserted_txs.contains(&spend_txid) {
-                missing_txs.push(spend_txid);
+                missing_txs.insert(spend_txid);
             }
             if let Some(spend_status) = op_status.status {
                 insert_anchor_or_seen_at_from_status(

--- a/crates/esplora/src/blocking_ext.rs
+++ b/crates/esplora/src/blocking_ext.rs
@@ -457,7 +457,7 @@ fn fetch_txs_with_outpoints<I: IntoIterator<Item = OutPoint>>(
 
     // get outpoint spend-statuses
     let mut outpoints = outpoints.into_iter();
-    let mut missing_txs = Vec::<Txid>::with_capacity(outpoints.len());
+    let mut missing_txs = HashSet::<Txid>::with_capacity(outpoints.len());
     loop {
         let handles = outpoints
             .by_ref()
@@ -483,7 +483,7 @@ fn fetch_txs_with_outpoints<I: IntoIterator<Item = OutPoint>>(
                     None => continue,
                 };
                 if !inserted_txs.contains(&spend_txid) {
-                    missing_txs.push(spend_txid);
+                    missing_txs.insert(spend_txid);
                 }
                 if let Some(spend_status) = op_status.status {
                     insert_anchor_or_seen_at_from_status(


### PR DESCRIPTION
### Description

Previously `fetch_txs_with_outpoints` collected spend txids into a Vec, so the same txid could be pushed multiple times when one transaction spent several input outpoints. This caused redundant `get_tx_info` calls to Esplora for the same transaction, wasting network and CPU without changing the resulting `TxUpdate`.

Use `HashSet<Txid>` for `missing_txs` in both async and blocking `fetch_txs_with_outpoints,` so each txid is only requested once while keeping the observable behaviour of `SyncResponse` / `TxUpdate` unchanged.

### Changelog notice

```

### Changed
- Use `HashSet` instead of `Vec` to track `missing_txs` in bdk_esplora, it deduplicates txids.

```

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
