### PR TITLE
Make `bdk_bitcoind_rpc` emitters support any checkpoint data type

### DIFF
--- a/crates/bitcoind_rpc/src/bip158.rs
+++ b/crates/bitcoind_rpc/src/bip158.rs
@@ -13,6 +13,8 @@ use bdk_core::CheckPoint;
 use bdk_core::FromBlockHeader;
 use bdk_core::ToBlockHash;
 use bitcoin::block::Header;
+use bitcoin::hashes::Hash;
+use bitcoin::pow::CompactTarget;
 use bitcoin::BlockHash;
 use bitcoin::{bip158::BlockFilter, Block, ScriptBuf};
 use bitcoincore_rpc;
@@ -33,7 +35,6 @@ use bitcoincore_rpc::{json::GetBlockHeaderResult, RpcApi};
 ///   occur. `FilterIter` will continue to yield events until it reaches the latest chain tip.
 ///   Events contain the updated checkpoint `cp` which may be incorporated into the local chain
 ///   state to stay in sync with the tip.
-#[derive(Debug)]
 pub struct FilterIter<'a, D = BlockHash> {
     /// RPC client
     client: &'a bitcoincore_rpc::Client,
@@ -43,26 +44,56 @@ pub struct FilterIter<'a, D = BlockHash> {
     cp: CheckPoint<D>,
     /// Header info, contains the prev and next hashes for each header.
     header: Option<GetBlockHeaderResult>,
+    /// Closure to convert a block header into checkpoint data `D`.
+    to_data: Box<dyn Fn(Header) -> D + Send + Sync>,
 }
 
-impl<'a, D> FilterIter<'a, D>
-where
-    D: ToBlockHash + Clone + Debug,
-{
-    /// Construct [`FilterIter`] with checkpoint, RPC client and SPKs.
-    pub fn new(
+impl<D: Debug> core::fmt::Debug for FilterIter<'_, D> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("FilterIter")
+            .field("spks", &self.spks)
+            .field("cp", &self.cp)
+            .field("header", &self.header)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'a, D: 'static> FilterIter<'a, D> {
+    /// Construct [`FilterIter`] with a custom closure to convert block headers into checkpoint
+    /// data.
+    ///
+    /// Use [`new`](Self::new) for the common case where `D` implements [`FromBlockHeader`].
+    pub fn new_with(
         client: &'a bitcoincore_rpc::Client,
         cp: CheckPoint<D>,
         spks: impl IntoIterator<Item = ScriptBuf>,
+        to_data: impl Fn(Header) -> D + Send + Sync + 'static,
     ) -> Self {
         Self {
             client,
             spks: spks.into_iter().collect(),
             cp,
             header: None,
+            to_data: Box::new(to_data),
         }
     }
+}
 
+impl<'a, D: FromBlockHeader + 'static> FilterIter<'a, D> {
+    /// Construct [`FilterIter`] with checkpoint, RPC client and SPKs.
+    pub fn new(
+        client: &'a bitcoincore_rpc::Client,
+        cp: CheckPoint<D>,
+        spks: impl IntoIterator<Item = ScriptBuf>,
+    ) -> Self {
+        Self::new_with(client, cp, spks, D::from_blockheader)
+    }
+}
+
+impl<'a, D> FilterIter<'a, D>
+where
+    D: ToBlockHash + Clone + Debug,
+{
     /// Return the agreement header with the remote node.
     ///
     /// Error if no agreement header is found.
@@ -78,10 +109,7 @@ where
         Err(Error::ReorgDepthExceeded)
     }
 
-    fn try_next_with<F>(&mut self, to_data: F) -> Result<Option<Event<D>>, Error>
-    where
-        F: Fn(Header) -> D,
-    {
+    fn try_next(&mut self) -> Result<Option<Event<D>>, Error> {
         let mut cp = self.cp.clone();
 
         let header = match self.header.take() {
@@ -111,10 +139,21 @@ where
         next_hash = next_header.hash;
         let next_height: u32 = next_header.height.try_into()?;
 
-        cp = cp.insert(
-            next_height,
-            to_data(self.client.get_block_header(&next_hash)?),
-        );
+        // Reconstruct the block header from the already-fetched GetBlockHeaderResult,
+        // avoiding an extra `get_block_header` RPC call.
+        let block_header = Header {
+            version: next_header.version,
+            prev_blockhash: next_header
+                .previous_block_hash
+                .unwrap_or_else(BlockHash::all_zeros),
+            merkle_root: next_header.merkle_root,
+            time: next_header.time as u32,
+            bits: CompactTarget::from_unprefixed_hex(&next_header.bits)
+                .map_err(|_| Error::InvalidBits(next_header.bits.clone()))?,
+            nonce: next_header.nonce,
+        };
+
+        cp = cp.insert(next_height, (self.to_data)(block_header));
 
         let mut block = None;
         let filter = BlockFilter::new(self.client.get_block_filter(&next_hash)?.filter.as_slice());
@@ -131,14 +170,6 @@ where
         self.cp = cp.clone();
 
         Ok(Some(Event { cp, block }))
-    }
-
-    /// Get the next event with a custom checkpoint data type.
-    pub fn next_with<F>(&mut self, to_data: F) -> Option<Result<Event<D>, Error>>
-    where
-        F: Fn(Header) -> D,
-    {
-        self.try_next_with(to_data).transpose()
     }
 }
 
@@ -165,12 +196,12 @@ impl Event {
 
 impl<D> Iterator for FilterIter<'_, D>
 where
-    D: ToBlockHash + FromBlockHeader + Clone + Debug,
+    D: ToBlockHash + Clone + Debug,
 {
     type Item = Result<Event<D>, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.try_next_with(D::from_blockheader).transpose()
+        self.try_next().transpose()
     }
 }
 
@@ -185,6 +216,8 @@ pub enum Error {
     ReorgDepthExceeded,
     /// Error converting an integer
     TryFromInt(core::num::TryFromIntError),
+    /// Invalid bits string from RPC
+    InvalidBits(String),
 }
 
 impl core::fmt::Display for Error {
@@ -194,6 +227,7 @@ impl core::fmt::Display for Error {
             Self::Bip158(e) => write!(f, "{e}"),
             Self::ReorgDepthExceeded => write!(f, "maximum reorg depth exceeded"),
             Self::TryFromInt(e) => write!(f, "{e}"),
+            Self::InvalidBits(s) => write!(f, "invalid bits string: {s}"),
         }
     }
 }

--- a/crates/bitcoind_rpc/src/lib.rs
+++ b/crates/bitcoind_rpc/src/lib.rs
@@ -16,10 +16,11 @@ extern crate alloc;
 
 use alloc::sync::Arc;
 use bdk_core::collections::{HashMap, HashSet};
-use bdk_core::{BlockId, CheckPoint};
+use bdk_core::{BlockId, CheckPoint, FromBlockHeader, ToBlockHash};
 use bitcoin::{Block, BlockHash, Transaction, Txid};
 use bitcoincore_rpc::{bitcoincore_rpc_json, RpcApi};
 use core::ops::Deref;
+use std::fmt::Debug;
 
 pub mod bip158;
 
@@ -30,13 +31,13 @@ pub use bitcoincore_rpc;
 /// Refer to [module-level documentation] for more.
 ///
 /// [module-level documentation]: crate
-pub struct Emitter<C> {
+pub struct Emitter<C, D = BlockHash> {
     client: C,
     start_height: u32,
 
     /// The checkpoint of the last-emitted block that is in the best chain. If it is later found
     /// that the block is no longer in the best chain, it will be popped off from here.
-    last_cp: CheckPoint<BlockHash>,
+    last_cp: CheckPoint<D>,
 
     /// The block result returned from rpc of the last-emitted block. As this result contains the
     /// next block's block hash (which we use to fetch the next block), we set this to `None`
@@ -62,10 +63,11 @@ pub struct Emitter<C> {
 /// to start empty (i.e. with no unconfirmed transactions).
 pub const NO_EXPECTED_MEMPOOL_TXS: core::iter::Empty<Arc<Transaction>> = core::iter::empty();
 
-impl<C> Emitter<C>
+impl<C, D> Emitter<C, D>
 where
     C: Deref,
     C::Target: RpcApi,
+    D: ToBlockHash + Clone + Debug,
 {
     /// Construct a new [`Emitter`].
     ///
@@ -80,7 +82,7 @@ where
     /// If it is known that the wallet is empty, [`NO_EXPECTED_MEMPOOL_TXS`] can be used.
     pub fn new(
         client: C,
-        last_cp: CheckPoint<BlockHash>,
+        last_cp: CheckPoint<D>,
         start_height: u32,
         expected_mempool_txs: impl IntoIterator<Item = impl Into<Arc<Transaction>>>,
     ) -> Self {
@@ -198,9 +200,18 @@ where
         Ok(mempool_event)
     }
 
-    /// Emit the next block height and block (if any).
-    pub fn next_block(&mut self) -> Result<Option<BlockEvent<Block>>, bitcoincore_rpc::Error> {
-        if let Some((checkpoint, block)) = poll(self, move |hash, client| client.get_block(hash))? {
+    /// Emit the next block, using `to_data` to construct checkpoint data from the block.
+    ///
+    /// This is the alternative to [`next_block`](Self::next_block) when [`FromBlockHeader`] isn't
+    /// implemented for `D`.
+    pub fn next_block_with<F>(
+        &mut self,
+        to_data: F,
+    ) -> Result<Option<BlockEvent<Block, D>>, bitcoincore_rpc::Error>
+    where
+        F: Fn(&Block) -> D,
+    {
+        if let Some((checkpoint, block)) = poll(self, to_data)? {
             // Stop tracking unconfirmed transactions that have been confirmed in this block.
             for tx in &block.txdata {
                 self.mempool_snapshot.remove(&tx.compute_txid());
@@ -208,6 +219,14 @@ where
             return Ok(Some(BlockEvent { block, checkpoint }));
         }
         Ok(None)
+    }
+
+    /// Emit the next block height and block (if any).
+    pub fn next_block(&mut self) -> Result<Option<BlockEvent<Block, D>>, bitcoincore_rpc::Error>
+    where
+        D: FromBlockHeader,
+    {
+        self.next_block_with(|block| D::from_blockheader(block.header))
     }
 }
 
@@ -223,7 +242,7 @@ pub struct MempoolEvent {
 
 /// A newly emitted block from [`Emitter`].
 #[derive(Debug)]
-pub struct BlockEvent<B> {
+pub struct BlockEvent<B = Block, D = BlockHash> {
     /// The block.
     pub block: B,
 
@@ -235,10 +254,10 @@ pub struct BlockEvent<B> {
     ///
     /// This is important as BDK structures require block-to-apply to be connected with another
     /// block in the original chain.
-    pub checkpoint: CheckPoint<BlockHash>,
+    pub checkpoint: CheckPoint<D>,
 }
 
-impl<B> BlockEvent<B> {
+impl<B, D> BlockEvent<B, D> {
     /// The block height of this new block.
     pub fn block_height(&self) -> u32 {
         self.checkpoint.height()
@@ -264,17 +283,17 @@ impl<B> BlockEvent<B> {
     }
 }
 
-enum PollResponse {
+enum PollResponse<D = BlockHash> {
     Block(bitcoincore_rpc_json::GetBlockResult),
     NoMoreBlocks,
     /// Fetched block is not in the best chain.
     BlockNotInBestChain,
-    AgreementFound(bitcoincore_rpc_json::GetBlockResult, CheckPoint<BlockHash>),
+    AgreementFound(bitcoincore_rpc_json::GetBlockResult, CheckPoint<D>),
     /// Force the genesis checkpoint down the receiver's throat.
     AgreementPointNotFound(BlockHash),
 }
 
-fn poll_once<C>(emitter: &Emitter<C>) -> Result<PollResponse, bitcoincore_rpc::Error>
+fn poll_once<C, D>(emitter: &Emitter<C, D>) -> Result<PollResponse<D>, bitcoincore_rpc::Error>
 where
     C: Deref,
     C::Target: RpcApi,
@@ -328,30 +347,32 @@ where
     Ok(PollResponse::AgreementPointNotFound(genesis_hash))
 }
 
-fn poll<C, V, F>(
-    emitter: &mut Emitter<C>,
-    get_item: F,
-) -> Result<Option<(CheckPoint<BlockHash>, V)>, bitcoincore_rpc::Error>
+fn poll<C, D, F>(
+    emitter: &mut Emitter<C, D>,
+    to_cp_data: F,
+) -> Result<Option<(CheckPoint<D>, Block)>, bitcoincore_rpc::Error>
 where
     C: Deref,
     C::Target: RpcApi,
-    F: Fn(&BlockHash, &C::Target) -> Result<V, bitcoincore_rpc::Error>,
+    D: ToBlockHash + Clone + Debug,
+    F: Fn(&Block) -> D,
 {
+    let client = &emitter.client;
     loop {
         match poll_once(emitter)? {
             PollResponse::Block(res) => {
                 let height = res.height as u32;
-                let hash = res.hash;
-                let item = get_item(&hash, &emitter.client)?;
+                let block = client.get_block(&res.hash)?;
+                let cp_data = to_cp_data(&block);
 
                 let new_cp = emitter
                     .last_cp
                     .clone()
-                    .push(height, hash)
+                    .push(height, cp_data)
                     .expect("must push");
                 emitter.last_cp = new_cp.clone();
                 emitter.last_block = Some(res);
-                return Ok(Some((new_cp, item)));
+                return Ok(Some((new_cp, block)));
             }
             PollResponse::NoMoreBlocks => {
                 emitter.last_block = None;
@@ -368,7 +389,9 @@ where
                 continue;
             }
             PollResponse::AgreementPointNotFound(genesis_hash) => {
-                emitter.last_cp = CheckPoint::new(0, genesis_hash);
+                let block = client.get_block(&genesis_hash)?;
+                let cp_data = to_cp_data(&block);
+                emitter.last_cp = CheckPoint::new(0, cp_data);
                 emitter.last_block = None;
                 continue;
             }

--- a/crates/bitcoind_rpc/src/lib.rs
+++ b/crates/bitcoind_rpc/src/lib.rs
@@ -55,6 +55,9 @@ pub struct Emitter<C, D = BlockHash> {
     /// sure the tip block is already emitted. When a block is emitted, the transactions in the
     /// block are removed from this field.
     mempool_snapshot: HashMap<Txid, Arc<Transaction>>,
+
+    /// Closure to convert a block into checkpoint data `D`.
+    to_cp_data: Box<dyn Fn(&Block) -> D + Send + Sync>,
 }
 
 /// Indicates that there are no initially-expected mempool transactions.
@@ -67,7 +70,40 @@ impl<C, D> Emitter<C, D>
 where
     C: Deref,
     C::Target: RpcApi,
-    D: ToBlockHash + Clone + Debug,
+    D: ToBlockHash + Clone + Debug + 'static,
+{
+    /// Construct a new [`Emitter`] with a custom closure to convert blocks into checkpoint data.
+    ///
+    /// Use [`new`](Self::new) for the common case where `D` implements [`FromBlockHeader`].
+    pub fn new_with(
+        client: C,
+        last_cp: CheckPoint<D>,
+        start_height: u32,
+        expected_mempool_txs: impl IntoIterator<Item = impl Into<Arc<Transaction>>>,
+        to_cp_data: impl Fn(&Block) -> D + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            client,
+            start_height,
+            last_cp,
+            last_block: None,
+            mempool_snapshot: expected_mempool_txs
+                .into_iter()
+                .map(|tx| {
+                    let tx: Arc<Transaction> = tx.into();
+                    (tx.compute_txid(), tx)
+                })
+                .collect(),
+            to_cp_data: Box::new(to_cp_data),
+        }
+    }
+}
+
+impl<C, D> Emitter<C, D>
+where
+    C: Deref,
+    C::Target: RpcApi,
+    D: ToBlockHash + FromBlockHeader + Clone + Debug + 'static,
 {
     /// Construct a new [`Emitter`].
     ///
@@ -86,27 +122,28 @@ where
         start_height: u32,
         expected_mempool_txs: impl IntoIterator<Item = impl Into<Arc<Transaction>>>,
     ) -> Self {
-        Self {
+        Self::new_with(
             client,
-            start_height,
             last_cp,
-            last_block: None,
-            mempool_snapshot: expected_mempool_txs
-                .into_iter()
-                .map(|tx| {
-                    let tx: Arc<Transaction> = tx.into();
-                    (tx.compute_txid(), tx)
-                })
-                .collect(),
-        }
+            start_height,
+            expected_mempool_txs,
+            |block| D::from_blockheader(block.header),
+        )
     }
+}
 
+impl<C, D> Emitter<C, D>
+where
+    C: Deref,
+    C::Target: RpcApi,
+    D: ToBlockHash + Clone + Debug + 'static,
+{
     /// Emit mempool transactions and any evicted [`Txid`]s.
     ///
     /// This method returns a [`MempoolEvent`] containing the full transactions (with their
     /// first-seen unix timestamps) that were emitted, and [`MempoolEvent::evicted`] which are
     /// any [`Txid`]s which were previously seen in the mempool and are now missing. Evicted txids
-    /// are only reported once the emitter’s checkpoint matches the RPC’s best block in both height
+    /// are only reported once the emitter's checkpoint matches the RPC's best block in both height
     /// and hash. Until `next_block()` advances the checkpoint to tip, `mempool()` will always
     /// return an empty `evicted` set.
     #[cfg(feature = "std")]
@@ -200,18 +237,9 @@ where
         Ok(mempool_event)
     }
 
-    /// Emit the next block, using `to_data` to construct checkpoint data from the block.
-    ///
-    /// This is the alternative to [`next_block`](Self::next_block) when [`FromBlockHeader`] isn't
-    /// implemented for `D`.
-    pub fn next_block_with<F>(
-        &mut self,
-        to_data: F,
-    ) -> Result<Option<BlockEvent<Block, D>>, bitcoincore_rpc::Error>
-    where
-        F: Fn(&Block) -> D,
-    {
-        if let Some((checkpoint, block)) = poll(self, to_data)? {
+    /// Emit the next block height and block (if any).
+    pub fn next_block(&mut self) -> Result<Option<BlockEvent<Block, D>>, bitcoincore_rpc::Error> {
+        if let Some((checkpoint, block)) = poll(self)? {
             // Stop tracking unconfirmed transactions that have been confirmed in this block.
             for tx in &block.txdata {
                 self.mempool_snapshot.remove(&tx.compute_txid());
@@ -219,14 +247,6 @@ where
             return Ok(Some(BlockEvent { block, checkpoint }));
         }
         Ok(None)
-    }
-
-    /// Emit the next block height and block (if any).
-    pub fn next_block(&mut self) -> Result<Option<BlockEvent<Block, D>>, bitcoincore_rpc::Error>
-    where
-        D: FromBlockHeader,
-    {
-        self.next_block_with(|block| D::from_blockheader(block.header))
     }
 }
 
@@ -347,15 +367,13 @@ where
     Ok(PollResponse::AgreementPointNotFound(genesis_hash))
 }
 
-fn poll<C, D, F>(
+fn poll<C, D>(
     emitter: &mut Emitter<C, D>,
-    to_cp_data: F,
 ) -> Result<Option<(CheckPoint<D>, Block)>, bitcoincore_rpc::Error>
 where
     C: Deref,
     C::Target: RpcApi,
-    D: ToBlockHash + Clone + Debug,
-    F: Fn(&Block) -> D,
+    D: ToBlockHash + Clone + Debug + 'static,
 {
     let client = &emitter.client;
     loop {
@@ -363,7 +381,7 @@ where
             PollResponse::Block(res) => {
                 let height = res.height as u32;
                 let block = client.get_block(&res.hash)?;
-                let cp_data = to_cp_data(&block);
+                let cp_data = (emitter.to_cp_data)(&block);
 
                 let new_cp = emitter
                     .last_cp
@@ -390,7 +408,7 @@ where
             }
             PollResponse::AgreementPointNotFound(genesis_hash) => {
                 let block = client.get_block(&genesis_hash)?;
-                let cp_data = to_cp_data(&block);
+                let cp_data = (emitter.to_cp_data)(&block);
                 emitter.last_cp = CheckPoint::new(0, cp_data);
                 emitter.last_block = None;
                 continue;

--- a/crates/bitcoind_rpc/tests/test_filter_iter.rs
+++ b/crates/bitcoind_rpc/tests/test_filter_iter.rs
@@ -1,7 +1,7 @@
 use bdk_bitcoind_rpc::bip158::{Error, FilterIter};
 use bdk_core::CheckPoint;
 use bdk_testenv::{anyhow, corepc_node, TestEnv};
-use bitcoin::{Address, Amount, Network, ScriptBuf};
+use bitcoin::{Address, Amount, BlockHash, Network, ScriptBuf};
 use bitcoincore_rpc::RpcApi;
 
 use crate::common::ClientExt;
@@ -63,7 +63,7 @@ fn filter_iter_error_wrong_network() -> anyhow::Result<()> {
     let _ = env.mine_blocks(10, None)?;
 
     // Try to initialize FilterIter with a CP on the wrong network
-    let cp = CheckPoint::new(0, bitcoin::hashes::Hash::hash(b"wrong-hash"));
+    let cp = CheckPoint::<BlockHash>::new(0, bitcoin::hashes::Hash::hash(b"wrong-hash"));
     let client = ClientExt::get_rpc_client(&env)?;
     let mut iter = FilterIter::new(&client, cp, [ScriptBuf::new()]);
     assert!(matches!(iter.next(), Some(Err(Error::ReorgDepthExceeded))));

--- a/crates/core/src/checkpoint.rs
+++ b/crates/core/src/checkpoint.rs
@@ -55,6 +55,24 @@ impl<D> Drop for CPInner<D> {
     }
 }
 
+/// Trait that converts [`Header`] to subset data.
+pub trait FromBlockHeader {
+    /// Returns the subset data from a block `header`.
+    fn from_blockheader(header: Header) -> Self;
+}
+
+impl FromBlockHeader for BlockHash {
+    fn from_blockheader(header: Header) -> Self {
+        header.block_hash()
+    }
+}
+
+impl FromBlockHeader for Header {
+    fn from_blockheader(header: Header) -> Self {
+        header
+    }
+}
+
 /// Trait that converts [`CheckPoint`] `data` to [`BlockHash`].
 ///
 /// Implementations of [`ToBlockHash`] must always return the block's consensus-defined hash. If
@@ -204,7 +222,7 @@ impl<D> CheckPoint<D> {
 // Methods where `D: ToBlockHash`
 impl<D> CheckPoint<D>
 where
-    D: ToBlockHash + fmt::Debug + Copy,
+    D: ToBlockHash + fmt::Debug + Clone,
 {
     const MTP_BLOCK_COUNT: u32 = 11;
 

--- a/crates/testenv/src/lib.rs
+++ b/crates/testenv/src/lib.rs
@@ -3,9 +3,18 @@
 pub mod utils;
 
 use anyhow::Context;
+use bdk_chain::bitcoin::{
+    block::Header, hash_types::TxMerkleNode, hex::FromHex, script::PushBytesBuf, transaction,
+    Address, Amount, Block, BlockHash, CompactTarget, ScriptBuf, Transaction, TxIn, TxOut, Txid,
+};
 use bdk_chain::CheckPoint;
-use bitcoin::{address::NetworkChecked, Address, Amount, BlockHash, Txid};
-use std::time::Duration;
+use bitcoin::address::NetworkChecked;
+use bitcoin::consensus::Decodable;
+use bitcoin::hex::HexToBytesError;
+use core::str::FromStr;
+use core::time::Duration;
+use electrsd::corepc_node::vtype::GetBlockTemplate;
+use electrsd::corepc_node::{TemplateRequest, TemplateRules};
 
 pub use electrsd;
 pub use electrsd::corepc_client;
@@ -42,6 +51,27 @@ impl Default for Config<'_> {
                 conf
             },
         }
+    }
+}
+
+/// Parameters for [`TestEnv::mine_block`].
+#[non_exhaustive]
+#[derive(Default)]
+pub struct MineParams {
+    /// If `true`, the block will be empty (no mempool transactions).
+    pub empty: bool,
+    /// Set a custom block timestamp. Defaults to `max(min_time, now)`.
+    pub time: Option<u32>,
+    /// Set a custom coinbase output script. Defaults to `OP_TRUE`.
+    pub coinbase_address: Option<ScriptBuf>,
+}
+
+impl MineParams {
+    fn address_or_anyone_can_spend(&self) -> ScriptBuf {
+        self.coinbase_address
+            .clone()
+            // OP_TRUE (anyone can spend)
+            .unwrap_or(ScriptBuf::from_bytes(vec![0x51]))
     }
 }
 
@@ -119,53 +149,138 @@ impl TestEnv {
         Ok(block_hashes)
     }
 
+    /// Get a block template from the node.
+    pub fn get_block_template(&self) -> anyhow::Result<GetBlockTemplate> {
+        use corepc_node::TemplateRequest;
+        Ok(self.bitcoind.client.get_block_template(&TemplateRequest {
+            rules: vec![
+                TemplateRules::Segwit,
+                TemplateRules::Taproot,
+                TemplateRules::Csv,
+            ],
+        })?)
+    }
+
     /// Mine a block that is guaranteed to be empty even with transactions in the mempool.
     #[cfg(feature = "std")]
     pub fn mine_empty_block(&self) -> anyhow::Result<(usize, BlockHash)> {
-        use bitcoin::secp256k1::rand::random;
-        use bitcoin::{
-            block::Header, hashes::Hash, transaction, Block, ScriptBuf, ScriptHash, Transaction,
-            TxIn, TxMerkleNode, TxOut,
-        };
-        use corepc_node::{TemplateRequest, TemplateRules};
-        let request = TemplateRequest {
-            rules: vec![TemplateRules::Segwit],
-        };
-        let bt = self
+        self.mine_block(MineParams {
+            empty: true,
+            ..Default::default()
+        })
+    }
+
+    /// Get the minimum valid timestamp for the next block.
+    pub fn min_time_for_next_block(&self) -> anyhow::Result<u32> {
+        Ok(self
             .bitcoind
             .client
-            .get_block_template(&request)?
-            .into_model()?;
+            .get_block_template(&TemplateRequest {
+                rules: vec![
+                    TemplateRules::Segwit,
+                    TemplateRules::Taproot,
+                    TemplateRules::Csv,
+                ],
+            })?
+            .min_time)
+    }
 
-        let txdata = vec![Transaction {
+    /// Mine a single block with the given [`MineParams`].
+    pub fn mine_block(&self, params: MineParams) -> anyhow::Result<(usize, BlockHash)> {
+        let bt = self.bitcoind.client.get_block_template(&TemplateRequest {
+            rules: vec![
+                TemplateRules::Segwit,
+                TemplateRules::Taproot,
+                TemplateRules::Csv,
+            ],
+        })?;
+        let coinbase_scriptsig = {
+            // BIP34 requires the height to be the first item in coinbase scriptSig.
+            // Bitcoin Core validates by checking if scriptSig STARTS with the expected
+            // encoding (using minimal opcodes like OP_1 for height 1).
+            // The scriptSig must also be 2-100 bytes total.
+            let mut builder = bdk_chain::bitcoin::script::Builder::new().push_int(bt.height);
+            for v in bt.coinbase_aux.values() {
+                let bytes = Vec::<u8>::from_hex(v).expect("must be valid hex");
+                let bytes_buf = PushBytesBuf::try_from(bytes).expect("must be valid bytes");
+                builder = builder.push_slice(bytes_buf);
+            }
+            let script = builder.into_script();
+            // Ensure scriptSig is at least 2 bytes (pad with OP_0 if needed)
+            if script.len() < 2 {
+                bdk_chain::bitcoin::script::Builder::new()
+                    .push_int(bt.height)
+                    .push_opcode(bdk_chain::bitcoin::opcodes::OP_0)
+                    .into_script()
+            } else {
+                script
+            }
+        };
+
+        let coinbase_outputs = if params.empty {
+            let value: Amount = Amount::from_sat(
+                (bt.coinbase_value - bt.transactions.iter().map(|tx| tx.fee).sum::<i64>()) as u64,
+            );
+            vec![TxOut {
+                value,
+                script_pubkey: params.address_or_anyone_can_spend(),
+            }]
+        } else {
+            core::iter::once(TxOut {
+                value: Amount::from_sat(bt.coinbase_value.try_into().expect("must fit into u64")),
+                script_pubkey: params.address_or_anyone_can_spend(),
+            })
+            .chain(
+                bt.default_witness_commitment
+                    .map(|s| -> Result<_, HexToBytesError> {
+                        Ok(TxOut {
+                            value: Amount::ZERO,
+                            script_pubkey: ScriptBuf::from_hex(&s)?,
+                        })
+                    })
+                    .transpose()?,
+            )
+            .collect()
+        };
+
+        let coinbase_tx = Transaction {
             version: transaction::Version::ONE,
             lock_time: bdk_chain::bitcoin::absolute::LockTime::from_height(0)?,
             input: vec![TxIn {
                 previous_output: bdk_chain::bitcoin::OutPoint::default(),
-                script_sig: ScriptBuf::builder()
-                    .push_int(bt.height as _)
-                    // random number so that re-mining creates unique block
-                    .push_int(random())
-                    .into_script(),
+                script_sig: coinbase_scriptsig,
                 sequence: bdk_chain::bitcoin::Sequence::default(),
                 witness: bdk_chain::bitcoin::Witness::new(),
             }],
-            output: vec![TxOut {
-                value: Amount::ZERO,
-                script_pubkey: ScriptBuf::new_p2sh(&ScriptHash::all_zeros()),
-            }],
-        }];
+            output: coinbase_outputs,
+        };
+
+        let txdata = if params.empty {
+            vec![coinbase_tx]
+        } else {
+            core::iter::once(coinbase_tx)
+                .chain(bt.transactions.iter().map(|tx| {
+                    let raw = Vec::<u8>::from_hex(&tx.data).expect("must be valid hex");
+                    Transaction::consensus_decode(&mut raw.as_slice()).expect("must decode tx")
+                }))
+                .collect()
+        };
 
         let mut block = Block {
             header: Header {
-                version: bt.version,
-                prev_blockhash: bt.previous_block_hash,
-                merkle_root: TxMerkleNode::all_zeros(),
-                time: Ord::max(
+                version: bdk_chain::bitcoin::blockdata::block::Version::from_consensus(bt.version),
+                prev_blockhash: BlockHash::from_str(&bt.previous_block_hash)?,
+                merkle_root: TxMerkleNode::from_raw_hash(
+                    bdk_chain::bitcoin::merkle_tree::calculate_root(
+                        txdata.iter().map(|tx| tx.compute_txid().to_raw_hash()),
+                    )
+                    .expect("must have atleast one tx"),
+                ),
+                time: params.time.unwrap_or(Ord::max(
                     bt.min_time,
                     std::time::UNIX_EPOCH.elapsed()?.as_secs() as u32,
-                ),
-                bits: bt.bits,
+                )),
+                bits: CompactTarget::from_unprefixed_hex(&bt.bits)?,
                 nonce: 0,
             },
             txdata,
@@ -173,16 +288,18 @@ impl TestEnv {
 
         block.header.merkle_root = block.compute_merkle_root().expect("must compute");
 
+        // Mine!
+        let target = block.header.target();
         for nonce in 0..=u32::MAX {
             block.header.nonce = nonce;
-            if block.header.target().is_met_by(block.block_hash()) {
-                break;
+            let blockhash = block.block_hash();
+            if target.is_met_by(blockhash) {
+                self.rpc_client().submit_block(&block)?;
+                return Ok((bt.height as usize, blockhash));
             }
         }
 
-        self.bitcoind.client.submit_block(&block)?;
-
-        Ok((bt.height as usize, block.block_hash()))
+        Err(anyhow::anyhow!("Cannot find nonce that meets the target"))
     }
 
     /// This method waits for the Electrum notification indicating that a new block has been mined.
@@ -318,9 +435,11 @@ impl TestEnv {
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]
 mod test {
-    use crate::TestEnv;
+    use crate::{MineParams, TestEnv};
+    use bdk_chain::bitcoin::{Amount, ScriptBuf};
     use core::time::Duration;
     use electrsd::corepc_node::anyhow::Result;
+    use std::collections::BTreeSet;
 
     /// This checks that reorgs initiated by `bitcoind` is detected by our `electrsd` instance.
     #[test]
@@ -352,6 +471,77 @@ mod test {
                 false => assert_ne!(block, reorged_block),
             }
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_mine_block() -> Result<()> {
+        let anyone_can_spend = ScriptBuf::from_bytes(vec![0x51]);
+
+        let env = TestEnv::new()?;
+
+        // So we can spend.
+        let addr = env
+            .rpc_client()
+            .get_new_address(None, None)?
+            .address()?
+            .assume_checked();
+        env.mine_blocks(100, Some(addr.clone()))?;
+
+        // Try mining a block with custom time.
+        let custom_time = env.min_time_for_next_block()? + 100;
+        let (_a_height, a_hash) = env.mine_block(MineParams {
+            empty: false,
+            time: Some(custom_time),
+            coinbase_address: None,
+        })?;
+        let a_block = env.rpc_client().get_block(a_hash)?;
+        assert_eq!(a_block.header.time, custom_time);
+        assert_eq!(
+            a_block.txdata[0].output[0].script_pubkey, anyone_can_spend,
+            "Subsidy address must be anyone_can_spend"
+        );
+
+        // Now try mining with min time & some txs.
+        let txid1 = env.send(&addr, Amount::from_sat(100_000))?;
+        let txid2 = env.send(&addr, Amount::from_sat(200_000))?;
+        let txid3 = env.send(&addr, Amount::from_sat(300_000))?;
+        let min_time = env.min_time_for_next_block()?;
+        let (_b_height, b_hash) = env.mine_block(MineParams {
+            empty: false,
+            time: Some(min_time),
+            coinbase_address: None,
+        })?;
+        let b_block = env.rpc_client().get_block(b_hash)?;
+        assert_eq!(b_block.header.time, min_time);
+        assert_eq!(
+            a_block.txdata[0].output[0].script_pubkey, anyone_can_spend,
+            "Subsidy address must be anyone_can_spend"
+        );
+        assert_eq!(
+            b_block
+                .txdata
+                .iter()
+                .skip(1) // ignore coinbase
+                .map(|tx| tx.compute_txid())
+                .collect::<BTreeSet<_>>(),
+            [txid1, txid2, txid3].into_iter().collect(),
+            "Must have all txs"
+        );
+
+        // Custom subsidy address.
+        let (_c_height, c_hash) = env.mine_block(MineParams {
+            empty: false,
+            time: None,
+            coinbase_address: Some(addr.script_pubkey()),
+        })?;
+        let c_block = env.rpc_client().get_block(c_hash)?;
+        assert_eq!(
+            c_block.txdata[0].output[0].script_pubkey,
+            addr.script_pubkey(),
+            "Custom address works"
+        );
 
         Ok(())
     }


### PR DESCRIPTION
### Description

Make `bdk_bitcoind_rpc` emitters support emitting `CheckPoint` updates with both `BlockHash` and `Header` data. To make this easier to implement, a `bdk_core::fromBlockHash` trait is introduced.

### Rationale

I think BDK should move towards making `Header` the most-used checkpoint data type (so chain-sources should be able to output that!). This allows us to accurately calculate time (MTP), provides the merkle root for verification (maybe anchors in the future can include the merkle proof), and provides the `prev_blockhash` value. 

However, we cannot force this change as users may want persisted data to be compatible with newer versions of BDK (and retain their `BlockId`-based persistence data).

### Changelog notice

```md
Added
- `FromBlockHash` trait which `BlockHash` and `Header` implement. This makes it easier for chain-sources to output `CheckPoint` updates with both types of data (and more in the future).
- `bdk_bitcoind_rpc` emitters now have new methods for emitting events with custom "checkpoint data" types.

Changed
- `bdk_bitcoind_rpc` emitters now have generic types for "checkpoint data" with backwards compatible defaults.
```

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature
