### PR TITLE
deps(bdk_chain)!: bump `miniscript` to `13.0.0`

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -29,7 +29,7 @@ jobs:
           - version: ${{ needs.prepare.outputs.rust_version }}
           - version: 1.85.0 # MSRV
         features:
-          - --no-default-features --features miniscript/no-std,bdk_chain/hashbrown
+          - --no-default-features --features bdk_chain/hashbrown
           - --all-features
     steps:
       - name: checkout
@@ -71,7 +71,7 @@ jobs:
       - name: Check bdk_chain
         working-directory: ./crates/chain
         # TODO "--target thumbv6m-none-eabi" should work but currently does not
-        run: cargo check --no-default-features --features miniscript/no-std,hashbrown
+        run: cargo check --no-default-features --features hashbrown
       - name: Check esplora
         working-directory: ./crates/esplora
         # TODO "--target thumbv6m-none-eabi" should work but currently does not

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 bitcoin = { version = "0.32.0", default-features = false }
 bdk_core = { path = "../core", version = "0.6.2", default-features = false }
 serde = { version = "1", optional = true, features = ["derive", "rc"] }
-miniscript = { version = "12.3.1", optional = true, default-features = false }
+miniscript = { version = "13.0.0", optional = true, default-features = false }
 
 # Feature dependencies
 rusqlite = { version = "0.31.0", features = ["bundled"], optional = true }

--- a/examples/example_cli/src/lib.rs
+++ b/examples/example_cli/src/lib.rs
@@ -1,7 +1,6 @@
 use bdk_chain::keychain_txout::DEFAULT_LOOKAHEAD;
 use serde_json::json;
 use std::cmp;
-use std::collections::HashMap;
 use std::env;
 use std::fmt;
 use std::str::FromStr;
@@ -11,11 +10,10 @@ use anyhow::bail;
 use anyhow::Context;
 use bdk_chain::bitcoin::{
     absolute, address::NetworkUnchecked, bip32, consensus, constants, hex::DisplayHex, relative,
-    secp256k1::Secp256k1, transaction, Address, Amount, Network, NetworkKind, PrivateKey, Psbt,
-    PublicKey, Sequence, Transaction, TxIn, TxOut,
+    secp256k1::Secp256k1, transaction, Address, Amount, Network, NetworkKind, Psbt, Sequence,
+    Transaction, TxIn, TxOut,
 };
 use bdk_chain::miniscript::{
-    descriptor::{DescriptorSecretKey, SinglePubKey},
     plan::{Assets, Plan},
     psbt::PsbtExt,
     Descriptor, DescriptorPublicKey, ForEachKey,
@@ -690,27 +688,14 @@ pub fn handle_commands<CS: clap::Subcommand, S: clap::Args>(
 
                 let secp = Secp256k1::new();
                 let (_, keymap) = Descriptor::parse_descriptor(&secp, &desc_str)?;
+
                 if keymap.is_empty() {
                     bail!("unable to sign")
                 }
 
-                // note: we're only looking at the first entry in the keymap
-                // the idea is to find something that impls `GetKey`
-                let sign_res = match keymap.iter().next().expect("not empty") {
-                    (DescriptorPublicKey::Single(single_pub), DescriptorSecretKey::Single(prv)) => {
-                        let pk = match single_pub.key {
-                            SinglePubKey::FullKey(pk) => pk,
-                            SinglePubKey::XOnly(_) => unimplemented!("single xonly pubkey"),
-                        };
-                        let keys: HashMap<PublicKey, PrivateKey> = [(pk, prv.key)].into();
-                        psbt.sign(&keys, &secp)
-                    }
-                    (_, DescriptorSecretKey::XPrv(k)) => psbt.sign(&k.xkey, &secp),
-                    _ => unimplemented!("multi xkey signer"),
-                };
-
-                let _ =
-                    sign_res.map_err(|errors| anyhow::anyhow!("failed to sign PSBT {errors:?}"))?;
+                let _sign_res = psbt
+                    .sign(&keymap, &secp)
+                    .map_err(|errors| anyhow::anyhow!("failed to sign PSBT {errors:?}"))?;
 
                 let mut obj = serde_json::Map::new();
                 obj.insert("psbt".to_string(), json!(psbt.to_string()));


### PR DESCRIPTION
### Description

The PR upgrades `miniscript` to it's latest `v13.0.0`, it's a breaking change so it's only meant to being merged in master, can't be backported to `release/chain-0.23.x`.

- upgrades `miniscript` version to `13.0.0`.
- fixes the usage of `psbt.sign` in `example_cli.

BREAKING_CHANGE: `bdk_chain` does re-exports the `miniscript` API, therefore bumping it's version is considered a breaking change.

### Notes to the reviewers

### Changelog notice

```
### Changed
- deps(bdk_chain): upgrades `miniscript` version to `13.0.0`.
- chore(example_cli): fixes the usage of `psbt.sign` in `example_cli.
```

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature