### PR TITLE
fixed CanonicalReason::Assumed to check for direct anchor when no descendant exists

### DIFF
--- a/crates/chain/src/canonical_view.rs
+++ b/crates/chain/src/canonical_view.rs
@@ -164,9 +164,15 @@ impl<A: Anchor> CanonicalView<A> {
                             last_seen: tx_node.last_seen,
                         },
                     },
-                    None => ChainPosition::Unconfirmed {
-                        first_seen: tx_node.first_seen,
-                        last_seen: tx_node.last_seen,
+                    None => match find_direct_anchor(&tx_node, chain, chain_tip)? {
+                        Some(anchor) => ChainPosition::Confirmed {
+                            anchor,
+                            transitively: None,
+                        },
+                        None => ChainPosition::Unconfirmed {
+                            first_seen: tx_node.first_seen,
+                            last_seen: tx_node.last_seen,
+                        },
                     },
                 },
                 CanonicalReason::Anchor { anchor, descendant } => match descendant {


### PR DESCRIPTION
fixes #2088 

Summary :- When a transaction is both in `assume_canonical` and has a `direct anchor`, it was incorrectly returned as `ChainPosition::Unconfirmed`. This fix adds a check for a direct anchor in the `None` descendant case, returning `ChainPosition::Confirmed` when an anchor exists.