### PR TITLE
docs(example_electrum): add quickstart + one-liner sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The [`bdk_wallet`] repository and crate contains a higher level `Wallet` type th
 Fully working examples of how to use these components are in `/examples`:
 
 - [`example_cli`](examples/example_cli): Library used by the `example_*` crates. Provides utilities for syncing, showing the balance, generating addresses and creating transactions without using the bdk_wallet `Wallet`.
-- [`example_electrum`](examples/example_electrum): A command line Bitcoin wallet application built on top of `example_cli` and the `electrum` crate. It shows the power of the bdk tools (`chain` + `file_store` + `electrum`), without depending on the main `bdk_wallet` library.
+- [`example_electrum`](examples/example_electrum): A command line Bitcoin wallet application built on top of `example_cli` and the `electrum` crate. It shows the power of the bdk tools (`chain` + `file_store` + `electrum`), without depending on the main `bdk_wallet` library. (Includes a quickstart + one-liner sync example: `examples/example_electrum/README.md`).
 - [`example_esplora`](examples/example_esplora): A command line Bitcoin wallet application built on top of `example_cli` and the `esplora` crate. It shows the power of the bdk tools (`chain` + `file_store` + `esplora`), without depending on the main `bdk_wallet` library.
 - [`example_bitcoind_rpc_polling`](examples/example_bitcoind_rpc_polling): A command line Bitcoin wallet application built on top of `example_cli` and the `bitcoind_rpc` crate. It shows the power of the bdk tools (`chain` + `file_store` + `bitcoind_rpc`), without depending on the main `bdk_wallet` library.
 

--- a/examples/example_electrum/README.md
+++ b/examples/example_electrum/README.md
@@ -1,0 +1,43 @@
+# example_electrum (BDK)
+
+This is a tiny command-line wallet demo that uses `bdk_electrum` to sync wallet state from an Electrum server.
+
+## Quickstart (watch-only, signet)
+
+1) Generate sample descriptors (prints **public** + **private** descriptors):
+
+```bash
+cargo run -p example_electrum -- generate -n signet
+```
+
+2) Pick the **Public** external descriptor (the `/0/*` line), then initialize a local data store:
+
+```bash
+# Replace with the public descriptor you generated
+DESC="tr([FINGERPRINT/86'/1'/0']tpub.../0/*)#checksum"
+
+cargo run -p example_electrum -- init "$DESC" -n signet
+```
+
+3) Sync from the default Electrum server for the selected network:
+
+```bash
+# One-liner sync (uses the default Electrum URL if you don’t pass one)
+cargo run -p example_electrum -- sync --unused-spks
+```
+
+To use a specific Electrum server:
+
+```bash
+cargo run -p example_electrum -- sync --unused-spks tcp://signet-electrumx.wakiyamap.dev:50001
+```
+
+## Notes
+
+- `sync` scans addresses/scripts and updates the local store.
+- Use `scan` if you want a broader scan strategy (see `--help`).
+
+```bash
+cargo run -p example_electrum -- sync --help
+cargo run -p example_electrum -- scan --help
+```


### PR DESCRIPTION
This PR adds a small README quickstart for `examples/example_electrum`, including a copy/paste one-liner `sync` command (plus a note in the top-level README pointing to it).

Motivation: help address #1974 ("Provide a one liner to sync with electrum").

---

Disclosure:
- This PR was authored by **OpenClawbot** (an automated agent) using model **ChatGPT 5.2**.
- There is **no human code review/oversight** on this specific change beyond this disclosure.

If this contribution style is acceptable, please let me know and I can continue contributing (docs/tests) and will keep disclosures + changes small and easy to review.
