### PR TITLE
Add `prev_blockhash` validation to `CheckPoint`

### DIFF
--- a/crates/chain/src/local_chain.rs
+++ b/crates/chain/src/local_chain.rs
@@ -6,8 +6,8 @@ use core::ops::RangeBounds;
 
 use crate::collections::BTreeMap;
 use crate::{BlockId, ChainOracle, Merge};
-use bdk_core::{CheckPointEntry, ToBlockHash};
 pub use bdk_core::{CheckPoint, CheckPointIter};
+use bdk_core::{CheckPointEntry, ToBlockHash};
 use bitcoin::block::Header;
 use bitcoin::BlockHash;
 

--- a/crates/chain/src/local_chain.rs
+++ b/crates/chain/src/local_chain.rs
@@ -263,7 +263,7 @@ where
         CheckPoint::from_blocks(blocks)
             .map(|tip| Self { tip })
             .map_err(|err| {
-                let last_cp = err.expect("must have atleast one block (genesis)");
+                let last_cp = err.expect("must have at least one block (genesis)");
                 ApplyBlockError::PrevBlockhashMismatch {
                     expected: last_cp.block_id(),
                 }

--- a/crates/chain/src/local_chain.rs
+++ b/crates/chain/src/local_chain.rs
@@ -15,7 +15,7 @@ use bitcoin::BlockHash;
 fn apply_changeset_to_checkpoint<D>(
     mut init_cp: CheckPoint<D>,
     changeset: &ChangeSet<D>,
-) -> Result<CheckPoint<D>, MissingGenesisError>
+) -> Result<CheckPoint<D>, ApplyBlockError>
 where
     D: ToBlockHash + fmt::Debug + Clone,
 {
@@ -48,7 +48,11 @@ where
         let new_tip = match base {
             Some(base) => base
                 .extend(extension)
-                .expect("extension is strictly greater than base"),
+                // Since `extension` is in height order, the only failure case is `prev_blockhash`
+                // mismatch.
+                .map_err(|last_cp| ApplyBlockError::PrevBlockhashMismatch {
+                    expected: last_cp.block_id(),
+                })?,
             None => LocalChain::from_blocks(extension)?.tip(),
         };
         init_cp = new_tip;
@@ -251,22 +255,27 @@ where
     ///
     /// The [`BTreeMap`] enforces the height order. However, the caller must ensure the blocks are
     /// all of the same chain.
-    pub fn from_blocks(blocks: BTreeMap<u32, D>) -> Result<Self, MissingGenesisError> {
+    pub fn from_blocks(blocks: BTreeMap<u32, D>) -> Result<Self, ApplyBlockError> {
         if !blocks.contains_key(&0) {
-            return Err(MissingGenesisError);
+            return Err(ApplyBlockError::MissingGenesis);
         }
 
-        Ok(Self {
-            tip: CheckPoint::from_blocks(blocks).expect("blocks must be in order"),
-        })
+        CheckPoint::from_blocks(blocks)
+            .map(|tip| Self { tip })
+            .map_err(|err| {
+                let last_cp = err.expect("must have atleast one block (genesis)");
+                ApplyBlockError::PrevBlockhashMismatch {
+                    expected: last_cp.block_id(),
+                }
+            })
     }
 
     /// Construct a [`LocalChain`] from an initial `changeset`.
-    pub fn from_changeset(changeset: ChangeSet<D>) -> Result<Self, MissingGenesisError> {
+    pub fn from_changeset(changeset: ChangeSet<D>) -> Result<Self, ApplyBlockError> {
         let genesis_entry = changeset.blocks.get(&0).cloned().flatten();
         let genesis_data = match genesis_entry {
             Some(data) => data,
-            None => return Err(MissingGenesisError),
+            None => return Err(ApplyBlockError::MissingGenesis),
         };
 
         let (mut chain, _) = Self::from_genesis(genesis_data);
@@ -310,7 +319,7 @@ where
     }
 
     /// Apply the given `changeset`.
-    pub fn apply_changeset(&mut self, changeset: &ChangeSet<D>) -> Result<(), MissingGenesisError> {
+    pub fn apply_changeset(&mut self, changeset: &ChangeSet<D>) -> Result<(), ApplyBlockError> {
         let old_tip = self.tip.clone();
         let new_tip = apply_changeset_to_checkpoint(old_tip, changeset)?;
         self.tip = new_tip;
@@ -485,6 +494,35 @@ impl<D> FromIterator<(u32, D)> for ChangeSet<D> {
     }
 }
 
+/// Error when applying blocks to a local chain.
+#[derive(Clone, Debug, PartialEq)]
+pub enum ApplyBlockError {
+    /// Genesis block is missing or would be altered.
+    MissingGenesis,
+    /// Block's `prev_blockhash` doesn't match the expected block.
+    PrevBlockhashMismatch {
+        /// The block that `prev_blockhash` should reference.
+        expected: BlockId,
+    },
+}
+
+impl core::fmt::Display for ApplyBlockError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ApplyBlockError::MissingGenesis => {
+                write!(f, "genesis block is missing or would be altered")
+            }
+            ApplyBlockError::PrevBlockhashMismatch { expected } => write!(
+                f,
+                "`prev_blockhash` doesn't match block at height {} ({})",
+                expected.height, expected.hash
+            ),
+        }
+    }
+}
+
+impl core::error::Error for ApplyBlockError {}
+
 /// An error which occurs when a [`LocalChain`] is constructed without a genesis checkpoint.
 #[derive(Clone, Debug, PartialEq)]
 pub struct MissingGenesisError;
@@ -592,6 +630,30 @@ fn merge_chains<D>(
 where
     D: ToBlockHash + fmt::Debug + Clone,
 {
+    // Apply the changeset to produce the final merged chain.
+    //
+    // `PrevBlockhashMismatch` should never happen because the merge iteration detects
+    // `prev_blockhash` conflicts and resolves them by invalidating conflicting blocks (setting
+    // them to `None` in the changeset) before we reach this point.
+    fn finish<D>(
+        original_tip: CheckPoint<D>,
+        changeset: ChangeSet<D>,
+    ) -> Result<(CheckPoint<D>, ChangeSet<D>), CannotConnectError>
+    where
+        D: ToBlockHash + fmt::Debug + Clone,
+    {
+        let new_tip = apply_changeset_to_checkpoint(original_tip, &changeset).map_err(|err| {
+            debug_assert!(
+                matches!(err, ApplyBlockError::MissingGenesis),
+                "PrevBlockhashMismatch should never happen"
+            );
+            CannotConnectError {
+                try_include_height: 0,
+            }
+        })?;
+        Ok((new_tip, changeset))
+    }
+
     let mut changeset = ChangeSet::<D>::default();
 
     let mut orig = original_tip.entry_iter();
@@ -676,11 +738,13 @@ where
                         if is_update_height_superset_of_original {
                             return Ok((update_tip, changeset));
                         } else {
-                            let new_tip = apply_changeset_to_checkpoint(original_tip, &changeset)
-                                .map_err(|_| CannotConnectError {
-                                try_include_height: 0,
-                            })?;
-                            return Ok((new_tip, changeset));
+                            return finish(original_tip, changeset);
+                        }
+                    }
+                    // Update placeholder with real data (if necessary).
+                    if let Some(u_data) = u.data_ref() {
+                        if o.is_placeholder() {
+                            changeset.blocks.insert(u.height(), Some(u_data.clone()));
                         }
                     }
                 } else {
@@ -715,10 +779,5 @@ where
         }
     }
 
-    let new_tip = apply_changeset_to_checkpoint(original_tip, &changeset).map_err(|_| {
-        CannotConnectError {
-            try_include_height: 0,
-        }
-    })?;
-    Ok((new_tip, changeset))
+    finish(original_tip, changeset)
 }

--- a/crates/chain/src/local_chain.rs
+++ b/crates/chain/src/local_chain.rs
@@ -631,10 +631,6 @@ where
     D: ToBlockHash + fmt::Debug + Clone,
 {
     // Apply the changeset to produce the final merged chain.
-    //
-    // `PrevBlockhashMismatch` should never happen because the merge iteration detects
-    // `prev_blockhash` conflicts and resolves them by invalidating conflicting blocks (setting
-    // them to `None` in the changeset) before we reach this point.
     fn finish<D>(
         original_tip: CheckPoint<D>,
         changeset: ChangeSet<D>,
@@ -643,12 +639,24 @@ where
         D: ToBlockHash + fmt::Debug + Clone,
     {
         let new_tip = apply_changeset_to_checkpoint(original_tip, &changeset).map_err(|err| {
-            debug_assert!(
-                matches!(err, ApplyBlockError::MissingGenesis),
-                "PrevBlockhashMismatch should never happen"
-            );
-            CannotConnectError {
-                try_include_height: 0,
+            match err {
+                ApplyBlockError::MissingGenesis => CannotConnectError {
+                    try_include_height: 0,
+                },
+                // The merge iteration is supposed to detect `prev_blockhash` conflicts and resolve
+                // them by invalidating conflicting blocks in the changeset. Reaching this arm means
+                // either the original chain was internally inconsistent or the iteration missed a
+                // case — a bug on our side. Debug builds panic; release builds surface the height
+                // where the mismatch surfaced so the caller at least has a useful pointer.
+                ApplyBlockError::PrevBlockhashMismatch { expected } => {
+                    debug_assert!(
+                        false,
+                        "merge_chains should have resolved prev_blockhash mismatch at {expected:?}",
+                    );
+                    CannotConnectError {
+                        try_include_height: expected.height,
+                    }
+                }
             }
         })?;
         Ok((new_tip, changeset))
@@ -692,7 +700,7 @@ where
         match (curr_orig.as_ref(), curr_update.as_ref()) {
             // Update block that doesn't exist in the original chain
             (o, Some(u)) if Some(u.height()) > o.map(|o| o.height()) => {
-                // Only append to `ChangeSet` when this is an actual checkpoint.
+                // Only append to `ChangeSet` when this is a non-placeholder checkpoint.
                 if let Some(data) = u.data() {
                     changeset.blocks.insert(u.height(), Some(data));
                 }
@@ -757,6 +765,12 @@ where
                     }
                     // We have an invalidation height so we set the height to the updated hash and
                     // also purge all the original chain block hashes above this block.
+                    //
+                    // `u.data()` returns `None` when `u` is a placeholder — in that case we erase
+                    // orig's checkpoint at this height without providing replacement data. The
+                    // implied block is still recoverable via the `prev_blockhash` of the occupied
+                    // checkpoint above it in the update chain (which is handled in its own
+                    // iteration).
                     changeset.blocks.insert(u.height(), u.data());
                     for invalidated_height in potentially_invalidated_heights.drain(..) {
                         changeset.blocks.insert(invalidated_height, None);

--- a/crates/chain/src/local_chain.rs
+++ b/crates/chain/src/local_chain.rs
@@ -497,7 +497,7 @@ impl<D> FromIterator<(u32, D)> for ChangeSet<D> {
 /// Error when applying blocks to a local chain.
 #[derive(Clone, Debug, PartialEq)]
 pub enum ApplyBlockError {
-    /// Genesis block is missing or would be altered.
+    /// Genesis block is missing.
     MissingGenesis,
     /// Block's `prev_blockhash` doesn't match the expected block.
     PrevBlockhashMismatch {
@@ -510,7 +510,7 @@ impl core::fmt::Display for ApplyBlockError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ApplyBlockError::MissingGenesis => {
-                write!(f, "genesis block is missing or would be altered")
+                write!(f, "genesis block is missing")
             }
             ApplyBlockError::PrevBlockhashMismatch { expected } => write!(
                 f,
@@ -748,6 +748,13 @@ where
                         }
                     }
                 } else {
+                    // Genesis block (height 0) cannot be replaced. If the original and
+                    // update disagree on genesis, they belong to different chains.
+                    if o.height() == 0 && !o.is_placeholder() {
+                        return Err(CannotConnectError {
+                            try_include_height: 0,
+                        });
+                    }
                     // We have an invalidation height so we set the height to the updated hash and
                     // also purge all the original chain block hashes above this block.
                     changeset.blocks.insert(u.height(), u.data());

--- a/crates/chain/src/local_chain.rs
+++ b/crates/chain/src/local_chain.rs
@@ -17,7 +17,7 @@ fn apply_changeset_to_checkpoint<D>(
     changeset: &ChangeSet<D>,
 ) -> Result<CheckPoint<D>, MissingGenesisError>
 where
-    D: ToBlockHash + fmt::Debug + Copy,
+    D: ToBlockHash + fmt::Debug + Clone,
 {
     if let Some(start_height) = changeset.blocks.keys().next().cloned() {
         // changes after point of agreement
@@ -34,10 +34,10 @@ where
             }
         }
 
-        for (&height, &data) in &changeset.blocks {
+        for (&height, data) in &changeset.blocks {
             match data {
                 Some(data) => {
-                    extension.insert(height, data);
+                    extension.insert(height, data.clone());
                 }
                 None => {
                     extension.remove(&height);
@@ -234,7 +234,7 @@ impl<D> LocalChain<D> {
 // Methods where `D: ToBlockHash`
 impl<D> LocalChain<D>
 where
-    D: ToBlockHash + fmt::Debug + Copy,
+    D: ToBlockHash + fmt::Debug + Clone,
 {
     /// Constructs a [`LocalChain`] from genesis data.
     pub fn from_genesis(data: D) -> (Self, ChangeSet<D>) {
@@ -263,7 +263,7 @@ where
 
     /// Construct a [`LocalChain`] from an initial `changeset`.
     pub fn from_changeset(changeset: ChangeSet<D>) -> Result<Self, MissingGenesisError> {
-        let genesis_entry = changeset.blocks.get(&0).copied().flatten();
+        let genesis_entry = changeset.blocks.get(&0).cloned().flatten();
         let genesis_data = match genesis_entry {
             Some(data) => data,
             None => return Err(MissingGenesisError),
@@ -412,7 +412,7 @@ where
             match cur.get(exp_height) {
                 Some(cp) => {
                     if cp.height() != exp_height
-                        || Some(cp.hash()) != exp_data.map(|d| d.to_blockhash())
+                        || Some(cp.hash()) != exp_data.as_ref().map(|d| d.to_blockhash())
                     {
                         return false;
                     }
@@ -590,7 +590,7 @@ fn merge_chains<D>(
     update_tip: CheckPoint<D>,
 ) -> Result<(CheckPoint<D>, ChangeSet<D>), CannotConnectError>
 where
-    D: ToBlockHash + fmt::Debug + Copy,
+    D: ToBlockHash + fmt::Debug + Clone,
 {
     let mut changeset = ChangeSet::<D>::default();
 

--- a/crates/chain/src/local_chain.rs
+++ b/crates/chain/src/local_chain.rs
@@ -6,7 +6,7 @@ use core::ops::RangeBounds;
 
 use crate::collections::BTreeMap;
 use crate::{BlockId, ChainOracle, Merge};
-use bdk_core::ToBlockHash;
+use bdk_core::{CheckPointEntry, ToBlockHash};
 pub use bdk_core::{CheckPoint, CheckPointIter};
 use bitcoin::block::Header;
 use bitcoin::BlockHash;
@@ -594,14 +594,14 @@ where
 {
     let mut changeset = ChangeSet::<D>::default();
 
-    let mut orig = original_tip.iter();
-    let mut update = update_tip.iter();
+    let mut orig = original_tip.entry_iter();
+    let mut update = update_tip.entry_iter();
 
     let mut curr_orig = None;
     let mut curr_update = None;
 
-    let mut prev_orig: Option<CheckPoint<D>> = None;
-    let mut prev_update: Option<CheckPoint<D>> = None;
+    let mut prev_orig: Option<CheckPointEntry<D>> = None;
+    let mut prev_update: Option<CheckPointEntry<D>> = None;
 
     let mut point_of_agreement_found = false;
 
@@ -630,13 +630,18 @@ where
         match (curr_orig.as_ref(), curr_update.as_ref()) {
             // Update block that doesn't exist in the original chain
             (o, Some(u)) if Some(u.height()) > o.map(|o| o.height()) => {
-                changeset.blocks.insert(u.height(), Some(u.data()));
+                // Only append to `ChangeSet` when this is an actual checkpoint.
+                if let Some(data) = u.data() {
+                    changeset.blocks.insert(u.height(), Some(data));
+                }
                 prev_update = curr_update.take();
             }
             // Original block that isn't in the update
             (Some(o), u) if Some(o.height()) > u.map(|u| u.height()) => {
-                // this block might be gone if an earlier block gets invalidated
-                potentially_invalidated_heights.push(o.height());
+                if !o.is_placeholder() {
+                    // this block might be gone if an earlier block gets invalidated
+                    potentially_invalidated_heights.push(o.height());
+                }
                 prev_orig_was_invalidated = false;
                 prev_orig = curr_orig.take();
 
@@ -667,7 +672,7 @@ where
                     prev_orig_was_invalidated = false;
                     // OPTIMIZATION 2 -- if we have the same underlying pointer at this point, we
                     // can guarantee that no older blocks are introduced.
-                    if o.eq_ptr(u) {
+                    if o.source_checkpoint().eq_ptr(&u.source_checkpoint()) {
                         if is_update_height_superset_of_original {
                             return Ok((update_tip, changeset));
                         } else {
@@ -681,7 +686,7 @@ where
                 } else {
                     // We have an invalidation height so we set the height to the updated hash and
                     // also purge all the original chain block hashes above this block.
-                    changeset.blocks.insert(u.height(), Some(u.data()));
+                    changeset.blocks.insert(u.height(), u.data());
                     for invalidated_height in potentially_invalidated_heights.drain(..) {
                         changeset.blocks.insert(invalidated_height, None);
                     }

--- a/crates/chain/tests/test_local_chain.rs
+++ b/crates/chain/tests/test_local_chain.rs
@@ -176,11 +176,11 @@ fn update_local_chain() {
         },
         TestLocalChain {
             name: "fix blockhash before agreement point",
-            chain: local_chain![(0, hash!("im-wrong")), (1, hash!("we-agree"))],
-            update: chain_update![(0, hash!("fix")), (1, hash!("we-agree"))],
+            chain: local_chain![(0, hash!("_")), (1, hash!("im-wrong")), (2, hash!("we-agree"))],
+            update: chain_update![(0, hash!("_")), (1, hash!("fix")), (2, hash!("we-agree"))],
             exp: ExpectedResult::Ok {
-                changeset: &[(0, Some(hash!("fix")))],
-                init_changeset: &[(0, Some(hash!("fix"))), (1, Some(hash!("we-agree")))],
+                changeset: &[(1, Some(hash!("fix")))],
+                init_changeset: &[(0, Some(hash!("_"))), (1, Some(hash!("fix"))), (2, Some(hash!("we-agree")))],
             },
         },
         // B and C are in both chain and update
@@ -319,6 +319,18 @@ fn update_local_chain() {
                     (3, Some(hash!("D'"))),
                 ],
             },
+        },
+        // Conflicting genesis with no point of agreement should fail.
+        //        | 0 | 2
+        // chain  | _   B
+        // update | _'  B'
+        TestLocalChain {
+            name: "conflicting genesis without agreement point",
+            chain: local_chain![(0, hash!("_")), (2, hash!("B"))],
+            update: chain_update![(0, hash!("_'")), (2, hash!("B'"))],
+            exp: ExpectedResult::Err(CannotConnectError {
+                try_include_height: 0,
+            }),
         },
     ]
     .into_iter()

--- a/crates/chain/tests/test_local_chain.rs
+++ b/crates/chain/tests/test_local_chain.rs
@@ -1228,7 +1228,9 @@ fn merge_chains_with_prev_blockhash() {
         // but no B exists. Update introduces A at height 1, which displaces C because
         // C's `prev_blockhash` ("B") doesn't match A's hash ("A").
         //
-        // Note: This can only happen if chains are constructed incorrectly.
+        // Note: This shape of chain isn't reachable via the public API in normal use, but the
+        // merge remains best-effort so a caller with pre-existing bad state (partial persistence,
+        // data loaded from an untrusted source, etc.) can still recover.
         TestLocalChain {
             name: "update displaces invalid block below point of agreement",
             chain: LocalChain::from_blocks(

--- a/crates/core/src/checkpoint.rs
+++ b/crates/core/src/checkpoint.rs
@@ -65,6 +65,11 @@ impl<D> Drop for CPInner<D> {
 pub trait ToBlockHash {
     /// Returns the [`BlockHash`] for the associated [`CheckPoint`] `data` type.
     fn to_blockhash(&self) -> BlockHash;
+
+    /// Returns `None` if the type has no knowledge of the previous [`BlockHash`].
+    fn prev_blockhash(&self) -> Option<BlockHash> {
+        None
+    }
 }
 
 impl ToBlockHash for BlockHash {
@@ -76,6 +81,10 @@ impl ToBlockHash for BlockHash {
 impl ToBlockHash for Header {
     fn to_blockhash(&self) -> BlockHash {
         self.block_hash()
+    }
+
+    fn prev_blockhash(&self) -> Option<BlockHash> {
+        Some(self.prev_blockhash)
     }
 }
 

--- a/crates/core/src/checkpoint.rs
+++ b/crates/core/src/checkpoint.rs
@@ -284,13 +284,13 @@ where
     /// Construct from an iterator of block data.
     ///
     /// Returns `Err(None)` if `blocks` doesn't yield any data. If the blocks are not in ascending
-    /// height order, then returns an `Err(..)` containing the last checkpoint that would have been
-    /// extended.
+    /// height order, or there are any `prev_blockhash` mismatches, then returns an `Err(..)`
+    /// containing the last checkpoint that would have been extended.
     pub fn from_blocks(blocks: impl IntoIterator<Item = (u32, D)>) -> Result<Self, Option<Self>> {
         let mut blocks = blocks.into_iter();
         let (height, data) = blocks.next().ok_or(None)?;
         let mut cp = CheckPoint::new(height, data);
-        cp = cp.extend(blocks)?;
+        cp = cp.extend(blocks).map_err(Some)?;
 
         Ok(cp)
     }

--- a/crates/core/src/checkpoint.rs
+++ b/crates/core/src/checkpoint.rs
@@ -385,7 +385,8 @@ where
     /// Puts another checkpoint onto the linked list representing the blockchain.
     ///
     /// Returns an `Err(self)` if:
-    /// * The block you are pushing on is not at a greater height that the one you are pushing on to.
+    /// * The block you are pushing on is not at a greater height that the one you are pushing on
+    ///   to.
     /// * The `prev_blockhash` does not match.
     pub fn push(self, height: u32, data: D) -> Result<Self, Self> {
         // Reject if trying to push at or below current height - chain must grow forward.

--- a/crates/core/src/checkpoint.rs
+++ b/crates/core/src/checkpoint.rs
@@ -283,9 +283,15 @@ where
 
     /// Construct from an iterator of block data.
     ///
+    /// # Returns
+    ///
+    /// Returns the checkpoint chain tip on success.
+    ///
+    /// # Errors
+    ///
     /// Returns `Err(None)` if `blocks` doesn't yield any data. If the blocks are not in ascending
-    /// height order, or there are any `prev_blockhash` mismatches, then returns an `Err(..)`
-    /// containing the last checkpoint that would have been extended.
+    /// height order, or there are any `prev_blockhash` mismatches, then returns `Err(Some(..))`
+    /// containing the last checkpoint that was successfully extended.
     pub fn from_blocks(blocks: impl IntoIterator<Item = (u32, D)>) -> Result<Self, Option<Self>> {
         let mut blocks = blocks.into_iter();
         let (height, data) = blocks.next().ok_or(None)?;

--- a/crates/core/src/checkpoint.rs
+++ b/crates/core/src/checkpoint.rs
@@ -317,8 +317,9 @@ where
     /// Inserts `data` at its `height` within the chain.
     ///
     /// If a checkpoint already exists at `height` with a matching hash, returns `self` unchanged.
-    /// If a checkpoint exists at `height` with a different hash, or if `prev_blockhash` conflicts
-    /// occur, the conflicting checkpoint and all checkpoints above it are removed.
+    /// Otherwise, if the insertion conflicts — either with an existing checkpoint at `height` (by
+    /// hash), or with the checkpoint at `height - 1` (via `data.prev_blockhash`) — every
+    /// checkpoint at or above `height` is removed.
     ///
     /// # Panics
     ///

--- a/crates/core/src/checkpoint_entry.rs
+++ b/crates/core/src/checkpoint_entry.rs
@@ -176,7 +176,8 @@ impl<D: ToBlockHash> CheckPointEntry<D> {
 
     /// Returns the entry located a number of heights below this one.
     pub fn floor_below(&self, offset: u32) -> Option<Self>
-    where D: Clone
+    where
+        D: Clone,
     {
         self.floor_at(self.height().checked_sub(offset)?)
     }

--- a/crates/core/src/checkpoint_entry.rs
+++ b/crates/core/src/checkpoint_entry.rs
@@ -1,3 +1,16 @@
+//! Checkpoint entries for `prev_blockhash`-aware iteration.
+//!
+//! A [`CheckPoint`] chain may have gaps (non-contiguous heights). However, each checkpoint's
+//! data can include a `prev_blockhash` that references the block one height below. This module
+//! provides [`CheckPointEntry`], which represents either:
+//!
+//! - **Occupied**: A real checkpoint stored at this height.
+//! - **Placeholder**: No checkpoint exists at this height, but the checkpoint above references it
+//!   via `prev_blockhash`. The placeholder contains the implied [`BlockId`].
+//!
+//! Use [`CheckPoint::entry_iter`] to iterate over entries, which yields placeholders for any
+//! gaps where `prev_blockhash` implies a block.
+
 use core::ops::RangeBounds;
 
 use bitcoin::BlockHash;

--- a/crates/core/src/checkpoint_entry.rs
+++ b/crates/core/src/checkpoint_entry.rs
@@ -1,0 +1,207 @@
+use core::ops::RangeBounds;
+
+use bitcoin::BlockHash;
+
+use crate::{BlockId, CheckPoint, ToBlockHash};
+
+/// An entry yielded by [`CheckPointIter`].
+#[derive(Debug, Clone)]
+pub enum CheckPointEntry<D> {
+    /// A placeholder entry: there is no checkpoint stored at this height,
+    /// but the checkpoint one height above links back here via its `prev_blockhash`.
+    Placeholder {
+        /// The block ID at *this* height.
+        block_id: BlockId,
+        /// The checkpoint one height *above* that links back to `block_id`.
+        checkpoint_above: CheckPoint<D>,
+    },
+    /// A real checkpoint recorded at this height.
+    Occupied(CheckPoint<D>),
+}
+
+impl<D> CheckPointEntry<D> {
+    /// The checkpoint at this height (if any).
+    pub fn checkpoint(&self) -> Option<CheckPoint<D>> {
+        match self {
+            CheckPointEntry::Placeholder { .. } => None,
+            CheckPointEntry::Occupied(checkpoint) => Some(checkpoint.clone()),
+        }
+    }
+
+    /// Returns `true` if this entry is a placeholder (inferred from `prev_blockhash`).
+    pub fn is_placeholder(&self) -> bool {
+        matches!(self, CheckPointEntry::Placeholder { .. })
+    }
+
+    /// The checkpoint that is the *source* of this entry.
+    ///
+    /// For an `Occupied` entry, this is the checkpoint itself.
+    /// For a `Placeholder` entry, this is the checkpoint above that references this height.
+    pub fn source_checkpoint(&self) -> CheckPoint<D> {
+        match self {
+            CheckPointEntry::Placeholder {
+                checkpoint_above, ..
+            } => checkpoint_above.clone(),
+            CheckPointEntry::Occupied(checkpoint) => checkpoint.clone(),
+        }
+    }
+
+    /// Returns the checkpoint at or below this entry's height.
+    pub fn floor_checkpoint(&self) -> Option<CheckPoint<D>> {
+        match self {
+            CheckPointEntry::Placeholder {
+                checkpoint_above: linking_checkpoint,
+                ..
+            } => linking_checkpoint.prev(),
+            CheckPointEntry::Occupied(checkpoint) => Some(checkpoint.clone()),
+        }
+    }
+
+    /// Returns a reference to the data recorded at this exact height (if any).
+    pub fn data_ref(&self) -> Option<&D> {
+        match self {
+            CheckPointEntry::Placeholder { .. } => None,
+            CheckPointEntry::Occupied(checkpoint) => Some(checkpoint.data_ref()),
+        }
+    }
+
+    /// Returns the data recorded at this exact height (if any).
+    pub fn data(&self) -> Option<D>
+    where
+        D: Clone,
+    {
+        self.data_ref().cloned()
+    }
+}
+
+impl<D: ToBlockHash> CheckPointEntry<D> {
+    /// The block ID of this entry.
+    pub fn block_id(&self) -> BlockId {
+        match self {
+            CheckPointEntry::Placeholder { block_id, .. } => *block_id,
+            CheckPointEntry::Occupied(checkpoint) => checkpoint.block_id(),
+        }
+    }
+
+    /// The blockhash of this entry.
+    pub fn hash(&self) -> BlockHash {
+        self.block_id().hash
+    }
+
+    /// The block height of this entry.
+    pub fn height(&self) -> u32 {
+        self.block_id().height
+    }
+
+    /// Get the previous entry in the chain.
+    pub fn prev(&self) -> Option<Self> {
+        let checkpoint = match self {
+            Self::Placeholder {
+                checkpoint_above, ..
+            } => {
+                return checkpoint_above.prev().map(Self::Occupied);
+            }
+            Self::Occupied(checkpoint) => checkpoint,
+        };
+
+        let prev_height = checkpoint.height().checked_sub(1)?;
+
+        let prev_blockhash = match checkpoint.data_ref().prev_blockhash() {
+            Some(blockhash) => blockhash,
+            None => return checkpoint.prev().map(Self::Occupied),
+        };
+
+        if let Some(prev_checkpoint) = checkpoint.prev() {
+            if prev_checkpoint.height() == prev_height {
+                return Some(Self::Occupied(prev_checkpoint));
+            }
+        }
+
+        Some(Self::Placeholder {
+            block_id: BlockId {
+                height: prev_height,
+                hash: prev_blockhash,
+            },
+            checkpoint_above: checkpoint.clone(),
+        })
+    }
+
+    /// Iterate over checkpoint entries backwards.
+    pub fn iter(&self) -> CheckPointEntryIter<D>
+    where
+        D: Clone,
+    {
+        self.clone().into_iter()
+    }
+
+    /// Get checkpoint entry at `height`.
+    ///
+    /// Returns `None` if checkpoint at `height` does not exist.
+    pub fn get(&self, height: u32) -> Option<Self>
+    where
+        D: Clone,
+    {
+        self.range(height..=height).next()
+    }
+
+    /// Iterate checkpoints over a height range.
+    pub fn range<R>(&self, range: R) -> impl Iterator<Item = CheckPointEntry<D>>
+    where
+        D: Clone,
+        R: RangeBounds<u32>,
+    {
+        let start_bound = range.start_bound().cloned();
+        let end_bound = range.end_bound().cloned();
+        self.iter()
+            .skip_while(move |cp_entry| match end_bound {
+                core::ops::Bound::Included(inc_bound) => cp_entry.height() > inc_bound,
+                core::ops::Bound::Excluded(exc_bound) => cp_entry.height() >= exc_bound,
+                core::ops::Bound::Unbounded => false,
+            })
+            .take_while(move |cp_entry| match start_bound {
+                core::ops::Bound::Included(inc_bound) => cp_entry.height() >= inc_bound,
+                core::ops::Bound::Excluded(exc_bound) => cp_entry.height() > exc_bound,
+                core::ops::Bound::Unbounded => true,
+            })
+    }
+
+    /// Returns the entry at `height` if one exists, otherwise the nearest checkpoint at a lower
+    /// height.
+    pub fn floor_at(&self, height: u32) -> Option<Self>
+    where
+        D: Clone,
+    {
+        self.range(..=height).next()
+    }
+
+    /// Returns the entry located a number of heights below this one.
+    pub fn floor_below(&self, offset: u32) -> Option<Self>
+    where D: Clone
+    {
+        self.floor_at(self.height().checked_sub(offset)?)
+    }
+}
+
+/// Iterates over checkpoint entries backwards.
+pub struct CheckPointEntryIter<D> {
+    next: Option<CheckPointEntry<D>>,
+}
+
+impl<D: ToBlockHash> Iterator for CheckPointEntryIter<D> {
+    type Item = CheckPointEntry<D>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let item = self.next.take()?;
+        self.next = item.prev();
+        Some(item)
+    }
+}
+
+impl<D: ToBlockHash> IntoIterator for CheckPointEntry<D> {
+    type Item = CheckPointEntry<D>;
+    type IntoIter = CheckPointEntryIter<D>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        CheckPointEntryIter { next: Some(self) }
+    }
+}

--- a/crates/core/src/checkpoint_entry.rs
+++ b/crates/core/src/checkpoint_entry.rs
@@ -17,8 +17,8 @@ use bitcoin::BlockHash;
 
 use crate::{BlockId, CheckPoint, ToBlockHash};
 
-/// An entry yielded by [`CheckPointIter`].
-#[derive(Debug, Clone)]
+/// An entry yielded by [`CheckPointEntryIter`].
+#[derive(Debug, Clone, PartialEq)]
 pub enum CheckPointEntry<D> {
     /// A placeholder entry: there is no checkpoint stored at this height,
     /// but the checkpoint one height above links back here via its `prev_blockhash`.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -65,6 +65,9 @@ pub use block_id::*;
 mod checkpoint;
 pub use checkpoint::*;
 
+mod checkpoint_entry;
+pub use checkpoint_entry::*;
+
 mod tx_update;
 pub use tx_update::*;
 

--- a/crates/core/tests/test_checkpoint.rs
+++ b/crates/core/tests/test_checkpoint.rs
@@ -186,3 +186,387 @@ fn test_mtp_sparse_chain() {
     assert_eq!(cp.median_time_past(), None);
     assert_eq!(cp.get(11).unwrap().median_time_past(), None);
 }
+
+// Custom struct for testing with prev_blockhash
+#[derive(Debug, Clone, Copy)]
+struct TestBlock {
+    blockhash: BlockHash,
+    prev_blockhash: BlockHash,
+}
+
+impl ToBlockHash for TestBlock {
+    fn to_blockhash(&self) -> BlockHash {
+        self.blockhash
+    }
+
+    fn prev_blockhash(&self) -> Option<BlockHash> {
+        Some(self.prev_blockhash)
+    }
+}
+
+/// Test inserting data with conflicting prev_blockhash should displace checkpoint and create
+/// placeholder.
+///
+/// When inserting data at height `h` with a `prev_blockhash` that conflicts with the checkpoint
+/// at height `h-1`, the checkpoint at `h-1` should be displaced and replaced with a placeholder
+/// containing the `prev_blockhash` from the inserted data.
+///
+/// Expected: Checkpoint at 99 gets displaced when inserting at 100 with conflicting prev_blockhash.
+#[test]
+fn checkpoint_insert_conflicting_prev_blockhash() {
+    // Create initial checkpoint at height 99
+    let block_99 = TestBlock {
+        blockhash: hash!("block_at_99"),
+        prev_blockhash: hash!("block_at_98"),
+    };
+    let cp = CheckPoint::new(99, block_99);
+
+    // Insert data at height 100 with a prev_blockhash that conflicts with checkpoint at 99
+    let block_100_conflicting = TestBlock {
+        blockhash: hash!("block_at_100"),
+        prev_blockhash: hash!("different_block_at_99"), // Conflicts with block_99.blockhash
+    };
+
+    let result = cp.insert(100, block_100_conflicting);
+
+    // Expected behavior: The checkpoint at 99 should be displaced
+    assert!(result.get(99).is_none(), "99 was displaced");
+
+    // The checkpoint at 100 should be inserted correctly
+    let height_100 = result.get(100).expect("checkpoint at 100 should exist");
+    assert_eq!(height_100.hash(), block_100_conflicting.blockhash);
+
+    // Verify chain structure
+    assert_eq!(result.height(), 100, "tip should be at height 100");
+    assert_eq!(result.iter().count(), 1, "should have 1 checkpoints (100)");
+}
+
+/// Test inserting data that conflicts with prev_blockhash of higher checkpoints should purge them.
+///
+/// When inserting data at height `h` where the blockhash conflicts with the `prev_blockhash` of
+/// checkpoint at height `h+1`, the checkpoint at `h+1` and all checkpoints above it should be
+/// purged from the chain.
+///
+/// Expected: Checkpoints at 100, 101, 102 get purged when inserting at 99 with conflicting
+/// blockhash.
+#[test]
+fn checkpoint_insert_purges_conflicting_tail() {
+    // Create a chain with multiple checkpoints
+    let block_98 = TestBlock {
+        blockhash: hash!("block_at_98"),
+        prev_blockhash: hash!("block_at_97"),
+    };
+    let block_99 = TestBlock {
+        blockhash: hash!("block_at_99"),
+        prev_blockhash: hash!("block_at_98"),
+    };
+    let block_100 = TestBlock {
+        blockhash: hash!("block_at_100"),
+        prev_blockhash: hash!("block_at_99"),
+    };
+    let block_101 = TestBlock {
+        blockhash: hash!("block_at_101"),
+        prev_blockhash: hash!("block_at_100"),
+    };
+    let block_102 = TestBlock {
+        blockhash: hash!("block_at_102"),
+        prev_blockhash: hash!("block_at_101"),
+    };
+
+    let cp = CheckPoint::from_blocks(vec![
+        (98, block_98),
+        (99, block_99),
+        (100, block_100),
+        (101, block_101),
+        (102, block_102),
+    ])
+    .expect("should create valid checkpoint chain");
+
+    // Verify initial chain has all checkpoints
+    assert_eq!(cp.iter().count(), 5);
+
+    // Insert a conflicting block at height 99
+    // The new block's hash will conflict with block_100's prev_blockhash
+    let conflicting_block_99 = TestBlock {
+        blockhash: hash!("different_block_at_99"),
+        prev_blockhash: hash!("block_at_98"), // Matches existing block_98
+    };
+
+    let result = cp.insert(99, conflicting_block_99);
+
+    // Expected: Heights 100, 101, 102 should be purged because block_100's
+    // prev_blockhash conflicts with the new block_99's hash
+    assert_eq!(
+        result.height(),
+        99,
+        "tip should be at height 99 after purging higher checkpoints"
+    );
+
+    // Check that only 98 and 99 remain
+    assert_eq!(
+        result.iter().count(),
+        2,
+        "should have 2 checkpoints (98, 99)"
+    );
+
+    // Verify height 99 has the new conflicting block
+    let height_99 = result.get(99).expect("checkpoint at 99 should exist");
+    assert_eq!(height_99.hash(), conflicting_block_99.blockhash);
+
+    // Verify height 98 remains unchanged
+    let height_98 = result.get(98).expect("checkpoint at 98 should exist");
+    assert_eq!(height_98.hash(), block_98.blockhash);
+
+    // Verify heights 100, 101, 102 are purged
+    assert!(
+        result.get(100).is_none(),
+        "checkpoint at 100 should be purged"
+    );
+    assert!(
+        result.get(101).is_none(),
+        "checkpoint at 101 should be purged"
+    );
+    assert!(
+        result.get(102).is_none(),
+        "checkpoint at 102 should be purged"
+    );
+}
+
+/// Test inserting between checkpoints with conflicts on both sides.
+///
+/// When inserting at height between two checkpoints where the inserted data's `prev_blockhash`
+/// conflicts with the lower checkpoint and its `blockhash` conflicts with the upper checkpoint's
+/// `prev_blockhash`, both checkpoints should be handled: lower displaced, upper purged.
+///
+/// Expected: Checkpoint at 4 displaced with placeholder, checkpoint at 6 purged.
+#[test]
+fn checkpoint_insert_between_conflicting_both_sides() {
+    // Create checkpoints at heights 4 and 6
+    let block_4 = TestBlock {
+        blockhash: hash!("block_at_4"),
+        prev_blockhash: hash!("block_at_3"),
+    };
+    let block_6 = TestBlock {
+        blockhash: hash!("block_at_6"),
+        prev_blockhash: hash!("block_at_5_original"), // This will conflict with inserted block 5
+    };
+
+    let cp = CheckPoint::from_blocks(vec![(4, block_4), (6, block_6)])
+        .expect("should create valid checkpoint chain");
+
+    // Verify initial state
+    assert_eq!(cp.iter().count(), 2);
+
+    // Insert at height 5 with conflicts on both sides
+    let block_5_conflicting = TestBlock {
+        blockhash: hash!("block_at_5_new"), // Conflicts with block_6.prev_blockhash
+        prev_blockhash: hash!("different_block_at_4"), // Conflicts with block_4.blockhash
+    };
+
+    let result = cp.insert(5, block_5_conflicting);
+
+    // Expected behavior:
+    // - Checkpoint at 4 should be displaced (omitted)
+    // - Checkpoint at 5 should have the inserted data
+    // - Checkpoint at 6 should be purged due to prev_blockhash conflict
+
+    // Verify height 4 is displaced with placeholder
+    assert!(result.get(4).is_none());
+
+    // Verify height 5 has the inserted data
+    let checkpoint_5 = result.get(5).expect("checkpoint at 5 should exist");
+    assert_eq!(checkpoint_5.height(), 5);
+    assert_eq!(checkpoint_5.hash(), block_5_conflicting.blockhash);
+
+    // Verify height 6 is purged
+    assert!(
+        result.get(6).is_none(),
+        "checkpoint at 6 should be purged due to prev_blockhash conflict"
+    );
+
+    // Verify chain structure
+    assert_eq!(result.height(), 5, "tip should be at height 5");
+    // Should have: checkpoint 5 only
+    assert_eq!(
+        result.iter().count(),
+        1,
+        "should have 1 checkpoint(s) (4 was displaced, 6 was evicted)"
+    );
+}
+
+/// Test that push returns Err(self) when trying to push at the same height.
+#[test]
+fn checkpoint_push_fails_same_height() {
+    let cp: CheckPoint<BlockHash> = CheckPoint::new(100, hash!("block_100"));
+
+    // Try to push at the same height (100)
+    let result = cp.clone().push(100, hash!("another_block_100"));
+
+    assert!(
+        result.is_err(),
+        "push should fail when height is same as current"
+    );
+    assert!(
+        result.unwrap_err().eq_ptr(&cp),
+        "should return self on error"
+    );
+}
+
+/// Test that push returns Err(self) when trying to push at a lower height.
+#[test]
+fn checkpoint_push_fails_lower_height() {
+    let cp: CheckPoint<BlockHash> = CheckPoint::new(100, hash!("block_100"));
+
+    // Try to push at a lower height (99)
+    let result = cp.clone().push(99, hash!("block_99"));
+
+    assert!(
+        result.is_err(),
+        "push should fail when height is lower than current"
+    );
+    assert!(
+        result.unwrap_err().eq_ptr(&cp),
+        "should return self on error"
+    );
+}
+
+/// Test that push returns Err(self) when prev_blockhash conflicts with self's hash.
+#[test]
+fn checkpoint_push_fails_conflicting_prev_blockhash() {
+    let cp: CheckPoint<TestBlock> = CheckPoint::new(
+        100,
+        TestBlock {
+            blockhash: hash!("block_100"),
+            prev_blockhash: hash!("block_99"),
+        },
+    );
+
+    // Create a block with a prev_blockhash that doesn't match cp's hash
+    let conflicting_block = TestBlock {
+        blockhash: hash!("block_101"),
+        prev_blockhash: hash!("wrong_block_100"), // This conflicts with cp's hash
+    };
+
+    // Try to push at height 101 (contiguous) with conflicting prev_blockhash
+    let result = cp.clone().push(101, conflicting_block);
+
+    assert!(
+        result.is_err(),
+        "push should fail when prev_blockhash conflicts"
+    );
+    assert!(
+        result.unwrap_err().eq_ptr(&cp),
+        "should return self on error"
+    );
+}
+
+/// Test that push succeeds when prev_blockhash matches self's hash for contiguous height.
+#[test]
+fn checkpoint_push_succeeds_matching_prev_blockhash() {
+    let cp: CheckPoint<TestBlock> = CheckPoint::new(
+        100,
+        TestBlock {
+            blockhash: hash!("block_100"),
+            prev_blockhash: hash!("block_99"),
+        },
+    );
+
+    // Create a block with matching prev_blockhash
+    let matching_block = TestBlock {
+        blockhash: hash!("block_101"),
+        prev_blockhash: hash!("block_100"), // Matches cp's hash
+    };
+
+    // Push at height 101 with matching prev_blockhash
+    let result = cp.push(101, matching_block);
+
+    assert!(
+        result.is_ok(),
+        "push should succeed when prev_blockhash matches"
+    );
+    let new_cp = result.unwrap();
+    assert_eq!(new_cp.height(), 101);
+    assert_eq!(new_cp.hash(), hash!("block_101"));
+}
+
+/// Test that push creates a placeholder for non-contiguous heights with prev_blockhash.
+#[test]
+fn checkpoint_push_creates_non_contiguous_chain() {
+    let cp: CheckPoint<TestBlock> = CheckPoint::new(
+        100,
+        TestBlock {
+            blockhash: hash!("block_100"),
+            prev_blockhash: hash!("block_99"),
+        },
+    );
+
+    // Create a block at non-contiguous height with prev_blockhash
+    let block_105 = TestBlock {
+        blockhash: hash!("block_105"),
+        prev_blockhash: hash!("block_104"),
+    };
+
+    // Push at height 105 (non-contiguous)
+    let result = cp.push(105, block_105);
+
+    assert!(
+        result.is_ok(),
+        "push should succeed for non-contiguous height"
+    );
+    let new_cp = result.unwrap();
+
+    // Verify the tip is at 105
+    assert_eq!(new_cp.height(), 105);
+    assert_eq!(new_cp.hash(), hash!("block_105"));
+
+    // Verify chain structure: 100, 105
+    assert_eq!(new_cp.iter().count(), 2);
+}
+
+/// Test `insert` should panic if trying to replace genesis with a different block.
+#[test]
+#[should_panic(expected = "inserted data implies different genesis")]
+fn checkpoint_insert_cannot_replace_genesis() {
+    let block_0 = TestBlock {
+        blockhash: hash!("block_0"),
+        prev_blockhash: hash!("genesis_parent"),
+    };
+    let block_1 = TestBlock {
+        blockhash: hash!("block_1"),
+        prev_blockhash: hash!("block_0"),
+    };
+
+    let cp = CheckPoint::from_blocks(vec![(0, block_0), (1, block_1)])
+        .expect("should create valid chain");
+
+    // Try to replace genesis with a different block - should panic
+    let block_0_new = TestBlock {
+        blockhash: hash!("block_0_new"),
+        prev_blockhash: hash!("genesis_parent_new"),
+    };
+    let _ = cp.insert(0, block_0_new);
+}
+
+/// Test `insert` should panic if inserted data's prev_blockhash implies a different genesis.
+#[test]
+#[should_panic(expected = "inserted data implies different genesis")]
+fn checkpoint_insert_cannot_displace_genesis() {
+    let block_0 = TestBlock {
+        blockhash: hash!("block_0"),
+        prev_blockhash: hash!("genesis_parent"),
+    };
+    let block_1 = TestBlock {
+        blockhash: hash!("block_1"),
+        prev_blockhash: hash!("block_0"),
+    };
+
+    let cp = CheckPoint::from_blocks(vec![(0, block_0), (1, block_1)])
+        .expect("should create valid chain");
+
+    // Insert at height 1 with prev_blockhash that conflicts with genesis - should panic
+    let block_1_new = TestBlock {
+        blockhash: hash!("block_1_new"),
+        prev_blockhash: hash!("different_block_0"), // Conflicts with block_0.hash
+    };
+    let _ = cp.insert(1, block_1_new);
+}

--- a/crates/core/tests/test_checkpoint.rs
+++ b/crates/core/tests/test_checkpoint.rs
@@ -456,6 +456,10 @@ fn checkpoint_push_fails_conflicting_prev_blockhash() {
         result.unwrap_err().eq_ptr(&cp),
         "should return self on error"
     );
+
+    // Verify the original checkpoint at 100 is still intact
+    assert_eq!(cp.height(), 100);
+    assert_eq!(cp.hash(), hash!("block_100"));
 }
 
 /// Test that push succeeds when prev_blockhash matches self's hash for contiguous height.
@@ -485,6 +489,11 @@ fn checkpoint_push_succeeds_matching_prev_blockhash() {
     let new_cp = result.unwrap();
     assert_eq!(new_cp.height(), 101);
     assert_eq!(new_cp.hash(), hash!("block_101"));
+    assert_eq!(
+        new_cp.iter().count(),
+        2,
+        "should have 2 checkpoints (100, 101)"
+    );
 }
 
 /// Test that push creates a placeholder for non-contiguous heights with prev_blockhash.


### PR DESCRIPTION
Closes #2021
Related to #2076
Replaces #2024
Replaces #2091

### Description

This PR adds `prev_blockhash` awareness to `CheckPoint`, enabling proper chain validation when merging checkpoint chains that store block headers or similar data with previous block hash information.

### Notes to the reviewers

This PR replaces some prior attempts:

* #2024 - where we made the `CheckPoint::data` optional - however this resulted in internal complexity and an API with annoying edge cases. The tests from this PR were still useful.

* #2091 - This second attempt had some good ideas, but was distracted from the goal of #2021. I mostly reused the `CheckPoint::insert` implementation of that PR.

### Changelog notice

```md
Added:
- `ToBlockHash::prev_blockhash()` - optional method to expose previous block hash
- `CheckPointEntry` - new type for iterating with `prev_blockhash` awareness, yielding "placeholder" entries for heights inferred from `prev_blockhash`
- `ApplyBlockError` - this is a new error type with two variants; `MissingGenesis` and `PrevBlockhashMismatch`. The second variant is a new error case introduced by `prev_blockhash` awareness.

Changed:
- `CheckPoint::push` - now errors when `prev_blockhash` conflicts with current tip (contiguous heights)
- `CheckPoint::insert` - now evicts/displaces checkpoints on `prev_blockhash` conflict
- `merge_chains` - now validates `prev_blockhash` consistency when merging
- `LocalChain<D>` generic parameter - relaxed constraint to `D: Clone` instead of `D: Copy`.

Fixed:
- `merge_chains` no longer replaces the genesis block.
```

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
