### PR TITLE
docs(chain): fix merge_chains documentation on genesis block replacement

### DIFF
--- a/crates/chain/src/local_chain.rs
+++ b/crates/chain/src/local_chain.rs
@@ -578,17 +578,24 @@ impl std::error::Error for ApplyHeaderError {}
 
 /// Applies `update_tip` onto `original_tip`.
 ///
-/// On success, a tuple is returned ([`CheckPoint`], [`ChangeSet`]).
+/// On success, returns a tuple containing [`CheckPoint`] and [`ChangeSet`].
 ///
 /// # Errors
 ///
-/// [`CannotConnectError`] occurs when the `original_tip` and `update_tip` chains are disjoint:
+/// [`CannotConnectError`] occurs when the `original_tip` and `update_tip`
+/// cannot be reconciled into a single consistent chain:
 ///
-/// - If no point of agreement is found between the update and original chains.
-/// - A point of agreement is found but the update is ambiguous above the point of agreement (a.k.a.
-///   the update and original chain both have a block above the point of agreement, but their
-///   heights do not overlap).
-/// - The update attempts to replace the genesis block of the original chain.
+/// - No point of agreement is found between the update and original chains,
+///   and the update does not form a consistent replacement.
+/// - A point of agreement is found, but the update is ambiguous above that
+///   point (i.e., both chains contain blocks above the agreement height
+///   with non-overlapping heights).
+///
+/// Note:
+/// The genesis block (height 0) may be replaced if the update forms a
+/// consistent chain and a point of agreement exists at a higher height.
+/// Replacing the genesis block alone does not trigger a
+/// [`CannotConnectError`].
 fn merge_chains<D>(
     original_tip: CheckPoint<D>,
     update_tip: CheckPoint<D>,


### PR DESCRIPTION
## Fix incorrect documentation about genesis block replacement

Fixes bitcoindevkit/bdk#2095 (part 1)

### The Problem

I noticed the docs for `merge_chains` said that trying to replace the genesis block would always fail with a `CannotConnectError`. But when I looked at the tests, there's actually a test case called "fix blockhash before agreement point" that does exactly that - it replaces the genesis block and expects it to succeed!

Here's the test:
```rust
chain: local_chain![(0, hash!("im-wrong")), (1, hash!("we-agree"))],
update: chain_update![(0, hash!("fix")), (1, hash!("we-agree"))],
exp: ExpectedResult::Ok { ... } // This passes!
```

So the docs were misleading - genesis replacement is actually allowed as long as there's agreement at a higher block.

### What I Changed

I updated the documentation to match what the code actually does:

**Before:** Said genesis replacement always fails  
**After:** Explains that genesis replacement is fine when the update is consistent and has a point of agreement at a higher height

I also cleaned up the wording to make it clearer when `CannotConnectError` actually happens.

### Testing

Ran the full test suite:
```bash
cargo test -p bdk_chain
```

All 58 tests pass ✅

### Impact

This is just a documentation fix - no code changes, no breaking changes. Just making the docs match reality so developers aren't confused.

### Note

Issue #2095 mentioned two problems. This PR fixes the first one (genesis block docs). The second issue about chain reorgs is a known limitation that's being worked on in #2091.