### PR TITLE
fix(chain): forward `confirmation_height_upper_bound` in `Anchor` implementation for `&A`

### DIFF
--- a/crates/chain/src/tx_data_traits.rs
+++ b/crates/chain/src/tx_data_traits.rs
@@ -81,6 +81,10 @@ impl<A: Anchor> Anchor for &A {
     fn anchor_block(&self) -> BlockId {
         <A as Anchor>::anchor_block(self)
     }
+
+    fn confirmation_height_upper_bound(&self) -> u32 {
+        <A as Anchor>::confirmation_height_upper_bound(self)
+    }
 }
 
 impl Anchor for BlockId {


### PR DESCRIPTION
### Description

The blanket `Anchor` impl for `&A` was missing the `confirmation_height_upper_bound` method, causing it to fall back to the default implementation instead of delegating to the inner type.

### Changelog notice

```md
Fixed:

- The `Anchor::confirmation_height_upper_bound` impl was missing for `&A`, causing it to fallback to the default impl.
```

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### Bugfixes:

~~* [ ] This pull request breaks the existing API~~
~~* [ ] I've added tests to reproduce the issue which are now passing~~
~~* [ ] I'm linking the issue being fixed by this PR~~
