### PR TITLE
Improved mutex poisoned error messages in examples

### DIFF
--- a/examples/example_electrum/src/main.rs
+++ b/examples/example_electrum/src/main.rs
@@ -129,7 +129,7 @@ fn main() -> anyhow::Result<()> {
     // Tell the electrum client about the txs and anchors we've already got locally so it doesn't
     // re-download .them
     {
-        let graph = graph.lock().unwrap();
+        let graph = graph.lock().expect("mutex poisoned");
         client.populate_tx_cache(graph.graph().full_txs().map(|tx_node| tx_node.tx));
         client.populate_anchor_cache(graph.graph().all_anchors().clone());
     }
@@ -141,8 +141,8 @@ fn main() -> anyhow::Result<()> {
             ..
         } => {
             let request = {
-                let graph = &*graph.lock().unwrap();
-                let chain = &*chain.lock().unwrap();
+                let graph = &*graph.lock().expect("mutex poisoned");
+                let chain = &*chain.lock().expect("mutex poisoned");
 
                 FullScanRequest::builder()
                     .chain_tip(chain.tip())
@@ -193,8 +193,8 @@ fn main() -> anyhow::Result<()> {
             ..
         } => {
             // Get a short lock on the tracker to get the spks we're interested in
-            let graph = graph.lock().unwrap();
-            let chain = chain.lock().unwrap();
+            let graph = graph.lock().expect("mutex poisoned");
+            let chain = chain.lock().expect("mutex poisoned");
 
             if !(all_spks || unused_spks || utxos || unconfirmed) {
                 unused_spks = true;
@@ -269,8 +269,8 @@ fn main() -> anyhow::Result<()> {
     };
 
     let db_changeset = {
-        let mut chain = chain.lock().unwrap();
-        let mut graph = graph.lock().unwrap();
+        let mut chain = chain.lock().expect("mutex poisoned");
+        let mut graph = graph.lock().expect("mutex poisoned");
 
         let chain_changeset = chain.apply_update(chain_update.expect("request has chain tip"))?;
 
@@ -290,7 +290,7 @@ fn main() -> anyhow::Result<()> {
         }
     };
 
-    let mut db = db.lock().unwrap();
+    let mut db = db.lock().expect("mutex poisoned");
     db.append(&db_changeset)?;
     Ok(())
 }

--- a/examples/example_esplora/src/main.rs
+++ b/examples/example_esplora/src/main.rs
@@ -235,8 +235,8 @@ fn main() -> anyhow::Result<()> {
             // Get a short lock on the structures to get spks, utxos, and txs that we are interested
             // in.
             {
-                let graph = graph.lock().unwrap();
-                let chain = chain.lock().unwrap();
+                let graph = graph.lock().expect("mutex poisoned");
+                let chain = chain.lock().expect("mutex poisoned");
                 let canonical_view = graph.canonical_view(
                     &*chain,
                     local_tip.block_id(),
@@ -290,7 +290,7 @@ fn main() -> anyhow::Result<()> {
     println!();
 
     // We persist the changes
-    let mut db = db.lock().unwrap();
+    let mut db = db.lock().expect("mutex poisoned");
     db.append(&ChangeSet {
         local_chain: local_chain_changeset,
         tx_graph: indexed_tx_graph_changeset.tx_graph,


### PR DESCRIPTION
### Description

This PR replaces unwrap() calls on Mutex::lock() with expect("mutex poisoned") in the example applications.
This provides clearer error messages in the event of mutex poisoning and improves debugging experience.
Changes are limited to the examples/ directory. No core library logic or public API is modified.

### Notes to the reviewers

This change is intentionally limited to example applications only.
Core crates were not modified.

The behavior remains the same — only the error message in the unlikely event of mutex poisoning is improved.

### Changelog notice

None (examples-only change).

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
