### PR TITLE
Improve unknown coin selection algorithm error message

### DIFF
--- a/examples/example_cli/src/lib.rs
+++ b/examples/example_cli/src/lib.rs
@@ -227,7 +227,7 @@ impl FromStr for CoinSelectionAlgo {
             "oldest-first" => OldestFirst,
             "newest-first" => NewestFirst,
             "bnb" => BranchAndBound,
-            unknown => bail!("unknown coin selection algorithm '{unknown}'"),
+            unknown => bail!("unknown coin selection algorithm '{}'. Supported algorithms: largest-first, smallest-first, oldest-first, newest-first, bnb", unknown),
         })
     }
 }


### PR DESCRIPTION
### Description

Improve the error message returned when an unknown coin selection algorithm is provided.

Previously, the error message only displayed:

unknown coin selection algorithm '{unknown}'


This change updates the message to clearly list the supported algorithms:

unknown coin selection algorithm '<value>'. Supported algorithms: largest-first, s

### Notes to the reviewers

This change only modifies the error message in the FromStr implementation of CoinSelectionAlgo.
No logic or behavior has been changed.

### Changelog notice

Improved CLI error message for invalid coin selection algorithm input.

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### New Features:

* [ ] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
