### PR TITLE
Add CODEOWNERS with primary and secondary maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+* @evanlinjin @oleonardolima
+/crates/chain/ @evanlinjin @oleonardolima
+/crates/core/ @evanlinjin @oleonardolima
+/crates/electrum/ @evanlinjin @oleonardolima
+/crates/esplora/ @oleonardolima @luisschwab
+/crates/bitcoind_rpc/ @evanlinjin @ValuedMammal
+/crates/testenv/ @tvpeter @luisschwab
+/crates/file_store/ @nymius


### PR DESCRIPTION
### Description

Add CODEOWNERS file with both primary and secondary maintainers for repo files with overrides for specific sub-crates.  See: https://github.com/bitcoindevkit#stable

fixes #1926 

### Notes to the reviewers

This will trigger a review request for above maintainers for any file changes in the repo.

see: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

### Changelog notice

none

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
