### PR TITLE
ci: remove slow and inefficient cargo caching

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -20,7 +20,7 @@ jobs:
         with:
             toolchain: nightly-2025-11-27
             override: true
-            cache: true
+            cache: false
             components: llvm-tools-preview
       - name: Install cargo-llvm-cov
         run: if [[ ! -e ~/.cargo/bin/cargo-llvm-cov ]]; then cargo install cargo-llvm-cov; fi

--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -41,7 +41,7 @@ jobs:
         with:
             toolchain: ${{ matrix.rust.version }}
             override: true
-            cache: true
+            cache: false
       - name: Pin dependencies for MSRV
         if: matrix.rust.version == '1.85.0'
         run: ./ci/pin-msrv.sh
@@ -66,7 +66,7 @@ jobs:
         with:
           toolchain: ${{ needs.prepare.outputs.rust_version }}
           override: true
-          cache: true
+          cache: false
           # target: "thumbv6m-none-eabi"
       - name: Check bdk_chain
         working-directory: ./crates/chain
@@ -98,7 +98,7 @@ jobs:
         with:
             toolchain: ${{ needs.prepare.outputs.rust_version }}
             override: true
-            cache: true
+            cache: false
             target: "wasm32-unknown-unknown"
       - name: Check esplora
         working-directory: ./crates/esplora
@@ -117,7 +117,7 @@ jobs:
         with:
             toolchain: nightly
             override: true
-            cache: true
+            cache: false
             components: rustfmt
       - name: Check fmt
         run: cargo fmt --all --check
@@ -137,7 +137,7 @@ jobs:
             toolchain: ${{ needs.prepare.outputs.rust_version }}
             components: clippy
             override: true
-            cache: true
+            cache: false
       - name: Clippy
         run: cargo clippy --all-features --all-targets -- -D warnings
 
@@ -162,7 +162,7 @@ jobs:
         with:
           toolchain: ${{ needs.prepare.outputs.rust_version }}
           override: true
-          cache: true
+          cache: false
       - name: Build
         working-directory: examples/${{ matrix.example-dir }}
         run: cargo build

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -17,9 +17,6 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5
-
       - name: Install zizmor
         run: cargo install zizmor --locked --version 1.6.0
 

--- a/crates/esplora/src/async_ext.rs
+++ b/crates/esplora/src/async_ext.rs
@@ -184,10 +184,10 @@ async fn fetch_latest_blocks<S: Sleeper>(
     client: &esplora_client::AsyncClient<S>,
 ) -> Result<BTreeMap<u32, BlockHash>, Error> {
     Ok(client
-        .get_blocks(None)
+        .get_block_infos(None)
         .await?
         .into_iter()
-        .map(|b| (b.time.height, b.id))
+        .map(|b| (b.height, b.id))
         .collect())
 }
 

--- a/crates/esplora/src/blocking_ext.rs
+++ b/crates/esplora/src/blocking_ext.rs
@@ -170,9 +170,9 @@ fn fetch_latest_blocks(
     client: &esplora_client::BlockingClient,
 ) -> Result<BTreeMap<u32, BlockHash>, Error> {
     Ok(client
-        .get_blocks(None)?
+        .get_block_infos(None)?
         .into_iter()
-        .map(|b| (b.time.height, b.id))
+        .map(|b| (b.height, b.id))
         .collect())
 }
 


### PR DESCRIPTION
### Description

This PR disables Cargo caching in GitHub Actions as recommended in #1637. Compressing and uploading the cache was consistently taking longer than the actual builds, slowing down the feedback loop.

I've also included a fix for `bdk_esplora` compilation failures. The build was breaking due to `-D warnings` and the deprecation of `get_blocks` in the latest `esplora-client`. I've migrated the extensions to use `get_block_infos`.

### Notes to the reviewers

- Disabling caching in [cont_integration.yml](cci:7://file:///Users/apple/bdk/.github/workflows/cont_integration.yml:0:0-0:0), [code_coverage.yml](cci:7://file:///Users/apple/bdk/.github/workflows/code_coverage.yml:0:0-0:0), and [zizmor.yml](cci:7://file:///Users/apple/bdk/.github/zizmor.yml:0:0-0:0).
- The `esplora` fix was required to get CI passing, as the deprecation warnings were blocking the build.
- Fixed field access from `.time.height` to `.height` as per the new `BlockInfo` struct.

### Changelog notice

- ci: remove inefficient cargo caching in workflows (#1637)
- fix(esplora): migrate from deprecated `get_blocks` to `get_block_infos`

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [x] I'm linking the issue being fixed by this PR (#1637)
