### PR TITLE
Fix `bdk_esplora` compilation error by bumping `esplora_client` version

### DIFF
--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 
 [dependencies]
 bdk_core = { path = "../core", version = "0.6.1", default-features = false }
-esplora-client = { version = "0.12.1", default-features = false }
+esplora-client = { version = "0.12.3", default-features = false }
 async-trait = { version = "0.1.66", optional = true }
 futures = { version = "0.3.26", optional = true }
 serde_json = { version = "1.0", features = ["alloc"] }


### PR DESCRIPTION
### Description

I didn't realize #2053 didn't actually compile when I merged it. This PR fixes this by bumping `esplora_client` to `0.12.3` so that the `.get_block_infos` method is always available.

### Changelog

```md
Fixed:
- Bump `esplora_client` to `0.12.3` so that the `.get_block_infos` method is always available.
```

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)