### PR TITLE
Replace `std::error::Error` with `core::error::Error`

### DIFF
--- a/crates/bitcoind_rpc/src/bip158.rs
+++ b/crates/bitcoind_rpc/src/bip158.rs
@@ -173,8 +173,7 @@ impl core::fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error {}
+impl core::error::Error for Error {}
 
 impl From<bitcoincore_rpc::Error> for Error {
     fn from(e: bitcoincore_rpc::Error) -> Self {

--- a/crates/chain/src/indexer/keychain_txout.rs
+++ b/crates/chain/src/indexer/keychain_txout.rs
@@ -1022,8 +1022,7 @@ impl<K: core::fmt::Display> core::fmt::Display for InsertDescriptorError<K> {
     }
 }
 
-#[cfg(feature = "std")]
-impl<K: core::fmt::Display + core::fmt::Debug> std::error::Error for InsertDescriptorError<K> {}
+impl<K: core::fmt::Display + core::fmt::Debug> core::error::Error for InsertDescriptorError<K> {}
 
 /// `ChangeSet` represents persistent updates to a [`KeychainTxOutIndex`].
 ///

--- a/crates/chain/src/indexer/spk_txout.rs
+++ b/crates/chain/src/indexer/spk_txout.rs
@@ -332,7 +332,7 @@ impl<I: Clone + Ord + core::fmt::Debug> SpkTxOutIndex<I> {
     /// # use bitcoin::{Address, Network, Transaction};
     /// # use std::str::FromStr;
     /// #
-    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn example() -> Result<(), Box<dyn core::error::Error>> {
     /// let mut index = SpkTxOutIndex::<u32>::default();
     ///
     /// // ... scan transactions to populate the index ...
@@ -382,7 +382,7 @@ impl<I: Clone + Ord + core::fmt::Debug> SpkTxOutIndex<I> {
     /// # use bitcoin::{Address, Network, Transaction};
     /// # use std::str::FromStr;
     /// #
-    /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn example() -> Result<(), Box<dyn core::error::Error>> {
     /// let mut index = SpkTxOutIndex::<u32>::default();
     ///
     /// // ... scan transactions to populate the index ...

--- a/crates/chain/src/local_chain.rs
+++ b/crates/chain/src/local_chain.rs
@@ -498,8 +498,7 @@ impl core::fmt::Display for MissingGenesisError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for MissingGenesisError {}
+impl core::error::Error for MissingGenesisError {}
 
 /// Represents a failure when trying to insert/remove a checkpoint to/from [`LocalChain`].
 #[derive(Clone, Debug, PartialEq)]
@@ -529,8 +528,7 @@ impl core::fmt::Display for AlterCheckPointError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for AlterCheckPointError {}
+impl core::error::Error for AlterCheckPointError {}
 
 /// Occurs when an update does not have a common checkpoint with the original chain.
 #[derive(Clone, Debug, PartialEq)]
@@ -549,8 +547,7 @@ impl core::fmt::Display for CannotConnectError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for CannotConnectError {}
+impl core::error::Error for CannotConnectError {}
 
 /// The error type for [`LocalChain::apply_header_connected_to`].
 #[derive(Debug, Clone, PartialEq)]
@@ -573,8 +570,7 @@ impl core::fmt::Display for ApplyHeaderError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ApplyHeaderError {}
+impl core::error::Error for ApplyHeaderError {}
 
 /// Applies `update_tip` onto `original_tip`.
 ///

--- a/crates/chain/src/rusqlite_impl.rs
+++ b/crates/chain/src/rusqlite_impl.rs
@@ -185,11 +185,11 @@ impl ToSql for Impl<bitcoin::Network> {
     }
 }
 
-fn from_sql_error<E: std::error::Error + Send + Sync + 'static>(err: E) -> FromSqlError {
+fn from_sql_error<E: core::error::Error + Send + Sync + 'static>(err: E) -> FromSqlError {
     FromSqlError::Other(Box::new(err))
 }
 
-fn to_sql_error<E: std::error::Error + Send + Sync + 'static>(err: E) -> rusqlite::Error {
+fn to_sql_error<E: core::error::Error + Send + Sync + 'static>(err: E) -> rusqlite::Error {
     rusqlite::Error::ToSqlConversionFailure(Box::new(err))
 }
 

--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -287,8 +287,7 @@ impl fmt::Display for CalculateFeeError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for CalculateFeeError {}
+impl core::error::Error for CalculateFeeError {}
 
 impl<A> TxGraph<A> {
     /// Iterate over all tx outputs known by [`TxGraph`].

--- a/crates/file_store/src/lib.rs
+++ b/crates/file_store/src/lib.rs
@@ -53,4 +53,4 @@ impl From<io::Error> for StoreError {
     }
 }
 
-impl std::error::Error for StoreError {}
+impl core::error::Error for StoreError {}

--- a/crates/file_store/src/store.rs
+++ b/crates/file_store/src/store.rs
@@ -278,7 +278,7 @@ impl<C> std::fmt::Display for StoreErrorWithDump<C> {
     }
 }
 
-impl<C: fmt::Debug> std::error::Error for StoreErrorWithDump<C> {}
+impl<C: fmt::Debug> core::error::Error for StoreErrorWithDump<C> {}
 
 #[cfg(test)]
 #[cfg_attr(coverage_nightly, coverage(off))]

--- a/examples/example_cli/src/lib.rs
+++ b/examples/example_cli/src/lib.rs
@@ -268,7 +268,7 @@ pub fn create_tx<O: ChainOracle>(
     feerate: f32,
 ) -> anyhow::Result<(Psbt, Option<ChangeInfo>)>
 where
-    O::Error: std::error::Error + Send + Sync + 'static,
+    O::Error: core::error::Error + Send + Sync + 'static,
 {
     let mut changeset = keychain_txout::ChangeSet::default();
 


### PR DESCRIPTION
Closes #2132

The `Error` trait is stable as of 1.81.0, so import it from `core` instead.
