### PR TITLE
chore(chain): deprecate `CanonicalIter`, and `ChainOracle` trait

### DIFF
--- a/crates/chain/src/canonical_iter.rs
+++ b/crates/chain/src/canonical_iter.rs
@@ -22,6 +22,10 @@ pub struct CanonicalizationParams {
 }
 
 /// Iterates over canonical txs.
+#[deprecated(
+    since = "0.23.3",
+    note = "`CanonicalIter` will be removed in a future release, replaced by `CanonicalTask` and `CanonicalViewTask`. See: https://github.com/bitcoindevkit/bdk/pull/2038"
+)]
 pub struct CanonicalIter<'g, A, C> {
     tx_graph: &'g TxGraph<A>,
     chain: &'g C,

--- a/crates/chain/src/chain_oracle.rs
+++ b/crates/chain/src/chain_oracle.rs
@@ -6,6 +6,10 @@ use crate::BlockId;
 /// is an ancestor of the `chain_tip`.
 ///
 /// [`is_block_in_chain`]: Self::is_block_in_chain
+#[deprecated(
+    since = "0.23.3",
+    note = "`ChainOracle` will be removed in a future release, replaced by `ChainQuery` in `bdk_core`. See: https://github.com/bitcoindevkit/bdk/pull/2038"
+)]
 pub trait ChainOracle {
     /// Error type.
     type Error: core::fmt::Debug;

--- a/crates/chain/src/lib.rs
+++ b/crates/chain/src/lib.rs
@@ -32,18 +32,22 @@ mod balance;
 pub use balance::*;
 mod chain_data;
 pub use chain_data::*;
+#[allow(deprecated)]
 pub mod indexed_tx_graph;
 pub use indexed_tx_graph::IndexedTxGraph;
 pub mod indexer;
 pub use indexer::spk_txout;
 pub use indexer::Indexer;
+#[allow(deprecated)]
 pub mod local_chain;
 mod tx_data_traits;
 pub use tx_data_traits::*;
+#[allow(deprecated)]
 pub mod tx_graph;
 pub use tx_graph::TxGraph;
 mod chain_oracle;
 pub use chain_oracle::*;
+#[allow(deprecated)]
 mod canonical_iter;
 pub use canonical_iter::*;
 

--- a/crates/chain/tests/test_tx_graph.rs
+++ b/crates/chain/tests/test_tx_graph.rs
@@ -3,6 +3,7 @@
 #[macro_use]
 mod common;
 use bdk_chain::{collections::*, BlockId, CanonicalizationParams, ConfirmationBlockTime};
+#[allow(deprecated)]
 use bdk_chain::{
     local_chain::LocalChain,
     tx_graph::{self, CalculateFeeError},
@@ -754,6 +755,7 @@ fn test_walk_ancestors() {
             .walk_ancestors(tx_e0.clone(), |depth, tx| Some((depth, tx)))
             .collect::<Vec<_>>(),
         // Only traverse unconfirmed ancestors of tx_e0 this time
+        #[allow(deprecated)]
         graph
             .walk_ancestors(tx_e0.clone(), |depth, tx| {
                 let tx_node = graph.get_tx_node(tx.compute_txid())?;

--- a/examples/example_cli/src/lib.rs
+++ b/examples/example_cli/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use bdk_chain::keychain_txout::DEFAULT_LOOKAHEAD;
 use serde_json::json;
 use std::cmp;


### PR DESCRIPTION
### Description

As both `CanonicalIter` and `ChainOracle` trait are being removed/replaced in #2038, and they're public types, we should deprecated them in a `0.23.x` release in case any user does use them directly.

### Notes to the reviewers

It's simply deprecating `CanonicalIter` and `ChainOracle` trait.

### Changelog notice

```
### Changed
- `CanonicalIter` and `ChainOracle` are planned to be removed in a future release, therefore have been deprecated.
```

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
