### PR TITLE
ci: switch from coveralls to codecov for coverage reporting

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -1,13 +1,20 @@
-on: [push, pull_request]
-
 name: Code Coverage
 
-permissions: {}
+# Generates code coverage reports using cargo-llvm-cov and uploads results to Codecov.
+# Runs on every push and pull request to track test coverage metrics.
+# Uploads coverage data to Codecov for tracking and produces an HTML report artifact for download.
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
-  Codecov:
+  Coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -18,24 +25,30 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-            toolchain: nightly-2025-11-27
-            override: true
-            cache: true
-            components: llvm-tools-preview
+          toolchain: nightly-2025-11-27
+          components: llvm-tools-preview
+          # override: true
+          cache: true
       - name: Install cargo-llvm-cov
-        run: if [[ ! -e ~/.cargo/bin/cargo-llvm-cov ]]; then cargo install cargo-llvm-cov; fi
-      - name: Make coverage directory
-        run: mkdir coverage
-      - name: Test and report coverage
-        run: cargo llvm-cov -q --doctests --branch --all --ignore-filename-regex "(example*|crates/testenv/*)" --all-features --lcov --output-path ./coverage/lcov.info
+        run: cargo install cargo-llvm-cov
+      - name: Generate coverage data
+        run: cargo llvm-cov --all --all-features --branch --quiet --doctests --ignore-filename-regex "(example*|crates/testenv/*)" --lcov --output-path lcov.info
+        env:
+          RUSTFLAGS: "--cfg coverage_nightly"
       - name: Generate HTML coverage report
-        run: genhtml -o coverage-report.html --ignore-errors unmapped ./coverage/lcov.info
-      - name: Coveralls upload
-        uses: coverallsapp/github-action@master
+        run: cargo llvm-cov --all --all-features --branch --quiet --doctests --ignore-filename-regex "(example*|crates/testenv/*)" --html
+        env:
+          RUSTFLAGS: "--cfg coverage_nightly"
+      - name: Codecov upload
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          files: ./lcov.info
+          flags: rust
+          name: codecov-bdk
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
           name: coverage-report
-          path: coverage-report.html
+          path: target/llvm-cov/html


### PR DESCRIPTION
closes #2093 

### Description

Migrates code coverage reporting from Coveralls to Codecov.

- **Replaced coverage service**: Switched from `coverallsapp/github-action` to `codecov/codecov-action@v5.5.2` (pinned commit SHA for security)
- **Added permissions**: Added `contents: read` and `pull-requests: write` to enable Codecov PR comments
- **Codecov configuration**: Added `flags: rust` and `name: codecov-bdk` for better organization

### Changelog notice

```
### Changed
- chore(ci): switch from coveralls to codecov
```
#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)