### PR TITLE
`chain 0.23.x`: Fix assumed canonical tx always being unconfirmed

### DIFF
--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -1028,8 +1028,8 @@ impl<A: Anchor> TxGraph<A> {
                 res.map(|(txid, _, canonical_reason)| {
                     let tx_node = self.get_tx_node(txid).expect("must contain tx");
                     let chain_position = match canonical_reason {
-                        CanonicalReason::Assumed { descendant } => match descendant {
-                            Some(_) => match find_direct_anchor(&tx_node, chain, chain_tip)? {
+                        CanonicalReason::Assumed { .. } => {
+                            match find_direct_anchor(&tx_node, chain, chain_tip)? {
                                 Some(anchor) => ChainPosition::Confirmed {
                                     anchor,
                                     transitively: None,
@@ -1038,12 +1038,8 @@ impl<A: Anchor> TxGraph<A> {
                                     first_seen: tx_node.first_seen,
                                     last_seen: tx_node.last_seen,
                                 },
-                            },
-                            None => ChainPosition::Unconfirmed {
-                                first_seen: tx_node.first_seen,
-                                last_seen: tx_node.last_seen,
-                            },
-                        },
+                            }
+                        }
                         CanonicalReason::Anchor { anchor, descendant } => match descendant {
                             Some(_) => match find_direct_anchor(&tx_node, chain, chain_tip)? {
                                 Some(anchor) => ChainPosition::Confirmed {

--- a/crates/chain/tests/test_tx_graph.rs
+++ b/crates/chain/tests/test_tx_graph.rs
@@ -1545,6 +1545,58 @@ fn test_get_first_seen_of_a_tx() {
     assert_eq!(first_seen, Some(seen_at));
 }
 
+#[test]
+fn test_assumed_canonical_with_anchor_is_confirmed() {
+    use bdk_chain::ChainPosition;
+
+    let chain = LocalChain::from_blocks(
+        [(0, hash!("genesis")), (2, hash!("b2"))]
+            .into_iter()
+            .collect(),
+    )
+    .unwrap();
+
+    // Create an anchored transaction that will be assumed canonical via `CanonicalizationParams`.
+    let tx = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(hash!("parent"), 0),
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(50_000),
+            script_pubkey: ScriptBuf::new(),
+        }],
+        ..new_tx(1)
+    };
+    let txid = tx.compute_txid();
+
+    let mut tx_graph = TxGraph::default();
+    let _ = tx_graph.insert_tx(tx);
+    let _ = tx_graph.insert_anchor(
+        txid,
+        ConfirmationBlockTime {
+            block_id: chain.get(2).unwrap().block_id(),
+            confirmation_time: 123456,
+        },
+    );
+
+    let canonical_tx = tx_graph
+        .list_canonical_txs(
+            &chain,
+            chain.tip().block_id(),
+            CanonicalizationParams {
+                assume_canonical: vec![txid],
+            },
+        )
+        .find(|c_tx| c_tx.tx_node.txid == txid)
+        .expect("tx must exist");
+
+    assert!(
+        matches!(canonical_tx.chain_position, ChainPosition::Confirmed { .. }),
+        "tx that is assumed canonical and has a direct anchor should have ChainPosition::Confirmed"
+    );
+}
+
 /// A helper structure to constructs multiple [`TxGraph`] scenarios, used in
 /// `test_list_ordered_canonical_txs`.
 struct Scenario<'a> {


### PR DESCRIPTION
### Description

Fixes #2088
Depends on #2148
Backport of #2110

### Changelog notice

```md
Fixed:
- Previously, assumed-canonical transactions always became unconfirmed even though the transaction may be anchored in the best chain.
```

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
