### PR TITLE
chore(release): bump `bdk_chain` to `0.23.3`

### DIFF
--- a/crates/chain/CHANGELOG.md
+++ b/crates/chain/CHANGELOG.md
@@ -7,6 +7,24 @@ Contributors do not need to change this file but do need to add changelog detail
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [chain-0.23.3]
+
+### Added
+
+- Add new `list_ordered_canonical_txs` method to `TxGraph` that returns canonical transactions in topological order. #2027
+- Add new `spent_txouts` and `created_txouts` methods on `SpkTxOutIndex` and `KeychainTxOutIndex`. #2161
+- Add new `SpentTxOut` and `CreatedTxOut` structs returned by `spent_txouts` and `created_txouts` functions. #2161
+
+### Fixed
+
+- Fixed `ChainPosition` ordering so unconfirmed transactions never seen in mempool appear last instead of first. #2146
+- The `Anchor::confirmation_height_upper_bound` impl was missing for `&A`, causing it to fallback to the default impl. #2149
+- Previously, assumed-canonical transactions always became unconfirmed even though the transaction may be anchored in the best chain. #2150
+
+### Changed
+
+- Simplified `FullTxOut` ordering to only use essential fields (chain_position, outpoint, spent_by). #2146
+
 ## [chain-0.23.2]
 
 ### Added
@@ -86,3 +104,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [chain-0.23.0]: https://github.com/bitcoindevkit/bdk/releases/tag/chain-0.23.0
 [chain-0.23.1]: https://github.com/bitcoindevkit/bdk/releases/tag/chain-0.23.1
 [chain-0.23.2]: https://github.com/bitcoindevkit/bdk/releases/tag/chain-0.23.2
+[chain-0.23.3]: https://github.com/bitcoindevkit/bdk/releases/tag/chain-0.23.3

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_chain"
-version = "0.23.2"
+version = "0.23.3"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"
@@ -17,7 +17,7 @@ workspace = true
 
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false }
-bdk_core = { path = "../core", version = "0.6.2", default-features = false }
+bdk_core = { path = "../core", version = "0.6.3", default-features = false }
 serde = { version = "1", optional = true, features = ["derive", "rc"] }
 miniscript = { version = "12.3.1", optional = true, default-features = false }
 

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [core-0.6.3]
+
+### Fixed
+
+- Fix `broken-intra-doc-link` for `KeychainTxOutIndex`. #2155
+
 ## [core-0.6.2]
 
 ### Added
@@ -57,3 +63,4 @@ This is because requests now have a `start_time`, instead of specifying a `seen_
 [core-0.6.0]: https://github.com/bitcoindevkit/bdk/releases/tag/core-0.6.0
 [core-0.6.1]: https://github.com/bitcoindevkit/bdk/releases/tag/core-0.6.1
 [core-0.6.2]: https://github.com/bitcoindevkit/bdk/releases/tag/core-0.6.2
+[core-0.6.3]: https://github.com/bitcoindevkit/bdk/releases/tag/core-0.6.3

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_core"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"

--- a/crates/core/src/spk_client.rs
+++ b/crates/core/src/spk_client.rs
@@ -136,9 +136,7 @@ impl<I> SyncRequestBuilder<I> {
     ///
     /// # Example
     ///
-    /// Sync revealed script pubkeys obtained from a
-    /// [`KeychainTxOutIndex`](../../bdk_chain/indexer/keychain_txout/struct.KeychainTxOutIndex.
-    /// html).
+    /// Sync revealed script pubkeys obtained from a [`KeychainTxOutIndex`](https://docs.rs/bdk_chain/latest/bdk_chain/indexer/keychain_txout/struct.KeychainTxOutIndex.html).
     ///
     /// ```rust
     /// # use bdk_chain::spk_client::SyncRequest;

--- a/crates/esplora/CHANGELOG.md
+++ b/crates/esplora/CHANGELOG.md
@@ -7,6 +7,13 @@ Contributors do not need to change this file but do need to add changelog detail
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [esplora-0.22.2]
+
+### Fixed
+
+- In `bdk_esplora` now avoids a panic in stop‑gap scan loop by tracking consecutive unused scripts to compute the gap boundary. #2148
+- Bump `esplora_client` to `0.12.3` (Therefore replacing `.get_blocks` with `.get_block_infos`). #2148
+
 ## [esplora-0.22.1]
 
 ### Added
@@ -45,3 +52,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [esplora-0.21.0]: https://github.com/bitcoindevkit/bdk/releases/tag/esplora-0.21.0
 [esplora-0.22.0]: https://github.com/bitcoindevkit/bdk/releases/tag/esplora-0.22.0
 [esplora-0.22.1]: https://github.com/bitcoindevkit/bdk/releases/tag/esplora-0.22.1
+[esplora-0.22.2]: https://github.com/bitcoindevkit/bdk/releases/tag/esplora-0.22.2

--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_esplora"
-version = "0.22.1"
+version = "0.22.2"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"
@@ -15,7 +15,7 @@ readme = "README.md"
 workspace = true
 
 [dependencies]
-bdk_core = { path = "../core", version = "0.6.1", default-features = false }
+bdk_core = { path = "../core", version = "0.6.3", default-features = false }
 esplora-client = { version = "0.12.3", default-features = false }
 async-trait = { version = "0.1.66", optional = true }
 futures = { version = "0.3.26", optional = true }


### PR DESCRIPTION
fixes #2070
addresses #2154

### Description

The PR bump the version for required packages for upcoming release, and update it's `CHANGELOG.md` files:

- bump `bdk_chain` to `0.23.3` and update it's `CHANGELOG`.
- bump `bdk_esplora` to `0.22.2` and update it's `CHANGELOG`.
- bump `bdk_core` to `0.6.3` and update it's `CHANGELOG`.

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
