### PR TITLE
Upgrade rusqlite from 0.31 to 0.32

### DIFF
--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1", optional = true, features = ["derive", "rc"] }
 miniscript = { version = "13.0.0", optional = true, default-features = false }
 
 # Feature dependencies
-rusqlite = { version = "0.31.0", features = ["bundled"], optional = true }
+rusqlite = { version = "0.32.0", features = ["bundled"], optional = true }
 
 [dev-dependencies]
 rand = "0.8"


### PR DESCRIPTION
## Summary

- Bump `rusqlite` dependency in `bdk_chain` from `0.31.0` to `0.32.0`
- No code changes required — the upgrade is fully API-compatible

## Motivation

Downstream projects that depend on both `bdk_chain` (via `bdk_wallet`) and crates requiring `rusqlite 0.32` (e.g. `breez-sdk-spark`) currently fail to compile due to a `libsqlite3-sys` `links` conflict:

- `rusqlite 0.31` → `libsqlite3-sys 0.28`
- `rusqlite 0.32` → `libsqlite3-sys 0.30`

Cargo's `links` mechanism prevents both versions from coexisting in the same dependency graph.

## Test plan

- [x] `cargo check -p bdk_chain --features rusqlite` — compiles clean
- [x] `cargo test -p bdk_chain --features rusqlite` — all rusqlite-specific tests pass (including `can_persist_anchors_and_txs_independently`, `v0_to_v3_schema_migration_is_backward_compatible`, `can_persist_first_seen`, `can_persist_last_evicted`)
- [x] No code changes needed in `rusqlite_impl.rs`