### PR TITLE
ci: check-docs for all workspace packages

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -166,3 +166,21 @@ jobs:
       - name: Build
         working-directory: examples/${{ matrix.example-dir }}
         run: cargo build
+
+  check-docs:
+    needs: prepare
+    name: Check documentation errors
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: ${{ needs.prepare.outputs.rust_version }}
+          override: true
+          cache: true
+      - name: Check docs
+        run: RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ Coding Conventions
 ------------------
 
 This codebase uses spaces, not tabs.
-Run `just check` to check formatting, linting, compilation and commit signing, `just fmt` to format code before commiting, and `just test` to run tests for all crates.
+Run `just check` to check formatting, linting, compilation and commit signing, `just fmt` to format code before commiting, `just test` to run tests for all crates, `just pre-push` to run the full pre-push suite before pushing changes and `just doc` to check documentation build warnings and errors for all packages.
 This is also enforced by the CI.
 All public items must be documented. We adhere to the [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/about.html) with respect to documentation.
 

--- a/crates/chain/src/indexer/keychain_txout.rs
+++ b/crates/chain/src/indexer/keychain_txout.rs
@@ -1096,13 +1096,13 @@ impl Merge for ChangeSet {
 
 /// Trait to extend [`SyncRequestBuilder`].
 pub trait SyncRequestBuilderExt<K> {
-    /// Add [`Script`](bitcoin::Script)s that are revealed by the `indexer` of the given `spk_range`
+    /// Add [`Script`]s that are revealed by the `indexer` of the given `spk_range`
     /// that will be synced against.
     fn revealed_spks_from_indexer<R>(self, indexer: &KeychainTxOutIndex<K>, spk_range: R) -> Self
     where
         R: core::ops::RangeBounds<K>;
 
-    /// Add [`Script`](bitcoin::Script)s that are revealed by the `indexer` but currently unused.
+    /// Add [`Script`]s that are revealed by the `indexer` but currently unused.
     fn unused_spks_from_indexer(self, indexer: &KeychainTxOutIndex<K>) -> Self;
 }
 

--- a/crates/core/src/spk_client.rs
+++ b/crates/core/src/spk_client.rs
@@ -137,8 +137,7 @@ impl<I, D> SyncRequestBuilder<I, D> {
     /// # Example
     ///
     /// Sync revealed script pubkeys obtained from a
-    /// [`KeychainTxOutIndex`](../../bdk_chain/indexer/keychain_txout/struct.KeychainTxOutIndex.
-    /// html).
+    /// [`KeychainTxOutIndex`](https://docs.rs/bdk_chain/latest/bdk_chain/indexer/keychain_txout/struct.KeychainTxOutIndex.html).
     ///
     /// ```rust
     /// # use bdk_chain::bitcoin::BlockHash;

--- a/justfile
+++ b/justfile
@@ -3,6 +3,7 @@ alias c := check
 alias f := fmt
 alias t := test
 alias p := pre-push
+alias d := doc
 
 _default:
   @just --list
@@ -57,3 +58,7 @@ _test-testenv:
 
 # Run pre-push suite: format, check, and test
 pre-push: fmt check test
+
+# Check documentation for all workspace packages
+doc:
+   RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps


### PR DESCRIPTION
fixes #2152 

### Description

This PR adds new CI job `check-docs` to validate that documentation builds for all workspace packages, also adds a new justfile recipe `just doc`.

It also fixes the existing errors in `bdk_chain` and `bdk_core`.

### Changelog notice

```
### Added

- ci: add new `check-docs` job.

### Changed

- fix(docs): in `keychain_txout.rs` and `spk_client.rs`
```

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### New Features:

* [ ] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
