### PR TITLE
fix(ci): pin required `icu_*` deps for 1.85.0

### DIFF
--- a/ci/pin-msrv.sh
+++ b/ci/pin-msrv.sh
@@ -10,4 +10,6 @@ set -euo pipefail
 # cargo clean
 # rustup override set 1.85.0
 
-# e.g cargo update -p home --precise "0.5.11"
+cargo update -p icu_normalizer --precise "2.1.1"
+cargo update -p icu_provider --precise "2.1.1"
+cargo update -p icu_locale_core --precise "2.1.1"


### PR DESCRIPTION
### Description

It fixes the 1.85.0 MSRV CI step, by pinning the following:

- icu_normalizer to "2.1.1"
- icu_provider to "2.1.1"
- icu_locale_core to "2.1.1"

### Changelog notice

```
### Changed

- fix(ci): pin required `icu_*` dependencies for 1.85.0 supported MSRV.

```

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
