### PR TITLE
refactor(tests): move TxTemplate from `chain` to `testenv`

### DIFF
--- a/crates/chain/benches/canonicalization.rs
+++ b/crates/chain/benches/canonicalization.rs
@@ -3,10 +3,8 @@ use bdk_chain::{keychain_txout::KeychainTxOutIndex, local_chain::LocalChain, Ind
 use bdk_core::{BlockId, CheckPoint};
 use bdk_core::{ConfirmationBlockTime, TxUpdate};
 use bdk_testenv::hash;
-use bitcoin::{
-    absolute, constants, hashes::Hash, key::Secp256k1, transaction, Amount, BlockHash, Network,
-    OutPoint, ScriptBuf, Transaction, TxIn, TxOut,
-};
+use bdk_testenv::utils::{genesis_block_id, new_standard_tx, spk_at_index, tip_block_id};
+use bitcoin::{key::Secp256k1, Amount, OutPoint, Transaction, TxIn, TxOut};
 use criterion::{criterion_group, criterion_main, Criterion};
 use miniscript::{Descriptor, DescriptorPublicKey};
 use std::sync::Arc;
@@ -14,43 +12,11 @@ use std::sync::Arc;
 type Keychain = ();
 type KeychainTxGraph = IndexedTxGraph<ConfirmationBlockTime, KeychainTxOutIndex<Keychain>>;
 
-/// New tx guaranteed to have at least one output
-fn new_tx(lt: u32) -> Transaction {
-    Transaction {
-        version: transaction::Version::TWO,
-        lock_time: absolute::LockTime::from_consensus(lt),
-        input: vec![],
-        output: vec![TxOut::NULL],
-    }
-}
-
-fn spk_at_index(txout_index: &KeychainTxOutIndex<Keychain>, index: u32) -> ScriptBuf {
-    txout_index
-        .get_descriptor(())
-        .unwrap()
-        .at_derivation_index(index)
-        .unwrap()
-        .script_pubkey()
-}
-
-fn genesis_block_id() -> BlockId {
-    BlockId {
-        height: 0,
-        hash: constants::genesis_block(Network::Regtest).block_hash(),
-    }
-}
-
-fn tip_block_id() -> BlockId {
-    BlockId {
-        height: 100,
-        hash: BlockHash::all_zeros(),
-    }
-}
-
 /// Add ancestor tx confirmed at `block_id` with `locktime` (used for uniqueness).
 /// The transaction always pays 1 BTC to SPK 0.
 fn add_ancestor_tx(graph: &mut KeychainTxGraph, block_id: BlockId, locktime: u32) -> OutPoint {
-    let spk_0 = spk_at_index(&graph.index, 0);
+    let descriptor = graph.index.get_descriptor(()).unwrap();
+    let spk_0 = spk_at_index(descriptor, 0);
     let tx = Transaction {
         input: vec![TxIn {
             previous_output: OutPoint::new(hash!("bogus"), locktime),
@@ -60,7 +26,7 @@ fn add_ancestor_tx(graph: &mut KeychainTxGraph, block_id: BlockId, locktime: u32
             value: Amount::ONE_BTC,
             script_pubkey: spk_0,
         }],
-        ..new_tx(locktime)
+        ..new_standard_tx(locktime)
     };
     let txid = tx.compute_txid();
     let _ = graph.insert_tx(tx);
@@ -77,7 +43,7 @@ fn add_ancestor_tx(graph: &mut KeychainTxGraph, block_id: BlockId, locktime: u32
 fn setup<F: Fn(&mut KeychainTxGraph, &LocalChain)>(f: F) -> (KeychainTxGraph, LocalChain) {
     const DESC: &str = "tr([ab28dc00/86h/1h/0h]tpubDCdDtzAMZZrkwKBxwNcGCqe4FRydeD9rfMisoi7qLdraG79YohRfPW4YgdKQhpgASdvh612xXNY5xYzoqnyCgPbkpK4LSVcH5Xv4cK7johH/0/*)";
     let cp = CheckPoint::from_blocks(
-        [genesis_block_id(), tip_block_id()]
+        [genesis_block_id(), tip_block_id(100)]
             .into_iter()
             .map(|block_id| (block_id.height, block_id.hash)),
     )
@@ -127,9 +93,10 @@ fn run_filter_chain_unspents(tx_graph: &KeychainTxGraph, chain: &LocalChain, exp
 pub fn many_conflicting_unconfirmed(c: &mut Criterion) {
     const CONFLICTING_TX_COUNT: u32 = 2100;
     let (tx_graph, chain) = std::hint::black_box(setup(|tx_graph, _chain| {
-        let previous_output = add_ancestor_tx(tx_graph, tip_block_id(), 0);
+        let previous_output = add_ancestor_tx(tx_graph, tip_block_id(100), 0);
+        let descriptor = tx_graph.index.get_descriptor(()).unwrap();
         // Create conflicting txs that spend from `previous_output`.
-        let spk_1 = spk_at_index(&tx_graph.index, 1);
+        let spk_1 = spk_at_index(descriptor, 1);
         for i in 1..=CONFLICTING_TX_COUNT {
             let tx = Transaction {
                 input: vec![TxIn {
@@ -140,7 +107,7 @@ pub fn many_conflicting_unconfirmed(c: &mut Criterion) {
                     value: Amount::ONE_BTC - Amount::from_sat(i as u64 * 10),
                     script_pubkey: spk_1.clone(),
                 }],
-                ..new_tx(i)
+                ..new_standard_tx(i)
             };
             let mut update = TxUpdate::default();
             update.seen_ats = [(tx.compute_txid(), i as u64)].into();
@@ -165,7 +132,7 @@ pub fn many_conflicting_unconfirmed(c: &mut Criterion) {
 pub fn many_chained_unconfirmed(c: &mut Criterion) {
     const TX_CHAIN_COUNT: u32 = 2100;
     let (tx_graph, chain) = std::hint::black_box(setup(|tx_graph, _chain| {
-        let mut previous_output = add_ancestor_tx(tx_graph, tip_block_id(), 0);
+        let mut previous_output = add_ancestor_tx(tx_graph, tip_block_id(100), 0);
         // Create a chain of unconfirmed txs where each subsequent tx spends the output of the
         // previous one.
         for i in 0..TX_CHAIN_COUNT {
@@ -175,7 +142,7 @@ pub fn many_chained_unconfirmed(c: &mut Criterion) {
                     previous_output,
                     ..Default::default()
                 }],
-                ..new_tx(i)
+                ..new_standard_tx(i)
             };
             let txid = tx.compute_txid();
             let mut update = TxUpdate::default();
@@ -204,7 +171,7 @@ pub fn nested_conflicts(c: &mut Criterion) {
     const CONFLICTS_PER_OUTPUT: usize = 3;
     const GRAPH_DEPTH: usize = 7;
     let (tx_graph, chain) = std::hint::black_box(setup(|tx_graph, _chain| {
-        let mut prev_ops = core::iter::once(add_ancestor_tx(tx_graph, tip_block_id(), 0))
+        let mut prev_ops = core::iter::once(add_ancestor_tx(tx_graph, tip_block_id(100), 0))
             .collect::<Vec<OutPoint>>();
         for depth in 1..GRAPH_DEPTH {
             for previous_output in core::mem::take(&mut prev_ops) {
@@ -225,7 +192,7 @@ pub fn nested_conflicts(c: &mut Criterion) {
                             value,
                             script_pubkey,
                         }],
-                        ..new_tx(conflict_i as _)
+                        ..new_standard_tx(conflict_i as _)
                     };
                     let txid = tx.compute_txid();
                     prev_ops.push(OutPoint::new(txid, 0));

--- a/crates/chain/benches/canonicalization.rs
+++ b/crates/chain/benches/canonicalization.rs
@@ -2,10 +2,8 @@ use bdk_chain::{keychain_txout::KeychainTxOutIndex, local_chain::LocalChain, Ind
 use bdk_core::{BlockId, CheckPoint};
 use bdk_core::{ConfirmationBlockTime, TxUpdate};
 use bdk_testenv::hash;
-use bitcoin::{
-    absolute, constants, hashes::Hash, key::Secp256k1, transaction, Amount, BlockHash, Network,
-    OutPoint, ScriptBuf, Transaction, TxIn, TxOut,
-};
+use bdk_testenv::utils::{genesis_block_id, new_standard_tx, spk_at_index, tip_block_id};
+use bitcoin::{key::Secp256k1, Amount, OutPoint, Transaction, TxIn, TxOut};
 use criterion::{criterion_group, criterion_main, Criterion};
 use miniscript::{Descriptor, DescriptorPublicKey};
 use std::sync::Arc;
@@ -13,43 +11,11 @@ use std::sync::Arc;
 type Keychain = ();
 type KeychainTxGraph = IndexedTxGraph<ConfirmationBlockTime, KeychainTxOutIndex<Keychain>>;
 
-/// New tx guaranteed to have at least one output
-fn new_tx(lt: u32) -> Transaction {
-    Transaction {
-        version: transaction::Version::TWO,
-        lock_time: absolute::LockTime::from_consensus(lt),
-        input: vec![],
-        output: vec![TxOut::NULL],
-    }
-}
-
-fn spk_at_index(txout_index: &KeychainTxOutIndex<Keychain>, index: u32) -> ScriptBuf {
-    txout_index
-        .get_descriptor(())
-        .unwrap()
-        .at_derivation_index(index)
-        .unwrap()
-        .script_pubkey()
-}
-
-fn genesis_block_id() -> BlockId {
-    BlockId {
-        height: 0,
-        hash: constants::genesis_block(Network::Regtest).block_hash(),
-    }
-}
-
-fn tip_block_id() -> BlockId {
-    BlockId {
-        height: 100,
-        hash: BlockHash::all_zeros(),
-    }
-}
-
 /// Add ancestor tx confirmed at `block_id` with `locktime` (used for uniqueness).
 /// The transaction always pays 1 BTC to SPK 0.
 fn add_ancestor_tx(graph: &mut KeychainTxGraph, block_id: BlockId, locktime: u32) -> OutPoint {
-    let spk_0 = spk_at_index(&graph.index, 0);
+    let descriptor = graph.index.get_descriptor(()).unwrap();
+    let spk_0 = spk_at_index(descriptor, 0);
     let tx = Transaction {
         input: vec![TxIn {
             previous_output: OutPoint::new(hash!("bogus"), locktime),
@@ -59,7 +25,7 @@ fn add_ancestor_tx(graph: &mut KeychainTxGraph, block_id: BlockId, locktime: u32
             value: Amount::ONE_BTC,
             script_pubkey: spk_0,
         }],
-        ..new_tx(locktime)
+        ..new_standard_tx(locktime)
     };
     let txid = tx.compute_txid();
     let _ = graph.insert_tx(tx);
@@ -76,7 +42,7 @@ fn add_ancestor_tx(graph: &mut KeychainTxGraph, block_id: BlockId, locktime: u32
 fn setup<F: Fn(&mut KeychainTxGraph, &LocalChain)>(f: F) -> (KeychainTxGraph, LocalChain) {
     const DESC: &str = "tr([ab28dc00/86h/1h/0h]tpubDCdDtzAMZZrkwKBxwNcGCqe4FRydeD9rfMisoi7qLdraG79YohRfPW4YgdKQhpgASdvh612xXNY5xYzoqnyCgPbkpK4LSVcH5Xv4cK7johH/0/*)";
     let cp = CheckPoint::from_blocks(
-        [genesis_block_id(), tip_block_id()]
+        [genesis_block_id(), tip_block_id(100)]
             .into_iter()
             .map(|block_id| (block_id.height, block_id.hash)),
     )
@@ -114,9 +80,10 @@ fn run_filter_chain_unspents(tx_graph: &KeychainTxGraph, chain: &LocalChain, exp
 pub fn many_conflicting_unconfirmed(c: &mut Criterion) {
     const CONFLICTING_TX_COUNT: u32 = 2100;
     let (tx_graph, chain) = std::hint::black_box(setup(|tx_graph, _chain| {
-        let previous_output = add_ancestor_tx(tx_graph, tip_block_id(), 0);
+        let previous_output = add_ancestor_tx(tx_graph, tip_block_id(100), 0);
+        let descriptor = tx_graph.index.get_descriptor(()).unwrap();
         // Create conflicting txs that spend from `previous_output`.
-        let spk_1 = spk_at_index(&tx_graph.index, 1);
+        let spk_1 = spk_at_index(descriptor, 1);
         for i in 1..=CONFLICTING_TX_COUNT {
             let tx = Transaction {
                 input: vec![TxIn {
@@ -127,7 +94,7 @@ pub fn many_conflicting_unconfirmed(c: &mut Criterion) {
                     value: Amount::ONE_BTC - Amount::from_sat(i as u64 * 10),
                     script_pubkey: spk_1.clone(),
                 }],
-                ..new_tx(i)
+                ..new_standard_tx(i)
             };
             let mut update = TxUpdate::default();
             update.seen_ats = [(tx.compute_txid(), i as u64)].into();
@@ -152,7 +119,7 @@ pub fn many_conflicting_unconfirmed(c: &mut Criterion) {
 pub fn many_chained_unconfirmed(c: &mut Criterion) {
     const TX_CHAIN_COUNT: u32 = 2100;
     let (tx_graph, chain) = std::hint::black_box(setup(|tx_graph, _chain| {
-        let mut previous_output = add_ancestor_tx(tx_graph, tip_block_id(), 0);
+        let mut previous_output = add_ancestor_tx(tx_graph, tip_block_id(100), 0);
         // Create a chain of unconfirmed txs where each subsequent tx spends the output of the
         // previous one.
         for i in 0..TX_CHAIN_COUNT {
@@ -162,7 +129,7 @@ pub fn many_chained_unconfirmed(c: &mut Criterion) {
                     previous_output,
                     ..Default::default()
                 }],
-                ..new_tx(i)
+                ..new_standard_tx(i)
             };
             let txid = tx.compute_txid();
             let mut update = TxUpdate::default();
@@ -191,7 +158,7 @@ pub fn nested_conflicts(c: &mut Criterion) {
     const CONFLICTS_PER_OUTPUT: usize = 3;
     const GRAPH_DEPTH: usize = 7;
     let (tx_graph, chain) = std::hint::black_box(setup(|tx_graph, _chain| {
-        let mut prev_ops = core::iter::once(add_ancestor_tx(tx_graph, tip_block_id(), 0))
+        let mut prev_ops = core::iter::once(add_ancestor_tx(tx_graph, tip_block_id(100), 0))
             .collect::<Vec<OutPoint>>();
         for depth in 1..GRAPH_DEPTH {
             for previous_output in core::mem::take(&mut prev_ops) {
@@ -212,7 +179,7 @@ pub fn nested_conflicts(c: &mut Criterion) {
                             value,
                             script_pubkey,
                         }],
-                        ..new_tx(conflict_i as _)
+                        ..new_standard_tx(conflict_i as _)
                     };
                     let txid = tx.compute_txid();
                     prev_ops.push(OutPoint::new(txid, 0));

--- a/crates/chain/benches/canonicalization.rs
+++ b/crates/chain/benches/canonicalization.rs
@@ -2,7 +2,7 @@ use bdk_chain::{keychain_txout::KeychainTxOutIndex, local_chain::LocalChain, Ind
 use bdk_core::{BlockId, CheckPoint};
 use bdk_core::{ConfirmationBlockTime, TxUpdate};
 use bdk_testenv::hash;
-use bdk_testenv::utils::{genesis_block_id, new_standard_tx, spk_at_index, tip_block_id};
+use bdk_testenv::utils::{genesis_block_id, new_tx, spk_at_index, tip_block_id};
 use bitcoin::{key::Secp256k1, Amount, OutPoint, Transaction, TxIn, TxOut};
 use criterion::{criterion_group, criterion_main, Criterion};
 use miniscript::{Descriptor, DescriptorPublicKey};
@@ -25,7 +25,7 @@ fn add_ancestor_tx(graph: &mut KeychainTxGraph, block_id: BlockId, locktime: u32
             value: Amount::ONE_BTC,
             script_pubkey: spk_0,
         }],
-        ..new_standard_tx(locktime)
+        ..new_tx(locktime)
     };
     let txid = tx.compute_txid();
     let _ = graph.insert_tx(tx);
@@ -94,7 +94,7 @@ pub fn many_conflicting_unconfirmed(c: &mut Criterion) {
                     value: Amount::ONE_BTC - Amount::from_sat(i as u64 * 10),
                     script_pubkey: spk_1.clone(),
                 }],
-                ..new_standard_tx(i)
+                ..new_tx(i)
             };
             let mut update = TxUpdate::default();
             update.seen_ats = [(tx.compute_txid(), i as u64)].into();
@@ -129,7 +129,7 @@ pub fn many_chained_unconfirmed(c: &mut Criterion) {
                     previous_output,
                     ..Default::default()
                 }],
-                ..new_standard_tx(i)
+                ..new_tx(i)
             };
             let txid = tx.compute_txid();
             let mut update = TxUpdate::default();
@@ -179,7 +179,7 @@ pub fn nested_conflicts(c: &mut Criterion) {
                             value,
                             script_pubkey,
                         }],
-                        ..new_standard_tx(conflict_i as _)
+                        ..new_tx(conflict_i as _)
                     };
                     let txid = tx.compute_txid();
                     prev_ops.push(OutPoint::new(txid, 0));

--- a/crates/chain/benches/indexer.rs
+++ b/crates/chain/benches/indexer.rs
@@ -3,11 +3,9 @@ use bdk_chain::{
     local_chain::LocalChain,
     CanonicalizationParams, IndexedTxGraph,
 };
-use bdk_core::{BlockId, CheckPoint, ConfirmationBlockTime, TxUpdate};
-use bitcoin::{
-    absolute, constants, hashes::Hash, key::Secp256k1, transaction, Amount, BlockHash, Network,
-    Transaction, TxIn, TxOut,
-};
+use bdk_core::{CheckPoint, ConfirmationBlockTime, TxUpdate};
+use bdk_testenv::utils::{genesis_block_id, new_standard_tx, tip_block_id};
+use bitcoin::{key::Secp256k1, Amount, Transaction, TxIn, TxOut};
 use criterion::{criterion_group, criterion_main, Criterion};
 use miniscript::Descriptor;
 use std::sync::Arc;
@@ -22,36 +20,13 @@ const TX_CT: u32 = 21;
 const USE_SPK_CACHE: bool = true;
 const AMOUNT: Amount = Amount::from_sat(1_000);
 
-fn new_tx(lt: u32) -> Transaction {
-    Transaction {
-        version: transaction::Version::TWO,
-        lock_time: absolute::LockTime::from_consensus(lt),
-        input: vec![],
-        output: vec![TxOut::NULL],
-    }
-}
-
-fn genesis_block_id() -> BlockId {
-    BlockId {
-        height: 0,
-        hash: constants::genesis_block(Network::Regtest).block_hash(),
-    }
-}
-
-fn tip_block_id() -> BlockId {
-    BlockId {
-        height: 100,
-        hash: BlockHash::all_zeros(),
-    }
-}
-
 fn setup<F: Fn(&mut KeychainTxGraph, &LocalChain)>(f: F) -> (KeychainTxGraph, LocalChain) {
     let desc = Descriptor::parse_descriptor(&Secp256k1::new(), DESC)
         .unwrap()
         .0;
 
     let cp = CheckPoint::from_blocks(
-        [genesis_block_id(), tip_block_id()]
+        [genesis_block_id(), tip_block_id(100)]
             .into_iter()
             .map(|block_id| (block_id.height, block_id.hash)),
     )
@@ -101,7 +76,7 @@ pub fn reindex_tx_graph(c: &mut Criterion) {
                     script_pubkey,
                     value: AMOUNT,
                 }],
-                ..new_tx(i)
+                ..new_standard_tx(i)
             };
             let txid = tx.compute_txid();
             let mut update = TxUpdate::default();

--- a/crates/chain/benches/indexer.rs
+++ b/crates/chain/benches/indexer.rs
@@ -3,11 +3,9 @@ use bdk_chain::{
     local_chain::LocalChain,
     IndexedTxGraph,
 };
-use bdk_core::{BlockId, CheckPoint, ConfirmationBlockTime, TxUpdate};
-use bitcoin::{
-    absolute, constants, hashes::Hash, key::Secp256k1, transaction, Amount, BlockHash, Network,
-    Transaction, TxIn, TxOut,
-};
+use bdk_core::{CheckPoint, ConfirmationBlockTime, TxUpdate};
+use bdk_testenv::utils::{genesis_block_id, new_standard_tx, tip_block_id};
+use bitcoin::{key::Secp256k1, Amount, Transaction, TxIn, TxOut};
 use criterion::{criterion_group, criterion_main, Criterion};
 use miniscript::Descriptor;
 use std::sync::Arc;
@@ -22,36 +20,13 @@ const TX_CT: u32 = 21;
 const USE_SPK_CACHE: bool = true;
 const AMOUNT: Amount = Amount::from_sat(1_000);
 
-fn new_tx(lt: u32) -> Transaction {
-    Transaction {
-        version: transaction::Version::TWO,
-        lock_time: absolute::LockTime::from_consensus(lt),
-        input: vec![],
-        output: vec![TxOut::NULL],
-    }
-}
-
-fn genesis_block_id() -> BlockId {
-    BlockId {
-        height: 0,
-        hash: constants::genesis_block(Network::Regtest).block_hash(),
-    }
-}
-
-fn tip_block_id() -> BlockId {
-    BlockId {
-        height: 100,
-        hash: BlockHash::all_zeros(),
-    }
-}
-
 fn setup<F: Fn(&mut KeychainTxGraph, &LocalChain)>(f: F) -> (KeychainTxGraph, LocalChain) {
     let desc = Descriptor::parse_descriptor(&Secp256k1::new(), DESC)
         .unwrap()
         .0;
 
     let cp = CheckPoint::from_blocks(
-        [genesis_block_id(), tip_block_id()]
+        [genesis_block_id(), tip_block_id(100)]
             .into_iter()
             .map(|block_id| (block_id.height, block_id.hash)),
     )
@@ -100,7 +75,7 @@ pub fn reindex_tx_graph(c: &mut Criterion) {
                     script_pubkey,
                     value: AMOUNT,
                 }],
-                ..new_tx(i)
+                ..new_standard_tx(i)
             };
             let txid = tx.compute_txid();
             let mut update = TxUpdate::default();

--- a/crates/chain/benches/indexer.rs
+++ b/crates/chain/benches/indexer.rs
@@ -4,8 +4,11 @@ use bdk_chain::{
     IndexedTxGraph,
 };
 use bdk_core::{CheckPoint, ConfirmationBlockTime, TxUpdate};
-use bdk_testenv::utils::{genesis_block_id, new_standard_tx, tip_block_id};
-use bitcoin::{key::Secp256k1, Amount, Transaction, TxIn, TxOut};
+use bdk_testenv::{
+    hash,
+    utils::{genesis_block_id, new_tx, tip_block_id},
+};
+use bitcoin::{key::Secp256k1, Amount, OutPoint, Transaction, TxIn, TxOut};
 use criterion::{criterion_group, criterion_main, Criterion};
 use miniscript::Descriptor;
 use std::sync::Arc;
@@ -70,12 +73,15 @@ pub fn reindex_tx_graph(c: &mut Criterion) {
         for i in 0..TX_CT {
             let script_pubkey = graph.index.reveal_next_spk(()).unwrap().0 .1;
             let tx = Transaction {
-                input: vec![TxIn::default()],
+                input: vec![TxIn {
+                    previous_output: OutPoint::new(hash!("prev"), i),
+                    ..Default::default()
+                }],
                 output: vec![TxOut {
                     script_pubkey,
                     value: AMOUNT,
                 }],
-                ..new_standard_tx(i)
+                ..new_tx(i)
             };
             let txid = tx.compute_txid();
             let mut update = TxUpdate::default();

--- a/crates/chain/tests/common/mod.rs
+++ b/crates/chain/tests/common/mod.rs
@@ -1,5 +1,0 @@
-#![cfg(feature = "miniscript")]
-
-mod tx_template;
-#[allow(unused_imports)]
-pub use tx_template::*;

--- a/crates/chain/tests/test_canonical_view_task.rs
+++ b/crates/chain/tests/test_canonical_view_task.rs
@@ -1,7 +1,9 @@
 #![cfg(feature = "miniscript")]
 
 use bdk_chain::{CanonicalReason, ChainPosition};
-use bdk_testenv::{block_id, hash, init_graph, local_chain, TxInTemplate, TxOutTemplate, TxTemplate};
+use bdk_testenv::{
+    block_id, hash, init_graph, local_chain, TxInTemplate, TxOutTemplate, TxTemplate,
+};
 use bitcoin::Txid;
 use std::collections::HashSet;
 

--- a/crates/chain/tests/test_canonical_view_task.rs
+++ b/crates/chain/tests/test_canonical_view_task.rs
@@ -1,11 +1,8 @@
 #![cfg(feature = "miniscript")]
 
-mod common;
-
 use bdk_chain::{CanonicalReason, ChainPosition};
-use bdk_testenv::{block_id, hash, local_chain};
+use bdk_testenv::{block_id, hash, init_graph, local_chain, TxInTemplate, TxOutTemplate, TxTemplate};
 use bitcoin::Txid;
-use common::*;
 use std::collections::HashSet;
 
 #[test]
@@ -28,37 +25,23 @@ fn test_assumed_canonical_scenarios() {
     ];
     let chain_tip = local_chain.tip().block_id();
 
-    // create arrays before scenario to avoid lifetime issues
     let tx_templates = [
-        TxTemplate {
-            tx_name: "txA",
-            inputs: &[TxInTemplate::Bogus],
-            outputs: &[TxOutTemplate::new(100000, Some(0))],
-            anchors: &[],
-            last_seen: None,
-            assume_canonical: false,
-        },
-        TxTemplate {
-            tx_name: "txB",
-            inputs: &[TxInTemplate::PrevTx("txA", 0)],
-            outputs: &[TxOutTemplate::new(50000, Some(0))],
-            anchors: &[block_id!(5, "block5")],
-            last_seen: None,
-            assume_canonical: false,
-        },
-        TxTemplate {
-            tx_name: "txC",
-            inputs: &[TxInTemplate::PrevTx("txB", 0)],
-            outputs: &[TxOutTemplate::new(25000, Some(0))],
-            anchors: &[],
-            last_seen: None,
-            assume_canonical: true,
-        },
+        TxTemplate::new("txA")
+            .with_inputs(vec![TxInTemplate::Bogus])
+            .with_outputs(vec![TxOutTemplate::new(100000, Some(0))]),
+        TxTemplate::new("txB")
+            .with_inputs(vec![TxInTemplate::PrevTx("txA", 0)])
+            .with_outputs(vec![TxOutTemplate::new(50000, Some(0))])
+            .with_anchors(vec![block_id!(5, "block5")]),
+        TxTemplate::new("txC")
+            .with_inputs(vec![TxInTemplate::PrevTx("txB", 0)])
+            .with_outputs(vec![TxOutTemplate::new(25000, Some(0))])
+            .with_assume_canonical(true),
     ];
 
     let exp_canonical_txs = HashSet::from(["txA", "txB", "txC"]);
 
-    let env = init_graph(&tx_templates);
+    let env = init_graph(tx_templates);
 
     // get the actual txid from given tx_name.
     let txid_c = *env.txid_to_name.get("txC").unwrap();

--- a/crates/chain/tests/test_canonical_view_task.rs
+++ b/crates/chain/tests/test_canonical_view_task.rs
@@ -46,7 +46,7 @@ fn test_assumed_canonical_scenarios() {
     let env = init_graph(tx_templates);
 
     // get the actual txid from given tx_name.
-    let txid_c = *env.txid_to_name.get("txC").unwrap();
+    let txid_c = *env.txids.get("txC").unwrap();
 
     // build the expected `CanonicalReason` with specific descendant txid's
     //
@@ -79,7 +79,7 @@ fn test_assumed_canonical_scenarios() {
     let exp_canonical_txids: HashSet<Txid> = exp_canonical_txs
         .iter()
         .map(|tx_name| {
-            *env.txid_to_name
+            *env.txids
                 .get(tx_name)
                 .expect("txid should exist for tx_name")
         })
@@ -99,7 +99,7 @@ fn test_assumed_canonical_scenarios() {
     // assert canonical reasons
     for (tx_name, exp_reason) in exp_reasons {
         let txid = env
-            .txid_to_name
+            .txids
             .get(tx_name)
             .expect("txid should exist for tx_name");
 
@@ -116,7 +116,7 @@ fn test_assumed_canonical_scenarios() {
         )
     }
 
-    let txid_b = *env.txid_to_name.get("txB").unwrap();
+    let txid_b = *env.txids.get("txB").unwrap();
 
     // build the expected `ChainPosition` with specific txid's for transitively confirmed txs.
     //
@@ -156,7 +156,7 @@ fn test_assumed_canonical_scenarios() {
     // assert final positions
     for (tx_name, exp_position) in exp_positions {
         let txid = *env
-            .txid_to_name
+            .txids
             .get(tx_name)
             .expect("txid should exist for tx_name");
 

--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -14,7 +14,7 @@ use bdk_testenv::{
     anyhow::{self},
     block_id,
     corepc_node::{Input, Output},
-    hash,
+    hash, spk,
     utils::{new_tx, DESCRIPTORS},
     TestEnv,
 };
@@ -23,16 +23,6 @@ use bitcoin::{
     TxIn, TxOut, Txid,
 };
 use miniscript::Descriptor;
-
-fn gen_spk() -> ScriptBuf {
-    use bitcoin::secp256k1::{Secp256k1, SecretKey};
-
-    let secp = Secp256k1::new();
-    let (x_only_pk, _) = SecretKey::new(&mut rand::thread_rng())
-        .public_key(&secp)
-        .x_only_public_key();
-    ScriptBuf::new_p2tr(&secp, x_only_pk, None)
-}
 
 /// Conflicts of relevant transactions must also be considered relevant.
 ///
@@ -65,7 +55,7 @@ fn relevant_conflicts() -> anyhow::Result<()> {
                 .address()?
                 .require_network(Network::Regtest)?;
 
-            let recv_spk = gen_spk();
+            let recv_spk = spk!();
             let recv_addr = Address::from_script(&recv_spk, &bitcoin::params::REGTEST)?;
 
             let mut graph = SpkTxGraph::default();

--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -1,8 +1,5 @@
 #![cfg(feature = "miniscript")]
 
-#[macro_use]
-mod common;
-
 use std::{collections::BTreeSet, str::FromStr, sync::Arc};
 
 use bdk_chain::{

--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -11,27 +11,13 @@ use bdk_chain::{
     SpkIterator,
 };
 use bdk_testenv::{
-    anyhow::{self},
-    bitcoind::{Input, Output},
-    block_id, hash,
-    utils::{new_tx, DESCRIPTORS},
-    TestEnv,
+    TestEnv, anyhow::{self}, bitcoind::{Input, Output}, block_id, hash, spk, utils::{DESCRIPTORS, new_tx}
 };
 use bitcoin::{
     secp256k1::Secp256k1, Address, Amount, BlockHash, Network, OutPoint, ScriptBuf, Transaction,
     TxIn, TxOut, Txid,
 };
 use miniscript::Descriptor;
-
-fn gen_spk() -> ScriptBuf {
-    use bitcoin::secp256k1::{Secp256k1, SecretKey};
-
-    let secp = Secp256k1::new();
-    let (x_only_pk, _) = SecretKey::new(&mut rand::thread_rng())
-        .public_key(&secp)
-        .x_only_public_key();
-    ScriptBuf::new_p2tr(&secp, x_only_pk, None)
-}
 
 /// Conflicts of relevant transactions must also be considered relevant.
 ///
@@ -64,7 +50,7 @@ fn relevant_conflicts() -> anyhow::Result<()> {
                 .address()?
                 .require_network(Network::Regtest)?;
 
-            let recv_spk = gen_spk();
+            let recv_spk = spk!();
             let recv_addr = Address::from_script(&recv_spk, &bitcoin::params::REGTEST)?;
 
             let mut graph = SpkTxGraph::default();

--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -11,7 +11,11 @@ use bdk_chain::{
     SpkIterator,
 };
 use bdk_testenv::{
-    TestEnv, anyhow::{self}, bitcoind::{Input, Output}, block_id, hash, spk, utils::{DESCRIPTORS, new_tx}
+    anyhow::{self},
+    bitcoind::{Input, Output},
+    block_id, hash, spk,
+    utils::{new_tx, DESCRIPTORS},
+    TestEnv,
 };
 use bitcoin::{
     secp256k1::Secp256k1, Address, Amount, BlockHash, Network, OutPoint, ScriptBuf, Transaction,

--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -12,7 +12,7 @@ use bdk_chain::{
 use bdk_testenv::{
     anyhow::{self},
     bitcoind::{Input, Output},
-    block_id, hash,
+    block_id, hash, spk,
     utils::{new_tx, DESCRIPTORS},
     TestEnv,
 };
@@ -21,16 +21,6 @@ use bitcoin::{
     TxIn, TxOut, Txid,
 };
 use miniscript::Descriptor;
-
-fn gen_spk() -> ScriptBuf {
-    use bitcoin::secp256k1::{Secp256k1, SecretKey};
-
-    let secp = Secp256k1::new();
-    let (x_only_pk, _) = SecretKey::new(&mut rand::thread_rng())
-        .public_key(&secp)
-        .x_only_public_key();
-    ScriptBuf::new_p2tr(&secp, x_only_pk, None)
-}
 
 /// Conflicts of relevant transactions must also be considered relevant.
 ///
@@ -63,7 +53,7 @@ fn relevant_conflicts() -> anyhow::Result<()> {
                 .address()?
                 .require_network(Network::Regtest)?;
 
-            let recv_spk = gen_spk();
+            let recv_spk = spk!();
             let recv_addr = Address::from_script(&recv_spk, &bitcoin::params::REGTEST)?;
 
             let mut graph = SpkTxGraph::default();

--- a/crates/chain/tests/test_keychain_txout_index.rs
+++ b/crates/chain/tests/test_keychain_txout_index.rs
@@ -7,9 +7,9 @@ use bdk_chain::{
 };
 use bdk_testenv::{
     hash,
-    utils::{new_tx, DESCRIPTORS},
+    utils::{new_tx, spk_at_index, DESCRIPTORS},
 };
-use bitcoin::{secp256k1::Secp256k1, Amount, OutPoint, ScriptBuf, Transaction, TxOut};
+use bitcoin::{Amount, OutPoint, ScriptBuf, Transaction, TxOut};
 use miniscript::{Descriptor, DescriptorPublicKey};
 
 #[derive(Clone, Debug, PartialEq, Eq, Ord, PartialOrd)]
@@ -50,13 +50,6 @@ fn init_txout_index(
         .unwrap();
 
     txout_index
-}
-
-fn spk_at_index(descriptor: &Descriptor<DescriptorPublicKey>, index: u32) -> ScriptBuf {
-    descriptor
-        .derived_descriptor(&Secp256k1::verification_only(), index)
-        .expect("must derive")
-        .script_pubkey()
 }
 
 // We create two empty changesets lhs and rhs, we then insert various descriptors with various

--- a/crates/chain/tests/test_keychain_txout_index.rs
+++ b/crates/chain/tests/test_keychain_txout_index.rs
@@ -1,5 +1,7 @@
 #![cfg(feature = "miniscript")]
 
+use std::vec;
+
 use bdk_chain::{
     collections::BTreeMap,
     indexer::keychain_txout::{ChangeSet, KeychainTxOutIndex},
@@ -708,7 +710,10 @@ fn reassigning_keychain_to_a_new_descriptor_should_error() {
 #[test]
 fn when_querying_over_a_range_of_keychains_the_utxos_should_show_up() {
     let mut indexer = KeychainTxOutIndex::<usize>::new(0, true);
-    let mut tx = new_tx(0);
+    let mut tx = Transaction {
+        output: vec![],
+        ..new_tx(0)
+    };
 
     for (i, descriptor) in DESCRIPTORS.iter().enumerate() {
         let descriptor = parse_descriptor(descriptor);

--- a/crates/chain/tests/test_tx_graph.rs
+++ b/crates/chain/tests/test_tx_graph.rs
@@ -1139,7 +1139,7 @@ fn test_chain_spends() {
         );
 
         // Chain position of the `tx_2` is now none, as it is older than `tx_2_conflict`
-        assert!(canonical_positions.get(&tx_2.compute_txid()).is_none());
+        assert!(!canonical_positions.contains_key(&tx_2.compute_txid()));
     }
 }
 
@@ -1278,30 +1278,20 @@ fn call_map_anchors_with_non_deterministic_anchor() {
     }
 
     let template = [
-        TxTemplate {
-            tx_name: "tx1",
-            inputs: &[TxInTemplate::Bogus],
-            outputs: &[TxOutTemplate::new(10000, Some(1))],
-            anchors: &[block_id!(1, "A")],
-            last_seen: None,
-            ..Default::default()
-        },
-        TxTemplate {
-            tx_name: "tx2",
-            inputs: &[TxInTemplate::PrevTx("tx1", 0)],
-            outputs: &[TxOutTemplate::new(20000, Some(2))],
-            anchors: &[block_id!(2, "B")],
-            ..Default::default()
-        },
-        TxTemplate {
-            tx_name: "tx3",
-            inputs: &[TxInTemplate::PrevTx("tx2", 0)],
-            outputs: &[TxOutTemplate::new(30000, Some(3))],
-            anchors: &[block_id!(3, "C"), block_id!(4, "D")],
-            ..Default::default()
-        },
+        TxTemplate::new("tx1")
+            .with_inputs(vec![TxInTemplate::Bogus])
+            .with_outputs(vec![TxOutTemplate::new(10_000, Some(1))])
+            .with_anchors(vec![block_id!(1, "A")]),
+        TxTemplate::new("tx2")
+            .with_inputs(vec![TxInTemplate::PrevTx("tx1".into(), 0)])
+            .with_outputs(vec![TxOutTemplate::new(20_000, Some(2))])
+            .with_anchors(vec![block_id!(2, "B")]),
+        TxTemplate::new("tx3")
+            .with_inputs(vec![TxInTemplate::PrevTx("tx2".into(), 0)])
+            .with_outputs(vec![TxOutTemplate::new(30_000, Some(3))])
+            .with_anchors(vec![block_id!(3, "C"), block_id!(4, "D")]),
     ];
-    let graph = init_graph(&template).tx_graph;
+    let graph = init_graph(template).tx_graph;
     let new_graph = graph.clone().map_anchors(|a| NonDeterministicAnchor {
         anchor_block: a,
         // A non-deterministic value

--- a/crates/chain/tests/test_tx_graph.rs
+++ b/crates/chain/tests/test_tx_graph.rs
@@ -1095,9 +1095,7 @@ fn test_chain_spends() {
 
         // Because this tx conflicts with an already confirmed transaction, chain position should
         // return none.
-        assert!(canonical_positions
-            .get(&tx_1_conflict.compute_txid())
-            .is_none());
+        assert!(!canonical_positions.contains_key(&tx_1_conflict.compute_txid()));
     }
 
     // Another conflicting tx that conflicts with tx_2.

--- a/crates/chain/tests/test_tx_graph.rs
+++ b/crates/chain/tests/test_tx_graph.rs
@@ -1,7 +1,5 @@
 #![cfg(feature = "miniscript")]
 
-#[macro_use]
-mod common;
 use bdk_chain::{collections::*, BlockId, CanonicalizationParams, ConfirmationBlockTime};
 use bdk_chain::{
     local_chain::LocalChain,
@@ -10,13 +8,13 @@ use bdk_chain::{
     Anchor, ChainOracle, ChainPosition, Merge,
 };
 use bdk_testenv::{block_id, hash, utils::new_tx};
+use bdk_testenv::{init_graph, TxInTemplate, TxOutTemplate, TxTemplate};
 use bitcoin::hex::FromHex;
 use bitcoin::Witness;
 use bitcoin::{
     absolute, hashes::Hash, transaction, Amount, BlockHash, OutPoint, ScriptBuf, SignedAmount,
     Transaction, TxIn, TxOut, Txid,
 };
-use common::*;
 use core::iter;
 use rand::RngCore;
 use std::sync::Arc;

--- a/crates/chain/tests/test_tx_graph.rs
+++ b/crates/chain/tests/test_tx_graph.rs
@@ -1,7 +1,5 @@
 #![cfg(feature = "miniscript")]
 
-#[macro_use]
-mod common;
 use bdk_chain::{collections::*, BlockId, ConfirmationBlockTime};
 use bdk_chain::{
     local_chain::LocalChain,
@@ -10,13 +8,13 @@ use bdk_chain::{
     Anchor, ChainPosition, Merge,
 };
 use bdk_testenv::{block_id, hash, utils::new_tx};
+use bdk_testenv::{init_graph, TxInTemplate, TxOutTemplate, TxTemplate};
 use bitcoin::hex::FromHex;
 use bitcoin::Witness;
 use bitcoin::{
     absolute, hashes::Hash, transaction, Amount, BlockHash, OutPoint, ScriptBuf, SignedAmount,
     Transaction, TxIn, TxOut, Txid,
 };
-use common::*;
 use core::iter;
 use rand::RngCore;
 use std::sync::Arc;
@@ -1097,9 +1095,7 @@ fn test_chain_spends() {
 
         // Because this tx conflicts with an already confirmed transaction, chain position should
         // return none.
-        assert!(canonical_positions
-            .get(&tx_1_conflict.compute_txid())
-            .is_none());
+        assert!(!canonical_positions.contains_key(&tx_1_conflict.compute_txid()));
     }
 
     // Another conflicting tx that conflicts with tx_2.
@@ -1143,7 +1139,7 @@ fn test_chain_spends() {
         );
 
         // Chain position of the `tx_2` is now none, as it is older than `tx_2_conflict`
-        assert!(canonical_positions.get(&tx_2.compute_txid()).is_none());
+        assert!(!canonical_positions.contains_key(&tx_2.compute_txid()));
     }
 }
 
@@ -1270,30 +1266,20 @@ fn call_map_anchors_with_non_deterministic_anchor() {
     }
 
     let template = [
-        TxTemplate {
-            tx_name: "tx1",
-            inputs: &[TxInTemplate::Bogus],
-            outputs: &[TxOutTemplate::new(10000, Some(1))],
-            anchors: &[block_id!(1, "A")],
-            last_seen: None,
-            ..Default::default()
-        },
-        TxTemplate {
-            tx_name: "tx2",
-            inputs: &[TxInTemplate::PrevTx("tx1", 0)],
-            outputs: &[TxOutTemplate::new(20000, Some(2))],
-            anchors: &[block_id!(2, "B")],
-            ..Default::default()
-        },
-        TxTemplate {
-            tx_name: "tx3",
-            inputs: &[TxInTemplate::PrevTx("tx2", 0)],
-            outputs: &[TxOutTemplate::new(30000, Some(3))],
-            anchors: &[block_id!(3, "C"), block_id!(4, "D")],
-            ..Default::default()
-        },
+        TxTemplate::new("tx1")
+            .with_inputs(vec![TxInTemplate::Bogus])
+            .with_outputs(vec![TxOutTemplate::new(10_000, Some(1))])
+            .with_anchors(vec![block_id!(1, "A")]),
+        TxTemplate::new("tx2")
+            .with_inputs(vec![TxInTemplate::PrevTx("tx1", 0)])
+            .with_outputs(vec![TxOutTemplate::new(20_000, Some(2))])
+            .with_anchors(vec![block_id!(2, "B")]),
+        TxTemplate::new("tx3")
+            .with_inputs(vec![TxInTemplate::PrevTx("tx2", 0)])
+            .with_outputs(vec![TxOutTemplate::new(30_000, Some(3))])
+            .with_anchors(vec![block_id!(3, "C"), block_id!(4, "D")]),
     ];
-    let graph = init_graph(&template).tx_graph;
+    let graph = init_graph(template).tx_graph;
     let new_graph = graph.clone().map_anchors(|a| NonDeterministicAnchor {
         anchor_block: a,
         // A non-deterministic value

--- a/crates/chain/tests/test_tx_graph_conflicts.rs
+++ b/crates/chain/tests/test_tx_graph_conflicts.rs
@@ -7,17 +7,17 @@ use bitcoin::{Amount, BlockHash, OutPoint};
 use std::collections::{BTreeSet, HashSet};
 
 #[allow(dead_code)]
-struct Scenario<'a> {
+struct Scenario {
     /// Name of the test scenario
-    name: &'a str,
+    name: &'static str,
     /// Transaction templates
-    tx_templates: &'a [TxTemplate<'a, BlockId>],
+    tx_templates: Vec<TxTemplate<BlockId>>,
     /// Names of txs that must exist in the output of `list_canonical_txs`
-    exp_chain_txs: HashSet<&'a str>,
+    exp_chain_txs: HashSet<&'static str>,
     /// Outpoints that must exist in the output of `filter_chain_txouts`
-    exp_chain_txouts: HashSet<(&'a str, u32)>,
+    exp_chain_txouts: HashSet<(&'static str, u32)>,
     /// Outpoints of UTXOs that must exist in the output of `filter_chain_unspents`
-    exp_unspents: HashSet<(&'a str, u32)>,
+    exp_unspents: HashSet<(&'static str, u32)>,
     /// Expected balances
     exp_balance: Balance,
 }
@@ -43,37 +43,22 @@ fn test_tx_conflict_handling() {
     let scenarios = [
         Scenario {
             name: "coinbase tx cannot be in mempool and be unconfirmed",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "unconfirmed_coinbase",
-                    inputs: &[TxInTemplate::Coinbase],
-                    outputs: &[TxOutTemplate::new(5000, Some(0))],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "confirmed_genesis",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10000, Some(1))],
-                    anchors: &[block_id!(1, "B")],
-                    last_seen: None,
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "unconfirmed_conflict",
-                    inputs: &[
-                        TxInTemplate::PrevTx("confirmed_genesis", 0),
-                        TxInTemplate::PrevTx("unconfirmed_coinbase", 0)
-                    ],
-                    outputs: &[TxOutTemplate::new(20000, Some(2))],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "confirmed_conflict",
-                    inputs: &[TxInTemplate::PrevTx("confirmed_genesis", 0)],
-                    outputs: &[TxOutTemplate::new(20000, Some(3))],
-                    anchors: &[block_id!(4, "E")],
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("unconfirmed_coinbase")
+                    .with_inputs(vec![TxInTemplate::Coinbase])
+                    .with_outputs(vec![TxOutTemplate::new(5_000, Some(0))]),
+                TxTemplate::new("confirmed_genesis")
+                    .with_inputs(vec![TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(1))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("unconfirmed_conflict")
+                    .with_inputs(vec![TxInTemplate::PrevTx("confirmed_genesis".into(), 0),
+                                TxInTemplate::PrevTx("unconfirmed_coinbase".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(2))]),
+                TxTemplate::new("confirmed_conflict")
+                    .with_inputs(vec![TxInTemplate::PrevTx("confirmed_genesis".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(3))])
+                    .with_anchors(vec![block_id!(4, "E")]),
             ],
             exp_chain_txs: HashSet::from(["confirmed_genesis", "confirmed_conflict"]),
             exp_chain_txouts: HashSet::from([("confirmed_genesis", 0), ("confirmed_conflict", 0)]),
@@ -85,28 +70,18 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "2 unconfirmed txs with same last_seens conflict",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "tx1",
-                    outputs: &[TxOutTemplate::new(40000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
-                    last_seen: None,
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_conflict_1",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0)],
-                    outputs: &[TxOutTemplate::new(20000, Some(2))],
-                    last_seen: Some(300),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_conflict_2",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0)],
-                    outputs: &[TxOutTemplate::new(30000, Some(3))],
-                    last_seen: Some(300),
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("tx1")
+                    .with_outputs(vec![TxOutTemplate::new(40_000, Some(0))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("tx_conflict_1")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(2))])
+                    .with_last_seen(Some(300)),
+                TxTemplate::new("tx_conflict_2")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(30000, Some(3))])
+                    .with_last_seen(Some(300)),
             ],
             // the txgraph is going to pick tx_conflict_2 because of higher lexicographical txid
             exp_chain_txs: HashSet::from(["tx1", "tx_conflict_2"]),
@@ -121,29 +96,19 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "2 unconfirmed txs with different last_seens conflict",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "tx1",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10000, Some(0)), TxOutTemplate::new(10000, Some(1))],
-                    anchors: &[block_id!(1, "B")],
-                    last_seen: None,
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_conflict_1",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0), TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(20000, Some(2))],
-                    last_seen: Some(200),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_conflict_2",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0),  TxInTemplate::PrevTx("tx1", 1)],
-                    outputs: &[TxOutTemplate::new(30000, Some(3))],
-                    last_seen: Some(300),
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("tx1")
+                    .with_inputs(vec![TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(0)), TxOutTemplate::new(10_000, Some(1))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("tx_conflict_1")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1".into(), 0), TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(2))])
+                    .with_last_seen(Some(200)),
+                TxTemplate::new("tx_conflict_2")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1".into(), 0), TxInTemplate::PrevTx("tx1".into(), 1)])
+                    .with_outputs(vec![TxOutTemplate::new(30_000, Some(3))])
+                    .with_last_seen(Some(300))
             ],
             exp_chain_txs: HashSet::from(["tx1", "tx_conflict_2"]),
             exp_chain_txouts: HashSet::from([("tx1", 0), ("tx1", 1), ("tx_conflict_2", 0)]),
@@ -157,36 +122,23 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "3 unconfirmed txs with different last_seens conflict",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "tx1",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
-                    last_seen: None,
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_conflict_1",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0), TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    last_seen: Some(200),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_conflict_2",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0)],
-                    outputs: &[TxOutTemplate::new(30000, Some(2))],
-                    last_seen: Some(300),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_conflict_3",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0)],
-                    outputs: &[TxOutTemplate::new(40000, Some(3))],
-                    last_seen: Some(400),
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("tx1")
+                    .with_inputs(vec![TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(10000, Some(0))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("tx_conflict_1")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1".into(), 0), TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(20000, Some(1))])
+                    .with_last_seen(Some(200)),
+                TxTemplate::new("tx_conflict_2")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(30000, Some(2))])
+                    .with_last_seen(Some(300)),
+                TxTemplate::new("tx_conflict_3")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(40000, Some(3))])
+                    .with_last_seen(Some(400)),
             ],
             exp_chain_txs: HashSet::from(["tx1", "tx_conflict_3"]),
             exp_chain_txouts: HashSet::from([("tx1", 0), ("tx_conflict_3", 0)]),
@@ -200,30 +152,20 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "unconfirmed tx conflicts with tx in orphaned block, orphaned higher last_seen",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "tx1",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
-                    last_seen: None,
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_conflict_1",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0), TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    last_seen: Some(200),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_orphaned_conflict",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0)],
-                    outputs: &[TxOutTemplate::new(30000, Some(2))],
-                    anchors: &[block_id!(4, "Orphaned Block")],
-                    last_seen: Some(300),
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("tx1")
+                    .with_inputs(vec![TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(0))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("tx_conflict_1")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1".into(), 0), TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(1))])
+                    .with_last_seen(Some(200)),
+                TxTemplate::new("tx_orphaned_conflict")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(30_000, Some(2))])
+                    .with_anchors(vec![block_id!(4, "Orphaned Block")])
+                    .with_last_seen(Some(300)),
             ],
             exp_chain_txs: HashSet::from(["tx1", "tx_orphaned_conflict"]),
             exp_chain_txouts: HashSet::from([("tx1", 0), ("tx_orphaned_conflict", 0)]),
@@ -237,30 +179,20 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "unconfirmed tx conflicts with tx in orphaned block, orphaned lower last_seen",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "tx1",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
-                    last_seen: None,
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_conflict_1",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0), TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    last_seen: Some(200),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_orphaned_conflict",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0)],
-                    outputs: &[TxOutTemplate::new(30000, Some(2))],
-                    anchors: &[block_id!(4, "Orphaned Block")],
-                    last_seen: Some(100),
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("tx1")
+                    .with_inputs(vec![TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(0))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("tx_conflict_1")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1".into(), 0), TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(1))])
+                    .with_last_seen(Some(200)),
+                TxTemplate::new("tx_orphaned_conflict")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(30_000, Some(2))])
+                    .with_anchors(vec![block_id!(4, "Orphaned Block")])
+                    .with_last_seen(Some(100)),
             ],
             exp_chain_txs: HashSet::from(["tx1", "tx_conflict_1"]),
             exp_chain_txouts: HashSet::from([("tx1", 0), ("tx_conflict_1", 0)]),
@@ -274,43 +206,27 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "multiple unconfirmed txs conflict with a confirmed tx",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "tx1",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
-                    last_seen: None,
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_conflict_1",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0), TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    last_seen: Some(200),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_conflict_2",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0)],
-                    outputs: &[TxOutTemplate::new(30000, Some(2))],
-                    last_seen: Some(300),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_conflict_3",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0)],
-                    outputs: &[TxOutTemplate::new(40000, Some(3))],
-                    last_seen: Some(400),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_confirmed_conflict",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0)],
-                    outputs: &[TxOutTemplate::new(50000, Some(4))],
-                    anchors: &[block_id!(1, "B")],
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("tx1")
+                    .with_inputs(vec![TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(0))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("tx_conflict_1")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1".into(), 0), TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(1))])
+                    .with_last_seen(Some(200)),
+                TxTemplate::new("tx_conflict_2")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(30_000, Some(2))])
+                    .with_last_seen(Some(300)),
+                TxTemplate::new("tx_conflict_3")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(40_000, Some(3))])
+                    .with_last_seen(Some(400)),
+                TxTemplate::new("tx_confirmed_conflict")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(50_000, Some(4))])
+                    .with_anchors(vec![block_id!(1, "B")]),
             ],
             exp_chain_txs: HashSet::from(["tx1", "tx_confirmed_conflict"]),
             exp_chain_txouts: HashSet::from([("tx1", 0), ("tx_confirmed_conflict", 0)]),
@@ -324,35 +240,23 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "B and B' spend A and conflict, C spends B, all the transactions are unconfirmed, B' has higher last_seen than B",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "A",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    last_seen: Some(22),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B",
-                    inputs: &[TxInTemplate::PrevTx("A", 0)],
-                    outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    last_seen: Some(23),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B'",
-                    inputs: &[TxInTemplate::PrevTx("A", 0)],
-                    outputs: &[TxOutTemplate::new(20000, Some(2))],
-                    last_seen: Some(24),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "C",
-                    inputs: &[TxInTemplate::PrevTx("B", 0)],
-                    outputs: &[TxOutTemplate::new(30000, Some(3))],
-                    last_seen: Some(25),
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("A")
+                    .with_inputs(vec![TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(0))])
+                    .with_last_seen(Some(22)),
+                TxTemplate::new("B")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(1))])
+                    .with_last_seen(Some(23)),
+                TxTemplate::new("B'")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(2))])
+                    .with_last_seen(Some(24)),
+                TxTemplate::new("C")
+                    .with_inputs(vec![TxInTemplate::PrevTx("B".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(30_000, Some(3))])
+                    .with_last_seen(Some(25))
             ],
             // A, B, C will appear in the list methods
             // This is because B' has a higher last seen than B, but C has a higher
@@ -369,34 +273,21 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "B and B' spend A and conflict, C spends B, A and B' are in best chain",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "A",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
-                    last_seen: None,
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B",
-                    inputs: &[TxInTemplate::PrevTx("A", 0)],
-                    outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B'",
-                    inputs: &[TxInTemplate::PrevTx("A", 0)],
-                    outputs: &[TxOutTemplate::new(20000, Some(2))],
-                    anchors: &[block_id!(4, "E")],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "C",
-                    inputs: &[TxInTemplate::PrevTx("B", 0)],
-                    outputs: &[TxOutTemplate::new(30000, Some(3))],
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("A")
+                    .with_inputs(&[TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(0))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("B")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(1))]),
+                TxTemplate::new("B'")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20000, Some(2))])
+                    .with_anchors(vec![block_id!(4, "E")]),
+                TxTemplate::new("C")
+                    .with_inputs(vec![TxInTemplate::PrevTx("B".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(30_000, Some(3))]),
             ],
             // B and C should not appear in the list methods
             exp_chain_txs: HashSet::from(["A", "B'"]),
@@ -411,35 +302,23 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "B and B' spend A and conflict, C spends B', A and B' are in best chain",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "A",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B",
-                    inputs: &[TxInTemplate::PrevTx("A", 0)],
-                    outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    last_seen: Some(2),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B'",
-                    inputs: &[TxInTemplate::PrevTx("A", 0)],
-                    outputs: &[TxOutTemplate::new(20000, Some(2))],
-                    anchors: &[block_id!(4, "E")],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "C",
-                    inputs: &[TxInTemplate::PrevTx("B'", 0)],
-                    outputs: &[TxOutTemplate::new(30000, Some(3))],
-                    last_seen: Some(1),
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("A")
+                    .with_inputs(vec![TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(0))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("B")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(1))])
+                    .with_last_seen(Some(2)),
+                TxTemplate::new("B'")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(2))])
+                    .with_anchors(vec![block_id!(4, "E")]),
+                TxTemplate::new("C")
+                    .with_inputs(vec![TxInTemplate::PrevTx("B'".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(30_000, Some(3))])
+                    .with_last_seen(Some(1))
             ],
             // B should not appear in the list methods
             exp_chain_txs: HashSet::from(["A", "B'", "C"]),
@@ -458,38 +337,22 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "B and B' spend A and conflict, C spends both B and B', A is in best chain",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "A",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
-                    last_seen: None,
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B",
-                    inputs: &[TxInTemplate::PrevTx("A", 0), TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    last_seen: Some(200),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B'",
-                    inputs: &[TxInTemplate::PrevTx("A", 0)],
-                    outputs: &[TxOutTemplate::new(30000, Some(2))],
-                    last_seen: Some(300),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "C",
-                    inputs: &[
-                        TxInTemplate::PrevTx("B", 0),
-                        TxInTemplate::PrevTx("B'", 0),
-                    ],
-                    outputs: &[TxOutTemplate::new(20000, Some(3))],
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("A")
+                    .with_inputs(vec![TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(0))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("B")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A".into(), 0), TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(1))])
+                    .with_last_seen(Some(200)),
+                TxTemplate::new("B'")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(30_000, Some(2))])
+                    .with_last_seen(Some(300)),
+                TxTemplate::new("C")
+                    .with_inputs(vec![TxInTemplate::PrevTx("B".into(), 0), TxInTemplate::PrevTx("B'".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(3))]),
             ],
             // C should not appear in the list methods
             exp_chain_txs: HashSet::from(["A", "B'"]),
@@ -504,38 +367,22 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "B and B' spend A and conflict, B' is confirmed, C spends both B and B', A is in best chain",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "A",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
-                    last_seen: None,
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B",
-                    inputs: &[TxInTemplate::PrevTx("A", 0), TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    last_seen: Some(200),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B'",
-                    inputs: &[TxInTemplate::PrevTx("A", 0)],
-                    outputs: &[TxOutTemplate::new(50000, Some(4))],
-                    anchors: &[block_id!(1, "B")],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "C",
-                    inputs: &[
-                        TxInTemplate::PrevTx("B", 0),
-                        TxInTemplate::PrevTx("B'", 0),
-                    ],
-                    outputs: &[TxOutTemplate::new(20000, Some(5))],
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("A")
+                    .with_inputs(&[TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(0))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("B")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A".into(), 0), TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(1))])
+                    .with_last_seen(Some(200)),
+                TxTemplate::new("B'")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(50_000, Some(4))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("C")
+                    .with_inputs(vec![TxInTemplate::PrevTx("B".into(), 0), TxInTemplate::PrevTx("B'".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(5))]),
             ],
             // C should not appear in the list methods
             exp_chain_txs: HashSet::from(["A", "B'"]),
@@ -550,44 +397,25 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "B and B' spend A and conflict, B' is confirmed, C spends both B and B', D spends C, A is in best chain",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "A",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
-                    last_seen: None,
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B",
-                    inputs: &[TxInTemplate::PrevTx("A", 0), TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    last_seen: Some(200),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B'",
-                    inputs: &[TxInTemplate::PrevTx("A", 0)],
-                    outputs: &[TxOutTemplate::new(50000, Some(4))],
-                    anchors: &[block_id!(1, "B")],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "C",
-                    inputs: &[
-                        TxInTemplate::PrevTx("B", 0),
-                        TxInTemplate::PrevTx("B'", 0),
-                    ],
-                    outputs: &[TxOutTemplate::new(20000, Some(5))],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "D",
-                    inputs: &[TxInTemplate::PrevTx("C", 0)],
-                    outputs: &[TxOutTemplate::new(20000, Some(6))],
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("A")
+                    .with_inputs(&[TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(0))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("B")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A".into(), 0), TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(1))])
+                    .with_last_seen(Some(200)),
+                TxTemplate::new("B'")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(50_000, Some(4))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("C")
+                    .with_inputs(vec![TxInTemplate::PrevTx("B".into(), 0),  TxInTemplate::PrevTx("B'".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(5))]),
+                TxTemplate::new("D")
+                    .with_inputs(vec![TxInTemplate::PrevTx("C".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(6))]),
             ],
             // D should not appear in the list methods
             exp_chain_txs: HashSet::from(["A", "B'"]),
@@ -602,26 +430,17 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "transitively confirmed ancestors",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "first",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(1000, Some(0))],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "second",
-                    inputs: &[TxInTemplate::PrevTx("first", 0)],
-                    outputs: &[TxOutTemplate::new(900, Some(0))],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "anchored",
-                    inputs: &[TxInTemplate::PrevTx("second", 0)],
-                    outputs: &[TxOutTemplate::new(800, Some(0))],
-                    anchors: &[block_id!(3, "D")],
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("first")
+                    .with_inputs(&[TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(1_000, Some(0))]),
+                TxTemplate::new("second")
+                    .with_inputs(vec![TxInTemplate::PrevTx("first".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(900, Some(0))]),
+                TxTemplate::new("anchored")
+                    .with_inputs(vec![TxInTemplate::PrevTx("second".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(800, Some(0))])
+                    .with_anchors(vec![block_id!(3, "D")]),
             ],
             exp_chain_txs: HashSet::from(["first", "second", "anchored"]),
             exp_chain_txouts: HashSet::from([("first", 0), ("second", 0), ("anchored", 0)]),
@@ -635,35 +454,23 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "transitively anchored txs should have priority over last seen",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "root",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10_000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "last_seen_conflict",
-                    inputs: &[TxInTemplate::PrevTx("root", 0)],
-                    outputs: &[TxOutTemplate::new(9900, Some(1))],
-                    last_seen: Some(1000),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "transitively_anchored_conflict",
-                    inputs: &[TxInTemplate::PrevTx("root", 0)],
-                    outputs: &[TxOutTemplate::new(9000, Some(1))],
-                    last_seen: Some(100),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "anchored",
-                    inputs: &[TxInTemplate::PrevTx("transitively_anchored_conflict", 0)],
-                    outputs: &[TxOutTemplate::new(8000, Some(2))],
-                    anchors: &[block_id!(4, "E")],
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("root")
+                    .with_inputs(&[TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(0))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("last_seen_conflict")
+                    .with_inputs(vec![TxInTemplate::PrevTx("root".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(9_900, Some(1))])
+                    .with_last_seen(Some(1_000)),
+                TxTemplate::new("transitively_anchored_conflict")
+                    .with_inputs(vec![TxInTemplate::PrevTx("root".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(9_000, Some(1))])
+                    .with_last_seen(Some(100)),
+                TxTemplate::new("anchored")
+                    .with_inputs(vec![TxInTemplate::PrevTx("transitively_anchored_conflict".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(8_000, Some(2))])
+                    .with_anchors(vec![block_id!(4, "E")]),
             ],
             exp_chain_txs: HashSet::from(["root", "transitively_anchored_conflict", "anchored"]),
             exp_chain_txouts: HashSet::from([("root", 0), ("transitively_anchored_conflict", 0), ("anchored", 0)]),
@@ -675,21 +482,15 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "tx anchored in orphaned block and not seen in mempool should be canon",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "root",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10_000, None)],
-                    anchors: &[block_id!(1, "B")],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx",
-                    inputs: &[TxInTemplate::PrevTx("root", 0)],
-                    outputs: &[TxOutTemplate::new(9000, Some(0))],
-                    anchors: &[block_id!(6, "not G")],
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("root")
+                    .with_inputs(vec![TxInTemplate::Bogus ])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, None)])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("tx")
+                    .with_inputs(vec![TxInTemplate::PrevTx("root".into(), 0) ])
+                    .with_outputs(vec![TxOutTemplate::new(9_000, Some(0))])
+                    .with_anchors(vec![block_id!(6, "not G")]),
             ],
             exp_chain_txs: HashSet::from(["root", "tx"]),
             exp_chain_txouts: HashSet::from([("tx", 0)]),
@@ -698,28 +499,19 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "tx spends from 2 conflicting transactions where a conflict spends another",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "A",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10_000, None)],
-                    last_seen: Some(1),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "S1",
-                    inputs: &[TxInTemplate::PrevTx("A", 0)],
-                    outputs: &[TxOutTemplate::new(9_000, None)],
-                    last_seen: Some(2),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "S2",
-                    inputs: &[TxInTemplate::PrevTx("A", 0), TxInTemplate::PrevTx("S1", 0)],
-                    outputs: &[TxOutTemplate::new(17_000, None)],
-                    last_seen: Some(3),
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("A")
+                    .with_inputs(&[TxInTemplate::Bogus ])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, None)])
+                    .with_last_seen(Some(1)),
+                TxTemplate::new("S1")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A".into(), 0) ])
+                    .with_outputs(vec![TxOutTemplate::new(9_000, None)])
+                    .with_last_seen(Some(2)),
+                TxTemplate::new("S2")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A".into(), 0), TxInTemplate::PrevTx("S1".into(), 0) ])
+                    .with_outputs(vec![TxOutTemplate::new(17_000, None)])
+                    .with_last_seen(Some(3)),
             ],
             exp_chain_txs: HashSet::from(["A", "S1"]),
             exp_chain_txouts: HashSet::from([]),
@@ -728,35 +520,23 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "tx spends from 2 conflicting transactions where the conflict is nested",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "A",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10_000, Some(0))],
-                    last_seen: Some(1),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "S1",
-                    inputs: &[TxInTemplate::PrevTx("A", 0)],
-                    outputs: &[TxOutTemplate::new(9_000, Some(0))],
-                    last_seen: Some(3),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B",
-                    inputs: &[TxInTemplate::PrevTx("S1", 0)],
-                    outputs: &[TxOutTemplate::new(8_000, Some(0))],
-                    last_seen: Some(2),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "S2",
-                    inputs: &[TxInTemplate::PrevTx("B", 0), TxInTemplate::PrevTx("A", 0)],
-                    outputs: &[TxOutTemplate::new(17_000, Some(0))],
-                    last_seen: Some(4),
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("A")
+                    .with_inputs(&[TxInTemplate::Bogus ])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(0))])
+                    .with_last_seen(Some(1)),
+                TxTemplate::new("S1")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A".into(), 0) ])
+                    .with_outputs(vec![TxOutTemplate::new(9_000, Some(0))])
+                    .with_last_seen(Some(3)),
+                TxTemplate::new("B")
+                    .with_inputs(vec![TxInTemplate::PrevTx("S1".into(), 0) ])
+                    .with_outputs(vec![TxOutTemplate::new(8_000, Some(0))])
+                    .with_last_seen(Some(2)),
+                TxTemplate::new("S2")
+                    .with_inputs(vec![TxInTemplate::PrevTx("B".into(), 0), TxInTemplate::PrevTx("A".into(), 0) ])
+                    .with_outputs(vec![TxOutTemplate::new(17_000, Some(0))])
+                    .with_last_seen(Some(4)),
             ],
             exp_chain_txs: HashSet::from(["A", "S1", "B"]),
             exp_chain_txouts: HashSet::from([("A", 0), ("B", 0), ("S1", 0)]),
@@ -765,35 +545,23 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "tx spends from 2 conflicting transactions where the conflict is nested (different last_seens)",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "A",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10_000, Some(0))],
-                    last_seen: Some(1),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "S1",
-                    inputs: &[TxInTemplate::PrevTx("A", 0)],
-                    outputs: &[TxOutTemplate::new(9_000, Some(0))],
-                    last_seen: Some(4),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B",
-                    inputs: &[TxInTemplate::PrevTx("S1", 0)],
-                    outputs: &[TxOutTemplate::new(8_000, Some(0))],
-                    last_seen: Some(2),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "S2",
-                    inputs: &[TxInTemplate::PrevTx("A", 0), TxInTemplate::PrevTx("B", 0)],
-                    outputs: &[TxOutTemplate::new(17_000, Some(0))],
-                    last_seen: Some(3),
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("A")
+                    .with_inputs(&[TxInTemplate::Bogus ])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(0))])
+                    .with_last_seen(Some(1)),
+                TxTemplate::new("S1")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A".into(), 0) ])
+                    .with_outputs(vec![TxOutTemplate::new(9_000, Some(0))])
+                    .with_last_seen(Some(4)),
+                TxTemplate::new("B")
+                    .with_inputs(vec![TxInTemplate::PrevTx("S1".into(), 0) ])
+                    .with_outputs(vec![TxOutTemplate::new(8_000, Some(0))])
+                    .with_last_seen(Some(2)),
+                TxTemplate::new("S2")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A".into(), 0), TxInTemplate::PrevTx("B".into(), 0) ])
+                    .with_outputs(vec![TxOutTemplate::new(17_000, Some(0))])
+                    .with_last_seen(Some(3)),
             ],
             exp_chain_txs: HashSet::from(["A", "S1", "B"]),
             exp_chain_txouts: HashSet::from([("A", 0), ("B", 0), ("S1", 0)]),
@@ -802,41 +570,25 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "assume-canonical-tx displaces unconfirmed chain",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "root",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[
-                        TxOutTemplate::new(21_000, Some(0)),
-                        TxOutTemplate::new(21_000, Some(1)),
-                    ],
-                    anchors: &[block_id!(1, "B")],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "unconfirmed",
-                    inputs: &[TxInTemplate::PrevTx("root", 0)],
-                    outputs: &[TxOutTemplate::new(20_000, Some(1))],
-                    last_seen: Some(2),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "unconfirmed_descendant",
-                    inputs: &[
-                        TxInTemplate::PrevTx("unconfirmed", 0),
-                        TxInTemplate::PrevTx("root", 1),
-                    ],
-                    outputs: &[TxOutTemplate::new(28_000, Some(2))],
-                    last_seen: Some(2),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "assume_canonical",
-                    inputs: &[TxInTemplate::PrevTx("root", 0)],
-                    outputs: &[TxOutTemplate::new(19_000, Some(3))],
-                    assume_canonical: true,
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("root")
+                    .with_inputs(&[TxInTemplate::Bogus ])
+                    .with_outputs(vec![TxOutTemplate::new(21_000, Some(0)),
+                TxOutTemplate::new(21_000, Some(1))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("unconfirmed")
+                    .with_inputs(vec![TxInTemplate::PrevTx("root".into(), 0) ])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(1))])
+                    .with_last_seen(Some(2)),
+                TxTemplate::new("unconfirmed_descendant")
+                    .with_inputs(vec![TxInTemplate::PrevTx("unconfirmed".into(), 0),
+                TxInTemplate::PrevTx("root".into(), 1) ])
+                    .with_outputs(vec![TxOutTemplate::new(28_000, Some(2))])
+                    .with_last_seen(Some(2)),
+                TxTemplate::new("assume_canonical")
+                    .with_inputs(vec![TxInTemplate::PrevTx("root".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(19_000, Some(3))])
+                    .with_assume_canonical(true),
             ],
             exp_chain_txs: HashSet::from(["root", "assume_canonical"]),
             exp_chain_txouts: HashSet::from([("root", 0), ("root", 1), ("assume_canonical", 0)]),
@@ -850,41 +602,24 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "assume-canonical-tx displaces confirmed chain",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "root",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[
-                        TxOutTemplate::new(21_000, Some(0)),
-                        TxOutTemplate::new(21_000, Some(1)),
-                    ],
-                    anchors: &[block_id!(1, "B")],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "confirmed",
-                    inputs: &[TxInTemplate::PrevTx("root", 0)],
-                    outputs: &[TxOutTemplate::new(20_000, Some(1))],
-                    anchors: &[block_id!(2, "C")],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "confirmed_descendant",
-                    inputs: &[
-                        TxInTemplate::PrevTx("confirmed", 0),
-                        TxInTemplate::PrevTx("root", 1),
-                    ],
-                    outputs: &[TxOutTemplate::new(28_000, Some(2))],
-                    anchors: &[block_id!(3, "D")],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "assume_canonical",
-                    inputs: &[TxInTemplate::PrevTx("root", 0)],
-                    outputs: &[TxOutTemplate::new(19_000, Some(3))],
-                    assume_canonical: true,
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("root")
+                    .with_inputs(&[TxInTemplate::Bogus ])
+                    .with_outputs(vec![TxOutTemplate::new(21_000, Some(0)),
+                TxOutTemplate::new(21_000, Some(1))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("confirmed")
+                    .with_inputs(vec![TxInTemplate::PrevTx("root".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(1))])
+                    .with_anchors(vec![block_id!(2, "C")]),
+                TxTemplate::new("confirmed_descendant")
+                    .with_inputs(vec![TxInTemplate::PrevTx("confirmed".into(), 0), TxInTemplate::PrevTx("root".into(), 1)])
+                    .with_outputs(vec![TxOutTemplate::new(28_000, Some(2))])
+                    .with_anchors(vec![block_id!(3, "D")]),
+                TxTemplate::new("assume_canonical")
+                    .with_inputs(vec![TxInTemplate::PrevTx("root".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(19_000, Some(3))])
+                    .with_assume_canonical(true),
             ],
             exp_chain_txs: HashSet::from(["root", "assume_canonical"]),
             exp_chain_txouts: HashSet::from([("root", 0), ("root", 1), ("assume_canonical", 0)]),
@@ -898,37 +633,23 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "assume-canonical txs respects order",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "root",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[
-                        TxOutTemplate::new(21_000, Some(0)),
-                    ],
-                    anchors: &[block_id!(1, "B")],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "assume_a",
-                    inputs: &[TxInTemplate::PrevTx("root", 0)],
-                    outputs: &[TxOutTemplate::new(20_000, Some(1))],
-                    assume_canonical: true,
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "assume_b",
-                    inputs: &[TxInTemplate::PrevTx("root", 0)],
-                    outputs: &[TxOutTemplate::new(19_000, Some(1))],
-                    assume_canonical: true,
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "assume_c",
-                    inputs: &[TxInTemplate::PrevTx("root", 0)],
-                    outputs: &[TxOutTemplate::new(18_000, Some(1))],
-                    assume_canonical: true,
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("root")
+                    .with_inputs(&[TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(21_000, Some(0))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("assume_a")
+                    .with_inputs(vec![TxInTemplate::PrevTx("root".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(1))])
+                    .with_assume_canonical(true),
+                TxTemplate::new("assume_b")
+                    .with_inputs(vec![TxInTemplate::PrevTx("root".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(19_000, Some(1))])
+                    .with_assume_canonical(true),
+                TxTemplate::new("assume_c")
+                    .with_inputs(vec![TxInTemplate::PrevTx("root".into(), 0)])
+                    .with_outputs(vec![TxOutTemplate::new(18_000, Some(1))])
+                    .with_assume_canonical(true),
             ],
             exp_chain_txs: HashSet::from(["root", "assume_c"]),
             exp_chain_txouts: HashSet::from([("root", 0), ("assume_c", 0)]),
@@ -942,15 +663,11 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "coinbase tx must not become unconfirmed",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "coinbase",
-                    inputs: &[TxInTemplate::Coinbase],
-                    outputs: &[TxOutTemplate::new(21_000, Some(0))],
-                    // Stale block
-                    anchors: &[block_id!(1, "B-prime")],
-                    ..Default::default()
-                }
+            tx_templates: vec![
+                TxTemplate::new("coinbase")
+                    .with_inputs(&[TxInTemplate::Coinbase])
+                    .with_outputs(vec![TxOutTemplate::new(21_000, Some(0))])
+                    .with_anchors(vec![block_id!(1, "B-prime")])
             ],
             exp_chain_txs: HashSet::from([]),
             exp_chain_txouts: HashSet::from([]),
@@ -965,7 +682,7 @@ fn test_tx_conflict_handling() {
     ];
 
     for scenario in scenarios {
-        let env = init_graph(scenario.tx_templates.iter());
+        let env = init_graph(scenario.tx_templates);
 
         let txs = env
             .tx_graph
@@ -976,7 +693,7 @@ fn test_tx_conflict_handling() {
         let exp_txs = scenario
             .exp_chain_txs
             .iter()
-            .map(|txid| *env.txid_to_name.get(txid).expect("txid must exist"))
+            .map(|&txid| *env.txid_to_name.get(txid).expect("txid must exist"))
             .collect::<BTreeSet<_>>();
         assert_eq!(
             txs, exp_txs,
@@ -993,9 +710,9 @@ fn test_tx_conflict_handling() {
         let exp_txouts = scenario
             .exp_chain_txouts
             .iter()
-            .map(|(txid, vout)| OutPoint {
+            .map(|&(txid, vout)| OutPoint {
                 txid: *env.txid_to_name.get(txid).expect("txid must exist"),
-                vout: *vout,
+                vout,
             })
             .collect::<BTreeSet<_>>();
         assert_eq!(
@@ -1013,9 +730,9 @@ fn test_tx_conflict_handling() {
         let exp_utxos = scenario
             .exp_unspents
             .iter()
-            .map(|(txid, vout)| OutPoint {
+            .map(|&(txid, vout)| OutPoint {
                 txid: *env.txid_to_name.get(txid).expect("txid must exist"),
-                vout: *vout,
+                vout,
             })
             .collect::<BTreeSet<_>>();
         assert_eq!(

--- a/crates/chain/tests/test_tx_graph_conflicts.rs
+++ b/crates/chain/tests/test_tx_graph_conflicts.rs
@@ -1,12 +1,9 @@
 #![cfg(feature = "miniscript")]
 
-#[macro_use]
-mod common;
-
 use bdk_chain::{local_chain::LocalChain, Balance, BlockId};
 use bdk_testenv::{block_id, hash, local_chain};
+use bdk_testenv::{init_graph, TxInTemplate, TxOutTemplate, TxTemplate};
 use bitcoin::{Amount, BlockHash, OutPoint};
-use common::*;
 use std::collections::{BTreeSet, HashSet};
 
 #[allow(dead_code)]

--- a/crates/chain/tests/test_tx_graph_conflicts.rs
+++ b/crates/chain/tests/test_tx_graph_conflicts.rs
@@ -1,26 +1,23 @@
 #![cfg(feature = "miniscript")]
 
-#[macro_use]
-mod common;
-
 use bdk_chain::{local_chain::LocalChain, Balance, BlockId};
 use bdk_testenv::{block_id, hash, local_chain};
+use bdk_testenv::{init_graph, TxInTemplate, TxOutTemplate, TxTemplate};
 use bitcoin::{Amount, BlockHash, OutPoint};
-use common::*;
 use std::collections::{BTreeSet, HashSet};
 
 #[allow(dead_code)]
-struct Scenario<'a> {
+struct Scenario {
     /// Name of the test scenario
-    name: &'a str,
+    name: &'static str,
     /// Transaction templates
-    tx_templates: &'a [TxTemplate<'a, BlockId>],
+    tx_templates: Vec<TxTemplate<BlockId>>,
     /// Names of txs that must exist in the output of `list_canonical_txs`
-    exp_chain_txs: HashSet<&'a str>,
+    exp_chain_txs: HashSet<&'static str>,
     /// Outpoints that must exist in the output of `filter_chain_txouts`
-    exp_chain_txouts: HashSet<(&'a str, u32)>,
+    exp_chain_txouts: HashSet<(&'static str, u32)>,
     /// Outpoints of UTXOs that must exist in the output of `filter_chain_unspents`
-    exp_unspents: HashSet<(&'a str, u32)>,
+    exp_unspents: HashSet<(&'static str, u32)>,
     /// Expected balances
     exp_balance: Balance,
 }
@@ -46,37 +43,22 @@ fn test_tx_conflict_handling() {
     let scenarios = [
         Scenario {
             name: "coinbase tx cannot be in mempool and be unconfirmed",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "unconfirmed_coinbase",
-                    inputs: &[TxInTemplate::Coinbase],
-                    outputs: &[TxOutTemplate::new(5000, Some(0))],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "confirmed_genesis",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10000, Some(1))],
-                    anchors: &[block_id!(1, "B")],
-                    last_seen: None,
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "unconfirmed_conflict",
-                    inputs: &[
-                        TxInTemplate::PrevTx("confirmed_genesis", 0),
-                        TxInTemplate::PrevTx("unconfirmed_coinbase", 0)
-                    ],
-                    outputs: &[TxOutTemplate::new(20000, Some(2))],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "confirmed_conflict",
-                    inputs: &[TxInTemplate::PrevTx("confirmed_genesis", 0)],
-                    outputs: &[TxOutTemplate::new(20000, Some(3))],
-                    anchors: &[block_id!(4, "E")],
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("unconfirmed_coinbase")
+                    .with_inputs(vec![TxInTemplate::Coinbase])
+                    .with_outputs(vec![TxOutTemplate::new(5_000, Some(0))]),
+                TxTemplate::new("confirmed_genesis")
+                    .with_inputs(vec![TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(1))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("unconfirmed_conflict")
+                    .with_inputs(vec![TxInTemplate::PrevTx("confirmed_genesis", 0),
+                                TxInTemplate::PrevTx("unconfirmed_coinbase", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(2))]),
+                TxTemplate::new("confirmed_conflict")
+                    .with_inputs(vec![TxInTemplate::PrevTx("confirmed_genesis", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(3))])
+                    .with_anchors(vec![block_id!(4, "E")]),
             ],
             exp_chain_txs: HashSet::from(["confirmed_genesis", "confirmed_conflict"]),
             exp_chain_txouts: HashSet::from([("confirmed_genesis", 0), ("confirmed_conflict", 0)]),
@@ -88,28 +70,18 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "2 unconfirmed txs with same last_seens conflict",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "tx1",
-                    outputs: &[TxOutTemplate::new(40000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
-                    last_seen: None,
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_conflict_1",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0)],
-                    outputs: &[TxOutTemplate::new(20000, Some(2))],
-                    last_seen: Some(300),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_conflict_2",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0)],
-                    outputs: &[TxOutTemplate::new(30000, Some(3))],
-                    last_seen: Some(300),
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("tx1")
+                    .with_outputs(vec![TxOutTemplate::new(40_000, Some(0))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("tx_conflict_1")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(2))])
+                    .with_last_seen(300),
+                TxTemplate::new("tx_conflict_2")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(30000, Some(3))])
+                    .with_last_seen(300),
             ],
             // the txgraph is going to pick tx_conflict_2 because of higher lexicographical txid
             exp_chain_txs: HashSet::from(["tx1", "tx_conflict_2"]),
@@ -124,29 +96,19 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "2 unconfirmed txs with different last_seens conflict",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "tx1",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10000, Some(0)), TxOutTemplate::new(10000, Some(1))],
-                    anchors: &[block_id!(1, "B")],
-                    last_seen: None,
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_conflict_1",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0), TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(20000, Some(2))],
-                    last_seen: Some(200),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_conflict_2",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0),  TxInTemplate::PrevTx("tx1", 1)],
-                    outputs: &[TxOutTemplate::new(30000, Some(3))],
-                    last_seen: Some(300),
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("tx1")
+                    .with_inputs(vec![TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(0)), TxOutTemplate::new(10_000, Some(1))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("tx_conflict_1")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1", 0), TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(2))])
+                    .with_last_seen(200),
+                TxTemplate::new("tx_conflict_2")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1", 0), TxInTemplate::PrevTx("tx1", 1)])
+                    .with_outputs(vec![TxOutTemplate::new(30_000, Some(3))])
+                    .with_last_seen(300)
             ],
             exp_chain_txs: HashSet::from(["tx1", "tx_conflict_2"]),
             exp_chain_txouts: HashSet::from([("tx1", 0), ("tx1", 1), ("tx_conflict_2", 0)]),
@@ -160,36 +122,23 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "3 unconfirmed txs with different last_seens conflict",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "tx1",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
-                    last_seen: None,
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_conflict_1",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0), TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    last_seen: Some(200),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_conflict_2",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0)],
-                    outputs: &[TxOutTemplate::new(30000, Some(2))],
-                    last_seen: Some(300),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_conflict_3",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0)],
-                    outputs: &[TxOutTemplate::new(40000, Some(3))],
-                    last_seen: Some(400),
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("tx1")
+                    .with_inputs(vec![TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(10000, Some(0))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("tx_conflict_1")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1", 0), TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(20000, Some(1))])
+                    .with_last_seen(200),
+                TxTemplate::new("tx_conflict_2")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(30000, Some(2))])
+                    .with_last_seen(300),
+                TxTemplate::new("tx_conflict_3")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(40000, Some(3))])
+                    .with_last_seen(400),
             ],
             exp_chain_txs: HashSet::from(["tx1", "tx_conflict_3"]),
             exp_chain_txouts: HashSet::from([("tx1", 0), ("tx_conflict_3", 0)]),
@@ -203,30 +152,20 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "unconfirmed tx conflicts with tx in orphaned block, orphaned higher last_seen",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "tx1",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
-                    last_seen: None,
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_conflict_1",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0), TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    last_seen: Some(200),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_orphaned_conflict",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0)],
-                    outputs: &[TxOutTemplate::new(30000, Some(2))],
-                    anchors: &[block_id!(4, "Orphaned Block")],
-                    last_seen: Some(300),
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("tx1")
+                    .with_inputs(vec![TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(0))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("tx_conflict_1")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1", 0), TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(1))])
+                    .with_last_seen(200),
+                TxTemplate::new("tx_orphaned_conflict")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(30_000, Some(2))])
+                    .with_anchors(vec![block_id!(4, "Orphaned Block")])
+                    .with_last_seen(300),
             ],
             exp_chain_txs: HashSet::from(["tx1", "tx_orphaned_conflict"]),
             exp_chain_txouts: HashSet::from([("tx1", 0), ("tx_orphaned_conflict", 0)]),
@@ -240,30 +179,20 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "unconfirmed tx conflicts with tx in orphaned block, orphaned lower last_seen",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "tx1",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
-                    last_seen: None,
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_conflict_1",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0), TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    last_seen: Some(200),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_orphaned_conflict",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0)],
-                    outputs: &[TxOutTemplate::new(30000, Some(2))],
-                    anchors: &[block_id!(4, "Orphaned Block")],
-                    last_seen: Some(100),
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("tx1")
+                    .with_inputs(vec![TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(0))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("tx_conflict_1")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1", 0), TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(1))])
+                    .with_last_seen(200),
+                TxTemplate::new("tx_orphaned_conflict")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(30_000, Some(2))])
+                    .with_anchors(vec![block_id!(4, "Orphaned Block")])
+                    .with_last_seen(100),
             ],
             exp_chain_txs: HashSet::from(["tx1", "tx_conflict_1"]),
             exp_chain_txouts: HashSet::from([("tx1", 0), ("tx_conflict_1", 0)]),
@@ -277,43 +206,27 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "multiple unconfirmed txs conflict with a confirmed tx",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "tx1",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
-                    last_seen: None,
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_conflict_1",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0), TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    last_seen: Some(200),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_conflict_2",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0)],
-                    outputs: &[TxOutTemplate::new(30000, Some(2))],
-                    last_seen: Some(300),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_conflict_3",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0)],
-                    outputs: &[TxOutTemplate::new(40000, Some(3))],
-                    last_seen: Some(400),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx_confirmed_conflict",
-                    inputs: &[TxInTemplate::PrevTx("tx1", 0)],
-                    outputs: &[TxOutTemplate::new(50000, Some(4))],
-                    anchors: &[block_id!(1, "B")],
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("tx1")
+                    .with_inputs(vec![TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(0))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("tx_conflict_1")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1", 0), TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(1))])
+                    .with_last_seen(200),
+                TxTemplate::new("tx_conflict_2")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(30_000, Some(2))])
+                    .with_last_seen(300),
+                TxTemplate::new("tx_conflict_3")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(40_000, Some(3))])
+                    .with_last_seen(400),
+                TxTemplate::new("tx_confirmed_conflict")
+                    .with_inputs(vec![TxInTemplate::PrevTx("tx1", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(50_000, Some(4))])
+                    .with_anchors(vec![block_id!(1, "B")]),
             ],
             exp_chain_txs: HashSet::from(["tx1", "tx_confirmed_conflict"]),
             exp_chain_txouts: HashSet::from([("tx1", 0), ("tx_confirmed_conflict", 0)]),
@@ -327,35 +240,23 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "B and B' spend A and conflict, C spends B, all the transactions are unconfirmed, B' has higher last_seen than B",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "A",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    last_seen: Some(22),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B",
-                    inputs: &[TxInTemplate::PrevTx("A", 0)],
-                    outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    last_seen: Some(23),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B'",
-                    inputs: &[TxInTemplate::PrevTx("A", 0)],
-                    outputs: &[TxOutTemplate::new(20000, Some(2))],
-                    last_seen: Some(24),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "C",
-                    inputs: &[TxInTemplate::PrevTx("B", 0)],
-                    outputs: &[TxOutTemplate::new(30000, Some(3))],
-                    last_seen: Some(25),
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("A")
+                    .with_inputs(vec![TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(0))])
+                    .with_last_seen(22),
+                TxTemplate::new("B")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(1))])
+                    .with_last_seen(23),
+                TxTemplate::new("B'")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(2))])
+                    .with_last_seen(24),
+                TxTemplate::new("C")
+                    .with_inputs(vec![TxInTemplate::PrevTx("B", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(30_000, Some(3))])
+                    .with_last_seen(25)
             ],
             // A, B, C will appear in the list methods
             // This is because B' has a higher last seen than B, but C has a higher
@@ -372,34 +273,21 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "B and B' spend A and conflict, C spends B, A and B' are in best chain",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "A",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
-                    last_seen: None,
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B",
-                    inputs: &[TxInTemplate::PrevTx("A", 0)],
-                    outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B'",
-                    inputs: &[TxInTemplate::PrevTx("A", 0)],
-                    outputs: &[TxOutTemplate::new(20000, Some(2))],
-                    anchors: &[block_id!(4, "E")],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "C",
-                    inputs: &[TxInTemplate::PrevTx("B", 0)],
-                    outputs: &[TxOutTemplate::new(30000, Some(3))],
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("A")
+                    .with_inputs(vec![TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(0))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("B")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(1))]),
+                TxTemplate::new("B'")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20000, Some(2))])
+                    .with_anchors(vec![block_id!(4, "E")]),
+                TxTemplate::new("C")
+                    .with_inputs(vec![TxInTemplate::PrevTx("B", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(30_000, Some(3))]),
             ],
             // B and C should not appear in the list methods
             exp_chain_txs: HashSet::from(["A", "B'"]),
@@ -414,35 +302,23 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "B and B' spend A and conflict, C spends B', A and B' are in best chain",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "A",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B",
-                    inputs: &[TxInTemplate::PrevTx("A", 0)],
-                    outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    last_seen: Some(2),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B'",
-                    inputs: &[TxInTemplate::PrevTx("A", 0)],
-                    outputs: &[TxOutTemplate::new(20000, Some(2))],
-                    anchors: &[block_id!(4, "E")],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "C",
-                    inputs: &[TxInTemplate::PrevTx("B'", 0)],
-                    outputs: &[TxOutTemplate::new(30000, Some(3))],
-                    last_seen: Some(1),
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("A")
+                    .with_inputs(vec![TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(0))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("B")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(1))])
+                    .with_last_seen(2),
+                TxTemplate::new("B'")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(2))])
+                    .with_anchors(vec![block_id!(4, "E")]),
+                TxTemplate::new("C")
+                    .with_inputs(vec![TxInTemplate::PrevTx("B'", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(30_000, Some(3))])
+                    .with_last_seen(1)
             ],
             // B should not appear in the list methods
             exp_chain_txs: HashSet::from(["A", "B'", "C"]),
@@ -461,38 +337,22 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "B and B' spend A and conflict, C spends both B and B', A is in best chain",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "A",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
-                    last_seen: None,
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B",
-                    inputs: &[TxInTemplate::PrevTx("A", 0), TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    last_seen: Some(200),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B'",
-                    inputs: &[TxInTemplate::PrevTx("A", 0)],
-                    outputs: &[TxOutTemplate::new(30000, Some(2))],
-                    last_seen: Some(300),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "C",
-                    inputs: &[
-                        TxInTemplate::PrevTx("B", 0),
-                        TxInTemplate::PrevTx("B'", 0),
-                    ],
-                    outputs: &[TxOutTemplate::new(20000, Some(3))],
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("A")
+                    .with_inputs(vec![TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(0))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("B")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A", 0), TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(1))])
+                    .with_last_seen(200),
+                TxTemplate::new("B'")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(30_000, Some(2))])
+                    .with_last_seen(300),
+                TxTemplate::new("C")
+                    .with_inputs(vec![TxInTemplate::PrevTx("B", 0), TxInTemplate::PrevTx("B'", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(3))]),
             ],
             // C should not appear in the list methods
             exp_chain_txs: HashSet::from(["A", "B'"]),
@@ -507,38 +367,22 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "B and B' spend A and conflict, B' is confirmed, C spends both B and B', A is in best chain",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "A",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
-                    last_seen: None,
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B",
-                    inputs: &[TxInTemplate::PrevTx("A", 0), TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    last_seen: Some(200),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B'",
-                    inputs: &[TxInTemplate::PrevTx("A", 0)],
-                    outputs: &[TxOutTemplate::new(50000, Some(4))],
-                    anchors: &[block_id!(1, "B")],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "C",
-                    inputs: &[
-                        TxInTemplate::PrevTx("B", 0),
-                        TxInTemplate::PrevTx("B'", 0),
-                    ],
-                    outputs: &[TxOutTemplate::new(20000, Some(5))],
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("A")
+                    .with_inputs(vec![TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(0))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("B")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A", 0), TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(1))])
+                    .with_last_seen(200),
+                TxTemplate::new("B'")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(50_000, Some(4))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("C")
+                    .with_inputs(vec![TxInTemplate::PrevTx("B", 0), TxInTemplate::PrevTx("B'", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(5))]),
             ],
             // C should not appear in the list methods
             exp_chain_txs: HashSet::from(["A", "B'"]),
@@ -553,44 +397,25 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "B and B' spend A and conflict, B' is confirmed, C spends both B and B', D spends C, A is in best chain",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "A",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
-                    last_seen: None,
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B",
-                    inputs: &[TxInTemplate::PrevTx("A", 0), TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(20000, Some(1))],
-                    last_seen: Some(200),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B'",
-                    inputs: &[TxInTemplate::PrevTx("A", 0)],
-                    outputs: &[TxOutTemplate::new(50000, Some(4))],
-                    anchors: &[block_id!(1, "B")],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "C",
-                    inputs: &[
-                        TxInTemplate::PrevTx("B", 0),
-                        TxInTemplate::PrevTx("B'", 0),
-                    ],
-                    outputs: &[TxOutTemplate::new(20000, Some(5))],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "D",
-                    inputs: &[TxInTemplate::PrevTx("C", 0)],
-                    outputs: &[TxOutTemplate::new(20000, Some(6))],
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("A")
+                    .with_inputs(vec![TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(0))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("B")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A", 0), TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(1))])
+                    .with_last_seen(200),
+                TxTemplate::new("B'")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(50_000, Some(4))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("C")
+                    .with_inputs(vec![TxInTemplate::PrevTx("B", 0),  TxInTemplate::PrevTx("B'", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(5))]),
+                TxTemplate::new("D")
+                    .with_inputs(vec![TxInTemplate::PrevTx("C", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(6))]),
             ],
             // D should not appear in the list methods
             exp_chain_txs: HashSet::from(["A", "B'"]),
@@ -605,26 +430,17 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "transitively confirmed ancestors",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "first",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(1000, Some(0))],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "second",
-                    inputs: &[TxInTemplate::PrevTx("first", 0)],
-                    outputs: &[TxOutTemplate::new(900, Some(0))],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "anchored",
-                    inputs: &[TxInTemplate::PrevTx("second", 0)],
-                    outputs: &[TxOutTemplate::new(800, Some(0))],
-                    anchors: &[block_id!(3, "D")],
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("first")
+                    .with_inputs(vec![TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(1_000, Some(0))]),
+                TxTemplate::new("second")
+                    .with_inputs(vec![TxInTemplate::PrevTx("first", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(900, Some(0))]),
+                TxTemplate::new("anchored")
+                    .with_inputs(vec![TxInTemplate::PrevTx("second", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(800, Some(0))])
+                    .with_anchors(vec![block_id!(3, "D")]),
             ],
             exp_chain_txs: HashSet::from(["first", "second", "anchored"]),
             exp_chain_txouts: HashSet::from([("first", 0), ("second", 0), ("anchored", 0)]),
@@ -638,35 +454,23 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "transitively anchored txs should have priority over last seen",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "root",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10_000, Some(0))],
-                    anchors: &[block_id!(1, "B")],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "last_seen_conflict",
-                    inputs: &[TxInTemplate::PrevTx("root", 0)],
-                    outputs: &[TxOutTemplate::new(9900, Some(1))],
-                    last_seen: Some(1000),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "transitively_anchored_conflict",
-                    inputs: &[TxInTemplate::PrevTx("root", 0)],
-                    outputs: &[TxOutTemplate::new(9000, Some(1))],
-                    last_seen: Some(100),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "anchored",
-                    inputs: &[TxInTemplate::PrevTx("transitively_anchored_conflict", 0)],
-                    outputs: &[TxOutTemplate::new(8000, Some(2))],
-                    anchors: &[block_id!(4, "E")],
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("root")
+                    .with_inputs(vec![TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(0))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("last_seen_conflict")
+                    .with_inputs(vec![TxInTemplate::PrevTx("root", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(9_900, Some(1))])
+                    .with_last_seen(1_000),
+                TxTemplate::new("transitively_anchored_conflict")
+                    .with_inputs(vec![TxInTemplate::PrevTx("root", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(9_000, Some(1))])
+                    .with_last_seen(100),
+                TxTemplate::new("anchored")
+                    .with_inputs(vec![TxInTemplate::PrevTx("transitively_anchored_conflict", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(8_000, Some(2))])
+                    .with_anchors(vec![block_id!(4, "E")]),
             ],
             exp_chain_txs: HashSet::from(["root", "transitively_anchored_conflict", "anchored"]),
             exp_chain_txouts: HashSet::from([("root", 0), ("transitively_anchored_conflict", 0), ("anchored", 0)]),
@@ -678,21 +482,15 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "tx anchored in orphaned block and not seen in mempool should be canon",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "root",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10_000, None)],
-                    anchors: &[block_id!(1, "B")],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "tx",
-                    inputs: &[TxInTemplate::PrevTx("root", 0)],
-                    outputs: &[TxOutTemplate::new(9000, Some(0))],
-                    anchors: &[block_id!(6, "not G")],
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("root")
+                    .with_inputs(vec![TxInTemplate::Bogus ])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, None)])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("tx")
+                    .with_inputs(vec![TxInTemplate::PrevTx("root", 0) ])
+                    .with_outputs(vec![TxOutTemplate::new(9_000, Some(0))])
+                    .with_anchors(vec![block_id!(6, "not G")]),
             ],
             exp_chain_txs: HashSet::from(["root", "tx"]),
             exp_chain_txouts: HashSet::from([("tx", 0)]),
@@ -701,28 +499,19 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "tx spends from 2 conflicting transactions where a conflict spends another",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "A",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10_000, None)],
-                    last_seen: Some(1),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "S1",
-                    inputs: &[TxInTemplate::PrevTx("A", 0)],
-                    outputs: &[TxOutTemplate::new(9_000, None)],
-                    last_seen: Some(2),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "S2",
-                    inputs: &[TxInTemplate::PrevTx("A", 0), TxInTemplate::PrevTx("S1", 0)],
-                    outputs: &[TxOutTemplate::new(17_000, None)],
-                    last_seen: Some(3),
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("A")
+                    .with_inputs(vec![TxInTemplate::Bogus ])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, None)])
+                    .with_last_seen(1),
+                TxTemplate::new("S1")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A", 0) ])
+                    .with_outputs(vec![TxOutTemplate::new(9_000, None)])
+                    .with_last_seen(2),
+                TxTemplate::new("S2")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A", 0), TxInTemplate::PrevTx("S1", 0) ])
+                    .with_outputs(vec![TxOutTemplate::new(17_000, None)])
+                    .with_last_seen(3),
             ],
             exp_chain_txs: HashSet::from(["A", "S1"]),
             exp_chain_txouts: HashSet::from([]),
@@ -731,35 +520,23 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "tx spends from 2 conflicting transactions where the conflict is nested",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "A",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10_000, Some(0))],
-                    last_seen: Some(1),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "S1",
-                    inputs: &[TxInTemplate::PrevTx("A", 0)],
-                    outputs: &[TxOutTemplate::new(9_000, Some(0))],
-                    last_seen: Some(3),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B",
-                    inputs: &[TxInTemplate::PrevTx("S1", 0)],
-                    outputs: &[TxOutTemplate::new(8_000, Some(0))],
-                    last_seen: Some(2),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "S2",
-                    inputs: &[TxInTemplate::PrevTx("B", 0), TxInTemplate::PrevTx("A", 0)],
-                    outputs: &[TxOutTemplate::new(17_000, Some(0))],
-                    last_seen: Some(4),
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("A")
+                    .with_inputs(vec![TxInTemplate::Bogus ])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(0))])
+                    .with_last_seen(1),
+                TxTemplate::new("S1")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A", 0) ])
+                    .with_outputs(vec![TxOutTemplate::new(9_000, Some(0))])
+                    .with_last_seen(3),
+                TxTemplate::new("B")
+                    .with_inputs(vec![TxInTemplate::PrevTx("S1", 0) ])
+                    .with_outputs(vec![TxOutTemplate::new(8_000, Some(0))])
+                    .with_last_seen(2),
+                TxTemplate::new("S2")
+                    .with_inputs(vec![TxInTemplate::PrevTx("B", 0), TxInTemplate::PrevTx("A", 0) ])
+                    .with_outputs(vec![TxOutTemplate::new(17_000, Some(0))])
+                    .with_last_seen(4),
             ],
             exp_chain_txs: HashSet::from(["A", "S1", "B"]),
             exp_chain_txouts: HashSet::from([("A", 0), ("B", 0), ("S1", 0)]),
@@ -768,35 +545,23 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "tx spends from 2 conflicting transactions where the conflict is nested (different last_seens)",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "A",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[TxOutTemplate::new(10_000, Some(0))],
-                    last_seen: Some(1),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "S1",
-                    inputs: &[TxInTemplate::PrevTx("A", 0)],
-                    outputs: &[TxOutTemplate::new(9_000, Some(0))],
-                    last_seen: Some(4),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "B",
-                    inputs: &[TxInTemplate::PrevTx("S1", 0)],
-                    outputs: &[TxOutTemplate::new(8_000, Some(0))],
-                    last_seen: Some(2),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "S2",
-                    inputs: &[TxInTemplate::PrevTx("A", 0), TxInTemplate::PrevTx("B", 0)],
-                    outputs: &[TxOutTemplate::new(17_000, Some(0))],
-                    last_seen: Some(3),
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("A")
+                    .with_inputs(vec![TxInTemplate::Bogus ])
+                    .with_outputs(vec![TxOutTemplate::new(10_000, Some(0))])
+                    .with_last_seen(1),
+                TxTemplate::new("S1")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A", 0) ])
+                    .with_outputs(vec![TxOutTemplate::new(9_000, Some(0))])
+                    .with_last_seen(4),
+                TxTemplate::new("B")
+                    .with_inputs(vec![TxInTemplate::PrevTx("S1", 0) ])
+                    .with_outputs(vec![TxOutTemplate::new(8_000, Some(0))])
+                    .with_last_seen(2),
+                TxTemplate::new("S2")
+                    .with_inputs(vec![TxInTemplate::PrevTx("A", 0), TxInTemplate::PrevTx("B", 0) ])
+                    .with_outputs(vec![TxOutTemplate::new(17_000, Some(0))])
+                    .with_last_seen(3),
             ],
             exp_chain_txs: HashSet::from(["A", "S1", "B"]),
             exp_chain_txouts: HashSet::from([("A", 0), ("B", 0), ("S1", 0)]),
@@ -805,41 +570,25 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "assume-canonical-tx displaces unconfirmed chain",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "root",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[
-                        TxOutTemplate::new(21_000, Some(0)),
-                        TxOutTemplate::new(21_000, Some(1)),
-                    ],
-                    anchors: &[block_id!(1, "B")],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "unconfirmed",
-                    inputs: &[TxInTemplate::PrevTx("root", 0)],
-                    outputs: &[TxOutTemplate::new(20_000, Some(1))],
-                    last_seen: Some(2),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "unconfirmed_descendant",
-                    inputs: &[
-                        TxInTemplate::PrevTx("unconfirmed", 0),
-                        TxInTemplate::PrevTx("root", 1),
-                    ],
-                    outputs: &[TxOutTemplate::new(28_000, Some(2))],
-                    last_seen: Some(2),
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "assume_canonical",
-                    inputs: &[TxInTemplate::PrevTx("root", 0)],
-                    outputs: &[TxOutTemplate::new(19_000, Some(3))],
-                    assume_canonical: true,
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("root")
+                    .with_inputs(vec![TxInTemplate::Bogus ])
+                    .with_outputs(vec![TxOutTemplate::new(21_000, Some(0)),
+                TxOutTemplate::new(21_000, Some(1))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("unconfirmed")
+                    .with_inputs(vec![TxInTemplate::PrevTx("root", 0) ])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(1))])
+                    .with_last_seen(2),
+                TxTemplate::new("unconfirmed_descendant")
+                    .with_inputs(vec![TxInTemplate::PrevTx("unconfirmed", 0),
+                TxInTemplate::PrevTx("root", 1) ])
+                    .with_outputs(vec![TxOutTemplate::new(28_000, Some(2))])
+                    .with_last_seen(2),
+                TxTemplate::new("assume_canonical")
+                    .with_inputs(vec![TxInTemplate::PrevTx("root", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(19_000, Some(3))])
+                    .with_assume_canonical(true),
             ],
             exp_chain_txs: HashSet::from(["root", "assume_canonical"]),
             exp_chain_txouts: HashSet::from([("root", 0), ("root", 1), ("assume_canonical", 0)]),
@@ -853,41 +602,24 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "assume-canonical-tx displaces confirmed chain",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "root",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[
-                        TxOutTemplate::new(21_000, Some(0)),
-                        TxOutTemplate::new(21_000, Some(1)),
-                    ],
-                    anchors: &[block_id!(1, "B")],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "confirmed",
-                    inputs: &[TxInTemplate::PrevTx("root", 0)],
-                    outputs: &[TxOutTemplate::new(20_000, Some(1))],
-                    anchors: &[block_id!(2, "C")],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "confirmed_descendant",
-                    inputs: &[
-                        TxInTemplate::PrevTx("confirmed", 0),
-                        TxInTemplate::PrevTx("root", 1),
-                    ],
-                    outputs: &[TxOutTemplate::new(28_000, Some(2))],
-                    anchors: &[block_id!(3, "D")],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "assume_canonical",
-                    inputs: &[TxInTemplate::PrevTx("root", 0)],
-                    outputs: &[TxOutTemplate::new(19_000, Some(3))],
-                    assume_canonical: true,
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("root")
+                    .with_inputs(vec![TxInTemplate::Bogus ])
+                    .with_outputs(vec![TxOutTemplate::new(21_000, Some(0)),
+                TxOutTemplate::new(21_000, Some(1))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("confirmed")
+                    .with_inputs(vec![TxInTemplate::PrevTx("root", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(1))])
+                    .with_anchors(vec![block_id!(2, "C")]),
+                TxTemplate::new("confirmed_descendant")
+                    .with_inputs(vec![TxInTemplate::PrevTx("confirmed", 0), TxInTemplate::PrevTx("root", 1)])
+                    .with_outputs(vec![TxOutTemplate::new(28_000, Some(2))])
+                    .with_anchors(vec![block_id!(3, "D")]),
+                TxTemplate::new("assume_canonical")
+                    .with_inputs(vec![TxInTemplate::PrevTx("root", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(19_000, Some(3))])
+                    .with_assume_canonical(true),
             ],
             exp_chain_txs: HashSet::from(["root", "assume_canonical"]),
             exp_chain_txouts: HashSet::from([("root", 0), ("root", 1), ("assume_canonical", 0)]),
@@ -901,37 +633,23 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "assume-canonical txs respects order",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "root",
-                    inputs: &[TxInTemplate::Bogus],
-                    outputs: &[
-                        TxOutTemplate::new(21_000, Some(0)),
-                    ],
-                    anchors: &[block_id!(1, "B")],
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "assume_a",
-                    inputs: &[TxInTemplate::PrevTx("root", 0)],
-                    outputs: &[TxOutTemplate::new(20_000, Some(1))],
-                    assume_canonical: true,
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "assume_b",
-                    inputs: &[TxInTemplate::PrevTx("root", 0)],
-                    outputs: &[TxOutTemplate::new(19_000, Some(1))],
-                    assume_canonical: true,
-                    ..Default::default()
-                },
-                TxTemplate {
-                    tx_name: "assume_c",
-                    inputs: &[TxInTemplate::PrevTx("root", 0)],
-                    outputs: &[TxOutTemplate::new(18_000, Some(1))],
-                    assume_canonical: true,
-                    ..Default::default()
-                },
+            tx_templates: vec![
+                TxTemplate::new("root")
+                    .with_inputs(vec![TxInTemplate::Bogus])
+                    .with_outputs(vec![TxOutTemplate::new(21_000, Some(0))])
+                    .with_anchors(vec![block_id!(1, "B")]),
+                TxTemplate::new("assume_a")
+                    .with_inputs(vec![TxInTemplate::PrevTx("root", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(20_000, Some(1))])
+                    .with_assume_canonical(true),
+                TxTemplate::new("assume_b")
+                    .with_inputs(vec![TxInTemplate::PrevTx("root", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(19_000, Some(1))])
+                    .with_assume_canonical(true),
+                TxTemplate::new("assume_c")
+                    .with_inputs(vec![TxInTemplate::PrevTx("root", 0)])
+                    .with_outputs(vec![TxOutTemplate::new(18_000, Some(1))])
+                    .with_assume_canonical(true),
             ],
             exp_chain_txs: HashSet::from(["root", "assume_c"]),
             exp_chain_txouts: HashSet::from([("root", 0), ("assume_c", 0)]),
@@ -945,15 +663,11 @@ fn test_tx_conflict_handling() {
         },
         Scenario {
             name: "coinbase tx must not become unconfirmed",
-            tx_templates: &[
-                TxTemplate {
-                    tx_name: "coinbase",
-                    inputs: &[TxInTemplate::Coinbase],
-                    outputs: &[TxOutTemplate::new(21_000, Some(0))],
-                    // Stale block
-                    anchors: &[block_id!(1, "B-prime")],
-                    ..Default::default()
-                }
+            tx_templates: vec![
+                TxTemplate::new("coinbase")
+                    .with_inputs(vec![TxInTemplate::Coinbase])
+                    .with_outputs(vec![TxOutTemplate::new(21_000, Some(0))])
+                    .with_anchors(vec![block_id!(1, "B-prime")])
             ],
             exp_chain_txs: HashSet::from([]),
             exp_chain_txouts: HashSet::from([]),
@@ -968,7 +682,7 @@ fn test_tx_conflict_handling() {
     ];
 
     for scenario in scenarios {
-        let env = init_graph(scenario.tx_templates.iter());
+        let env = init_graph(scenario.tx_templates);
 
         let canonical_view = local_chain.canonical_view(
             &env.tx_graph,
@@ -983,7 +697,7 @@ fn test_tx_conflict_handling() {
         let exp_txs = scenario
             .exp_chain_txs
             .iter()
-            .map(|txid| *env.txid_to_name.get(txid).expect("txid must exist"))
+            .map(|&txid| *env.txid_to_name.get(txid).expect("txid must exist"))
             .collect::<BTreeSet<_>>();
         assert_eq!(
             txs, exp_txs,
@@ -998,9 +712,9 @@ fn test_tx_conflict_handling() {
         let exp_txouts = scenario
             .exp_chain_txouts
             .iter()
-            .map(|(txid, vout)| OutPoint {
+            .map(|&(txid, vout)| OutPoint {
                 txid: *env.txid_to_name.get(txid).expect("txid must exist"),
-                vout: *vout,
+                vout,
             })
             .collect::<BTreeSet<_>>();
         assert_eq!(
@@ -1016,9 +730,9 @@ fn test_tx_conflict_handling() {
         let exp_utxos = scenario
             .exp_unspents
             .iter()
-            .map(|(txid, vout)| OutPoint {
+            .map(|&(txid, vout)| OutPoint {
                 txid: *env.txid_to_name.get(txid).expect("txid must exist"),
-                vout: *vout,
+                vout,
             })
             .collect::<BTreeSet<_>>();
         assert_eq!(

--- a/crates/chain/tests/test_tx_graph_conflicts.rs
+++ b/crates/chain/tests/test_tx_graph_conflicts.rs
@@ -697,7 +697,7 @@ fn test_tx_conflict_handling() {
         let exp_txs = scenario
             .exp_chain_txs
             .iter()
-            .map(|&txid| *env.txid_to_name.get(txid).expect("txid must exist"))
+            .map(|&txid| *env.txids.get(txid).expect("txid must exist"))
             .collect::<BTreeSet<_>>();
         assert_eq!(
             txs, exp_txs,
@@ -713,7 +713,7 @@ fn test_tx_conflict_handling() {
             .exp_chain_txouts
             .iter()
             .map(|&(txid, vout)| OutPoint {
-                txid: *env.txid_to_name.get(txid).expect("txid must exist"),
+                txid: *env.txids.get(txid).expect("txid must exist"),
                 vout,
             })
             .collect::<BTreeSet<_>>();
@@ -731,7 +731,7 @@ fn test_tx_conflict_handling() {
             .exp_unspents
             .iter()
             .map(|&(txid, vout)| OutPoint {
-                txid: *env.txid_to_name.get(txid).expect("txid must exist"),
+                txid: *env.txids.get(txid).expect("txid must exist"),
                 vout,
             })
             .collect::<BTreeSet<_>>();

--- a/crates/testenv/Cargo.toml
+++ b/crates/testenv/Cargo.toml
@@ -16,9 +16,10 @@ readme = "README.md"
 workspace = true
 
 [dependencies]
-bdk_chain = { path = "../chain", version = "0.23.1", default-features = false }
+bdk_chain = { path = "../chain", version = "0.23.1", default-features = false, features = ["miniscript"]}
 electrsd = { version = "0.38.0", features = [ "legacy" ], default-features = false }
 bitcoin = { version = "0.32.0", default-features = false }
+rand = { version = "0.8.0", default-features = false, features = ["std", "small_rng", "std_rng"] }
 
 [dev-dependencies]
 bdk_testenv = { path = "." }

--- a/crates/testenv/Cargo.toml
+++ b/crates/testenv/Cargo.toml
@@ -16,9 +16,10 @@ readme = "README.md"
 workspace = true
 
 [dependencies]
-bdk_chain = { path = "../chain", version = "0.23.1", default-features = false }
+bdk_chain = { path = "../chain", version = "0.23.1", default-features = false, features = ["miniscript"]}
 electrsd = { version = "0.36.1", features = [ "legacy" ], default-features = false }
 bitcoin = { version = "0.32.0", default-features = false }
+rand = { version = "0.8.0", default-features = false, features = ["std", "small_rng", "std_rng"] }
 
 [dev-dependencies]
 bdk_testenv = { path = "." }

--- a/crates/testenv/Cargo.toml
+++ b/crates/testenv/Cargo.toml
@@ -16,7 +16,7 @@ readme = "README.md"
 workspace = true
 
 [dependencies]
-bdk_chain = { path = "../chain", version = "0.23.1", default-features = false }
+bdk_chain = { path = "../chain", version = "0.23.1", default-features = false, features = ["miniscript"]}
 electrsd = { version = "0.38.0", features = [ "legacy" ], default-features = false }
 bitcoin = { version = "0.32.0", default-features = false }
 rand = { version = "0.8.0", default-features = false, features = ["std", "small_rng", "std_rng"] }

--- a/crates/testenv/Cargo.toml
+++ b/crates/testenv/Cargo.toml
@@ -19,6 +19,7 @@ workspace = true
 bdk_chain = { path = "../chain", version = "0.23.1", default-features = false }
 electrsd = { version = "0.38.0", features = [ "legacy" ], default-features = false }
 bitcoin = { version = "0.32.0", default-features = false }
+rand = { version = "0.8.0", default-features = false, features = ["std", "small_rng", "std_rng"] }
 
 [dev-dependencies]
 bdk_testenv = { path = "." }

--- a/crates/testenv/src/lib.rs
+++ b/crates/testenv/src/lib.rs
@@ -1,6 +1,8 @@
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
+pub mod tx_template;
 pub mod utils;
+pub use tx_template::*;
 
 use anyhow::Context;
 use bdk_chain::bitcoin::{

--- a/crates/testenv/src/lib.rs
+++ b/crates/testenv/src/lib.rs
@@ -1,3 +1,63 @@
+//! # BDK Test Environment
+//!
+//! Testing utilities for building and testing Bitcoin applications against a local
+//! regtest network. The struct [`TestEnv`], manages a single `bitcoind` node
+//! with a connected `electrs` instance and drives them through common test scenarios.
+//!
+//! ## Features
+//!
+//! * **Node management** — spin up and configure `bitcoind` and `electrs` via [`TestEnv`] and
+//!   [`Config`]. The default configuration enables HTTP on `electrsd`, as required by `bdk_esplora`
+//!   tests.
+//! * **Block mining** — generate blocks with [`TestEnv::mine_blocks`], or shape individual blocks
+//!   with [`TestEnv::mine_block`] and [`MineParams`] to produce empty blocks, set custom
+//!   timestamps, or choose the coinbase output script.
+//! * **Chain reorganizations** — fork and reorg the chain with [`TestEnv::invalidate_blocks`],
+//!   [`TestEnv::reorg`], and [`TestEnv::reorg_empty_blocks`] to exercise how an application handles
+//!   conflicting chain states.
+//! * **Transactions & sync** — broadcast via Bitcoin Core RPC ([`TestEnv::send`]) and block on the
+//!   Electrum server with [`TestEnv::wait_until_electrum_sees_block`] and
+//!   [`TestEnv::wait_until_electrum_sees_txid`] to keep components in sync during tests.
+//! * **Transaction-graph templates** — build deterministic transaction histories and conflict
+//!   scenarios with the [`tx_template`] module, without a running node.
+//!
+//! ## Example
+//!
+//! ```rust,no_run
+//! use bdk_chain::bitcoin::Amount;
+//! use bdk_testenv::TestEnv;
+//! use core::time::Duration;
+//!
+//! # fn main() -> bdk_testenv::anyhow::Result<()> {
+//! // Spin up a regtest bitcoind + electrs environment with the default config.
+//! let env = TestEnv::new()?;
+//!
+//! // Get a fresh address from the bitcoind node.
+//! let addr = env
+//!     .rpc_client()
+//!     .get_new_address(None, None)?
+//!     .address()?
+//!     .assume_checked();
+//!
+//! // Mine 100 blocks to mature a coinbase reward to that address.
+//! env.mine_blocks(100, Some(addr.clone()))?;
+//!
+//! // Broadcast a transaction and wait for electrs to index it.
+//! let txid = env.send(&addr, Amount::from_sat(100_000))?;
+//! env.wait_until_electrum_sees_txid(txid, Duration::from_secs(5))?;
+//!
+//! // Mine an empty block, ignoring the mempool.
+//! env.mine_empty_block()?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Re-exports
+//!
+//! For convenience, this crate re-exports [`electrsd`], [`bitcoind`], [`anyhow`],
+//! [`corepc_client`], and [`electrum_client`], so tests can use matching versions
+//! without declaring those dependencies themselves.
+
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 pub mod tx_template;

--- a/crates/testenv/src/tx_template.rs
+++ b/crates/testenv/src/tx_template.rs
@@ -1,57 +1,79 @@
-#![cfg(feature = "miniscript")]
+//! Transaction templates for constructing complex transaction histories for testing purposes.
 
-use bdk_testenv::utils::DESCRIPTORS;
-use rand::distributions::{Alphanumeric, DistString};
-use std::collections::HashMap;
-
-use bdk_chain::{spk_txout::SpkTxOutIndex, tx_graph::TxGraph, Anchor, CanonicalizationParams};
+use crate::utils::DESCRIPTORS;
+use bdk_chain::{
+    miniscript::Descriptor, spk_txout::SpkTxOutIndex, tx_graph::TxGraph, Anchor,
+    CanonicalizationParams,
+};
 use bitcoin::{
     locktime::absolute::LockTime, secp256k1::Secp256k1, transaction, Amount, OutPoint, ScriptBuf,
     Sequence, Transaction, TxIn, TxOut, Txid, Witness,
 };
-use miniscript::Descriptor;
+use rand::distributions::{Alphanumeric, DistString};
+use std::collections::HashMap;
 
-/// Template for creating a transaction in `TxGraph`.
+/// Template for creating a transaction in a [`TxGraph`].
 ///
-/// The incentive for transaction templates is to create a transaction history in a simple manner to
-/// avoid having to explicitly hash previous transactions to form previous outpoints of later
-/// transactions.
+/// This is the main building block for constructing complex transaction histories
+/// for tests. It allows you to refer to previous transactions by name instead of
+/// manually managing txids and outpoints.
 #[derive(Clone, Copy, Default)]
 pub struct TxTemplate<'a, A> {
-    /// Uniquely identifies the transaction, before it can have a txid.
+    /// A unique name used to refer to this transaction in other templates.
     pub tx_name: &'a str,
+
+    /// The inputs of this transaction.
     pub inputs: &'a [TxInTemplate<'a>],
+
+    /// The outputs of this transaction.
     pub outputs: &'a [TxOutTemplate],
+
+    /// Anchors (confirmations) for this transaction.
     pub anchors: &'a [A],
+
+    /// Unix timestamp when this transaction was last seen in the mempool.
     pub last_seen: Option<u64>,
+
+    /// If `true`, this transaction will be treated as canonical regardless of
+    /// conflict resolution rules (used for testing forced canonicalization).
     pub assume_canonical: bool,
 }
 
+/// Describes how an input is created in a [`TxTemplate`].
 #[allow(dead_code)]
 pub enum TxInTemplate<'a> {
-    /// This will give a random txid and vout.
+    /// A random (bogus) previous output. Useful when the actual prevout doesn't matter.
     Bogus,
 
-    /// This is used for coinbase transactions because they do not have previous outputs.
+    /// A coinbase input (no previous output).
     Coinbase,
 
-    /// Contains the `tx_name` and `vout` that we are spending. The rule is that we must only spend
-    /// from tx of a previous `TxTemplate`.
+    /// Spends from a previous transaction defined in the template list.
+    ///
+    /// The rule is that the referenced transaction (`prev_name`) must appear
+    /// earlier in the list passed to [`init_graph`].
     PrevTx(&'a str, usize),
 }
 
+/// Describes an output in a [`TxTemplate`].
 pub struct TxOutTemplate {
+    /// Value in satoshis.
     pub value: u64,
-    pub spk_index: Option<u32>, // some = get spk from SpkTxOutIndex, none = random spk
+    /// If `Some(index)`, the output will use the script pubkey at that index
+    /// from the test descriptor set. If `None`, a random (empty) script is used.
+    pub spk_index: Option<u32>,
 }
 
-#[allow(unused)]
 impl TxOutTemplate {
     pub fn new(value: u64, spk_index: Option<u32>) -> Self {
         TxOutTemplate { value, spk_index }
     }
 }
 
+/// The result of calling [`init_graph`].
+///
+/// Contains the built [`TxGraph`], the associated indexer, and a mapping from
+/// template names to their final txids.
 #[allow(dead_code)]
 pub struct TxTemplateEnv<'a, A> {
     pub tx_graph: TxGraph<A>,
@@ -60,14 +82,21 @@ pub struct TxTemplateEnv<'a, A> {
     pub canonicalization_params: CanonicalizationParams,
 }
 
-#[allow(dead_code)]
+/// Builds a [`TxGraph`] (and associated indexer) from a list of [`TxTemplate`]s.
+///
+/// This is the main entry point for using transaction templates in tests.
+/// It handles txid generation, outpoint wiring, anchor insertion, and last-seen
+/// timestamps automatically.
 pub fn init_graph<'a, A: Anchor + Clone + 'a>(
     tx_templates: impl IntoIterator<Item = &'a TxTemplate<'a, A>>,
 ) -> TxTemplateEnv<'a, A> {
     let (descriptor, _) =
         Descriptor::parse_descriptor(&Secp256k1::signing_only(), DESCRIPTORS[2]).unwrap();
+
     let mut tx_graph = TxGraph::<A>::default();
     let mut indexer = SpkTxOutIndex::default();
+
+    // Pre-populate the indexer with 10 script pubkeys from the test descriptor
     (0..10).for_each(|index| {
         indexer.insert_spk(
             index,
@@ -77,9 +106,10 @@ pub fn init_graph<'a, A: Anchor + Clone + 'a>(
                 .script_pubkey(),
         );
     });
-    let mut txid_to_name = HashMap::<&'a str, Txid>::new();
 
+    let mut txid_to_name = HashMap::<&'a str, Txid>::new();
     let mut canonicalization_params = CanonicalizationParams::default();
+
     for (bogus_txin_vout, tx_tmp) in tx_templates.into_iter().enumerate() {
         let tx = Transaction {
             version: transaction::Version::non_standard(0),
@@ -137,19 +167,24 @@ pub fn init_graph<'a, A: Anchor + Clone + 'a>(
         };
 
         let txid = tx.compute_txid();
+
         if tx_tmp.assume_canonical {
             canonicalization_params.assume_canonical.push(txid);
         }
+
         txid_to_name.insert(tx_tmp.tx_name, txid);
         indexer.scan(&tx);
         let _ = tx_graph.insert_tx(tx.clone());
+
         for anchor in tx_tmp.anchors.iter() {
             let _ = tx_graph.insert_anchor(txid, anchor.clone());
         }
+
         if let Some(last_seen) = tx_tmp.last_seen {
             let _ = tx_graph.insert_seen_at(txid, last_seen);
         }
     }
+
     TxTemplateEnv {
         tx_graph,
         indexer,

--- a/crates/testenv/src/tx_template.rs
+++ b/crates/testenv/src/tx_template.rs
@@ -10,26 +10,29 @@ use bitcoin::{
     Sequence, Transaction, TxIn, TxOut, Txid, Witness,
 };
 use rand::distributions::{Alphanumeric, DistString};
-use std::collections::HashMap;
+use std::{borrow::Cow, collections::HashMap};
 
 /// Template for creating a transaction in a [`TxGraph`].
 ///
 /// This is the main building block for constructing complex transaction histories
 /// for tests. It allows you to refer to previous transactions by name instead of
 /// manually managing txids and outpoints.
-#[derive(Clone, Copy, Default)]
-pub struct TxTemplate<'a, A> {
+#[derive(Clone)]
+pub struct TxTemplate<A>
+where
+    A: Clone + 'static,
+{
     /// A unique name used to refer to this transaction in other templates.
-    pub tx_name: &'a str,
+    pub tx_name: Cow<'static, str>,
 
     /// The inputs of this transaction.
-    pub inputs: &'a [TxInTemplate<'a>],
+    pub inputs: Cow<'static, [TxInTemplate]>,
 
     /// The outputs of this transaction.
-    pub outputs: &'a [TxOutTemplate],
+    pub outputs: Cow<'static, [TxOutTemplate]>,
 
     /// Anchors (confirmations) for this transaction.
-    pub anchors: &'a [A],
+    pub anchors: Cow<'static, [A]>,
 
     /// Unix timestamp when this transaction was last seen in the mempool.
     pub last_seen: Option<u64>,
@@ -39,9 +42,69 @@ pub struct TxTemplate<'a, A> {
     pub assume_canonical: bool,
 }
 
+impl<A> Default for TxTemplate<A>
+where
+    A: Clone + 'static,
+{
+    fn default() -> Self {
+        Self {
+            tx_name: Cow::Borrowed(""),
+            inputs: Cow::Borrowed(&[]),
+            outputs: Cow::Borrowed(&[]),
+            anchors: Cow::Borrowed(&[]),
+            last_seen: None,
+            assume_canonical: false,
+        }
+    }
+}
+
+impl<A> TxTemplate<A>
+where
+    A: Clone + 'static,
+{
+    /// Create a new template with a name.
+    pub fn new(name: impl Into<Cow<'static, str>>) -> Self {
+        Self {
+            tx_name: name.into(),
+            ..Default::default()
+        }
+    }
+
+    //// Set inputs. Accepts `&[TxInTemplate]`, `Vec<TxInTemplate>`, or a static slice.
+    pub fn with_inputs(mut self, inputs: impl Into<Cow<'static, [TxInTemplate]>>) -> Self {
+        self.inputs = inputs.into();
+        self
+    }
+
+    /// Set outputs with `Vec<TxOutTemplate>` or `&'static [TxOutTemplate]`.
+    pub fn with_outputs(mut self, outputs: impl Into<Cow<'static, [TxOutTemplate]>>) -> Self {
+        self.outputs = outputs.into();
+        self
+    }
+
+    /// Set anchors. Supports `Vec<A>` or `&'static [A]`.
+    pub fn with_anchors(mut self, anchors: impl Into<Cow<'static, [A]>>) -> Self {
+        self.anchors = anchors.into();
+        self
+    }
+
+    /// Mark this transaction as canonical.
+    pub fn with_assume_canonical(mut self, assume: bool) -> Self {
+        self.assume_canonical = assume;
+        self
+    }
+
+    /// Set the last-seen mempool timestamp.
+    pub fn with_last_seen(mut self, last_seen: Option<u64>) -> Self {
+        self.last_seen = last_seen;
+        self
+    }
+}
+
 /// Describes how an input is created in a [`TxTemplate`].
+#[derive(Clone, Debug)]
 #[allow(dead_code)]
-pub enum TxInTemplate<'a> {
+pub enum TxInTemplate {
     /// A random (bogus) previous output. Useful when the actual prevout doesn't matter.
     Bogus,
 
@@ -52,10 +115,11 @@ pub enum TxInTemplate<'a> {
     ///
     /// The rule is that the referenced transaction (`prev_name`) must appear
     /// earlier in the list passed to [`init_graph`].
-    PrevTx(&'a str, usize),
+    PrevTx(Cow<'static, str>, usize),
 }
 
 /// Describes an output in a [`TxTemplate`].
+#[derive(Clone, Debug)]
 pub struct TxOutTemplate {
     /// Value in satoshis.
     pub value: u64,
@@ -75,10 +139,10 @@ impl TxOutTemplate {
 /// Contains the built [`TxGraph`], the associated indexer, and a mapping from
 /// template names to their final txids.
 #[allow(dead_code)]
-pub struct TxTemplateEnv<'a, A> {
+pub struct TxTemplateEnv<A> {
     pub tx_graph: TxGraph<A>,
     pub indexer: SpkTxOutIndex<u32>,
-    pub txid_to_name: HashMap<&'a str, Txid>,
+    pub txid_to_name: HashMap<Cow<'static, str>, Txid>,
     pub canonicalization_params: CanonicalizationParams,
 }
 
@@ -87,9 +151,9 @@ pub struct TxTemplateEnv<'a, A> {
 /// This is the main entry point for using transaction templates in tests.
 /// It handles txid generation, outpoint wiring, anchor insertion, and last-seen
 /// timestamps automatically.
-pub fn init_graph<'a, A: Anchor + Clone + 'a>(
-    tx_templates: impl IntoIterator<Item = &'a TxTemplate<'a, A>>,
-) -> TxTemplateEnv<'a, A> {
+pub fn init_graph<A: Anchor + Clone + 'static>(
+    tx_templates: impl IntoIterator<Item = TxTemplate<A>>,
+) -> TxTemplateEnv<A> {
     let (descriptor, _) =
         Descriptor::parse_descriptor(&Secp256k1::signing_only(), DESCRIPTORS[2]).unwrap();
 
@@ -107,7 +171,7 @@ pub fn init_graph<'a, A: Anchor + Clone + 'a>(
         );
     });
 
-    let mut txid_to_name = HashMap::<&'a str, Txid>::new();
+    let mut txid_to_name = HashMap::<Cow<'static, str>, Txid>::new();
     let mut canonicalization_params = CanonicalizationParams::default();
 
     for (bogus_txin_vout, tx_tmp) in tx_templates.into_iter().enumerate() {

--- a/crates/testenv/src/tx_template.rs
+++ b/crates/testenv/src/tx_template.rs
@@ -1,69 +1,151 @@
-#![cfg(feature = "miniscript")]
+//! Transaction templates for constructing complex transaction histories for testing purposes.
 
-use bdk_testenv::utils::DESCRIPTORS;
-use rand::distributions::{Alphanumeric, DistString};
-use std::collections::HashMap;
-
-use bdk_chain::{spk_txout::SpkTxOutIndex, tx_graph::TxGraph, Anchor, CanonicalParams};
+use crate::utils::DESCRIPTORS;
+use bdk_chain::{
+    miniscript::Descriptor, spk_txout::SpkTxOutIndex, tx_graph::TxGraph, Anchor,
+    CanonicalParams,
+};
 use bitcoin::{
     locktime::absolute::LockTime, secp256k1::Secp256k1, transaction, Amount, OutPoint, ScriptBuf,
     Sequence, Transaction, TxIn, TxOut, Txid, Witness,
 };
-use miniscript::Descriptor;
+use rand::distributions::{Alphanumeric, DistString};
+use std::collections::HashMap;
 
-/// Template for creating a transaction in `TxGraph`.
+/// Template for creating a transaction in a [`TxGraph`].
 ///
-/// The incentive for transaction templates is to create a transaction history in a simple manner to
-/// avoid having to explicitly hash previous transactions to form previous outpoints of later
-/// transactions.
-#[derive(Clone, Copy, Default)]
-pub struct TxTemplate<'a, A> {
-    /// Uniquely identifies the transaction, before it can have a txid.
-    pub tx_name: &'a str,
-    pub inputs: &'a [TxInTemplate<'a>],
-    pub outputs: &'a [TxOutTemplate],
-    pub anchors: &'a [A],
+/// This is the main building block for constructing complex transaction histories
+/// for tests. It allows you to refer to previous transactions by name instead of
+/// manually managing txids and outpoints.
+#[derive(Clone)]
+pub struct TxTemplate<A> {
+    /// A unique name used to refer to this transaction in other templates.
+    pub tx_name: &'static str,
+
+    /// The inputs of this transaction.
+    pub inputs: Vec<TxInTemplate>,
+
+    /// The outputs of this transaction.
+    pub outputs: Vec<TxOutTemplate>,
+
+    /// Anchors (confirmations) for this transaction.
+    pub anchors: Vec<A>,
+
+    /// Unix timestamp when this transaction was last seen in the mempool.
     pub last_seen: Option<u64>,
+
+    /// If `true`, this transaction will be treated as canonical regardless of
+    /// conflict resolution rules (used for testing forced canonicalization).
     pub assume_canonical: bool,
 }
 
+/// Describes how an input is created in a [`TxTemplate`].
+#[derive(Clone, Debug)]
 #[allow(dead_code)]
-pub enum TxInTemplate<'a> {
-    /// This will give a random txid and vout.
+pub enum TxInTemplate {
+    /// A random (bogus) previous output. Useful when the actual prevout doesn't matter.
     Bogus,
 
-    /// This is used for coinbase transactions because they do not have previous outputs.
+    /// A coinbase input (no previous output).
     Coinbase,
 
-    /// Contains the `tx_name` and `vout` that we are spending. The rule is that we must only spend
-    /// from tx of a previous `TxTemplate`.
-    PrevTx(&'a str, usize),
+    /// Spends from a previous transaction defined in the template list.
+    ///
+    /// The rule is that the referenced transaction (`prev_name`) must appear
+    /// earlier in the list passed to [`init_graph`].
+    PrevTx(&'static str, usize),
 }
 
+/// Describes an output in a [`TxTemplate`].
+#[derive(Clone, Copy, Debug)]
 pub struct TxOutTemplate {
+    /// Value in satoshis.
     pub value: u64,
-    pub spk_index: Option<u32>, // some = get spk from SpkTxOutIndex, none = random spk
+    /// If `Some(index)`, the output will use the script pubkey at that index
+    /// from the test descriptor set. If `None`, a random (empty) script is used.
+    pub spk_index: Option<u32>,
 }
 
-#[allow(unused)]
+impl<A> Default for TxTemplate<A> {
+    fn default() -> Self {
+        Self {
+            tx_name: "",
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            anchors: Vec::new(),
+            last_seen: None,
+            assume_canonical: false,
+        }
+    }
+}
+
+impl<A> TxTemplate<A> {
+    /// Create a new template with a name.
+    pub fn new(tx_name: &'static str) -> Self {
+        Self {
+            tx_name,
+            ..Default::default()
+        }
+    }
+
+    /// Set the inputs of this transaction.
+    pub fn with_inputs(mut self, inputs: Vec<TxInTemplate>) -> Self {
+        self.inputs = inputs;
+        self
+    }
+
+    /// Set the outputs of this transaction.
+    pub fn with_outputs(mut self, outputs: Vec<TxOutTemplate>) -> Self {
+        self.outputs = outputs;
+        self
+    }
+
+    /// Set the anchors (confirmations) of this transaction.
+    pub fn with_anchors(mut self, anchors: Vec<A>) -> Self {
+        self.anchors = anchors;
+        self
+    }
+
+    /// Mark this transaction as canonical.
+    pub fn with_assume_canonical(mut self, assume: bool) -> Self {
+        self.assume_canonical = assume;
+        self
+    }
+
+    /// Set the last-seen mempool timestamp.
+    pub fn with_last_seen(mut self, last_seen: u64) -> Self {
+        self.last_seen = Some(last_seen);
+        self
+    }
+}
+
 impl TxOutTemplate {
     pub fn new(value: u64, spk_index: Option<u32>) -> Self {
         TxOutTemplate { value, spk_index }
     }
 }
 
+/// The result of calling [`init_graph`].
+///
+/// Contains the built [`TxGraph`], the associated indexer, and a mapping from
+/// template names to their final txids.
 #[allow(dead_code)]
-pub struct TxTemplateEnv<'a, A> {
+pub struct TxTemplateEnv<A> {
     pub tx_graph: TxGraph<A>,
     pub indexer: SpkTxOutIndex<u32>,
-    pub txid_to_name: HashMap<&'a str, Txid>,
+    pub txid_to_name: HashMap<&'static str, Txid>,
     pub canonicalization_params: CanonicalParams,
 }
 
+/// Builds a [`TxGraph`] (and associated indexer) from a list of [`TxTemplate`]s.
+///
+/// This is the main entry point for using transaction templates in tests.
+/// It handles txid generation, outpoint wiring, anchor insertion, and last-seen
+/// timestamps automatically.
 #[allow(dead_code)]
-pub fn init_graph<'a, A: Anchor + Clone + 'a>(
-    tx_templates: impl IntoIterator<Item = &'a TxTemplate<'a, A>>,
-) -> TxTemplateEnv<'a, A> {
+pub fn init_graph<A: Anchor + Clone>(
+    tx_templates: impl IntoIterator<Item = TxTemplate<A>>,
+) -> TxTemplateEnv<A> {
     let (descriptor, _) =
         Descriptor::parse_descriptor(&Secp256k1::signing_only(), DESCRIPTORS[2]).unwrap();
     let mut tx_graph = TxGraph::<A>::default();
@@ -77,9 +159,9 @@ pub fn init_graph<'a, A: Anchor + Clone + 'a>(
                 .script_pubkey(),
         );
     });
-    let mut txid_to_name = HashMap::<&'a str, Txid>::new();
-
+    let mut txid_to_name = HashMap::<&'static str, Txid>::new();
     let mut canonicalization_params = CanonicalParams::default();
+    
     for (bogus_txin_vout, tx_tmp) in tx_templates.into_iter().enumerate() {
         let tx = Transaction {
             version: transaction::Version::non_standard(0),

--- a/crates/testenv/src/tx_template.rs
+++ b/crates/testenv/src/tx_template.rs
@@ -2,8 +2,7 @@
 
 use crate::utils::DESCRIPTORS;
 use bdk_chain::{
-    miniscript::Descriptor, spk_txout::SpkTxOutIndex, tx_graph::TxGraph, Anchor,
-    CanonicalParams,
+    miniscript::Descriptor, spk_txout::SpkTxOutIndex, tx_graph::TxGraph, Anchor, CanonicalParams,
 };
 use bitcoin::{
     locktime::absolute::LockTime, secp256k1::Secp256k1, transaction, Amount, OutPoint, ScriptBuf,
@@ -161,7 +160,7 @@ pub fn init_graph<A: Anchor + Clone>(
     });
     let mut txid_to_name = HashMap::<&'static str, Txid>::new();
     let mut canonicalization_params = CanonicalParams::default();
-    
+
     for (bogus_txin_vout, tx_tmp) in tx_templates.into_iter().enumerate() {
         let tx = Transaction {
             version: transaction::Version::non_standard(0),

--- a/crates/testenv/src/tx_template.rs
+++ b/crates/testenv/src/tx_template.rs
@@ -40,7 +40,6 @@ pub struct TxTemplate<A> {
 
 /// Describes how an input is created in a [`TxTemplate`].
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
 pub enum TxInTemplate {
     /// A random (bogus) previous output. Useful when the actual prevout doesn't matter.
     Bogus,
@@ -50,8 +49,9 @@ pub enum TxInTemplate {
 
     /// Spends from a previous transaction defined in the template list.
     ///
-    /// The rule is that the referenced transaction (`prev_name`) must appear
-    /// earlier in the list passed to [`init_graph`].
+    /// - `0` (`&'static str`): the `tx_name` of the transaction to spend from. It must appear
+    ///   earlier in the list passed to [`init_graph`] (otherwise `init_graph` panics).
+    /// - `1` (`usize`): the output index (vout) of that transaction to spend.
     PrevTx(&'static str, usize),
 }
 
@@ -119,6 +119,8 @@ impl<A> TxTemplate<A> {
 }
 
 impl TxOutTemplate {
+    /// Create an output of `value` sats. `spk_index` selects a script pubkey
+    /// from the test descriptor set, or `None` for an empty script.
     pub fn new(value: u64, spk_index: Option<u32>) -> Self {
         TxOutTemplate { value, spk_index }
     }
@@ -128,11 +130,16 @@ impl TxOutTemplate {
 ///
 /// Contains the built [`TxGraph`], the associated indexer, and a mapping from
 /// template names to their final txids.
-#[allow(dead_code)]
 pub struct TxTemplateEnv<A> {
+    /// The graph built from the templates.
     pub tx_graph: TxGraph<A>,
+    /// Indexer holding the test descriptor's script pubkeys, scanned
+    /// against every built transaction.
     pub indexer: SpkTxOutIndex<u32>,
-    pub txid_to_name: HashMap<&'static str, Txid>,
+    /// Maps each template's `tx_name` to the txid it was assigned.
+    pub txids: HashMap<&'static str, Txid>,
+    /// Canonicalization params, pre-populated with the txids of every template
+    /// marked [`assume_canonical`](TxTemplate::assume_canonical).
     pub canonicalization_params: CanonicalParams,
 }
 
@@ -141,7 +148,6 @@ pub struct TxTemplateEnv<A> {
 /// This is the main entry point for using transaction templates in tests.
 /// It handles txid generation, outpoint wiring, anchor insertion, and last-seen
 /// timestamps automatically.
-#[allow(dead_code)]
 pub fn init_graph<A: Anchor + Clone>(
     tx_templates: impl IntoIterator<Item = TxTemplate<A>>,
 ) -> TxTemplateEnv<A> {
@@ -149,19 +155,23 @@ pub fn init_graph<A: Anchor + Clone>(
         Descriptor::parse_descriptor(&Secp256k1::signing_only(), DESCRIPTORS[2]).unwrap();
     let mut tx_graph = TxGraph::<A>::default();
     let mut indexer = SpkTxOutIndex::default();
-    (0..10).for_each(|index| {
-        indexer.insert_spk(
-            index,
-            descriptor
-                .at_derivation_index(index)
-                .unwrap()
-                .script_pubkey(),
-        );
-    });
-    let mut txid_to_name = HashMap::<&'static str, Txid>::new();
+    let mut txids = HashMap::<&'static str, Txid>::new();
     let mut canonicalization_params = CanonicalParams::default();
 
     for (bogus_txin_vout, tx_tmp) in tx_templates.into_iter().enumerate() {
+        for output in &tx_tmp.outputs {
+            if let Some(index) = output.spk_index {
+                if indexer.spk_at_index(&index).is_none() {
+                    indexer.insert_spk(
+                        index,
+                        descriptor
+                            .at_derivation_index(index)
+                            .unwrap()
+                            .script_pubkey(),
+                    );
+                }
+            }
+        }
         let tx = Transaction {
             version: transaction::Version::non_standard(0),
             lock_time: LockTime::ZERO,
@@ -189,7 +199,7 @@ pub fn init_graph<A: Anchor + Clone>(
                         witness: Witness::new(),
                     },
                     TxInTemplate::PrevTx(prev_name, prev_vout) => {
-                        let prev_txid = txid_to_name.get(prev_name).expect(
+                        let prev_txid = txids.get(prev_name).expect(
                             "txin template must spend from tx of template that comes before",
                         );
                         TxIn {
@@ -221,7 +231,7 @@ pub fn init_graph<A: Anchor + Clone>(
         if tx_tmp.assume_canonical {
             canonicalization_params.assume_canonical.push(txid);
         }
-        txid_to_name.insert(tx_tmp.tx_name, txid);
+        txids.insert(tx_tmp.tx_name, txid);
         indexer.scan(&tx);
         let _ = tx_graph.insert_tx(tx.clone());
         for anchor in tx_tmp.anchors.iter() {
@@ -234,7 +244,7 @@ pub fn init_graph<A: Anchor + Clone>(
     TxTemplateEnv {
         tx_graph,
         indexer,
-        txid_to_name,
+        txids,
         canonicalization_params,
     }
 }

--- a/crates/testenv/src/tx_template.rs
+++ b/crates/testenv/src/tx_template.rs
@@ -60,8 +60,10 @@ pub enum TxInTemplate {
 pub struct TxOutTemplate {
     /// Value in satoshis.
     pub value: u64,
-    /// If `Some(index)`, the output will use the script pubkey at that index
-    /// from the test descriptor set. If `None`, a random (empty) script is used.
+    /// If `Some(index)`, the output uses the script pubkey derived at that
+    /// index from the test descriptor. Valid indices are `0..2^31` (the
+    /// non-hardened range); a hardened index (`>= 2^31`) makes [`init_graph`]
+    /// panic. If `None`, an empty script is used.
     pub spk_index: Option<u32>,
 }
 

--- a/crates/testenv/src/utils.rs
+++ b/crates/testenv/src/utils.rs
@@ -1,4 +1,12 @@
-use bdk_chain::bitcoin;
+use bdk_chain::{
+    bitcoin,
+    miniscript::{Descriptor, DescriptorPublicKey},
+    BlockId,
+};
+use bitcoin::{
+    absolute::LockTime, constants, hashes::Hash, key::Secp256k1, transaction::Version, BlockHash,
+    Network, ScriptBuf, Transaction, TxOut,
+};
 
 #[allow(unused_macros)]
 #[macro_export]
@@ -67,14 +75,59 @@ macro_rules! changeset {
     }};
 }
 
+/// Generate a dummy script pubkey.
+#[allow(unused_macros)]
+#[macro_export]
+macro_rules! spk {
+    () => {{
+        let secp = bitcoin::secp256k1::Secp256k1::new();
+        let (x_only_pk, _) = bitcoin::secp256k1::SecretKey::new(&mut rand::thread_rng())
+            .public_key(&secp)
+            .x_only_public_key();
+        bitcoin::ScriptBuf::new_p2tr(&secp, x_only_pk, None)
+    }};
+}
+
 #[allow(unused)]
-pub fn new_tx(lt: u32) -> bitcoin::Transaction {
-    bitcoin::Transaction {
+pub fn new_tx(lt: u32) -> Transaction {
+    Transaction {
         version: bitcoin::transaction::Version::non_standard(0x00),
         lock_time: bitcoin::absolute::LockTime::from_consensus(lt),
         input: vec![],
         output: vec![],
     }
+}
+
+/// Initialize a standard transaction with a guaranteed output.
+pub fn new_standard_tx(lt: u32) -> Transaction {
+    Transaction {
+        version: Version::TWO,
+        lock_time: LockTime::from_consensus(lt),
+        input: vec![],
+        output: vec![TxOut::NULL],
+    }
+}
+
+pub fn genesis_block_id() -> BlockId {
+    BlockId {
+        height: 0,
+        hash: constants::genesis_block(Network::Regtest).block_hash(),
+    }
+}
+
+pub fn tip_block_id(height: u32) -> BlockId {
+    BlockId {
+        height,
+        hash: BlockHash::all_zeros(),
+    }
+}
+
+/// Derives a [`ScriptBuf`] (scriptPubkey) from the provided descriptor at a specific index.
+pub fn spk_at_index(descriptor: &Descriptor<DescriptorPublicKey>, index: u32) -> ScriptBuf {
+    descriptor
+        .derived_descriptor(&Secp256k1::verification_only(), index)
+        .expect("must derive")
+        .script_pubkey()
 }
 
 #[allow(unused)]

--- a/crates/testenv/src/utils.rs
+++ b/crates/testenv/src/utils.rs
@@ -1,3 +1,19 @@
+//! Shared test utilities: macros, helper functions, and test-vector constants.
+//!
+//! These helpers back BDK's own tests and downstream crates testing against a regtest
+//! environment such as [`TestEnv`](crate::TestEnv). They are not intended for production use.
+//!
+//! - Macros: [`block_id!`](crate::block_id), [`hash!`](crate::hash),
+//!   [`local_chain!`](crate::local_chain), [`chain_update!`](crate::chain_update),
+//!   [`spk!`](crate::spk)
+//! - Functions: [`new_tx`], [`genesis_block_id`], [`tip_block_id`], [`spk_at_index`]
+//! - Constants: [`DESCRIPTORS`]
+//!
+//! # Warning
+//!
+//! **Never use key material from this module on mainnet or with real funds.**
+//! [`DESCRIPTORS`] embeds publicly-known extended private keys.
+
 use bdk_chain::{
     bitcoin,
     miniscript::{Descriptor, DescriptorPublicKey},
@@ -8,6 +24,19 @@ use bitcoin::{
     Network, ScriptBuf, Transaction, TxOut,
 };
 
+/// Constructs a [`BlockId`](bdk_chain::BlockId) from a height and a label.
+///
+/// The label is a string literal whose *bytes are hashed* to produce a deterministic,
+/// readable dummy block hash.
+///
+/// # Examples
+///
+/// ```rust
+/// use bdk_testenv::block_id;
+///
+/// let block = block_id!(1, "B");
+/// assert_eq!(block.height, 1);
+/// ```
 #[allow(unused_macros)]
 #[macro_export]
 macro_rules! block_id {
@@ -19,6 +48,20 @@ macro_rules! block_id {
     }};
 }
 
+/// Hashes a string literal into a hash type (e.g. [`BlockHash`], [`Txid`](bitcoin::Txid)).
+///
+/// The literal's bytes are hashed, giving a deterministic value from a readable label.
+///
+/// # Examples
+///
+/// ```rust
+/// use bdk_testenv::hash;
+/// use bitcoin::BlockHash;
+///
+/// let a: BlockHash = hash!("block1");
+/// let b: BlockHash = hash!("block1");
+/// assert_eq!(a, b, "the same label always hashes the same");
+/// ```
 #[allow(unused_macros)]
 #[macro_export]
 macro_rules! hash {
@@ -27,6 +70,20 @@ macro_rules! hash {
     }};
 }
 
+/// Builds a [`LocalChain`](bdk_chain::local_chain::LocalChain) from `(height, hash)` pairs.
+///
+/// The list must include the genesis block at height `0`, otherwise this panics.
+///
+/// # Examples
+///
+/// ```rust
+/// use bdk_chain::local_chain::LocalChain;
+/// use bdk_testenv::{hash, local_chain};
+/// use bitcoin::BlockHash;
+///
+/// let chain: LocalChain<BlockHash> = local_chain![(0, hash!("genesis")), (1, hash!("block1"))];
+/// assert_eq!(chain.tip().block_id().height, 1);
+/// ```
 #[allow(unused_macros)]
 #[macro_export]
 macro_rules! local_chain {
@@ -37,6 +94,22 @@ macro_rules! local_chain {
     }};
 }
 
+/// Builds a [`LocalChain`](bdk_chain::local_chain::LocalChain) from `(height, hash)` pairs
+/// and returns its tip checkpoint.
+///
+/// Handy for constructing chain updates in tests. As with [`local_chain!`], the list must
+/// include the genesis block at height `0`.
+///
+/// # Examples
+///
+/// ```rust
+/// use bdk_chain::local_chain::CheckPoint;
+/// use bdk_testenv::{chain_update, hash};
+/// use bitcoin::BlockHash;
+///
+/// let update: CheckPoint<BlockHash> = chain_update![(0, hash!("genesis")), (1, hash!("block1"))];
+/// assert_eq!(update.block_id().height, 1);
+/// ```
 #[allow(unused_macros)]
 #[macro_export]
 macro_rules! chain_update {
@@ -48,7 +121,21 @@ macro_rules! chain_update {
     }};
 }
 
-/// Generate a dummy script pubkey.
+/// Generates a random P2TR [`ScriptBuf`] to use as a dummy script pubkey.
+///
+/// Takes no arguments and returns a fresh, random script on every call, so it is
+/// **not** deterministic.
+///
+/// # Examples
+///
+/// ```rust
+/// use bdk_testenv::spk;
+/// use bitcoin::ScriptBuf;
+///
+/// let a: ScriptBuf = spk!();
+/// let b: ScriptBuf = spk!();
+/// assert_ne!(a, b, "each call generates a new random spk");
+/// ```
 #[allow(unused_macros)]
 #[macro_export]
 macro_rules! spk {
@@ -61,7 +148,19 @@ macro_rules! spk {
     }};
 }
 
-/// Initialize a standard transaction with a guaranteed output.
+/// Creates a dummy [`Transaction`] whose only distinguishing feature is its lock time.
+///
+/// The transaction is version 2 with no inputs and a single [`TxOut::NULL`] output, so
+/// varying `lt` is enough to produce distinct txids for tests that just need several
+/// unrelated transactions.
+///
+/// # Examples
+///
+/// ```rust
+/// use bdk_testenv::utils::new_tx;
+///
+/// assert_ne!(new_tx(0).compute_txid(), new_tx(1).compute_txid());
+/// ```
 #[allow(unused)]
 pub fn new_tx(lt: u32) -> Transaction {
     Transaction {
@@ -72,6 +171,18 @@ pub fn new_tx(lt: u32) -> Transaction {
     }
 }
 
+/// Returns the [`BlockId`] of the **regtest** genesis block.
+///
+/// The hash is Bitcoin's real regtest genesis hash, so chains built from this agree with
+/// a `bitcoind -regtest` node. It does not match mainnet, testnet, or signet genesis.
+///
+/// # Examples
+///
+/// ```rust
+/// use bdk_testenv::utils::genesis_block_id;
+///
+/// assert_eq!(genesis_block_id().height, 0);
+/// ```
 pub fn genesis_block_id() -> BlockId {
     BlockId {
         height: 0,
@@ -79,6 +190,15 @@ pub fn genesis_block_id() -> BlockId {
     }
 }
 
+/// Returns a placeholder [`BlockId`] at `height`, with an all-zero block hash.
+///
+/// # Examples
+///
+/// ```rust
+/// use bdk_testenv::utils::tip_block_id;
+///
+/// assert_eq!(tip_block_id(42).height, 42);
+/// ```
 pub fn tip_block_id(height: u32) -> BlockId {
     BlockId {
         height,
@@ -86,7 +206,24 @@ pub fn tip_block_id(height: u32) -> BlockId {
     }
 }
 
-/// Derives a [`ScriptBuf`] (scriptPubkey) from the provided descriptor at a specific index.
+/// Derives the [`ScriptBuf`] (scriptPubkey) of `descriptor` at the given derivation index.
+///
+/// # Panics
+///
+/// Panics if the descriptor cannot be derived at `index`, likely when `index`
+/// is hardened (`>= 2^31`), which a public descriptor cannot derive.
+///
+/// # Examples
+///
+/// ```rust
+/// use bdk_chain::miniscript::Descriptor;
+/// use bdk_testenv::utils::{spk_at_index, DESCRIPTORS};
+///
+/// let secp = bdk_chain::bitcoin::secp256k1::Secp256k1::signing_only();
+/// let (descriptor, _) = Descriptor::parse_descriptor(&secp, DESCRIPTORS[0]).unwrap();
+///
+/// assert_ne!(spk_at_index(&descriptor, 0), spk_at_index(&descriptor, 1));
+/// ```
 pub fn spk_at_index(descriptor: &Descriptor<DescriptorPublicKey>, index: u32) -> ScriptBuf {
     descriptor
         .derived_descriptor(&Secp256k1::verification_only(), index)
@@ -94,6 +231,16 @@ pub fn spk_at_index(descriptor: &Descriptor<DescriptorPublicKey>, index: u32) ->
         .script_pubkey()
 }
 
+/// Descriptors used by BDK's own tests.
+///
+/// # Warning
+///
+/// **Never use these on mainnet or with real funds.**
+///
+/// These embed extended private keys (`xprv`/`tprv`) that are well-known public test vectors,
+/// anyone can derive the same keys and spend from them. Any funds sent to an address derived from
+/// these descriptors can be swept by anyone.
+#[doc(hidden)]
 #[allow(unused)]
 pub const DESCRIPTORS: [&str; 7] = [
     "tr([73c5da0a/86'/0'/0']xprv9xgqHN7yz9MwCkxsBPN5qetuNdQSUttZNKw1dcYTV4mkaAFiBVGQziHs3NRSWMkCzvgjEe3n9xV8oYywvM8at9yRqyaZVz6TYYhX98VjsUk/0/*)",

--- a/crates/testenv/src/utils.rs
+++ b/crates/testenv/src/utils.rs
@@ -48,33 +48,6 @@ macro_rules! chain_update {
     }};
 }
 
-#[allow(unused_macros)]
-#[macro_export]
-macro_rules! changeset {
-    (checkpoints: $($tail:tt)*) => { changeset!(index: TxHeight, checkpoints: $($tail)*) };
-    (
-        index: $ind:ty,
-        checkpoints: [ $(( $height:expr, $cp_to:expr )),* ]
-        $(,txids: [ $(( $txid:expr, $tx_to:expr )),* ])?
-    ) => {{
-        use bdk_chain::collections::BTreeMap;
-
-        #[allow(unused_mut)]
-        bdk_chain::sparse_chain::ChangeSet::<$ind> {
-            checkpoints: {
-                let mut changes = BTreeMap::default();
-                $(changes.insert($height, $cp_to);)*
-                changes
-            },
-            txids: {
-                let mut changes = BTreeMap::default();
-                $($(changes.insert($txid, $tx_to.map(|h: TxHeight| h.into()));)*)?
-                changes
-            }
-        }
-    }};
-}
-
 /// Generate a dummy script pubkey.
 #[allow(unused_macros)]
 #[macro_export]
@@ -88,18 +61,9 @@ macro_rules! spk {
     }};
 }
 
+/// Initialize a standard transaction with a guaranteed output.
 #[allow(unused)]
 pub fn new_tx(lt: u32) -> Transaction {
-    Transaction {
-        version: bitcoin::transaction::Version::non_standard(0x00),
-        lock_time: bitcoin::absolute::LockTime::from_consensus(lt),
-        input: vec![],
-        output: vec![],
-    }
-}
-
-/// Initialize a standard transaction with a guaranteed output.
-pub fn new_standard_tx(lt: u32) -> Transaction {
     Transaction {
         version: Version::TWO,
         lock_time: LockTime::from_consensus(lt),


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->
This PR moves the `TxTemplate` from the `chain` crate into the `testenv`. It also updates the `TxTemplate` to use the `Cow` smart pointer, adds method implementations to `TxTemplate`, and migrates tests to the builder API.

This PR addresses the first and second todos on #1936 and #2275

### Changelog notice

- moved `TxTemplate` from chain to testenv
- added builder API methods to TxTemplate 
- update documentation for util module

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
