### PR TITLE
chore(release)!: bump bdk_electrum to 0.24.0

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -60,6 +60,8 @@ jobs:
           cargo update -p proptest --precise "1.8.0"
           cargo update -p "getrandom@0.4.2" --precise "0.2.17"
           cargo update -p "hyper-rustls" --precise "0.27.7"
+          cargo update -p openssl --precise "0.10.78"
+          cargo update -p openssl-sys --precise "0.9.114"
       - name: Pin dependencies for MSRV
         if: matrix.rust.version == '1.63.0'
         run: ./ci/pin-msrv.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ print_stderr = "deny"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage,coverage_nightly)'] }
+
+[patch.crates-io]
+electrum-client = { git = "https://github.com/oleonardolima/rust-electrum-client.git", branch = "release/electrum-client-0.25.0" }

--- a/ci/pin-msrv.sh
+++ b/ci/pin-msrv.sh
@@ -53,7 +53,7 @@ cargo update -p unicode-ident --precise "1.0.13"
 cargo update -p hyper-util --precise "0.1.6"
 cargo update -p pin-project --precise "1.1.5"
 cargo update -p pin-project-internal --precise "1.1.5"
-cargo update -p "rustls@0.23.39" --precise "0.23.26"
+cargo update -p "rustls@0.23.40" --precise "0.23.26"
 cargo update -p "libc" --precise "0.2.183"
 cargo update -p "semver" --precise "1.0.27"
 

--- a/crates/electrum/CHANGELOG.md
+++ b/crates/electrum/CHANGELOG.md
@@ -7,6 +7,14 @@ Contributors do not need to change this file but do need to add changelog detail
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [electrum-0.24.0]
+
+### Changed
+
+- fix(ci): pin `openssl`, and `rustls`.
+- chore(deps): bump `electrum-client` to 0.25.0.
+- chore: update to use new `electrum-client` features without `use-` prefix.
+
 ## [electrum-0.23.2]
 
 ### Added
@@ -76,3 +84,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [electrum-0.23.0]: https://github.com/bitcoindevkit/bdk/releases/tag/electrum-0.23.0
 [electrum-0.23.1]: https://github.com/bitcoindevkit/bdk/releases/tag/electrum-0.23.1
 [electrum-0.23.2]: https://github.com/bitcoindevkit/bdk/releases/tag/electrum-0.23.2
+[electrum-0.24.0]: https://github.com/bitcoindevkit/bdk/releases/tag/electrum-0.24.0

--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 
 [dependencies]
 bdk_core = { path = "../core", version = "0.6.1" }
-electrum-client = { version = "0.24.0", features = [ "proxy" ], default-features = false }
+electrum-client = { version = "0.25.0", features = [ "proxy" ], default-features = false }
 
 [dev-dependencies]
 bdk_testenv = { path = "../testenv" }
@@ -23,14 +23,17 @@ criterion = { version = "0.2" }
 
 [features]
 default = ["use-rustls"]
-use-rustls = ["electrum-client/use-rustls"]
-use-rustls-ring = ["electrum-client/use-rustls-ring"]
-use-openssl = ["electrum-client/use-openssl"]
+use-rustls = ["electrum-client/rustls"]
+use-rustls-ring = ["electrum-client/rustls-ring"]
+use-openssl = ["electrum-client/openssl"]
 
 [[test]]
 name = "test_electrum"
-required-features = ["use-rustls"]
+required-features = ["rustls"]
 
 [[bench]]
 name = "test_sync"
 harness = false
+
+[patch.crates-io]
+electrum-client = { git = "https://github.com/oleonardolima/rust-electrum-client.git", branch = "release/electrum-client-0.25.0" }

--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_electrum"
-version = "0.23.2"
+version = "0.24.0"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"

--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 
 [dependencies]
 bdk_core = { path = "../core", version = "0.6.1" }
-electrum-client = { version = "0.24.0", features = [ "proxy" ], default-features = false }
+electrum-client = { version = "0.25.0", features = [ "proxy" ], default-features = false }
 
 [dev-dependencies]
 bdk_testenv = { path = "../testenv" }
@@ -23,9 +23,9 @@ criterion = { version = "0.2" }
 
 [features]
 default = ["use-rustls"]
-use-rustls = ["electrum-client/use-rustls"]
-use-rustls-ring = ["electrum-client/use-rustls-ring"]
-use-openssl = ["electrum-client/use-openssl"]
+use-rustls = ["electrum-client/rustls"]
+use-rustls-ring = ["electrum-client/rustls-ring"]
+use-openssl = ["electrum-client/openssl"]
 
 [[test]]
 name = "test_electrum"


### PR DESCRIPTION
### Description

- chore(release)!: bump bdk_electrum to 0.24.0
- fix MSRV (1.75.0) CI by pining both: openssl and openssl-sys
- bump `electrum-client` to latest `0.25.0`
- updates the `bdk_electrum` features to use `electrum-client` latest ones.

### Changelog notice

```
### Changed
- chore(release)!: bump bdk_electrum to 0.24.0
- chore(deps): bump `electrum-client` to 0.25.0
- chore(bdk_electrum): update the features to match/use the `electrum-client` latest ones.
- fix(ci): pin both `openssl` and `openssl-sys` for 1.75.0 MSRV
```

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
