### PR TITLE
Have MTP in checkpoint data and report missing blocks

### DIFF
--- a/crates/core/src/checkpoint.rs
+++ b/crates/core/src/checkpoint.rs
@@ -120,6 +120,25 @@ impl<D: ToBlockHash> ToBlockHash for WithMtp<D> {
     }
 }
 
+/// Error returned by [`CheckPoint::compute_mtp`] when one or more required ancestor
+/// checkpoints are missing from the chain.
+///
+/// The `heights` field lists every height in the MTP window (`h-10..=h`) that the caller
+/// needs to fetch and insert before `compute_mtp` can succeed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MissingBlocks {
+    /// Heights whose checkpoints were expected but not found in the chain.
+    pub heights: Vec<u32>,
+}
+
+impl fmt::Display for MissingBlocks {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "missing block data for heights {:?}", self.heights)
+    }
+}
+
+impl core::error::Error for MissingBlocks {}
+
 impl<D> PartialEq for CheckPoint<D> {
     fn eq(&self, other: &Self) -> bool {
         let self_cps = self.iter().map(|cp| cp.block_id());
@@ -257,31 +276,36 @@ where
     /// Note: This is a pseudo-median that takes the higher of the two middle values rather than
     /// averaging them. This matches the BIP-0113 specification.
     ///
-    /// Returns `None` if any of the 11 required ancestor checkpoints are missing from the chain.
+    /// Returns `Err(MissingBlocks)` listing every missing height when one or more ancestors in
+    /// the MTP window are not present in the chain. Callers can use this to drive a fetch-retry
+    /// loop against their chain source.
     ///
     /// If you want a compile-time guarantee that MTP is always available without walking the
     /// chain, store it directly on each checkpoint via [`WithMtp`] and use
     /// [`CheckPoint::mtp`] instead.
-    pub fn compute_mtp(&self) -> Option<u32>
+    pub fn compute_mtp(&self) -> Result<u32, MissingBlocks>
     where
         D: ToBlockTime,
     {
         let current_height = self.height();
         let earliest_height = current_height.saturating_sub(Self::MTP_BLOCK_COUNT - 1);
 
-        let mut timestamps = (earliest_height..=current_height)
-            .map(|height| {
-                // Return `None` for missing blocks or missing block times
-                let cp = self.get(height)?;
-                let block_time = cp.data_ref().to_blocktime();
-                Some(block_time)
-            })
-            .collect::<Option<Vec<u32>>>()?;
+        let mut timestamps = Vec::with_capacity(Self::MTP_BLOCK_COUNT as usize);
+        let mut missing = Vec::new();
+        for height in earliest_height..=current_height {
+            match self.get(height) {
+                Some(cp) => timestamps.push(cp.data_ref().to_blocktime()),
+                None => missing.push(height),
+            }
+        }
+        if !missing.is_empty() {
+            return Err(MissingBlocks { heights: missing });
+        }
         timestamps.sort_unstable();
 
         // If there are more than 1 middle values, use the higher middle value.
         // This is mathematically incorrect, but this is the BIP-0113 specification.
-        Some(timestamps[timestamps.len() / 2])
+        Ok(timestamps[timestamps.len() / 2])
     }
 
     /// Construct from an iterator of block data.

--- a/crates/core/src/checkpoint.rs
+++ b/crates/core/src/checkpoint.rs
@@ -93,6 +93,33 @@ impl ToBlockTime for Header {
     }
 }
 
+/// Wraps [`CheckPoint`] `data` with a precomputed median-time-past (MTP) value.
+///
+/// Using `CheckPoint<WithMtp<D>>` provides a compile-time guarantee that the MTP is available
+/// for every checkpoint in the chain, without needing to walk back 11 blocks to compute it.
+///
+/// See [BIP-0113](https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki) for the MTP
+/// definition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct WithMtp<D> {
+    /// The median-time-past for this block.
+    pub mtp: u32,
+    /// The wrapped checkpoint data.
+    pub inner: D,
+}
+
+impl<D: ToBlockTime> ToBlockTime for WithMtp<D> {
+    fn to_blocktime(&self) -> u32 {
+        self.inner.to_blocktime()
+    }
+}
+
+impl<D: ToBlockHash> ToBlockHash for WithMtp<D> {
+    fn to_blockhash(&self) -> BlockHash {
+        self.inner.to_blockhash()
+    }
+}
+
 impl<D> PartialEq for CheckPoint<D> {
     fn eq(&self, other: &Self) -> bool {
         let self_cps = self.iter().map(|cp| cp.block_id());
@@ -221,17 +248,21 @@ where
         }))
     }
 
-    /// Calculate the median time past (MTP) for this checkpoint.
+    /// Computes the median-time-past (MTP) for this checkpoint by walking back through the chain.
     ///
-    /// Uses 11 blocks (heights h-10 through h, where h is the current height) to compute the MTP
-    /// for the current block. This is used in Bitcoin's consensus rules for time-based validations
-    /// (BIP-0113).
+    /// Uses 11 blocks (heights `h-10` through `h`, where `h` is this checkpoint's height) to
+    /// compute the MTP. This is used in Bitcoin's consensus rules for time-based validations
+    /// (see [BIP-0113](https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki)).
     ///
-    /// Note: This is a pseudo-median that doesn't average the two middle values.
+    /// Note: This is a pseudo-median that takes the higher of the two middle values rather than
+    /// averaging them. This matches the BIP-0113 specification.
     ///
-    /// Returns `None` if the data type doesn't support block times or if any of the required
-    /// 11 sequential blocks are missing.
-    pub fn median_time_past(&self) -> Option<u32>
+    /// Returns `None` if any of the 11 required ancestor checkpoints are missing from the chain.
+    ///
+    /// If you want a compile-time guarantee that MTP is always available without walking the
+    /// chain, store it directly on each checkpoint via [`WithMtp`] and use
+    /// [`CheckPoint::mtp`] instead.
+    pub fn compute_mtp(&self) -> Option<u32>
     where
         D: ToBlockTime,
     {
@@ -317,7 +348,6 @@ where
         base.extend(core::iter::once((height, data)).chain(tail.into_iter().rev()))
             .expect("tail is in order")
     }
-
     /// Puts another checkpoint onto the linked list representing the blockchain.
     ///
     /// Returns an `Err(self)` if the block you are pushing on is not at a greater height that the
@@ -335,6 +365,16 @@ where
         } else {
             Err(self)
         }
+    }
+}
+
+impl<D> CheckPoint<WithMtp<D>> {
+    /// Returns the precomputed median-time-past (MTP) stored on this checkpoint.
+    ///
+    /// Unlike [`CheckPoint::compute_mtp`], this does not walk the chain — the MTP was computed
+    /// when the checkpoint was constructed and is guaranteed to be present by the type system.
+    pub fn mtp(&self) -> u32 {
+        self.data_ref().mtp
     }
 }
 

--- a/crates/core/tests/test_checkpoint.rs
+++ b/crates/core/tests/test_checkpoint.rs
@@ -1,4 +1,4 @@
-use bdk_core::{CheckPoint, ToBlockHash, ToBlockTime, WithMtp};
+use bdk_core::{CheckPoint, MissingBlocks, ToBlockHash, ToBlockTime, WithMtp};
 use bdk_testenv::{block_id, hash};
 use bitcoin::hashes::Hash;
 use bitcoin::BlockHash;
@@ -86,19 +86,19 @@ fn test_median_time_past_with_timestamps() {
     let cp = CheckPoint::from_blocks(blocks).expect("must construct valid chain");
 
     // Height 11: 11 previous blocks (11..=1), pseudo-median at index 6 = 1060
-    assert_eq!(cp.compute_mtp(), Some(1060));
+    assert_eq!(cp.compute_mtp(), Ok(1060));
 
     // Height 10: 11 previous blocks (10..=0), pseudo-median at index 5 = 1050
-    assert_eq!(cp.get(10).unwrap().compute_mtp(), Some(1050));
+    assert_eq!(cp.get(10).unwrap().compute_mtp(), Ok(1050));
 
     // Height 5: 6 previous blocks (5..=0), pseudo-median at index 3 = 1030
-    assert_eq!(cp.get(5).unwrap().compute_mtp(), Some(1030));
+    assert_eq!(cp.get(5).unwrap().compute_mtp(), Ok(1030));
 
     // Height 3: 4 previous blocks (3..=0), pseudo-median at index 2 = 1020
-    assert_eq!(cp.get(3).unwrap().compute_mtp(), Some(1020));
+    assert_eq!(cp.get(3).unwrap().compute_mtp(), Ok(1020));
 
     // Height 0: 1 block at index 0 = 1000
-    assert_eq!(cp.get(0).unwrap().compute_mtp(), Some(1000));
+    assert_eq!(cp.get(0).unwrap().compute_mtp(), Ok(1000));
 }
 
 #[test]
@@ -113,14 +113,14 @@ fn test_previous_median_time_past_edge_cases() {
     // At height 10: next_mtp uses all 11 blocks (0-10)
     // Times: [1000, 1100, 1200, 1300, 1400, 1500, 1600, 1700, 1800, 1900, 2000]
     // Median at index 5 = 1500
-    assert_eq!(cp.compute_mtp(), Some(1500));
+    assert_eq!(cp.compute_mtp(), Ok(1500));
 
     // At height 9: mtp uses blocks 0-9 (10 blocks)
     // Times: [1000, 1100, 1200, 1300, 1400, 1500, 1600, 1700, 1800, 1900]
     // Median at index 5 = 1400
-    assert_eq!(cp.get(9).unwrap().compute_mtp(), Some(1500));
+    assert_eq!(cp.get(9).unwrap().compute_mtp(), Ok(1500));
 
-    // Test sparse chain where next_mtp returns None due to missing blocks
+    // Test sparse chain where compute_mtp reports the missing heights
     let sparse = vec![
         (0, BlockWithTime(0, 1000)),
         (5, BlockWithTime(5, 1050)),
@@ -128,8 +128,13 @@ fn test_previous_median_time_past_edge_cases() {
     ];
     let sparse_cp = CheckPoint::from_blocks(sparse).expect("must construct valid chain");
 
-    // At height 10: next_mtp needs blocks 0-10 but many are missing
-    assert_eq!(sparse_cp.compute_mtp(), None);
+    // At height 10: window is 0..=10; only 0, 5, 10 are present.
+    assert_eq!(
+        sparse_cp.compute_mtp(),
+        Err(MissingBlocks {
+            heights: vec![1, 2, 3, 4, 6, 7, 8, 9],
+        })
+    );
 }
 
 #[test]
@@ -155,18 +160,18 @@ fn test_mtp_with_non_monotonic_times() {
     // Height 10:
     // mtp uses blocks 0-10: sorted
     // [1000,1100,1200,1300,1400,1500,1600,1700,1800,1900,2000] Median at index 5 = 1500
-    assert_eq!(cp.get(10).unwrap().compute_mtp(), Some(1500));
+    assert_eq!(cp.get(10).unwrap().compute_mtp(), Ok(1500));
 
     // Height 11:
     // mtp uses blocks 1-11: sorted
     // [1000,1100,1200,1300,1400,1600,1650,1700,1800,1900,2000] Median at index 5 = 1600
-    assert_eq!(cp.compute_mtp(), Some(1600));
+    assert_eq!(cp.compute_mtp(), Ok(1600));
 
     // Test with smaller chain to verify sorting at different heights
     let cp3 = cp.get(3).unwrap();
     // Height 3: timestamps [1100, 1800, 1200, 1500] -> sorted [1100, 1200, 1500, 1800]
     // Pseudo-median at index 2 = 1500
-    assert_eq!(cp3.compute_mtp(), Some(1500));
+    assert_eq!(cp3.compute_mtp(), Ok(1500));
 }
 
 #[test]
@@ -182,9 +187,20 @@ fn test_mtp_sparse_chain() {
 
     let cp = CheckPoint::from_blocks(blocks).expect("must construct valid chain");
 
-    // All heights should return None due to missing sequential blocks
-    assert_eq!(cp.compute_mtp(), None);
-    assert_eq!(cp.get(11).unwrap().compute_mtp(), None);
+    // Tip is at height 15, window is 5..=15; present in window: 7, 11, 15.
+    assert_eq!(
+        cp.compute_mtp(),
+        Err(MissingBlocks {
+            heights: vec![5, 6, 8, 9, 10, 12, 13, 14],
+        })
+    );
+    // At height 11 the window is 1..=11; present in window: 3, 7, 11.
+    assert_eq!(
+        cp.get(11).unwrap().compute_mtp(),
+        Err(MissingBlocks {
+            heights: vec![1, 2, 4, 5, 6, 8, 9, 10],
+        })
+    );
 }
 
 #[test]

--- a/crates/core/tests/test_checkpoint.rs
+++ b/crates/core/tests/test_checkpoint.rs
@@ -1,4 +1,4 @@
-use bdk_core::{CheckPoint, ToBlockHash, ToBlockTime};
+use bdk_core::{CheckPoint, ToBlockHash, ToBlockTime, WithMtp};
 use bdk_testenv::{block_id, hash};
 use bitcoin::hashes::Hash;
 use bitcoin::BlockHash;
@@ -86,19 +86,19 @@ fn test_median_time_past_with_timestamps() {
     let cp = CheckPoint::from_blocks(blocks).expect("must construct valid chain");
 
     // Height 11: 11 previous blocks (11..=1), pseudo-median at index 6 = 1060
-    assert_eq!(cp.median_time_past(), Some(1060));
+    assert_eq!(cp.compute_mtp(), Some(1060));
 
     // Height 10: 11 previous blocks (10..=0), pseudo-median at index 5 = 1050
-    assert_eq!(cp.get(10).unwrap().median_time_past(), Some(1050));
+    assert_eq!(cp.get(10).unwrap().compute_mtp(), Some(1050));
 
     // Height 5: 6 previous blocks (5..=0), pseudo-median at index 3 = 1030
-    assert_eq!(cp.get(5).unwrap().median_time_past(), Some(1030));
+    assert_eq!(cp.get(5).unwrap().compute_mtp(), Some(1030));
 
     // Height 3: 4 previous blocks (3..=0), pseudo-median at index 2 = 1020
-    assert_eq!(cp.get(3).unwrap().median_time_past(), Some(1020));
+    assert_eq!(cp.get(3).unwrap().compute_mtp(), Some(1020));
 
     // Height 0: 1 block at index 0 = 1000
-    assert_eq!(cp.get(0).unwrap().median_time_past(), Some(1000));
+    assert_eq!(cp.get(0).unwrap().compute_mtp(), Some(1000));
 }
 
 #[test]
@@ -113,12 +113,12 @@ fn test_previous_median_time_past_edge_cases() {
     // At height 10: next_mtp uses all 11 blocks (0-10)
     // Times: [1000, 1100, 1200, 1300, 1400, 1500, 1600, 1700, 1800, 1900, 2000]
     // Median at index 5 = 1500
-    assert_eq!(cp.median_time_past(), Some(1500));
+    assert_eq!(cp.compute_mtp(), Some(1500));
 
     // At height 9: mtp uses blocks 0-9 (10 blocks)
     // Times: [1000, 1100, 1200, 1300, 1400, 1500, 1600, 1700, 1800, 1900]
     // Median at index 5 = 1400
-    assert_eq!(cp.get(9).unwrap().median_time_past(), Some(1500));
+    assert_eq!(cp.get(9).unwrap().compute_mtp(), Some(1500));
 
     // Test sparse chain where next_mtp returns None due to missing blocks
     let sparse = vec![
@@ -129,7 +129,7 @@ fn test_previous_median_time_past_edge_cases() {
     let sparse_cp = CheckPoint::from_blocks(sparse).expect("must construct valid chain");
 
     // At height 10: next_mtp needs blocks 0-10 but many are missing
-    assert_eq!(sparse_cp.median_time_past(), None);
+    assert_eq!(sparse_cp.compute_mtp(), None);
 }
 
 #[test]
@@ -155,18 +155,18 @@ fn test_mtp_with_non_monotonic_times() {
     // Height 10:
     // mtp uses blocks 0-10: sorted
     // [1000,1100,1200,1300,1400,1500,1600,1700,1800,1900,2000] Median at index 5 = 1500
-    assert_eq!(cp.get(10).unwrap().median_time_past(), Some(1500));
+    assert_eq!(cp.get(10).unwrap().compute_mtp(), Some(1500));
 
     // Height 11:
     // mtp uses blocks 1-11: sorted
     // [1000,1100,1200,1300,1400,1600,1650,1700,1800,1900,2000] Median at index 5 = 1600
-    assert_eq!(cp.median_time_past(), Some(1600));
+    assert_eq!(cp.compute_mtp(), Some(1600));
 
     // Test with smaller chain to verify sorting at different heights
     let cp3 = cp.get(3).unwrap();
     // Height 3: timestamps [1100, 1800, 1200, 1500] -> sorted [1100, 1200, 1500, 1800]
     // Pseudo-median at index 2 = 1500
-    assert_eq!(cp3.median_time_past(), Some(1500));
+    assert_eq!(cp3.compute_mtp(), Some(1500));
 }
 
 #[test]
@@ -183,6 +183,46 @@ fn test_mtp_sparse_chain() {
     let cp = CheckPoint::from_blocks(blocks).expect("must construct valid chain");
 
     // All heights should return None due to missing sequential blocks
-    assert_eq!(cp.median_time_past(), None);
-    assert_eq!(cp.get(11).unwrap().median_time_past(), None);
+    assert_eq!(cp.compute_mtp(), None);
+    assert_eq!(cp.get(11).unwrap().compute_mtp(), None);
+}
+
+#[test]
+fn test_with_mtp_returns_stored_value() {
+    let blocks: Vec<(u32, WithMtp<BlockHash>)> = vec![
+        (
+            0,
+            WithMtp {
+                mtp: 1000,
+                inner: hash!("a"),
+            },
+        ),
+        (
+            1,
+            WithMtp {
+                mtp: 1010,
+                inner: hash!("b"),
+            },
+        ),
+        (
+            2,
+            WithMtp {
+                mtp: 1020,
+                inner: hash!("c"),
+            },
+        ),
+        (
+            3,
+            WithMtp {
+                mtp: 1030,
+                inner: hash!("d"),
+            },
+        ),
+    ];
+
+    let cp = CheckPoint::from_blocks(blocks).expect("must construct valid chain");
+
+    assert_eq!(cp.mtp(), 1030);
+    assert_eq!(cp.get(2).unwrap().mtp(), 1020);
+    assert_eq!(cp.get(0).unwrap().mtp(), 1000);
 }


### PR DESCRIPTION
### Description

Context: https://github.com/bitcoindevkit/bdk/issues/2076#issuecomment-4261182538

Carries median-time-past (MTP) on each checkpoint at the type level, and reworks `compute_mtp` so callers can drive fetch-retry loops when ancestor blocks are missing.

- `WithMtp<D>` wrapper: `CheckPoint<WithMtp<D>>` is a compile-time guarantee that MTP is present on every checkpoint in the chain. Code that needs MTP can take `CheckPoint<WithMtp<D>>` and read it via `CheckPoint::mtp()` without ever having to handle a "MTP couldn't be computed" case — the type system rules that out. Compare to the alternative of computing MTP on demand, which forces every consumer to deal with the failure path even when the chain source already has the data.
- `compute_mtp` returns `Result<u32, MissingBlocks>` instead of `Option<u32>`. `MissingBlocks` lists every height in the MTP window (`h-10..=h`) that the chain is missing, so callers — especially light-client chain sources like Electrum that don't expose MTP directly — can batch-fetch exactly the headers they need and retry.
- Rename `median_time_past` → `compute_mtp` to distinguish the chain-walking constructor from the `mtp()` accessor on `CheckPoint<WithMtp<D>>`.

### Notes to the reviewers

Breaking change, marked `feat(core)!`. Two API breaks:
- `median_time_past` → `compute_mtp`
- `compute_mtp` returns `Result<u32, MissingBlocks>` (was `Option<u32>`)

### Changelog notice

```md
Added:
- `WithMtp<D>` wrapper: `CheckPoint<WithMtp<D>>` guarantees at the type level that MTP is present for every checkpoint.
- `CheckPoint::mtp()` on `CheckPoint<WithMtp<D>>`.
- `MissingBlocks` error type.

Changed:
- `CheckPoint::median_time_past` renamed to `CheckPoint::compute_mtp`; return type changed from `Option<u32>` to `Result<u32, MissingBlocks>`.
```

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
