### PR TITLE
fix(electrum): verify txid of server-returned transactions

### DIFF
--- a/crates/electrum/src/bdk_electrum_client.rs
+++ b/crates/electrum/src/bdk_electrum_client.rs
@@ -78,6 +78,12 @@ impl<E: ElectrumApi> BdkElectrumClient<E> {
         drop(tx_cache);
 
         let tx = Arc::new(self.inner.transaction_get(&txid)?);
+        let returned_txid = tx.compute_txid();
+        if returned_txid != txid {
+            return Err(Error::Message(format!(
+                "electrum server returned transaction with unexpected txid: expected {txid}, got {returned_txid}"
+            )));
+        }
 
         self.tx_cache.lock().unwrap().insert(txid, Arc::clone(&tx));
 


### PR DESCRIPTION
### Description

An Electrum server could return an arbitrary transaction when `fetch_tx()` requests a specific txid. The returned transaction was cached and used without verifying that its computed txid matches the requested one.

Add a verification check that `tx.compute_txid() == txid` after fetching from the server, returning an error on mismatch. Include a unit test with a mock Electrum client that exercises both the mismatch rejection and the matching-txid happy path.