### PR TITLE
feat(chain): add walk_ancestors_from_root to TxGraph

### DIFF
--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -498,6 +498,24 @@ impl<A: Clone + Ord> TxGraph<A> {
         TxAncestors::new_exclude_root(self, tx, walk_map)
     }
 
+    /// Creates an iterator that filters and maps ancestor transactions.
+    ///
+    /// Similar to [`Self::walk_ancestors`] but includes the starting `tx` in the iteration at
+    /// `depth` 0.
+    ///
+    /// Refer to [`Self::walk_ancestors`] for `walk_map` usage.
+    pub fn walk_ancestors_from_root<'g, T, F, O>(
+        &'g self,
+        tx: T,
+        walk_map: F,
+    ) -> TxAncestors<'g, A, F, O>
+    where
+        T: Into<Arc<Transaction>>,
+        F: FnMut(usize, Arc<Transaction>) -> Option<O> + 'g,
+    {
+        TxAncestors::new_include_root(self, tx, walk_map)
+    }
+
     /// Creates an iterator that filters and maps descendants from the starting `txid`.
     ///
     /// The supplied closure takes in two inputs `(depth, descendant_txid)`:


### PR DESCRIPTION
Solves https://github.com/bitcoindevkit/bdk/issues/2216

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

Add `walk_ancestors_from_root` method to `TxGraph`, which mirrors the existing `walk_ancestors` but includes the root transaction in the iteration. 

### Notes to the reviewers

An alternative implementation would have been to make TxAncestors::new_include_root public directly, instead of adding a wrapper method on TxGraph. Not sure which approach is preferable here.

### Changelog notice

#### Added
`TxGraph::walk_ancestors_from_root`

### Checklists

#### All Submissions:

* [X] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### New Features:

* [ ] I've added tests for the new feature
* [X] I've added docs for the new feature