### PR TITLE
 Add target limit to sync requests (#1818)

### DIFF
--- a/crates/core/src/spk_client.rs
+++ b/crates/core/src/spk_client.rs
@@ -2,7 +2,7 @@
 use crate::{
     alloc::{boxed::Box, collections::VecDeque, vec::Vec},
     collections::{BTreeMap, HashMap, HashSet},
-    CheckPoint, ConfirmationBlockTime, Indexed,
+    BlockId, CheckPoint, ConfirmationBlockTime, Indexed,
 };
 use bitcoin::{BlockHash, OutPoint, Script, ScriptBuf, Txid};
 
@@ -129,6 +129,14 @@ impl<I, D> SyncRequestBuilder<I, D> {
     /// This is used to update [`LocalChain`](../../bdk_chain/local_chain/struct.LocalChain.html).
     pub fn chain_tip(mut self, cp: CheckPoint<D>) -> Self {
         self.inner.chain_tip = Some(cp);
+        self
+    }
+
+    /// Set the target chain tip for the sync request.
+    ///
+    /// The sync will not fetch chain data beyond this target.
+    pub fn target(mut self, target: BlockId) -> Self {
+        self.inner.target = Some(target);
         self
     }
 
@@ -259,6 +267,7 @@ impl<I, D> SyncRequestBuilder<I, D> {
 pub struct SyncRequest<I = (), D = BlockHash> {
     start_time: u64,
     chain_tip: Option<CheckPoint<D>>,
+    target: Option<BlockId>,
     spks: VecDeque<(I, ScriptBuf)>,
     spks_consumed: usize,
     spk_expected_txids: HashMap<ScriptBuf, HashSet<Txid>>,
@@ -289,6 +298,7 @@ impl<I, D> SyncRequest<I, D> {
             inner: Self {
                 start_time,
                 chain_tip: None,
+                target: None,
                 spks: VecDeque::new(),
                 spks_consumed: 0,
                 spk_expected_txids: HashMap::new(),
@@ -335,6 +345,11 @@ impl<I, D> SyncRequest<I, D> {
     /// Get the chain tip [`CheckPoint`] of this request (if any).
     pub fn chain_tip(&self) -> Option<CheckPoint<D>> {
         self.chain_tip.clone()
+    }
+
+    /// Get the target chain tip [`BlockId`] of this request (if any).
+    pub fn target(&self) -> Option<BlockId> {
+        self.target
     }
 
     /// Advances the sync request and returns the next [`ScriptBuf`] with corresponding [`Txid`]
@@ -444,6 +459,14 @@ impl<K: Ord, D> FullScanRequestBuilder<K, D> {
         self
     }
 
+    /// Set the target chain tip for the full scan request.
+    ///
+    /// The sync will not fetch chain data beyond this target.
+    pub fn target(mut self, target: BlockId) -> Self {
+        self.inner.target = Some(target);
+        self
+    }
+
     /// Set the spk iterator for a given `keychain`.
     pub fn spks_for_keychain(
         mut self,
@@ -495,6 +518,7 @@ impl<K: Ord, D> FullScanRequestBuilder<K, D> {
 pub struct FullScanRequest<K, D = BlockHash> {
     start_time: u64,
     chain_tip: Option<CheckPoint<D>>,
+    target: Option<BlockId>,
     spks_by_keychain: BTreeMap<K, Box<dyn Iterator<Item = Indexed<ScriptBuf>> + Send>>,
     last_revealed: BTreeMap<K, u32>,
     inspect: Box<InspectFullScan<K>>,
@@ -520,6 +544,7 @@ impl<K: Ord + Clone, D> FullScanRequest<K, D> {
             inner: Self {
                 start_time,
                 chain_tip: None,
+                target: None,
                 spks_by_keychain: BTreeMap::new(),
                 last_revealed: BTreeMap::new(),
                 inspect: Box::new(|_, _, _| ()),
@@ -549,6 +574,11 @@ impl<K: Ord + Clone, D> FullScanRequest<K, D> {
     /// Get the chain tip [`CheckPoint`] of this request (if any).
     pub fn chain_tip(&self) -> Option<CheckPoint<D>> {
         self.chain_tip.clone()
+    }
+
+    /// Get the target chain tip [`BlockId`] of this request (if any).
+    pub fn target(&self) -> Option<BlockId> {
+        self.target
     }
 
     /// List all keychains contained in this request.

--- a/crates/electrum/src/bdk_electrum_client.rs
+++ b/crates/electrum/src/bdk_electrum_client.rs
@@ -132,7 +132,11 @@ impl<E: ElectrumApi> BdkElectrumClient<E> {
         let start_time = request.start_time();
 
         let tip_and_latest_blocks = match request.chain_tip() {
-            Some(chain_tip) => Some(fetch_tip_and_latest_blocks(&self.inner, chain_tip)?),
+            Some(chain_tip) => Some(fetch_tip_and_latest_blocks(
+                &self.inner,
+                chain_tip,
+                request.target(),
+            )?),
             None => None,
         };
 
@@ -150,6 +154,7 @@ impl<E: ElectrumApi> BdkElectrumClient<E> {
                 spks,
                 stop_gap,
                 last_revealed,
+                request.target(),
                 batch_size,
                 &mut pending_anchors,
             )? {
@@ -215,9 +220,10 @@ impl<E: ElectrumApi> BdkElectrumClient<E> {
     ) -> Result<SyncResponse, Error> {
         let mut request: SyncRequest<I> = request.into();
         let start_time = request.start_time();
+        let target = request.target();
 
         let tip_and_latest_blocks = match request.chain_tip() {
-            Some(chain_tip) => Some(fetch_tip_and_latest_blocks(&self.inner, chain_tip)?),
+            Some(chain_tip) => Some(fetch_tip_and_latest_blocks(&self.inner, chain_tip, target)?),
             None => None,
         };
 
@@ -232,6 +238,7 @@ impl<E: ElectrumApi> BdkElectrumClient<E> {
                 .map(|(i, spk)| (i as u32, spk)),
             usize::MAX,
             None,
+            target,
             batch_size,
             &mut pending_anchors,
         )?;
@@ -239,12 +246,14 @@ impl<E: ElectrumApi> BdkElectrumClient<E> {
             start_time,
             &mut tx_update,
             request.iter_txids(),
+            target,
             &mut pending_anchors,
         )?;
         self.populate_with_outpoints(
             start_time,
             &mut tx_update,
             request.iter_outpoints(),
+            target,
             &mut pending_anchors,
         )?;
 
@@ -288,6 +297,7 @@ impl<E: ElectrumApi> BdkElectrumClient<E> {
         mut spks_with_expected_txids: impl Iterator<Item = (u32, SpkWithExpectedTxids)>,
         stop_gap: usize,
         last_revealed: Option<u32>,
+        target: Option<BlockId>,
         batch_size: usize,
         pending_anchors: &mut Vec<(Txid, usize)>,
     ) -> Result<Option<u32>, Error> {
@@ -335,7 +345,11 @@ impl<E: ElectrumApi> BdkElectrumClient<E> {
                     match tx_res.height.try_into() {
                         // Returned heights 0 & -1 are reserved for unconfirmed txs.
                         Ok(height) if height > 0 => {
-                            pending_anchors.push((tx_res.tx_hash, height));
+                            if target.map_or(true, |t| height as u32 <= t.height) {
+                                pending_anchors.push((tx_res.tx_hash, height));
+                            } else {
+                                tx_update.seen_ats.insert((tx_res.tx_hash, start_time));
+                            }
                         }
                         _ => {
                             tx_update.seen_ats.insert((tx_res.tx_hash, start_time));
@@ -355,6 +369,7 @@ impl<E: ElectrumApi> BdkElectrumClient<E> {
         start_time: u64,
         tx_update: &mut TxUpdate<ConfirmationBlockTime>,
         outpoints: impl IntoIterator<Item = OutPoint>,
+        target: Option<BlockId>,
         pending_anchors: &mut Vec<(Txid, usize)>,
     ) -> Result<(), Error> {
         // Collect valid outpoints with their corresponding `spk` and `tx`.
@@ -398,7 +413,11 @@ impl<E: ElectrumApi> BdkElectrumClient<E> {
                         match res.height.try_into() {
                             // Returned heights 0 & -1 are reserved for unconfirmed txs.
                             Ok(height) if height > 0 => {
-                                pending_anchors.push((res.tx_hash, height));
+                                if target.map_or(true, |t| height as u32 <= t.height) {
+                                    pending_anchors.push((res.tx_hash, height));
+                                } else {
+                                    tx_update.seen_ats.insert((res.tx_hash, start_time));
+                                }
                             }
                             _ => {
                                 tx_update.seen_ats.insert((res.tx_hash, start_time));
@@ -420,7 +439,11 @@ impl<E: ElectrumApi> BdkElectrumClient<E> {
                         match res.height.try_into() {
                             // Returned heights 0 & -1 are reserved for unconfirmed txs.
                             Ok(height) if height > 0 => {
-                                pending_anchors.push((res.tx_hash, height));
+                                if target.map_or(true, |t| height as u32 <= t.height) {
+                                    pending_anchors.push((res.tx_hash, height));
+                                } else {
+                                    tx_update.seen_ats.insert((res.tx_hash, start_time));
+                                }
                             }
                             _ => {
                                 tx_update.seen_ats.insert((res.tx_hash, start_time));
@@ -440,6 +463,7 @@ impl<E: ElectrumApi> BdkElectrumClient<E> {
         start_time: u64,
         tx_update: &mut TxUpdate<ConfirmationBlockTime>,
         txids: impl IntoIterator<Item = Txid>,
+        target: Option<BlockId>,
         pending_anchors: &mut Vec<(Txid, usize)>,
     ) -> Result<(), Error> {
         let mut txs = Vec::<(Txid, Arc<Transaction>)>::new();
@@ -501,7 +525,11 @@ impl<E: ElectrumApi> BdkElectrumClient<E> {
                 match res.height.try_into() {
                     // Returned heights 0 & -1 are reserved for unconfirmed txs.
                     Ok(height) if height > 0 => {
-                        pending_anchors.push((tx.0, height));
+                        if target.map_or(true, |t| height as u32 <= t.height) {
+                            pending_anchors.push((tx.0, height));
+                        } else {
+                            tx_update.seen_ats.insert((res.tx_hash, start_time));
+                        }
                     }
                     _ => {
                         tx_update.seen_ats.insert((res.tx_hash, start_time));
@@ -652,9 +680,16 @@ impl<E: ElectrumApi> BdkElectrumClient<E> {
 fn fetch_tip_and_latest_blocks(
     client: &impl ElectrumApi,
     prev_tip: CheckPoint<BlockHash>,
+    target: Option<BlockId>,
 ) -> Result<(CheckPoint<BlockHash>, BTreeMap<u32, BlockHash>), Error> {
     let HeaderNotification { height, .. } = client.block_headers_subscribe()?;
-    let new_tip_height = height as u32;
+    let mut new_tip_height = height as u32;
+
+    if let Some(t) = target {
+        if new_tip_height > t.height {
+            new_tip_height = t.height;
+        }
+    }
 
     // If electrum returns a tip height that is lower than our previous tip, then checkpoints do
     // not need updating. We just return the previous tip and use that as the point of agreement.
@@ -868,6 +903,50 @@ mod test {
         // Anchor cache should also contain new hash.
         let cache = electrum_client.anchor_cache.lock().unwrap();
         assert!(cache.get(&(txid, new_hash)).is_some());
+
+        Ok(())
+    }
+
+    #[cfg(feature = "default")]
+    #[test]
+    fn test_target_limit() -> anyhow::Result<()> {
+        use bdk_chain::BlockId;
+
+        let env = TestEnv::new()?;
+        let client = electrum_client::Client::new(env.electrsd.electrum_url.as_str()).unwrap();
+        let electrum_client = BdkElectrumClient::new(client);
+
+        let addr = env.rpc_client().get_new_address(None, None)?.address()?.assume_checked();
+        let spk = addr.script_pubkey();
+
+        // Send funds to address.
+        let txid = env.send(&addr, Amount::from_sat(50_000))?;
+
+        let target_height: u32 = env.rpc_client().get_block_count()?.into_model().0 as u32;
+        let target_hash = electrum_client.inner.block_header(target_height as _)?.block_hash();
+
+        // Mine a block to confirm the transaction.
+        env.mine_blocks(1, None)?;
+        env.wait_until_electrum_sees_block(Duration::from_secs(6))?;
+
+        let bogus_genesis = constants::genesis_block(Network::Testnet).block_hash();
+        let cp = CheckPoint::new(0, bogus_genesis);
+
+        let target = BlockId {
+            height: target_height,
+            hash: target_hash,
+        };
+
+        let req = SyncRequest::builder()
+            .chain_tip(cp)
+            .spks([spk])
+            .target(target)
+            .build();
+
+        let res = electrum_client.sync(req, 10, false)?;
+
+        assert!(res.tx_update.anchors.is_empty(), "anchors should be empty");
+        assert!(res.tx_update.seen_ats.iter().any(|(t, _)| *t == txid), "tx should be in seen_ats");
 
         Ok(())
     }

--- a/crates/esplora/src/async_ext.rs
+++ b/crates/esplora/src/async_ext.rs
@@ -69,8 +69,9 @@ where
         let keychains = request.keychains();
 
         let chain_tip = request.chain_tip();
+        let target = request.target();
         let latest_blocks = if chain_tip.is_some() {
-            Some(fetch_latest_blocks(self).await?)
+            Some(fetch_latest_blocks(self, target).await?)
         } else {
             None
         };
@@ -90,6 +91,7 @@ where
                 keychain_spks,
                 stop_gap,
                 last_revealed,
+                target,
                 parallel_requests,
             )
             .await?;
@@ -122,8 +124,9 @@ where
         let start_time = request.start_time();
 
         let chain_tip = request.chain_tip();
+        let target = request.target();
         let latest_blocks = if chain_tip.is_some() {
-            Some(fetch_latest_blocks(self).await?)
+            Some(fetch_latest_blocks(self, target).await?)
         } else {
             None
         };
@@ -136,6 +139,7 @@ where
                 start_time,
                 &mut inserted_txs,
                 request.iter_spks_with_expected_txids(),
+                target,
                 parallel_requests,
             )
             .await?,
@@ -146,6 +150,7 @@ where
                 start_time,
                 &mut inserted_txs,
                 request.iter_txids(),
+                target,
                 parallel_requests,
             )
             .await?,
@@ -156,6 +161,7 @@ where
                 start_time,
                 &mut inserted_txs,
                 request.iter_outpoints(),
+                target,
                 parallel_requests,
             )
             .await?,
@@ -184,13 +190,21 @@ where
 /// alternating between chain-sources.
 async fn fetch_latest_blocks<S: Sleeper>(
     client: &esplora_client::AsyncClient<S>,
+    target: Option<BlockId>,
 ) -> Result<BTreeMap<u32, BlockHash>, Error> {
-    Ok(client
+    let mut latest_blocks = client
         .get_block_infos(None)
         .await?
         .into_iter()
+        .filter(|b| target.map_or(true, |t| b.height <= t.height))
         .map(|b| (b.height, b.id))
-        .collect())
+        .collect::<BTreeMap<u32, BlockHash>>();
+
+    if let Some(t) = target {
+        latest_blocks.entry(t.height).or_insert(t.hash);
+    }
+
+    Ok(latest_blocks)
 }
 
 /// Used instead of [`esplora_client::BlockingClient::get_block_hash`].
@@ -308,6 +322,7 @@ async fn fetch_txs_with_keychain_spks<I, S>(
     mut keychain_spks: I,
     stop_gap: usize,
     last_revealed: Option<u32>,
+    target: Option<BlockId>,
     parallel_requests: usize,
 ) -> Result<(TxUpdate<ConfirmationBlockTime>, Option<u32>), Error>
 where
@@ -369,7 +384,13 @@ where
                 if inserted_txs.insert(tx.txid) {
                     update.txs.push(tx.to_tx().into());
                 }
-                insert_anchor_or_seen_at_from_status(&mut update, start_time, tx.txid, tx.status);
+                insert_anchor_or_seen_at_from_status(
+                    &mut update,
+                    start_time,
+                    tx.txid,
+                    tx.status,
+                    target,
+                );
                 insert_prevouts(&mut update, tx.vin);
             }
             update
@@ -398,6 +419,7 @@ async fn fetch_txs_with_spks<I, S>(
     start_time: u64,
     inserted_txs: &mut HashSet<Txid>,
     spks: I,
+    target: Option<BlockId>,
     parallel_requests: usize,
 ) -> Result<TxUpdate<ConfirmationBlockTime>, Error>
 where
@@ -412,6 +434,7 @@ where
         spks.into_iter().enumerate().map(|(i, spk)| (i as u32, spk)),
         usize::MAX,
         None,
+        target,
         parallel_requests,
     )
     .await
@@ -429,6 +452,7 @@ async fn fetch_txs_with_txids<I, S>(
     start_time: u64,
     inserted_txs: &mut HashSet<Txid>,
     txids: I,
+    target: Option<BlockId>,
     parallel_requests: usize,
 ) -> Result<TxUpdate<ConfirmationBlockTime>, Error>
 where
@@ -462,7 +486,13 @@ where
                 if inserted_txs.insert(txid) {
                     update.txs.push(tx_info.to_tx().into());
                 }
-                insert_anchor_or_seen_at_from_status(&mut update, start_time, txid, tx_info.status);
+                insert_anchor_or_seen_at_from_status(
+                    &mut update,
+                    start_time,
+                    txid,
+                    tx_info.status,
+                    target,
+                );
                 insert_prevouts(&mut update, tx_info.vin);
             }
         }
@@ -481,6 +511,7 @@ async fn fetch_txs_with_outpoints<I, S>(
     start_time: u64,
     inserted_txs: &mut HashSet<Txid>,
     outpoints: I,
+    target: Option<BlockId>,
     parallel_requests: usize,
 ) -> Result<TxUpdate<ConfirmationBlockTime>, Error>
 where
@@ -499,6 +530,7 @@ where
             start_time,
             inserted_txs,
             outpoints.iter().copied().map(|op| op.txid),
+            target,
             parallel_requests,
         )
         .await?,
@@ -535,6 +567,7 @@ where
                     start_time,
                     spend_txid,
                     spend_status,
+                    target,
                 );
             }
         }
@@ -546,6 +579,7 @@ where
             start_time,
             inserted_txs,
             missing_txs,
+            target,
             parallel_requests,
         )
         .await?,

--- a/crates/esplora/src/blocking_ext.rs
+++ b/crates/esplora/src/blocking_ext.rs
@@ -59,8 +59,9 @@ impl EsploraExt for esplora_client::BlockingClient {
         let start_time = request.start_time();
 
         let chain_tip = request.chain_tip();
+        let target = request.target();
         let latest_blocks = if chain_tip.is_some() {
-            Some(fetch_latest_blocks(self)?)
+            Some(fetch_latest_blocks(self, target)?)
         } else {
             None
         };
@@ -80,6 +81,7 @@ impl EsploraExt for esplora_client::BlockingClient {
                 keychain_spks,
                 stop_gap,
                 last_revealed,
+                target,
                 parallel_requests,
             )?;
             tx_update.extend(update);
@@ -114,8 +116,9 @@ impl EsploraExt for esplora_client::BlockingClient {
         let start_time = request.start_time();
 
         let chain_tip = request.chain_tip();
+        let target = request.target();
         let latest_blocks = if chain_tip.is_some() {
-            Some(fetch_latest_blocks(self)?)
+            Some(fetch_latest_blocks(self, target)?)
         } else {
             None
         };
@@ -127,6 +130,7 @@ impl EsploraExt for esplora_client::BlockingClient {
             start_time,
             &mut inserted_txs,
             request.iter_spks_with_expected_txids(),
+            target,
             parallel_requests,
         )?);
         tx_update.extend(fetch_txs_with_txids(
@@ -134,6 +138,7 @@ impl EsploraExt for esplora_client::BlockingClient {
             start_time,
             &mut inserted_txs,
             request.iter_txids(),
+            target,
             parallel_requests,
         )?);
         tx_update.extend(fetch_txs_with_outpoints(
@@ -141,6 +146,7 @@ impl EsploraExt for esplora_client::BlockingClient {
             start_time,
             &mut inserted_txs,
             request.iter_outpoints(),
+            target,
             parallel_requests,
         )?);
 
@@ -170,12 +176,20 @@ impl EsploraExt for esplora_client::BlockingClient {
 /// alternating between chain-sources.
 fn fetch_latest_blocks(
     client: &esplora_client::BlockingClient,
+    target: Option<BlockId>,
 ) -> Result<BTreeMap<u32, BlockHash>, Error> {
-    Ok(client
+    let mut latest_blocks = client
         .get_block_infos(None)?
         .into_iter()
+        .filter(|b| target.map_or(true, |t| b.height <= t.height))
         .map(|b| (b.height, b.id))
-        .collect())
+        .collect::<BTreeMap<u32, BlockHash>>();
+
+    if let Some(t) = target {
+        latest_blocks.entry(t.height).or_insert(t.hash);
+    }
+
+    Ok(latest_blocks)
 }
 
 /// Used instead of [`esplora_client::BlockingClient::get_block_hash`].
@@ -280,6 +294,7 @@ fn fetch_txs_with_keychain_spks<I: Iterator<Item = Indexed<SpkWithExpectedTxids>
     mut keychain_spks: I,
     stop_gap: usize,
     last_revealed: Option<u32>,
+    target: Option<BlockId>,
     parallel_requests: usize,
 ) -> Result<(TxUpdate<ConfirmationBlockTime>, Option<u32>), Error> {
     type TxsOfSpkIndex = (u32, Vec<esplora_client::Tx>, HashSet<Txid>);
@@ -338,7 +353,13 @@ fn fetch_txs_with_keychain_spks<I: Iterator<Item = Indexed<SpkWithExpectedTxids>
                 if inserted_txs.insert(tx.txid) {
                     update.txs.push(tx.to_tx().into());
                 }
-                insert_anchor_or_seen_at_from_status(&mut update, start_time, tx.txid, tx.status);
+                insert_anchor_or_seen_at_from_status(
+                    &mut update,
+                    start_time,
+                    tx.txid,
+                    tx.status,
+                    target,
+                );
                 insert_prevouts(&mut update, tx.vin);
             }
             update
@@ -367,6 +388,7 @@ fn fetch_txs_with_spks<I: IntoIterator<Item = SpkWithExpectedTxids>>(
     start_time: u64,
     inserted_txs: &mut HashSet<Txid>,
     spks: I,
+    target: Option<BlockId>,
     parallel_requests: usize,
 ) -> Result<TxUpdate<ConfirmationBlockTime>, Error> {
     fetch_txs_with_keychain_spks(
@@ -376,6 +398,7 @@ fn fetch_txs_with_spks<I: IntoIterator<Item = SpkWithExpectedTxids>>(
         spks.into_iter().enumerate().map(|(i, spk)| (i as u32, spk)),
         usize::MAX,
         None,
+        target,
         parallel_requests,
     )
     .map(|(update, _)| update)
@@ -392,6 +415,7 @@ fn fetch_txs_with_txids<I: IntoIterator<Item = Txid>>(
     start_time: u64,
     inserted_txs: &mut HashSet<Txid>,
     txids: I,
+    target: Option<BlockId>,
     parallel_requests: usize,
 ) -> Result<TxUpdate<ConfirmationBlockTime>, Error> {
     let mut update = TxUpdate::<ConfirmationBlockTime>::default();
@@ -426,7 +450,13 @@ fn fetch_txs_with_txids<I: IntoIterator<Item = Txid>>(
                 if inserted_txs.insert(txid) {
                     update.txs.push(tx_info.to_tx().into());
                 }
-                insert_anchor_or_seen_at_from_status(&mut update, start_time, txid, tx_info.status);
+                insert_anchor_or_seen_at_from_status(
+                    &mut update,
+                    start_time,
+                    txid,
+                    tx_info.status,
+                    target,
+                );
                 insert_prevouts(&mut update, tx_info.vin);
             }
         }
@@ -445,6 +475,7 @@ fn fetch_txs_with_outpoints<I: IntoIterator<Item = OutPoint>>(
     start_time: u64,
     inserted_txs: &mut HashSet<Txid>,
     outpoints: I,
+    target: Option<BlockId>,
     parallel_requests: usize,
 ) -> Result<TxUpdate<ConfirmationBlockTime>, Error> {
     let outpoints = outpoints.into_iter().collect::<Vec<_>>();
@@ -457,6 +488,7 @@ fn fetch_txs_with_outpoints<I: IntoIterator<Item = OutPoint>>(
         start_time,
         inserted_txs,
         outpoints.iter().map(|op| op.txid),
+        target,
         parallel_requests,
     )?);
 
@@ -496,6 +528,7 @@ fn fetch_txs_with_outpoints<I: IntoIterator<Item = OutPoint>>(
                         start_time,
                         spend_txid,
                         spend_status,
+                        target,
                     );
                 }
             }
@@ -507,6 +540,7 @@ fn fetch_txs_with_outpoints<I: IntoIterator<Item = OutPoint>>(
         start_time,
         inserted_txs,
         missing_txs,
+        target,
         parallel_requests,
     )?);
     Ok(update)

--- a/crates/esplora/src/lib.rs
+++ b/crates/esplora/src/lib.rs
@@ -43,6 +43,7 @@ fn insert_anchor_or_seen_at_from_status(
     start_time: u64,
     txid: Txid,
     status: TxStatus,
+    target: Option<BlockId>,
 ) {
     if let TxStatus {
         block_height: Some(height),
@@ -51,14 +52,16 @@ fn insert_anchor_or_seen_at_from_status(
         ..
     } = status
     {
-        let anchor = ConfirmationBlockTime {
-            block_id: BlockId { height, hash },
-            confirmation_time: time,
-        };
-        update.anchors.insert((anchor, txid));
-    } else {
-        update.seen_ats.insert((txid, start_time));
+        if target.map_or(true, |t| height <= t.height) {
+            let anchor = ConfirmationBlockTime {
+                block_id: BlockId { height, hash },
+                confirmation_time: time,
+            };
+            update.anchors.insert((anchor, txid));
+            return;
+        }
     }
+    update.seen_ats.insert((txid, start_time));
 }
 
 /// Inserts floating txouts into `tx_graph` using [`Vin`](esplora_client::api::Vin)s returned by


### PR DESCRIPTION
Introduced an optional target chain tip limit to SyncRequest and FullScanRequest to restrict synchronization from fetching or processing blockchain data beyond the specified block.