### PR TITLE
chore(release): bump `bdk_chain` to `0.23.4`

### DIFF
--- a/crates/bitcoind_rpc/CHANGELOG.md
+++ b/crates/bitcoind_rpc/CHANGELOG.md
@@ -7,6 +7,11 @@ Contributors do not need to change this file but do need to add changelog detail
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [bitcoind_rpc-0.22.1]
+
+### Fixed:
+- `Emitter` producing un-connectable checkpoints when `start_height` is above the agreement point after a reorg. #2198
+
 ## [bitcoind_rpc-0.22.0]
 
 ### Fixed
@@ -76,3 +81,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [bitcoind_rpc-0.20.0]: https://github.com/bitcoindevkit/bdk/releases/tag/bitcoind_rpc-0.20.0
 [bitcoind_rpc-0.21.0]: https://github.com/bitcoindevkit/bdk/releases/tag/bitcoind_rpc-0.21.0
 [bitcoind_rpc-0.22.0]: https://github.com/bitcoindevkit/bdk/releases/tag/bitcoind_rpc-0.22.0
+[bitcoind_rpc-0.22.1]: https://github.com/bitcoindevkit/bdk/releases/tag/bitcoind_rpc-0.22.1

--- a/crates/bitcoind_rpc/Cargo.toml
+++ b/crates/bitcoind_rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_bitcoind_rpc"
-version = "0.22.0"
+version = "0.22.1"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"

--- a/crates/chain/CHANGELOG.md
+++ b/crates/chain/CHANGELOG.md
@@ -7,6 +7,15 @@ Contributors do not need to change this file but do need to add changelog detail
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [chain-0.23.4]
+
+### Fixed
+
+- Fixed `CanonicalIter` assumed-tx processing by adding missing `continue` #2170
+- Fixed `merge_chains`  to prevent it replacing the genesis block #2174
+- Fixed `full_scan` to now always scans the full revealed range before applying `stop_gap` past `last_revealed` #2222
+- Fixed integer overflow in `SpkIterator::new_with_range` #2229
+
 ## [chain-0.23.3]
 
 ### Added
@@ -105,3 +114,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [chain-0.23.1]: https://github.com/bitcoindevkit/bdk/releases/tag/chain-0.23.1
 [chain-0.23.2]: https://github.com/bitcoindevkit/bdk/releases/tag/chain-0.23.2
 [chain-0.23.3]: https://github.com/bitcoindevkit/bdk/releases/tag/chain-0.23.3
+[chain-0.23.4]: https://github.com/bitcoindevkit/bdk/releases/tag/chain-0.23.4

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_chain"
-version = "0.23.3"
+version = "0.23.4"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"

--- a/crates/core/CHANGELOG.md
+++ b/crates/core/CHANGELOG.md
@@ -7,7 +7,11 @@ Contributors do not need to change this file but do need to add changelog detail
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [core-0.6.4]
+
+### Fixed
+
+- Fixed `full_scan` now always scans the full revealed range before applying `stop_gap` past `last_revealed` #2222
 
 ## [core-0.6.3]
 
@@ -64,3 +68,4 @@ This is because requests now have a `start_time`, instead of specifying a `seen_
 [core-0.6.1]: https://github.com/bitcoindevkit/bdk/releases/tag/core-0.6.1
 [core-0.6.2]: https://github.com/bitcoindevkit/bdk/releases/tag/core-0.6.2
 [core-0.6.3]: https://github.com/bitcoindevkit/bdk/releases/tag/core-0.6.3
+[core-0.6.4]: https://github.com/bitcoindevkit/bdk/releases/tag/core-0.6.4

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_core"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 rust-version = "1.63"
 homepage = "https://bitcoindevkit.org"

--- a/crates/electrum/CHANGELOG.md
+++ b/crates/electrum/CHANGELOG.md
@@ -7,6 +7,14 @@ Contributors do not need to change this file but do need to add changelog detail
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [electrum-0.24.1]
+
+### Fixed:
+
+- `BdkElectrumClient::sync` now correctly retrieves confirmation status for transactions which first output is an `OP_RETURN` or `OP_FALSE OP_RETURN` #2197
+- Fixed `full_scan` now always scans the full revealed range before applying `stop_gap` past `last_revealed` #2222
+- Add a verification check that `tx.compute_txid() == txid` after fetching from the server, returning an error on mismatch #2228
+
 ## [electrum-0.24.0]
 
 ### Changed
@@ -85,3 +93,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [electrum-0.23.1]: https://github.com/bitcoindevkit/bdk/releases/tag/electrum-0.23.1
 [electrum-0.23.2]: https://github.com/bitcoindevkit/bdk/releases/tag/electrum-0.23.2
 [electrum-0.24.0]: https://github.com/bitcoindevkit/bdk/releases/tag/electrum-0.24.0
+[electrum-0.24.1]: https://github.com/bitcoindevkit/bdk/releases/tag/electrum-0.24.1

--- a/crates/electrum/Cargo.toml
+++ b/crates/electrum/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_electrum"
-version = "0.24.0"
+version = "0.24.1"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"

--- a/crates/esplora/CHANGELOG.md
+++ b/crates/esplora/CHANGELOG.md
@@ -7,6 +7,16 @@ Contributors do not need to change this file but do need to add changelog detail
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [esplora-0.22.3]
+
+### Fixed
+
+- Fixed `full_scan` now always scans the full revealed range before applying `stop_gap` past `last_revealed` #2222
+
+### Changed
+
+- Use `HashSet` instead of `Vec` to track `missing_txs` in bdk_esplora, it deduplicates txids. #2230
+
 ## [esplora-0.22.2]
 
 ### Fixed
@@ -53,3 +63,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [esplora-0.22.0]: https://github.com/bitcoindevkit/bdk/releases/tag/esplora-0.22.0
 [esplora-0.22.1]: https://github.com/bitcoindevkit/bdk/releases/tag/esplora-0.22.1
 [esplora-0.22.2]: https://github.com/bitcoindevkit/bdk/releases/tag/esplora-0.22.2
+[esplora-0.22.3]: https://github.com/bitcoindevkit/bdk/releases/tag/esplora-0.22.3

--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bdk_esplora"
-version = "0.22.2"
+version = "0.22.3"
 edition = "2021"
 homepage = "https://bitcoindevkit.org"
 repository = "https://github.com/bitcoindevkit/bdk"


### PR DESCRIPTION
supersedes #2207
closes #2206

### Description

- bump `bump bdk_chain` to `0.23.4`
- bump `bdk_core` to `0.6.4`
- bump `bdk_bitcoind_rpc` to `0.22.1`
- bump `bdk_electrum` to `0.24.1`
- bump `bdk_esplora` to `0.22.3`
- update all needed `CHANGELOG`s

### Notes to the reviewers

### Changelog notice

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
