### PR TITLE
fix(chain,core): prevent serde from implicitly leaking std into no_std environments

### DIFF
--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false }
 bdk_core = { path = "../core", version = "0.6.2", default-features = false }
-serde = { version = "1", optional = true, features = ["derive", "rc"] }
+serde = { version = "1", optional = true, default-features = false, features = ["derive", "rc", "alloc"] }
 miniscript = { version = "13.0.0", optional = true, default-features = false }
 
 # Feature dependencies

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -12,12 +12,12 @@ readme = "README.md"
 
 [dependencies]
 bitcoin = { version = "0.32", default-features = false }
-serde = { version = "1", optional = true, features = ["derive", "rc"] }
+serde = { version = "1", optional = true, default-features=false, features = ["derive"] }
 hashbrown = { version = "0.14.5", optional = true, default-features = false, features = ["ahash", "inline-more"] }
 
 [features]
 default = ["std"]
-std = ["bitcoin/std"]
+std = ["bitcoin/std", "serde?/std"]
 serde = ["dep:serde", "bitcoin/serde", "hashbrown?/serde"]
 
 [dev-dependencies]


### PR DESCRIPTION
### Description

Fix silent `serde/std` leak in `bdk_core` and `bdk_chain` both crates declared their `serde` optional dependency without `default features = false`, causing serde's std feature to activate unconditionally even in no_std builds.

- `bdk_core`: added `default-features = false` + `serde?/std` in std feature. 
- Dropped `rc` the only two serde-derived types (`BlockId`, `ConfirmationBlockTime`) are pure scalars needing neither `serde/rc` nor `serde/alloc`.
- `bdk_chain`: added `default-features = false` and explicitly enabled`alloc` and `rc` directly on the `serde dep` + `serde?/std` in std. Both are required because `tx_graph::ChangeSet` holds `BTreeSet<Arc<Transaction>>` and `serde` gates `Arc<T>: Serialize` behind `all(feature = "rc", any(feature = "std", feature = "alloc"))`.

This fix was identified while working on (https://github.com/bitcoindevkit/bdk_wallet/pull/494).

### Notes to the reviewers

The `alloc` and `rc` features are placed on the serde dependency directly rather than behind a separate feature flag because `bdk_chain` unconditionally requires `alloc` anyway. 

### Changelog notice
```
### Fixed

- fix(core): serde dep was missing `default-features = false`, leaking `serde/std` into no_std builds and remove unnecessary `rc` feature .
- fix(chain): same leak fixed and `serde/alloc` and `serde/rc` now explicitly enabled on the dep .
```

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)