### PR TITLE
fix(electrum): backport PR#2188

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -62,6 +62,7 @@ jobs:
           cargo update -p "hyper-rustls" --precise "0.27.7"
           cargo update -p openssl --precise "0.10.78"
           cargo update -p openssl-sys --precise "0.9.114"
+          cargo update -p zeroize --precise "1.8.2"
       - name: Pin dependencies for MSRV
         if: matrix.rust.version == '1.63.0'
         run: ./ci/pin-msrv.sh

--- a/ci/pin-msrv.sh
+++ b/ci/pin-msrv.sh
@@ -62,6 +62,7 @@ cargo update -p base58ck --precise "0.1.1"
 cargo update -p bitcoin-io --precise "0.1.4"
 cargo update -p bitcoin-units --precise "0.1.4"
 cargo update -p filetime --precise "0.2.27"
+cargo update -p zeroize --precise "1.8.2"
 
 # all pinning required due to `clap` usage in `example_cli`
 cargo update -p "clap@4.6.1" --precise "4.5.17"

--- a/crates/electrum/src/bdk_electrum_client.rs
+++ b/crates/electrum/src/bdk_electrum_client.rs
@@ -82,6 +82,12 @@ impl<E: ElectrumApi> BdkElectrumClient<E> {
         drop(tx_cache);
 
         let tx = Arc::new(self.inner.transaction_get(&txid)?);
+        let returned_txid = tx.compute_txid();
+        if returned_txid != txid {
+            return Err(Error::Message(format!(
+                "electrum server returned transaction with unexpected txid: expected {txid}, got {returned_txid}"
+            )));
+        }
 
         self.tx_cache.lock().unwrap().insert(txid, Arc::clone(&tx));
 


### PR DESCRIPTION
### Description

It's a backport for the the `bdk_electrum` fix introduced by https://github.com/bitcoindevkit/bdk/pull/2188. If you're interested in the original fix, check the original PR for discussion/rationale.

### Changelog notice

```
### Fixed
- Add a verification check that tx.compute_txid() == txid after fetching from the server, returning an error on mismatch
```

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
