### PR TITLE
fix(esplora): backport PR#2104

### DIFF
--- a/crates/esplora/src/async_ext.rs
+++ b/crates/esplora/src/async_ext.rs
@@ -506,7 +506,7 @@ where
 
     // get outpoint spend-statuses
     let mut outpoints = outpoints.into_iter();
-    let mut missing_txs = Vec::<Txid>::with_capacity(outpoints.len());
+    let mut missing_txs = HashSet::<Txid>::with_capacity(outpoints.len());
     loop {
         let handles = outpoints
             .by_ref()
@@ -527,7 +527,7 @@ where
                 None => continue,
             };
             if !inserted_txs.contains(&spend_txid) {
-                missing_txs.push(spend_txid);
+                missing_txs.insert(spend_txid);
             }
             if let Some(spend_status) = op_status.status {
                 insert_anchor_or_seen_at_from_status(

--- a/crates/esplora/src/blocking_ext.rs
+++ b/crates/esplora/src/blocking_ext.rs
@@ -462,7 +462,7 @@ fn fetch_txs_with_outpoints<I: IntoIterator<Item = OutPoint>>(
 
     // get outpoint spend-statuses
     let mut outpoints = outpoints.into_iter();
-    let mut missing_txs = Vec::<Txid>::with_capacity(outpoints.len());
+    let mut missing_txs = HashSet::<Txid>::with_capacity(outpoints.len());
     loop {
         let handles = outpoints
             .by_ref()
@@ -488,7 +488,7 @@ fn fetch_txs_with_outpoints<I: IntoIterator<Item = OutPoint>>(
                     None => continue,
                 };
                 if !inserted_txs.contains(&spend_txid) {
-                    missing_txs.push(spend_txid);
+                    missing_txs.insert(spend_txid);
                 }
                 if let Some(spend_status) = op_status.status {
                     insert_anchor_or_seen_at_from_status(


### PR DESCRIPTION
### Description

It's a backport for the the `bdk_esplora` fix introduced by https://github.com/bitcoindevkit/bdk/pull/2104. If you're interested in the original fix, check the original PR for discussion/rationale.

### Changelog notice

```
### Changed
- Use `HashSet` instead of `Vec` to track `missing_txs` in bdk_esplora, it deduplicates txids.
```

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)