### PR TITLE
test(core): cover SyncRequest progress and expected txids

### DIFF
--- a/crates/core/tests/test_spk_client.rs
+++ b/crates/core/tests/test_spk_client.rs
@@ -1,4 +1,6 @@
-use bdk_core::spk_client::{FullScanResponse, SyncResponse};
+use bdk_core::spk_client::{FullScanResponse, SyncProgress, SyncRequest, SyncResponse};
+use bitcoin::{hashes::Hash, OutPoint, ScriptBuf, Txid};
+use std::sync::{Arc, Mutex};
 
 #[test]
 fn test_empty() {
@@ -9,5 +11,96 @@ fn test_empty() {
     assert!(
         SyncResponse::<()>::default().is_empty(),
         "Default `SyncResponse` must be empty"
+    );
+}
+
+#[test]
+fn sync_request_reports_progress_to_inspect() {
+    let spk = ScriptBuf::from_bytes(vec![0x51]);
+    let txid = txid_from_byte(1);
+    let outpoint = OutPoint::new(txid_from_byte(2), 3);
+    let inspected = Arc::new(Mutex::new(Vec::new()));
+
+    let mut request = SyncRequest::builder_at(42)
+        .spks([spk.clone()])
+        .txids([txid])
+        .outpoints([outpoint])
+        .inspect({
+            let inspected = Arc::clone(&inspected);
+            move |item, progress| {
+                inspected
+                    .lock()
+                    .expect("inspect log must not be poisoned")
+                    .push((item.to_string(), progress));
+            }
+        })
+        .build();
+
+    assert_eq!(request.start_time(), 42);
+    assert_eq!(request.progress().remaining(), 3);
+    assert_eq!(
+        request.next_spk_with_expected_txids().map(|s| s.spk),
+        Some(spk)
+    );
+    assert_eq!(request.next_txid(), Some(txid));
+    assert_eq!(request.next_outpoint(), Some(outpoint));
+    assert_eq!(request.progress().remaining(), 0);
+
+    let inspected = inspected.lock().expect("inspect log must not be poisoned");
+    assert_eq!(inspected.len(), 3);
+    assert_progress(&inspected[0].1, (1, 0), (0, 1), (0, 1));
+    assert_progress(&inspected[1].1, (1, 0), (1, 0), (0, 1));
+    assert_progress(&inspected[2].1, (1, 0), (1, 0), (1, 0));
+    assert!(inspected[0].0.contains("script"));
+    assert!(inspected[1].0.contains("txid"));
+    assert!(inspected[2].0.contains("outpoint"));
+}
+
+#[test]
+fn sync_request_returns_expected_txids_for_matching_spk() {
+    let spk = ScriptBuf::from_bytes(vec![0x51]);
+    let other_spk = ScriptBuf::from_bytes(vec![0x52]);
+    let expected_txid = txid_from_byte(42);
+    let unrelated_txid = txid_from_byte(99);
+
+    let mut request = SyncRequest::builder_at(0)
+        .spks([spk.clone(), other_spk])
+        .expected_spk_txids([(spk.clone(), expected_txid)])
+        .expected_spk_txids([(ScriptBuf::from_bytes(vec![0x53]), unrelated_txid)])
+        .build();
+
+    let first = request
+        .next_spk_with_expected_txids()
+        .expect("first spk must be present");
+    assert_eq!(first.spk, spk);
+    assert_eq!(first.expected_txids.len(), 1);
+    assert!(first.expected_txids.contains(&expected_txid));
+
+    let second = request
+        .next_spk_with_expected_txids()
+        .expect("second spk must be present");
+    assert!(second.expected_txids.is_empty());
+}
+
+fn txid_from_byte(byte: u8) -> Txid {
+    Txid::from_byte_array([byte; 32])
+}
+
+fn assert_progress(
+    progress: &SyncProgress,
+    spks: (usize, usize),
+    txids: (usize, usize),
+    outpoints: (usize, usize),
+) {
+    assert_eq!(
+        (
+            progress.spks_consumed,
+            progress.spks_remaining,
+            progress.txids_consumed,
+            progress.txids_remaining,
+            progress.outpoints_consumed,
+            progress.outpoints_remaining,
+        ),
+        (spks.0, spks.1, txids.0, txids.1, outpoints.0, outpoints.1)
     );
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Description

<!-- Describe the purpose of this PR, what's being adding and/or fixed -->


Adds coverage for `SyncRequest` behavior in `bdk_core::spk_client`.

The new tests verify that:
- `SyncRequest` reports progress correctly as scripts, txids, and outpoints are consumed.
- the `inspect` callback observes the post-consumption progress for each item.
- expected txids are returned only for the matching script pubkey.



### Notes to the reviewers

<!-- In this section you can include notes directed to the reviewers, like explaining why some parts
of the PR were done in a specific way -->

This is a test-only change. I chose this area because `SyncRequest` is public API used by chain clients, but the existing `spk_client` test coverage only checked empty response defaults. Covering progress reporting and expected txid matching helps lock in behavior that client integrations may rely on, without changing the implementation or API surface.


### Changelog notice

<!-- Notice the release manager should include in the release tag message changelog -->
<!-- See https://keepachangelog.com/en/1.0.0/ for examples -->

No changelog entry needed; this is test coverage only.
### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### New Features:

* [x] I've added tests for the new feature
* [ ] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR
