### PR TITLE
feat(core): add non-consuming SyncRequest iterators

### DIFF
--- a/crates/core/src/spk_client.rs
+++ b/crates/core/src/spk_client.rs
@@ -383,14 +383,46 @@ impl<I, D> SyncRequest<I, D> {
         SyncIter::<I, D, SpkWithExpectedTxids>::new(self)
     }
 
-    /// Iterate over [`Txid`]s contained in this request.
-    pub fn iter_txids(&mut self) -> impl ExactSizeIterator<Item = Txid> + '_ {
+    /// Drain and iterate over [`Txid`]s contained in this request, consuming them.
+    pub fn drain_txids(&mut self) -> impl ExactSizeIterator<Item = Txid> + '_ {
         SyncIter::<I, D, Txid>::new(self)
     }
 
-    /// Iterate over [`OutPoint`]s contained in this request.
-    pub fn iter_outpoints(&mut self) -> impl ExactSizeIterator<Item = OutPoint> + '_ {
+    /// Drain and iterate over [`OutPoint`]s contained in this request, consuming them.
+    pub fn drain_outpoints(&mut self) -> impl ExactSizeIterator<Item = OutPoint> + '_ {
         SyncIter::<I, D, OutPoint>::new(self)
+    }
+
+    /// Iterate over [`Txid`]s contained in this request.
+    #[deprecated(
+        note = "use `drain_txids` for consuming iteration or `txids` for read-only iteration"
+    )]
+    pub fn iter_txids(&mut self) -> impl ExactSizeIterator<Item = Txid> + '_ {
+        self.drain_txids()
+    }
+
+    /// Iterate over [`OutPoint`]s contained in this request.
+    #[deprecated(
+        note = "use `drain_outpoints` for consuming iteration or `outpoints` for read-only iteration"
+    )]
+    pub fn iter_outpoints(&mut self) -> impl ExactSizeIterator<Item = OutPoint> + '_ {
+        self.drain_outpoints()
+    }
+
+    /// Iterate over script pubkeys (with indexes) contained in this request, without
+    /// consuming them.
+    pub fn spks(&self) -> impl ExactSizeIterator<Item = &(I, ScriptBuf)> + '_ {
+        self.spks.iter()
+    }
+
+    /// Iterate over [`Txid`]s contained in this request, without consuming them.
+    pub fn txids(&self) -> impl ExactSizeIterator<Item = &Txid> + '_ {
+        self.txids.iter()
+    }
+
+    /// Iterate over [`OutPoint`]s contained in this request, without consuming them.
+    pub fn outpoints(&self) -> impl ExactSizeIterator<Item = &OutPoint> + '_ {
+        self.outpoints.iter()
     }
 
     fn _call_inspect(&mut self, item: SyncItem<I>) {

--- a/crates/core/tests/test_spk_client.rs
+++ b/crates/core/tests/test_spk_client.rs
@@ -1,6 +1,4 @@
-use bdk_core::bitcoin::hashes::Hash;
-use bdk_core::bitcoin::{BlockHash, OutPoint, Txid};
-use bdk_core::spk_client::{FullScanResponse, SyncRequest, SyncResponse};
+use bdk_core::spk_client::{FullScanResponse, SyncResponse};
 
 #[test]
 fn test_empty() {
@@ -11,57 +9,5 @@ fn test_empty() {
     assert!(
         SyncResponse::<()>::default().is_empty(),
         "Default `SyncResponse` must be empty"
-    );
-}
-
-#[test]
-fn test_spks_does_not_consume() {
-    let spk1 = bitcoin::ScriptBuf::new();
-    let spk2 = bitcoin::ScriptBuf::new();
-
-    let request: SyncRequest<u32, BlockHash> = SyncRequest::builder()
-        .spks_with_indexes(vec![(0u32, spk1), (1u32, spk2)])
-        .build();
-
-    assert_eq!(request.spks().count(), 2);
-    assert_eq!(request.spks().count(), 2, "must not consume");
-}
-
-#[test]
-fn test_txids_does_not_consume() {
-    let txid1 = Txid::from_byte_array([0x01; 32]);
-
-    let request: SyncRequest<(), BlockHash> = SyncRequest::builder().txids(vec![txid1]).build();
-
-    assert_eq!(request.txids().count(), 1);
-    assert_eq!(request.txids().count(), 1, "must not consume");
-}
-
-#[test]
-fn test_outpoints_does_not_consume() {
-    let outpoint1 = OutPoint::null();
-
-    let request: SyncRequest<(), BlockHash> =
-        SyncRequest::builder().outpoints(vec![outpoint1]).build();
-
-    assert_eq!(request.outpoints().count(), 1);
-    assert_eq!(request.outpoints().count(), 1, "must not consume");
-}
-
-#[test]
-fn test_drain_txids_still_consumes_all_items() {
-    let txid1 = Txid::from_byte_array([0x01; 32]);
-    let txid2 = Txid::from_byte_array([0x02; 32]);
-
-    let mut request: SyncRequest<(), BlockHash> =
-        SyncRequest::builder().txids(vec![txid1, txid2]).build();
-
-    assert_eq!(request.txids().count(), 2);
-
-    let consumed: Vec<_> = request.drain_txids().collect();
-    assert_eq!(
-        consumed.len(),
-        2,
-        "drain_txids must still consume all items"
     );
 }

--- a/crates/core/tests/test_spk_client.rs
+++ b/crates/core/tests/test_spk_client.rs
@@ -1,4 +1,6 @@
-use bdk_core::spk_client::{FullScanResponse, SyncResponse};
+use bdk_core::bitcoin::hashes::Hash;
+use bdk_core::bitcoin::{BlockHash, OutPoint, Txid};
+use bdk_core::spk_client::{FullScanResponse, SyncRequest, SyncResponse};
 
 #[test]
 fn test_empty() {
@@ -9,5 +11,57 @@ fn test_empty() {
     assert!(
         SyncResponse::<()>::default().is_empty(),
         "Default `SyncResponse` must be empty"
+    );
+}
+
+#[test]
+fn test_spks_does_not_consume() {
+    let spk1 = bitcoin::ScriptBuf::new();
+    let spk2 = bitcoin::ScriptBuf::new();
+
+    let request: SyncRequest<u32, BlockHash> = SyncRequest::builder()
+        .spks_with_indexes(vec![(0u32, spk1), (1u32, spk2)])
+        .build();
+
+    assert_eq!(request.spks().count(), 2);
+    assert_eq!(request.spks().count(), 2, "must not consume");
+}
+
+#[test]
+fn test_txids_does_not_consume() {
+    let txid1 = Txid::from_byte_array([0x01; 32]);
+
+    let request: SyncRequest<(), BlockHash> = SyncRequest::builder().txids(vec![txid1]).build();
+
+    assert_eq!(request.txids().count(), 1);
+    assert_eq!(request.txids().count(), 1, "must not consume");
+}
+
+#[test]
+fn test_outpoints_does_not_consume() {
+    let outpoint1 = OutPoint::null();
+
+    let request: SyncRequest<(), BlockHash> =
+        SyncRequest::builder().outpoints(vec![outpoint1]).build();
+
+    assert_eq!(request.outpoints().count(), 1);
+    assert_eq!(request.outpoints().count(), 1, "must not consume");
+}
+
+#[test]
+fn test_drain_txids_still_consumes_all_items() {
+    let txid1 = Txid::from_byte_array([0x01; 32]);
+    let txid2 = Txid::from_byte_array([0x02; 32]);
+
+    let mut request: SyncRequest<(), BlockHash> =
+        SyncRequest::builder().txids(vec![txid1, txid2]).build();
+
+    assert_eq!(request.txids().count(), 2);
+
+    let consumed: Vec<_> = request.drain_txids().collect();
+    assert_eq!(
+        consumed.len(),
+        2,
+        "drain_txids must still consume all items"
     );
 }

--- a/crates/electrum/src/bdk_electrum_client.rs
+++ b/crates/electrum/src/bdk_electrum_client.rs
@@ -238,13 +238,13 @@ impl<E: ElectrumApi> BdkElectrumClient<E> {
         self.populate_with_txids(
             start_time,
             &mut tx_update,
-            request.iter_txids(),
+            request.drain_txids(),
             &mut pending_anchors,
         )?;
         self.populate_with_outpoints(
             start_time,
             &mut tx_update,
-            request.iter_outpoints(),
+            request.drain_outpoints(),
             &mut pending_anchors,
         )?;
 

--- a/crates/esplora/src/async_ext.rs
+++ b/crates/esplora/src/async_ext.rs
@@ -145,7 +145,7 @@ where
                 self,
                 start_time,
                 &mut inserted_txs,
-                request.iter_txids(),
+                request.drain_txids(),
                 parallel_requests,
             )
             .await?,
@@ -155,7 +155,7 @@ where
                 self,
                 start_time,
                 &mut inserted_txs,
-                request.iter_outpoints(),
+                request.drain_outpoints(),
                 parallel_requests,
             )
             .await?,

--- a/crates/esplora/src/blocking_ext.rs
+++ b/crates/esplora/src/blocking_ext.rs
@@ -133,14 +133,14 @@ impl EsploraExt for esplora_client::BlockingClient {
             self,
             start_time,
             &mut inserted_txs,
-            request.iter_txids(),
+            request.drain_txids(),
             parallel_requests,
         )?);
         tx_update.extend(fetch_txs_with_outpoints(
             self,
             start_time,
             &mut inserted_txs,
-            request.iter_outpoints(),
+            request.drain_outpoints(),
             parallel_requests,
         )?);
 


### PR DESCRIPTION
### Description
This PR introduces dedicated consuming and non-consuming iteration APIs for `SyncRequest` while preserving backwards compatibility, as proposed in #2220.

Previously, `SyncRequest` exposed `iter_txids(&mut self)` and `iter_outpoints(&mut self)` as consuming iterators(draining the request via `SyncIter`), despite their `iter_*` naming suggesting read-only iteration. At the same time, there was no API for inspecting pending `spks`, `txids`, or `outpoints` without consuming the request.

This PR addresses these issues while preserving backwards compatibility.

### API Changes

**Adds new read-only accessors:**
- `SyncRequest::spks(&self)`
- `SyncRequest::txids(&self)`
- `SyncRequest::outpoints(&self)`

**Renames the consuming API to:**
- `SyncRequest::drain_txids(&mut self)`
- `SyncRequest::drain_outpoints(&mut self)`

**Reintroduces:**
- `SyncRequest::iter_txids(&mut self)`
- `SyncRequest::iter_outpoints(&mut self)`

as deprecated compatibilty wrappers that delegate to the corresponding `drain_*` methods. This preserves existing downstream code while providing a migration path to the clearer API.

### Backend updates
Updated all in-tree call-sites to use the new consuming APIs:
- `bdk_esplora` (blocking and async)
- `bdk_electrum`

### Testing
Added tests verifying that:
- `spks()`, `txids()`, and `outpoints()` are non-consuming.
- Repeated calls to the read-only accessors return consistent results.
- `drain_txids()` continues to consume all items as before.

### Design rationale
This follows the Rust API Guidelines:

- `drain_*` clearly indicates consuming iteration over the request contents.
- `spks()`, `txids()`, and `outpoints()` provide borrowed, read-only access.
- Existing `iter_*` APIs remain available as deprecated compatibility wrappers, avoiding an immediate breaking change for downstream users.

Fixes #2220

### Notes to the reviewers
1. This revision follows the API direction suggested during review:
 - consuming methods renamed to `drain_*`
 - read-only methods exposed as `spks()`, `txids()`, and `outpoints()`
 - `iter_*` methods retained as deprecated compatibility wrappers

2. The read-only accessors return `impl ExactSizeIterator + '_`, matching the capabilities of the underlying collections.
3. I observed an intermittent failure of `bdk_electrum`'s `test_sync` during local testing (`trusted_pending` vs `confirmed` balance assertion). Re-running the same test on the same commit passed without any code changes, suggesting pre-existing test flakiness rather than a regression introduced by this PR.

**Verified locally with:**
-  `cargo fmt`
- `cargo build`
- `cargo test -p bdk_core --test test_spk_client`
- multiple runs of `cargo test -p bdk_electrum --test test_electrum`

### Changelog notice

### Added
- Added `SyncRequest::spks`, `SyncRequest::txids`, and `SyncRequest::outpoints` for non-consuming inspection of pending sync data.

### Changed
- Added `SyncRequest::drain_txids` and `SyncRequest::drain_outpoints` as the consuming iterator APIs.
- Deprecated `SyncRequest::iter_txids` and `SyncRequest::iter_outpoints` in favor of `drain_*` for consuming iteration or the new read-only accessors.

### Checklists
**All Submissions**
- [x] I followed the contribution guidelines.

**New Features**
- [x] I've added tests for the new feature.
- [x] I've added docs for the new feature.

**Bugfixes**
- [x] I'm linking the issue being fixed by this PR. 