### PR TITLE
chore(chain): make TxAncestors::new_include_root public

### DIFF
--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -1209,7 +1209,7 @@ where
     F: FnMut(usize, Arc<Transaction>) -> Option<O>,
 {
     /// Creates a `TxAncestors` that includes the starting `Transaction` when iterating.
-    pub(crate) fn new_include_root(
+    pub fn new_include_root(
         graph: &'g TxGraph<A>,
         tx: impl Into<Arc<Transaction>>,
         filter_map: F,


### PR DESCRIPTION
### Description

Makes `TxAncestors::new_include_root` public. The `TxAncestors` struct itself is already `pub`, but its `new_include_root` constructor was `pub(crate)`, preventing external users from constructing an ancestor iterator that includes the root transaction. This aligns the constructor's visibility with the struct's.

Closes #2216

### Notes to the reviewers

Only `TxAncestors::new_include_root` was changed. `TxDescendants::new_include_root` (and the corresponding `new_exclude_root` methods on both types) were left untouched since the issue scope was limited to `TxAncestors`.

### Changelog notice

- Made `TxAncestors::new_include_root` public. (#2216) 

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### New Features:

N/A - this PR only changes the visibility of an existing constructor, it does not add new functionality.

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [ ] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR
