### PR TITLE
fix(core,chain): disable serde default features for no_std

### DIFF
--- a/.github/workflows/cont_integration.yml
+++ b/.github/workflows/cont_integration.yml
@@ -72,6 +72,27 @@ jobs:
         working-directory: ./crates/chain
         # TODO "--target thumbv6m-none-eabi" should work but currently does not
         run: cargo check --no-default-features --features hashbrown
+      - name: Check serde does not enable serde/std in no_std builds
+        run: |
+          set -euo pipefail
+          check_no_serde_std() {
+            local pkg="$1" features="$2"
+            if cargo tree -p "$pkg" -e features \
+                --no-default-features --features "$features" --no-dev-dependencies \
+                | grep -q 'serde feature "std"'; then
+              echo "error: serde/std enabled for $pkg with features=$features"
+              exit 1
+            fi
+          }
+          check_no_serde_std bdk_core serde
+          check_no_serde_std bdk_chain serde
+      - name: Install ARM cross-compiler
+        run: sudo apt-get update && sudo apt-get install -y gcc-arm-none-eabi
+      - name: Add bare-metal target
+        run: rustup target add thumbv7em-none-eabihf
+      - name: Check bdk_chain serde on bare-metal target
+        working-directory: ./crates/chain
+        run: cargo check --no-default-features --features serde --target thumbv7em-none-eabihf
       - name: Check esplora
         working-directory: ./crates/esplora
         # TODO "--target thumbv6m-none-eabi" should work but currently does not

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 [dependencies]
 bitcoin = { version = "0.32.0", default-features = false }
 bdk_core = { path = "../core", version = "0.6.2", default-features = false }
-serde = { version = "1", optional = true, features = ["derive", "rc"] }
+serde = { version = "1", optional = true, default-features = false, features = ["derive", "rc", "alloc"] }
 miniscript = { version = "13.0.0", optional = true, default-features = false }
 
 # Feature dependencies
@@ -32,7 +32,7 @@ criterion = { version = "0.7" }
 
 [features]
 default = ["std", "miniscript"]
-std = ["bitcoin/std", "miniscript?/std", "bdk_core/std"]
+std = ["bitcoin/std", "miniscript?/std", "bdk_core/std", "serde?/std"]
 serde = ["dep:serde", "bitcoin/serde", "miniscript?/serde", "bdk_core/serde"]
 hashbrown = ["bdk_core/hashbrown"]
 rusqlite = ["std", "dep:rusqlite", "serde"]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -12,12 +12,12 @@ readme = "README.md"
 
 [dependencies]
 bitcoin = { version = "0.32", default-features = false }
-serde = { version = "1", optional = true, features = ["derive", "rc"] }
+serde = { version = "1", optional = true, default-features = false, features = ["derive", "rc", "alloc"] }
 hashbrown = { version = "0.14.5", optional = true, default-features = false, features = ["ahash", "inline-more"] }
 
 [features]
 default = ["std"]
-std = ["bitcoin/std"]
+std = ["bitcoin/std", "serde?/std"]
 serde = ["dep:serde", "bitcoin/serde", "hashbrown?/serde"]
 
 [dev-dependencies]


### PR DESCRIPTION
### Description

Fixes #2208.

Both `bdk_core` and `bdk_chain` declared their `serde` dependency without `default-features = false`. Since serde's default feature set includes `std`, enabling `bdk_chain/serde` (or `bdk_core/serde`) in a downstream `no_std` crate activated `serde/std` through Cargo's feature unification, breaking compilation on bare-metal targets where `std` is unavailable.

This PR disables serde's default features in both crates and re-enables `serde/std` only through each crate's own `std` feature.

**Changes**
- `bdk_core` / `bdk_chain`: `serde = { version = "1", optional = true, default-features = false, features = ["derive", "rc", "alloc"] }`
  - `alloc` mirrors the `bitcoin` crate and is required for `no_std + alloc` serialization
  - `rc` is kept unchanged (existing behavior)
- Propagate `serde/std` only via each crate's `std` feature using `serde?/std`
- CI (`check-no-std` job): added a `cargo tree` feature-graph assertion (`--no-dev-dependencies`) that fails if `serde/std` is pulled into a `no_std` build, plus a `thumbv7em-none-eabihf` bare-metal `cargo check`

### Notes to the reviewers

`cargo check --no-default-features --features serde` on the host passes even *before* this fix, because the host provides `std`. The bug only surfaces on targets without `std`, so verification uses `cargo tree -e features` (dependency-graph proof) and a bare-metal target (compile proof).

Verified locally:
- `no_std + serde` no longer pulls `serde feature "std"` for `bdk_core` and `bdk_chain`
- `std + serde` still enables `serde/std` (no behavior change for std users)
- Full test suite green: `bdk_core`, `bdk_chain`, `bdk_file_store`, `bdk_testenv`, `bdk_bitcoind_rpc`, `bdk_electrum`, `bdk_esplora`
- `cargo clippy --all-features --all-targets -- -D warnings`, `cargo doc`, and `cargo +nightly fmt --all --check` all pass

<img width="1343" height="950" alt="image" src="https://github.com/user-attachments/assets/9fb5010e-5adf-4b2b-a271-e015a237b676" />


**Follow-up (out of scope):** a `no_std + miniscript + serde` combination may still pull `serde/std` via upstream `miniscript`'s serde dependency, which does not disable its default features. That is a separate upstream concern and is not addressed here.

### Changelog notice

- Fixed `bdk_core` and `bdk_chain` incorrectly enabling `serde/std` in `no_std` builds when the `serde` feature was enabled.

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### Bugfixes:

* [x] I've added tests to reproduce the issue which are now passing
* [x] I'm linking the issue being fixed by this PR