### PR TITLE
fix(chain): skip evicted txs in leftover canonicalization

### DIFF
--- a/crates/chain/src/canonical_task.rs
+++ b/crates/chain/src/canonical_task.rs
@@ -119,7 +119,12 @@ impl<'g, A: Anchor> ChainQuery for CanonicalTask<'g, A> {
                 }
                 CanonicalStage::LeftOverTxs => {
                     if let Some((txid, tx, height)) = self.unprocessed_leftover_txs.pop_front() {
-                        if !self.is_canonicalized(txid) && !tx.is_coinbase() {
+                        let is_evicted = self
+                            .tx_graph
+                            .get_tx_node(txid)
+                            .expect("leftover transaction must exist")
+                            .is_evicted();
+                        if !self.is_canonicalized(txid) && !tx.is_coinbase() && !is_evicted {
                             let observed_in = ObservedIn::Block(height);
                             self.mark_canonical(
                                 txid,

--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -225,6 +225,20 @@ pub struct TxNode<'a, T, A> {
     pub last_evicted: Option<u64>,
 }
 
+impl<T, A> TxNode<'_, T, A> {
+    /// Whether the transaction has been evicted from the mempool.
+    ///
+    /// Only mempool observation timestamps are considered; anchors have no effect. A transaction
+    /// is evicted when its last-evicted timestamp is at least as recent as its last-seen timestamp.
+    pub fn is_evicted(&self) -> bool {
+        match (self.last_seen, self.last_evicted) {
+            (_, None) => false,
+            (Some(last_seen), Some(last_evicted)) => last_evicted >= last_seen,
+            (None, Some(_)) => true,
+        }
+    }
+}
+
 impl<T, A> Deref for TxNode<'_, T, A> {
     type Target = T;
 

--- a/crates/chain/tests/test_canonical_view.rs
+++ b/crates/chain/tests/test_canonical_view.rs
@@ -2,7 +2,7 @@
 
 use std::collections::BTreeMap;
 
-use bdk_chain::{local_chain::LocalChain, ConfirmationBlockTime, TxGraph};
+use bdk_chain::{local_chain::LocalChain, BlockId, ConfirmationBlockTime, TxGraph};
 use bdk_testenv::{hash, utils::new_tx};
 use bitcoin::{Amount, BlockHash, OutPoint, ScriptBuf, Transaction, TxIn, TxOut};
 
@@ -293,4 +293,48 @@ fn test_min_confirmations_multiple_transactions() {
         Amount::from_sat(20_000 + 30_000) // tx1 + tx2
     );
     assert_eq!(balance_high.untrusted_pending, Amount::ZERO);
+}
+
+/// Txs with stale anchor and that have `last_evicted >= last_seen` should be excluded from
+/// canonicalization.
+#[test]
+fn test_evicted_stale_anchored_tx_not_canonical() {
+    let blocks: BTreeMap<u32, BlockHash> =
+        [(0, hash!("genesis")), (1, hash!("b1")), (2, hash!("tip"))]
+            .into_iter()
+            .collect();
+    let chain = LocalChain::from_blocks(blocks).unwrap();
+
+    let mut tx_graph = TxGraph::default();
+    let tx = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(hash!("parent"), 0),
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(50_000),
+            script_pubkey: ScriptBuf::new(),
+        }],
+        ..new_tx(1)
+    };
+    let txid = tx.compute_txid();
+    let _ = tx_graph.insert_tx(tx);
+    let _ = tx_graph.insert_anchor(
+        txid,
+        ConfirmationBlockTime {
+            block_id: BlockId {
+                height: 1,
+                hash: hash!("stale"),
+            },
+            confirmation_time: 123456,
+        },
+    );
+    let _ = tx_graph.insert_seen_at(txid, 100);
+    let _ = tx_graph.insert_evicted_at(txid, 200);
+
+    let view = chain.canonical_view(&tx_graph, chain.tip().block_id(), Default::default());
+    assert!(
+        !view.txs().any(|tx| tx.txid == txid),
+        "evicted leftover tx must not be canonical"
+    );
 }

--- a/crates/chain/tests/test_tx_graph.rs
+++ b/crates/chain/tests/test_tx_graph.rs
@@ -1456,6 +1456,32 @@ fn tx_graph_update_conversion() {
 }
 
 #[test]
+fn tx_node_is_evicted() {
+    let anchors = [block_id!(1, "A")].into();
+    let test_cases = [
+        (None, None, false),
+        (Some(10), None, false),
+        (None, Some(10), true),
+        (Some(10), Some(9), false),
+        (Some(10), Some(10), true),
+        (Some(10), Some(11), true),
+    ];
+
+    for (last_seen, last_evicted, expected) in test_cases {
+        let node = tx_graph::TxNode {
+            txid: hash!("tx"),
+            tx: (),
+            anchors: &anchors,
+            first_seen: None,
+            last_seen,
+            last_evicted,
+        };
+
+        assert_eq!(node.is_evicted(), expected);
+    }
+}
+
+#[test]
 fn test_seen_at_updates() {
     // Update both first_seen and last_seen
     let seen_at = 1000000_u64;


### PR DESCRIPTION
### Description

`CanonicalStage::LeftOverTxs` doesn't filter evicted txs and can mark them canonical. So a stale-anchored tx that was evicted/replaced could still show as unconfirmed.

Example: a tx confirms, then a reorg leaves only a stale anchor. Leftover treats it as unconfirmed. If it's later RBF'd or missing from the mempool, leftover still marks it unconfirmed.

### Changelog notice
- Add `TxNode::is_evicted()` for determining mempool eviction state.
- Skip evicted transactions during leftover canonicalization.

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
* [ ] I'm linking the issue being fixed by this PR