### PR TITLE
feat(chain)!: taint-aware `CanonicalView::balance` 

### DIFF
--- a/crates/bitcoind_rpc/tests/test_emitter.rs
+++ b/crates/bitcoind_rpc/tests/test_emitter.rs
@@ -325,7 +325,11 @@ fn get_balance(
             recv_chain.tip().block_id(),
             Default::default(),
         )
-        .balance(outpoints, |_, _| true, 0);
+        .balance(
+            outpoints.into_iter().map(|(_, op)| op),
+            bdk_chain::taints_unowned(&recv_graph.index),
+            |pos| pos.is_confirmed(),
+        );
     Ok(balance)
 }
 
@@ -409,7 +413,7 @@ fn tx_can_become_unconfirmed_after_reorg() -> anyhow::Result<()> {
         assert_eq!(
             get_balance(&recv_chain, &recv_graph)?,
             Balance {
-                trusted_pending: SEND_AMOUNT * reorg_count as u64,
+                untrusted_pending: SEND_AMOUNT * reorg_count as u64,
                 confirmed: SEND_AMOUNT * (ADDITIONAL_COUNT - reorg_count) as u64,
                 ..Balance::default()
             },

--- a/crates/chain/Cargo.toml
+++ b/crates/chain/Cargo.toml
@@ -44,3 +44,7 @@ harness = false
 [[bench]]
 name = "indexer"
 harness = false
+
+[[bench]]
+name = "trust_classification"
+harness = false

--- a/crates/chain/benches/indexer.rs
+++ b/crates/chain/benches/indexer.rs
@@ -85,7 +85,11 @@ fn do_bench(indexed_tx_graph: &KeychainTxGraph, chain: &LocalChain) {
     let op = graph.index.outpoints().clone();
     let bal = chain
         .canonical_view(graph.graph(), chain.tip().block_id(), Default::default())
-        .balance(op, |_, _| false, 1);
+        .balance(
+            op.into_iter().map(|(_, o)| o),
+            bdk_chain::taints_unowned(&graph.index),
+            |pos| pos.is_confirmed(),
+        );
     assert_eq!(bal.total(), AMOUNT * TX_CT as u64);
 }
 

--- a/crates/chain/benches/trust_classification.rs
+++ b/crates/chain/benches/trust_classification.rs
@@ -1,0 +1,485 @@
+//! Benchmarks for `classify_outpoints` (the classifier `balance` folds over).
+//!
+//! Each group builds a synthetic canonical graph and times classifying every UTXO across a range
+//! of sizes. What we care about is how the cost grows with the unconfirmed ancestry, so the
+//! confirmed part is kept minimal and everything interesting lives in the mempool.
+
+use std::collections::BTreeMap;
+
+use bdk_chain::{
+    local_chain::LocalChain, CanonicalView, ChainPosition, ConfirmationBlockTime, TxGraph,
+};
+use bdk_testenv::{hash, utils::new_tx};
+use bitcoin::{Amount, BlockHash, OutPoint, Script, ScriptBuf, Transaction, TxIn, TxOut, Txid};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+
+// Minimal 2-block chain. Confirmed txs just anchor at height 1.
+fn make_chain() -> LocalChain {
+    let blocks: BTreeMap<u32, BlockHash> = [(0, hash!("genesis")), (1, hash!("b1"))]
+        .into_iter()
+        .collect();
+    LocalChain::from_blocks(blocks).unwrap()
+}
+
+// The two predicates `classify_outpoints` takes, faking what a wallet would pass:
+// `does_taint` = the tx pulls in coins that aren't ours, `is_settled` = the tx is confirmed.
+#[allow(clippy::type_complexity)]
+fn does_taint_and_is_settled<'a>(
+    view: &'a CanonicalView<ConfirmationBlockTime>,
+    owned: &ScriptBuf,
+) -> (
+    impl FnMut(&bdk_chain::CanonicalTx<ChainPosition<ConfirmationBlockTime>>) -> bool + 'a,
+    impl Fn(&ChainPosition<ConfirmationBlockTime>) -> bool,
+) {
+    let owned = owned.clone();
+    let is_mine = move |spk: &Script| spk == owned.as_script();
+    let does_taint = move |c_tx: &bdk_chain::CanonicalTx<ChainPosition<ConfirmationBlockTime>>| {
+        c_tx.tx
+            .input
+            .iter()
+            .any(|txin| match view.tx(txin.previous_output.txid) {
+                Some(prev) => {
+                    !is_mine(&prev.tx.output[txin.previous_output.vout as usize].script_pubkey)
+                }
+                // input from a tx we don't have, treat it as foreign
+                None => true,
+            })
+    };
+    let is_settled =
+        |pos: &ChainPosition<ConfirmationBlockTime>| matches!(pos, ChainPosition::Confirmed { .. });
+    (does_taint, is_settled)
+}
+
+// Per-UTXO memoized classification (`classify_outpoints`).
+fn run_classify(
+    utxo_txids: &[Txid],
+    view: &CanonicalView<ConfirmationBlockTime>,
+    owned: &ScriptBuf,
+) {
+    let outpoints = utxo_txids.iter().map(|&txid| OutPoint::new(txid, 0));
+    let (does_taint, is_settled) = does_taint_and_is_settled(view, owned);
+    for item in view.classify_outpoints(outpoints, does_taint, is_settled) {
+        std::hint::black_box(item);
+    }
+}
+
+// One confirmed owned root with `width` outputs, each starting a `depth`-deep chain of unconfirmed
+// owned txs. Nothing taints. Walking back, every chain converges on the shared root.
+fn setup_fan_in(
+    width: usize,
+    depth: usize,
+) -> (
+    LocalChain,
+    TxGraph<ConfirmationBlockTime>,
+    Vec<Txid>,
+    ScriptBuf,
+) {
+    let chain = make_chain();
+    let mut tx_graph = TxGraph::default();
+    let owned = ScriptBuf::from(vec![1u8]);
+
+    let root_tx = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(hash!("external"), 0),
+            ..Default::default()
+        }],
+        output: (0..width)
+            .map(|_| TxOut {
+                value: Amount::from_sat(100_000),
+                script_pubkey: owned.clone(),
+            })
+            .collect(),
+        ..new_tx(0)
+    };
+    let root_txid = root_tx.compute_txid();
+    let _ = tx_graph.insert_tx(root_tx);
+    let _ = tx_graph.insert_anchor(
+        root_txid,
+        ConfirmationBlockTime {
+            block_id: chain.get(1).unwrap().block_id(),
+            confirmation_time: 1,
+        },
+    );
+
+    let mut utxo_txids = vec![];
+    for chain_i in 0..width {
+        let mut prev = OutPoint::new(root_txid, chain_i as u32);
+        for layer in 0..depth {
+            let tx = Transaction {
+                input: vec![TxIn {
+                    previous_output: prev,
+                    ..Default::default()
+                }],
+                output: vec![TxOut {
+                    value: Amount::from_sat(90_000),
+                    script_pubkey: owned.clone(),
+                }],
+                ..new_tx((chain_i * depth + layer + 1) as u32)
+            };
+            let txid = tx.compute_txid();
+            let _ = tx_graph.insert_tx(tx);
+            let _ = tx_graph.insert_seen_at(txid, 100);
+            prev = OutPoint::new(txid, 0);
+            if layer == depth - 1 {
+                utxo_txids.push(txid);
+            }
+        }
+    }
+    (chain, tx_graph, utxo_txids, owned)
+}
+
+// Like fan_in but each chain gets its own confirmed root, so there is no shared ancestor.
+// Nothing taints.
+fn setup_disjoint(
+    width: usize,
+    depth: usize,
+) -> (
+    LocalChain,
+    TxGraph<ConfirmationBlockTime>,
+    Vec<Txid>,
+    ScriptBuf,
+) {
+    let chain = make_chain();
+    let mut tx_graph = TxGraph::default();
+    let owned = ScriptBuf::from(vec![1u8]);
+
+    let mut utxo_txids = vec![];
+    for chain_i in 0..width {
+        let root_tx = Transaction {
+            input: vec![TxIn {
+                previous_output: OutPoint::new(hash!("external"), chain_i as u32),
+                ..Default::default()
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(100_000),
+                script_pubkey: owned.clone(),
+            }],
+            ..new_tx(chain_i as u32)
+        };
+        let root_txid = root_tx.compute_txid();
+        let _ = tx_graph.insert_tx(root_tx);
+        let _ = tx_graph.insert_anchor(
+            root_txid,
+            ConfirmationBlockTime {
+                block_id: chain.get(1).unwrap().block_id(),
+                confirmation_time: 1,
+            },
+        );
+
+        let mut prev = OutPoint::new(root_txid, 0);
+        for layer in 0..depth {
+            let tx = Transaction {
+                input: vec![TxIn {
+                    previous_output: prev,
+                    ..Default::default()
+                }],
+                output: vec![TxOut {
+                    value: Amount::from_sat(90_000),
+                    script_pubkey: owned.clone(),
+                }],
+                ..new_tx((width + chain_i * depth + layer) as u32)
+            };
+            let txid = tx.compute_txid();
+            let _ = tx_graph.insert_tx(tx);
+            let _ = tx_graph.insert_seen_at(txid, 100);
+            prev = OutPoint::new(txid, 0);
+            if layer == depth - 1 {
+                utxo_txids.push(txid);
+            }
+        }
+    }
+    (chain, tx_graph, utxo_txids, owned)
+}
+
+// An unconfirmed root paying foreign scripts. Each chain's first tx spends it, so it taints, and
+// the taint carries down the chain. Every UTXO ends up untrusted.
+fn setup_untrusted_fan_in(
+    width: usize,
+    depth: usize,
+) -> (
+    LocalChain,
+    TxGraph<ConfirmationBlockTime>,
+    Vec<Txid>,
+    ScriptBuf,
+) {
+    let chain = make_chain();
+    let mut tx_graph = TxGraph::default();
+    let owned = ScriptBuf::from(vec![1u8]);
+    let foreign = ScriptBuf::from(vec![2u8]); // not owned -> untrusted
+
+    // Unconfirmed root with a foreign input
+    let root_tx = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(hash!("external"), 0),
+            ..Default::default()
+        }],
+        output: (0..width)
+            .map(|_| TxOut {
+                value: Amount::from_sat(100_000),
+                script_pubkey: foreign.clone(),
+            })
+            .collect(),
+        ..new_tx(0)
+    };
+    let root_txid = root_tx.compute_txid();
+    let _ = tx_graph.insert_tx(root_tx);
+    let _ = tx_graph.insert_seen_at(root_txid, 50);
+
+    let mut utxo_txids = vec![];
+    for chain_i in 0..width {
+        let mut prev = OutPoint::new(root_txid, chain_i as u32);
+        for layer in 0..depth {
+            let tx = Transaction {
+                input: vec![TxIn {
+                    previous_output: prev,
+                    ..Default::default()
+                }],
+                output: vec![TxOut {
+                    value: Amount::from_sat(90_000),
+                    script_pubkey: owned.clone(),
+                }],
+                ..new_tx((chain_i * depth + layer + 1) as u32)
+            };
+            let txid = tx.compute_txid();
+            let _ = tx_graph.insert_tx(tx);
+            let _ = tx_graph.insert_seen_at(txid, 100);
+            prev = OutPoint::new(txid, 0);
+            if layer == depth - 1 {
+                utxo_txids.push(txid);
+            }
+        }
+    }
+    (chain, tx_graph, utxo_txids, owned)
+}
+
+// `shared` confirmed base txs, and `utxos` outputs that each spend  all of the base txs (many
+// inputs converging on the same ancestors). Given importance on shared ancestry and nothing taints.
+fn setup_diamond(
+    shared: usize,
+    utxos: usize,
+) -> (
+    LocalChain,
+    TxGraph<ConfirmationBlockTime>,
+    Vec<Txid>,
+    ScriptBuf,
+) {
+    let chain = make_chain();
+    let mut tx_graph = TxGraph::default();
+    let owned = ScriptBuf::from(vec![1u8]);
+
+    let root_tx = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(hash!("external"), 0),
+            ..Default::default()
+        }],
+        output: (0..shared)
+            .map(|_| TxOut {
+                value: Amount::from_sat(1_000_000),
+                script_pubkey: owned.clone(),
+            })
+            .collect(),
+        ..new_tx(0)
+    };
+    let root_txid = root_tx.compute_txid();
+    let _ = tx_graph.insert_tx(root_tx);
+    let _ = tx_graph.insert_anchor(
+        root_txid,
+        ConfirmationBlockTime {
+            block_id: chain.get(1).unwrap().block_id(),
+            confirmation_time: 1,
+        },
+    );
+
+    let mut base_txids = vec![];
+    for i in 0..shared {
+        let base_tx = Transaction {
+            input: vec![TxIn {
+                previous_output: OutPoint::new(root_txid, i as u32),
+                ..Default::default()
+            }],
+            output: (0..utxos)
+                .map(|_| TxOut {
+                    value: Amount::from_sat(90_000),
+                    script_pubkey: owned.clone(),
+                })
+                .collect(),
+            ..new_tx((i + 1) as u32)
+        };
+        let base_txid = base_tx.compute_txid();
+        let _ = tx_graph.insert_tx(base_tx);
+        let _ = tx_graph.insert_seen_at(base_txid, 50);
+        base_txids.push(base_txid);
+    }
+
+    let mut utxo_txids = vec![];
+    for j in 0..utxos {
+        let utxo_tx = Transaction {
+            input: base_txids
+                .iter()
+                .map(|&base_txid| TxIn {
+                    previous_output: OutPoint::new(base_txid, j as u32),
+                    ..Default::default()
+                })
+                .collect(),
+            output: vec![TxOut {
+                value: Amount::from_sat(10_000),
+                script_pubkey: owned.clone(),
+            }],
+            ..new_tx((shared + 1 + j) as u32)
+        };
+        let utxo_txid = utxo_tx.compute_txid();
+        let _ = tx_graph.insert_tx(utxo_tx);
+        let _ = tx_graph.insert_seen_at(utxo_txid, 100);
+        utxo_txids.push(utxo_txid);
+    }
+    (chain, tx_graph, utxo_txids, owned)
+}
+
+// Each UTXO sits below a short owned tail, a single tainting tx, and a deep unconfirmed foreign
+// ancestry above it. The taint is found right above the UTXO, so the classifier can stop there
+// instead of walking the whole foreign chain. Every UTXO ends up untrusted.
+fn setup_tainted_midchain(
+    width: usize,
+    depth: usize,
+) -> (
+    LocalChain,
+    TxGraph<ConfirmationBlockTime>,
+    Vec<Txid>,
+    ScriptBuf,
+) {
+    let chain = make_chain();
+    let mut tx_graph = TxGraph::default();
+    let owned = ScriptBuf::from(vec![1u8]);
+    let foreign = ScriptBuf::from(vec![2u8]);
+
+    let mut n: u32 = 0;
+    let mut utxo_txids = vec![];
+    for chain_i in 0..width {
+        let mut prev = OutPoint::new(hash!("external"), chain_i as u32);
+        for _ in 0..depth {
+            let tx = Transaction {
+                input: vec![TxIn {
+                    previous_output: prev,
+                    ..Default::default()
+                }],
+                output: vec![TxOut {
+                    value: Amount::from_sat(100_000),
+                    script_pubkey: foreign.clone(),
+                }],
+                ..new_tx(n)
+            };
+            n += 1;
+            let txid = tx.compute_txid();
+            let _ = tx_graph.insert_tx(tx);
+            let _ = tx_graph.insert_seen_at(txid, 100);
+            prev = OutPoint::new(txid, 0);
+        }
+        let taint_tx = Transaction {
+            input: vec![TxIn {
+                previous_output: prev,
+                ..Default::default()
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(90_000),
+                script_pubkey: owned.clone(),
+            }],
+            ..new_tx(n)
+        };
+        n += 1;
+        let taint_txid = taint_tx.compute_txid();
+        let _ = tx_graph.insert_tx(taint_tx);
+        let _ = tx_graph.insert_seen_at(taint_txid, 100);
+        let utxo_tx = Transaction {
+            input: vec![TxIn {
+                previous_output: OutPoint::new(taint_txid, 0),
+                ..Default::default()
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(80_000),
+                script_pubkey: owned.clone(),
+            }],
+            ..new_tx(n)
+        };
+        n += 1;
+        let utxo_txid = utxo_tx.compute_txid();
+        let _ = tx_graph.insert_tx(utxo_tx);
+        let _ = tx_graph.insert_seen_at(utxo_txid, 100);
+        utxo_txids.push(utxo_txid);
+    }
+    (chain, tx_graph, utxo_txids, owned)
+}
+
+fn bench_fan_in(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fan_in");
+    for (width, depth) in [(10, 3), (50, 5), (100, 10), (500, 20)] {
+        let label = format!("{width}w×{depth}d");
+        let (chain, tx_graph, utxo_txids, owned) = setup_fan_in(width, depth);
+        let view = chain.canonical_view(&tx_graph, chain.tip().block_id(), Default::default());
+        group.bench_with_input(BenchmarkId::new("classify", &label), &(), |b, _| {
+            b.iter(|| run_classify(&utxo_txids, &view, &owned));
+        });
+    }
+    group.finish();
+}
+
+fn bench_disjoint(c: &mut Criterion) {
+    let mut group = c.benchmark_group("disjoint");
+    for (width, depth) in [(10, 3), (50, 5), (100, 10), (500, 20)] {
+        let label = format!("{width}w×{depth}d");
+        let (chain, tx_graph, utxo_txids, owned) = setup_disjoint(width, depth);
+        let view = chain.canonical_view(&tx_graph, chain.tip().block_id(), Default::default());
+        group.bench_with_input(BenchmarkId::new("classify", &label), &(), |b, _| {
+            b.iter(|| run_classify(&utxo_txids, &view, &owned));
+        });
+    }
+    group.finish();
+}
+
+fn bench_untrusted_fan_in(c: &mut Criterion) {
+    let mut group = c.benchmark_group("untrusted_fan_in");
+    for (width, depth) in [(10, 3), (50, 5), (100, 10), (500, 20)] {
+        let label = format!("{width}w×{depth}d");
+        let (chain, tx_graph, utxo_txids, owned) = setup_untrusted_fan_in(width, depth);
+        let view = chain.canonical_view(&tx_graph, chain.tip().block_id(), Default::default());
+        group.bench_with_input(BenchmarkId::new("classify", &label), &(), |b, _| {
+            b.iter(|| run_classify(&utxo_txids, &view, &owned));
+        });
+    }
+    group.finish();
+}
+
+fn bench_diamond(c: &mut Criterion) {
+    let mut group = c.benchmark_group("diamond");
+    for (shared, utxos) in [(5, 20), (10, 50), (20, 100), (50, 500)] {
+        let label = format!("{shared}s×{utxos}u");
+        let (chain, tx_graph, utxo_txids, owned) = setup_diamond(shared, utxos);
+        let view = chain.canonical_view(&tx_graph, chain.tip().block_id(), Default::default());
+        group.bench_with_input(BenchmarkId::new("classify", &label), &(), |b, _| {
+            b.iter(|| run_classify(&utxo_txids, &view, &owned));
+        });
+    }
+    group.finish();
+}
+
+fn bench_tainted_midchain(c: &mut Criterion) {
+    let mut group = c.benchmark_group("tainted_midchain");
+    for (width, depth) in [(10, 3), (50, 5), (100, 10), (500, 20)] {
+        let label = format!("{width}w×{depth}d");
+        let (chain, tx_graph, utxo_txids, owned) = setup_tainted_midchain(width, depth);
+        let view = chain.canonical_view(&tx_graph, chain.tip().block_id(), Default::default());
+        group.bench_with_input(BenchmarkId::new("classify", &label), &(), |b, _| {
+            b.iter(|| run_classify(&utxo_txids, &view, &owned));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_fan_in,
+    bench_disjoint,
+    bench_untrusted_fan_in,
+    bench_diamond,
+    bench_tainted_midchain
+);
+criterion_main!(benches);

--- a/crates/chain/src/canonical.rs
+++ b/crates/chain/src/canonical.rs
@@ -28,9 +28,7 @@ use alloc::vec::Vec;
 use core::{fmt, ops::RangeBounds};
 
 use bdk_core::BlockId;
-use bitcoin::{
-    constants::COINBASE_MATURITY, Amount, OutPoint, ScriptBuf, Transaction, TxOut, Txid,
-};
+use bitcoin::{constants::COINBASE_MATURITY, OutPoint, ScriptBuf, Transaction, TxOut, Txid};
 
 use crate::{spk_txout::SpkTxOutIndex, Anchor, Balance, CanonicalViewTask, ChainPosition, TxGraph};
 
@@ -434,7 +432,8 @@ impl<A: Anchor> CanonicalView<A> {
     /// * `does_taint` - Returns `true` for a transaction that pulls in untrusted funds (e.g. it
     ///   spends an output the wallet doesn't own). It drives the [`Trust`] of an unsettled output:
     ///   a tainting transaction in its ancestry makes it [`Untrusted`](Trust::Untrusted). Outputs
-    ///   with missing ancestry stay [`Unknown`](Trust::Unknown) regardless of this predicate.
+    ///   with missing ancestry stay [`Unknown`](Trust::Unknown) regardless of this predicate. Use
+    ///   [`taints_unowned`] to classify everything foreign as untrusted.
     /// * `is_settled` - Returns `true` for the [position](ChainPosition) of a transaction we
     ///   consider settled (unlikely to be replaced), for example one with enough confirmations.
     pub fn classify_outpoints<'a>(
@@ -493,7 +492,7 @@ impl<A: Anchor> CanonicalView<A> {
 
         // `Enter`: if tx is unsettled and not directly tainted, queue its parents.
         // `Exit`: by now every parent is resolved, so the tx is tainted if any parent is.
-        enum Frame<A: Anchor> {
+        enum Frame<A> {
             Enter(Txid),
             Exit(CanonicalTx<ChainPosition<A>>),
         }
@@ -545,7 +544,7 @@ impl<A: Anchor> CanonicalView<A> {
                         let parent_trust = cache
                             .get(&txin.previous_output.txid)
                             .copied()
-                            .unwrap_or(Trust::Trusted);
+                            .expect("parent transaction should already be cached");
                         trust = match (trust, parent_trust) {
                             (Trust::Untrusted, _) | (_, Trust::Untrusted) => Trust::Untrusted,
                             (Trust::Unknown, _) | (_, Trust::Unknown) => Trust::Unknown,
@@ -564,33 +563,17 @@ impl<A: Anchor> CanonicalView<A> {
         cache[&seed_txid]
     }
 
-    /// Calculate the total balance of the given outpoints.
+    /// Calculate the total [`Balance`] of the given outpoints.
     ///
-    /// This method computes a detailed balance breakdown for a set of outpoints, categorizing
-    /// outputs as confirmed, pending (trusted/untrusted), or immature based on their chain
-    /// position and the provided trust predicate.
+    /// This is a fold over [`classify_outpoints`](Self::classify_outpoints): each output's value is
+    /// added to the bucket matching its [`Eligibility`].
     ///
-    /// # Arguments
-    ///
-    /// * `outpoints` - Iterator of `(identifier, outpoint)` pairs to calculate balance for
-    /// * `trust_predicate` - Function that returns `true` for trusted scripts. Trusted outputs
-    ///   count toward `trusted_pending` balance, while untrusted ones count toward
-    ///   `untrusted_pending`
-    /// * `min_confirmations` - Minimum confirmations required for an output to be considered
-    ///   confirmed. Outputs with fewer confirmations are treated as pending.
-    ///
-    /// # Minimum Confirmations
-    ///
-    /// The `min_confirmations` parameter controls when outputs are considered confirmed. A
-    /// `min_confirmations` value of `0` is equivalent to `1` (require at least 1 confirmation).
-    ///
-    /// Outputs with fewer than `min_confirmations` are categorized as pending (trusted or
-    /// untrusted based on the trust predicate).
+    /// See `classify_outpoints` for `does_taint` and `is_settled` meaning.
     ///
     /// # Example
     ///
     /// ```
-    /// # use bdk_chain::{CanonicalParams, TxGraph, local_chain::LocalChain, keychain_txout::KeychainTxOutIndex};
+    /// # use bdk_chain::{CanonicalParams, ChainPosition, TxGraph, local_chain::LocalChain, keychain_txout::KeychainTxOutIndex};
     /// # use bdk_core::BlockId;
     /// # use bitcoin::hashes::Hash;
     /// # let tx_graph = TxGraph::<BlockId>::default();
@@ -598,64 +581,62 @@ impl<A: Anchor> CanonicalView<A> {
     /// # let chain_tip = chain.tip().block_id();
     /// # let view = chain.canonical_view(&tx_graph, chain_tip, CanonicalParams::default());
     /// # let indexer = KeychainTxOutIndex::<&str>::default();
-    /// // Calculate balance with 6 confirmations, trusting all outputs
+    /// let tip_height = view.tip().height;
+    /// // Calculate balance requiring 6 confirmations.
     /// let balance = view.balance(
-    ///     indexer.outpoints().into_iter().map(|(k, op)| (k.clone(), *op)),
-    ///     |_keychain, _script| true,  // Trust all outputs
-    ///     6,  // Require 6 confirmations
+    ///     indexer.outpoints().iter().map(|(_, op)| *op),
+    ///     bdk_chain::taints_unowned(&indexer),
+    ///     |pos: &ChainPosition<_>| {
+    ///         pos.confirmation_height_upper_bound()
+    ///             .is_some_and(|h| tip_height.saturating_sub(h).saturating_add(1) >= 6)
+    ///     },
     /// );
     /// ```
-    pub fn balance<'v, O: Clone + 'v>(
-        &'v self,
-        outpoints: impl IntoIterator<Item = (O, OutPoint)> + 'v,
-        mut trust_predicate: impl FnMut(&O, &CanonicalTxOut<ChainPosition<A>>) -> bool,
-        min_confirmations: u32,
+    pub fn balance(
+        &self,
+        outpoints: impl IntoIterator<Item = OutPoint>,
+        does_taint: impl FnMut(&CanonicalTx<ChainPosition<A>>) -> bool,
+        is_settled: impl Fn(&ChainPosition<A>) -> bool,
     ) -> Balance {
-        let mut immature = Amount::ZERO;
-        let mut trusted_pending = Amount::ZERO;
-        let mut untrusted_pending = Amount::ZERO;
-        let mut confirmed = Amount::ZERO;
+        self.classify_outpoints(outpoints, does_taint, is_settled)
+            .collect()
+    }
+}
 
-        for (spk_i, txout) in self.filter_unspent_outpoints(outpoints) {
-            match &txout.pos {
-                ChainPosition::Confirmed { anchor, .. } => {
-                    let confirmation_height = anchor.confirmation_height_upper_bound();
-                    let confirmations = self
-                        .tip
-                        .height
-                        .saturating_sub(confirmation_height)
-                        .saturating_add(1);
-                    let min_confirmations = min_confirmations.max(1); // 0 and 1 behave identically
-
-                    if confirmations < min_confirmations {
-                        // Not enough confirmations, treat as trusted/untrusted pending
-                        if trust_predicate(&spk_i, &txout) {
-                            trusted_pending += txout.txout.value;
-                        } else {
-                            untrusted_pending += txout.txout.value;
-                        }
-                    } else if txout.is_confirmed_and_spendable(self.tip.height) {
-                        confirmed += txout.txout.value;
-                    } else if !txout.is_mature(self.tip.height) {
-                        immature += txout.txout.value;
-                    }
+impl<A: Anchor> FromIterator<(CanonicalTxOut<ChainPosition<A>>, Eligibility)> for Balance {
+    /// Sums each output's value into the [`Balance`] bucket matching its [`Eligibility`].
+    fn from_iter<I: IntoIterator<Item = (CanonicalTxOut<ChainPosition<A>>, Eligibility)>>(
+        iter: I,
+    ) -> Self {
+        let mut balance = Balance::default();
+        for (txout, eligibility) in iter {
+            let bucket = match eligibility {
+                Eligibility::Immature => &mut balance.immature,
+                Eligibility::Settled => &mut balance.confirmed,
+                Eligibility::Unsettled(Trust::Trusted) => &mut balance.trusted_pending,
+                Eligibility::Unsettled(Trust::Untrusted | Trust::Unknown) => {
+                    &mut balance.untrusted_pending
                 }
-                ChainPosition::Unconfirmed { .. } => {
-                    if trust_predicate(&spk_i, &txout) {
-                        trusted_pending += txout.txout.value;
-                    } else {
-                        untrusted_pending += txout.txout.value;
-                    }
-                }
-            }
+            };
+            *bucket += txout.txout.value;
         }
+        balance
+    }
+}
 
-        Balance {
-            immature,
-            trusted_pending,
-            untrusted_pending,
-            confirmed,
-        }
+/// A `does_taint` predicate: a transaction taints when any input spends a coin this indexer
+/// doesn't recognise as ours, including one whose parent we've never seen.
+pub fn taints_unowned<'a, P, I>(
+    indexer: &'a impl AsRef<SpkTxOutIndex<I>>,
+) -> impl Fn(&CanonicalTx<P>) -> bool + 'a
+where
+    I: fmt::Debug + Clone + Ord + 'a,
+{
+    let indexer = indexer.as_ref();
+    move |c_tx| {
+        c_tx.tx.input.iter().any(|txin| {
+            !txin.previous_output.is_null() && indexer.txout(txin.previous_output).is_none()
+        })
     }
 }
 

--- a/crates/chain/src/canonical.rs
+++ b/crates/chain/src/canonical.rs
@@ -22,7 +22,7 @@
 //! }
 //! ```
 
-use crate::collections::HashMap;
+use crate::collections::{HashMap, HashSet};
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::{fmt, ops::RangeBounds};
@@ -33,6 +33,32 @@ use bitcoin::{
 };
 
 use crate::{spk_txout::SpkTxOutIndex, Anchor, Balance, CanonicalViewTask, ChainPosition, TxGraph};
+
+/// The spend-eligibility classification of a canonical output, produced by
+/// [`CanonicalView::classify_outpoints`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Eligibility {
+    /// An output the caller considers settled, per the `is_settled` predicate given to
+    /// [`classify_outpoints`](CanonicalView::classify_outpoints). Typically confirmed deeply
+    /// enough to be unlikely to be replaced, but the caller decides.
+    Settled,
+    /// A coinbase output that has not yet matured and is not spendable.
+    Immature,
+    /// An output not yet settled.
+    Unsettled(Trust),
+}
+
+/// Describes whether an [`Unsettled`](Eligibility::Unsettled) output is trusted, untrusted, or of
+/// unknown trust because the `CanonicalView` doesn't have its full ancestry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Trust {
+    /// Ancestors spend owned outputs.
+    Trusted,
+    /// Ancestors spend foreign outputs.
+    Untrusted,
+    /// Some ancestor is not in Canonical set.
+    Unknown,
+}
 
 /// A single canonical transaction with its position.
 ///
@@ -394,6 +420,150 @@ impl<A, P: Clone> Canonical<A, P> {
 }
 
 impl<A: Anchor> CanonicalView<A> {
+    /// Classify each of the given `outpoints` by its [spend eligibility](Eligibility).
+    /// This is the primitive behind [`balance`](Self::balance).
+    ///  
+    /// Callers that need richer handling (coin selection, coin control, or
+    /// wallet-specific categories like "locked") can fold over this instead of `balance`.
+    ///
+    /// Outpoints that are already spent, or that aren't part of this canonical view, are skipped.
+    ///
+    /// # Arguments
+    ///
+    /// * `outpoints` - The outpoints to classify.
+    /// * `does_taint` - Returns `true` for a transaction that pulls in untrusted funds (e.g. it
+    ///   spends an output the wallet doesn't own). It drives the [`Trust`] of an unsettled output:
+    ///   a tainting transaction in its ancestry makes it [`Untrusted`](Trust::Untrusted). Outputs
+    ///   with missing ancestry stay [`Unknown`](Trust::Unknown) regardless of this predicate.
+    /// * `is_settled` - Returns `true` for the [position](ChainPosition) of a transaction we
+    ///   consider settled (unlikely to be replaced), for example one with enough confirmations.
+    pub fn classify_outpoints<'a>(
+        &'a self,
+        outpoints: impl IntoIterator<Item = OutPoint> + 'a,
+        mut does_taint: impl FnMut(&CanonicalTx<ChainPosition<A>>) -> bool + 'a,
+        is_settled: impl Fn(&ChainPosition<A>) -> bool + 'a,
+    ) -> impl Iterator<Item = (CanonicalTxOut<ChainPosition<A>>, Eligibility)> + 'a {
+        let tip = self.tip.height;
+        // Shared across outpoints so an ancestor reached by several of them is only walked once.
+        let mut cache = HashMap::<Txid, Trust>::new();
+        outpoints
+            .into_iter()
+            .filter_map(move |op| self.txout(op))
+            .filter(|txo| txo.spent_by.is_none())
+            .map(move |txout| {
+                let eligibility = if !txout.is_mature(tip) {
+                    Eligibility::Immature
+                } else if is_settled(&txout.pos) {
+                    Eligibility::Settled
+                } else {
+                    Eligibility::Unsettled(self.ancestry_trust(
+                        txout.outpoint.txid,
+                        &mut does_taint,
+                        &is_settled,
+                        &mut cache,
+                    ))
+                };
+                (txout, eligibility)
+            })
+    }
+
+    /// Returns the [`Trust`] of `seed_txid` based on its unsettled ancestry.
+    ///
+    /// Walks backwards from `seed_txid`, stopping at settled ancestors.
+    /// An ancestor missing from the [`CanonicalView`] set is [`Unknown`](Trust::Unknown).
+    /// Each visited transaction is cached, so an ancestor shared by several outpoints only gets
+    /// walked once across the calls to this method that share the same `cache`.
+    /// The walk stops at [`Settled`](Eligibility::Settled) transactions and at
+    /// [`Unknown`](Trust::Unknown) ones, and performs a short-circuit as soon as a tainting
+    /// transaction is found.
+    fn ancestry_trust<F, S>(
+        &self,
+        seed_txid: Txid,
+        does_taint: &mut F,
+        is_settled: &S,
+        cache: &mut HashMap<Txid, Trust>,
+    ) -> Trust
+    where
+        F: FnMut(&CanonicalTx<ChainPosition<A>>) -> bool,
+        S: Fn(&ChainPosition<A>) -> bool,
+    {
+        if let Some(&trust) = cache.get(&seed_txid) {
+            return trust;
+        }
+
+        // `Enter`: if tx is unsettled and not directly tainted, queue its parents.
+        // `Exit`: by now every parent is resolved, so the tx is tainted if any parent is.
+        enum Frame<A: Anchor> {
+            Enter(Txid),
+            Exit(CanonicalTx<ChainPosition<A>>),
+        }
+
+        let mut stack = alloc::vec![Frame::Enter(seed_txid)];
+        // Txids currently on the stack between their `Enter` and `Exit`, so we don't queue the
+        // same parent twice while it's still being processed.
+        let mut pending = HashSet::<Txid>::new();
+
+        while let Some(frame) = stack.pop() {
+            match frame {
+                Frame::Enter(txid) => {
+                    if cache.contains_key(&txid) || pending.contains(&txid) {
+                        continue;
+                    }
+                    let Some(c_tx) = self.tx(txid) else {
+                        // Missing from the `CanonicalView`.
+                        cache.insert(txid, Trust::Unknown);
+                        continue;
+                    };
+                    if is_settled(&c_tx.pos) {
+                        cache.insert(txid, Trust::Trusted);
+                        continue;
+                    }
+                    if does_taint(&c_tx) {
+                        // Directly tainted
+                        cache.insert(txid, Trust::Untrusted);
+                        continue;
+                    }
+                    pending.insert(txid);
+                    stack.push(Frame::Exit(c_tx.clone()));
+                    for txin in &c_tx.tx.input {
+                        // Previous output is coinbase
+                        if txin.previous_output.is_null() {
+                            continue;
+                        }
+                        let parent_txid = txin.previous_output.txid;
+                        if !cache.contains_key(&parent_txid) && !pending.contains(&parent_txid) {
+                            stack.push(Frame::Enter(parent_txid));
+                        }
+                    }
+                }
+                Frame::Exit(c_tx) => {
+                    let mut trust = Trust::Trusted;
+                    for txin in &c_tx.tx.input {
+                        if txin.previous_output.is_null() {
+                            continue;
+                        }
+                        let parent_trust = cache
+                            .get(&txin.previous_output.txid)
+                            .copied()
+                            .unwrap_or(Trust::Trusted);
+                        trust = match (trust, parent_trust) {
+                            (Trust::Untrusted, _) | (_, Trust::Untrusted) => Trust::Untrusted,
+                            (Trust::Unknown, _) | (_, Trust::Unknown) => Trust::Unknown,
+                            _ => Trust::Trusted,
+                        };
+                        if trust == Trust::Untrusted {
+                            break;
+                        }
+                    }
+                    cache.insert(c_tx.txid, trust);
+                    pending.remove(&c_tx.txid);
+                }
+            }
+        }
+
+        cache[&seed_txid]
+    }
+
     /// Calculate the total balance of the given outpoints.
     ///
     /// This method computes a detailed balance breakdown for a set of outpoints, categorizing

--- a/crates/chain/tests/test_canonical_view.rs
+++ b/crates/chain/tests/test_canonical_view.rs
@@ -2,12 +2,24 @@
 
 use std::collections::BTreeMap;
 
-use bdk_chain::{local_chain::LocalChain, BlockId, ConfirmationBlockTime, TxGraph};
+use bdk_chain::{local_chain::LocalChain, BlockId, ChainPosition, ConfirmationBlockTime, TxGraph};
 use bdk_testenv::{hash, utils::new_tx};
 use bitcoin::{Amount, BlockHash, OutPoint, ScriptBuf, Transaction, TxIn, TxOut};
 
+/// Builds an `is_settled` predicate requiring at least `min_confirmations` confirmations.
+fn settled(
+    tip_height: u32,
+    min_confirmations: u32,
+) -> impl Fn(&ChainPosition<ConfirmationBlockTime>) -> bool {
+    let min_confirmations = min_confirmations.max(1); // 0 and 1 behave identically
+    move |pos| {
+        pos.confirmation_height_upper_bound()
+            .is_some_and(|h| tip_height.saturating_sub(h).saturating_add(1) >= min_confirmations)
+    }
+}
+
 #[test]
-fn test_min_confirmations_parameter() {
+fn test_is_settled_boundary() {
     // Create a local chain with several blocks
     let blocks: BTreeMap<u32, BlockHash> = [
         (0, hash!("block0")),
@@ -55,12 +67,13 @@ fn test_min_confirmations_parameter() {
 
     let canonical_view =
         chain.canonical_view(&tx_graph, chain.tip().block_id(), Default::default());
+    let tip_height = canonical_view.tip().height;
 
     // Test min_confirmations = 1: Should be confirmed (has 6 confirmations)
     let balance_1_conf = canonical_view.balance(
-        [((), outpoint)],
-        |_, _| true, // trust all
-        1,
+        [outpoint],
+        |_tx| false, // leave trust to ancestry
+        settled(tip_height, 1),
     );
 
     assert_eq!(balance_1_conf.confirmed, Amount::from_sat(50_000));
@@ -68,31 +81,21 @@ fn test_min_confirmations_parameter() {
 
     // Test min_confirmations = 6: Should be confirmed (has exactly 6 confirmations)
     let balance_6_conf = canonical_view.balance(
-        [((), outpoint)],
-        |_, _| true, // trust all
-        6,
+        [outpoint],
+        |_tx| false, // leave trust to ancestry
+        settled(tip_height, 6),
     );
     assert_eq!(balance_6_conf.confirmed, Amount::from_sat(50_000));
     assert_eq!(balance_6_conf.trusted_pending, Amount::ZERO);
 
     // Test min_confirmations = 7: Should be trusted pending (only has 6 confirmations)
     let balance_7_conf = canonical_view.balance(
-        [((), outpoint)],
-        |_, _| true, // trust all
-        7,
+        [outpoint],
+        |_tx| false, // leave trust to ancestry
+        settled(tip_height, 7),
     );
     assert_eq!(balance_7_conf.confirmed, Amount::ZERO);
     assert_eq!(balance_7_conf.trusted_pending, Amount::from_sat(50_000));
-
-    // Test min_confirmations = 0: Should behave same as 1 (confirmed)
-    let balance_0_conf = canonical_view.balance(
-        [((), outpoint)],
-        |_, _| true, // trust all
-        0,
-    );
-    assert_eq!(balance_0_conf.confirmed, Amount::from_sat(50_000));
-    assert_eq!(balance_0_conf.trusted_pending, Amount::ZERO);
-    assert_eq!(balance_0_conf, balance_1_conf);
 }
 
 #[test]
@@ -117,10 +120,33 @@ fn test_min_confirmations_with_untrusted_tx() {
 
     let mut tx_graph = TxGraph::default();
 
+    // A settled parent, so ancestry alone would make the child trusted and `does_taint` is what
+    // decides the outcome.
+    let parent = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(hash!("root"), 0),
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(25_000),
+            script_pubkey: ScriptBuf::new(),
+        }],
+        ..new_tx(0)
+    };
+    let parent_txid = parent.compute_txid();
+    let _ = tx_graph.insert_tx(parent.clone());
+    let _ = tx_graph.insert_anchor(
+        parent_txid,
+        ConfirmationBlockTime {
+            block_id: chain.get(1).unwrap().block_id(),
+            confirmation_time: 100,
+        },
+    );
+
     // Create a transaction
     let tx = Transaction {
         input: vec![TxIn {
-            previous_output: OutPoint::new(hash!("parent"), 0),
+            previous_output: OutPoint::new(parent_txid, 0),
             ..Default::default()
         }],
         output: vec![TxOut {
@@ -143,18 +169,28 @@ fn test_min_confirmations_with_untrusted_tx() {
 
     let canonical_view =
         chain.canonical_view(&tx_graph, chain.tip().block_id(), Default::default());
+    let tip_height = canonical_view.tip().height;
 
-    // Test with min_confirmations = 5 and untrusted predicate
+    // Test with min_confirmations = 5 and everything tainted
     let balance = canonical_view.balance(
-        [((), outpoint)],
-        |_, _| false, // don't trust
-        5,
+        [outpoint],
+        |_tx| true, // taint everything
+        settled(tip_height, 5),
     );
 
     // Should be untrusted pending (not enough confirmations and not trusted)
     assert_eq!(balance.confirmed, Amount::ZERO);
     assert_eq!(balance.trusted_pending, Amount::ZERO);
     assert_eq!(balance.untrusted_pending, Amount::from_sat(25_000));
+
+    // Without the taint, the settled ancestry makes it trusted instead.
+    let balance = canonical_view.balance(
+        [outpoint],
+        |_tx| false, // leave trust to ancestry
+        settled(tip_height, 5),
+    );
+    assert_eq!(balance.trusted_pending, Amount::from_sat(25_000));
+    assert_eq!(balance.untrusted_pending, Amount::ZERO);
 }
 
 #[test]
@@ -209,7 +245,7 @@ fn test_min_confirmations_multiple_transactions() {
             confirmation_time: 123456,
         },
     );
-    outpoints.push(((), outpoint0));
+    outpoints.push(outpoint0);
 
     // Transaction 1: anchored at height 10, has 6 confirmations (15-10+1 = 6)
     let tx1 = Transaction {
@@ -233,7 +269,7 @@ fn test_min_confirmations_multiple_transactions() {
             confirmation_time: 123457,
         },
     );
-    outpoints.push(((), outpoint1));
+    outpoints.push(outpoint1);
 
     // Transaction 2: anchored at height 13, has 3 confirmations (15-13+1 = 3)
     let tx2 = Transaction {
@@ -257,16 +293,17 @@ fn test_min_confirmations_multiple_transactions() {
             confirmation_time: 123458,
         },
     );
-    outpoints.push(((), outpoint2));
+    outpoints.push(outpoint2);
 
     let canonical_view =
         chain.canonical_view(&tx_graph, chain.tip().block_id(), Default::default());
+    let tip_height = canonical_view.tip().height;
 
     // Test with min_confirmations = 5
     // tx0: 11 confirmations -> confirmed
     // tx1: 6 confirmations -> confirmed
     // tx2: 3 confirmations -> trusted pending
-    let balance = canonical_view.balance(outpoints.clone(), |_, _| true, 5);
+    let balance = canonical_view.balance(outpoints.clone(), |_tx| false, settled(tip_height, 5));
 
     assert_eq!(
         balance.confirmed,
@@ -282,7 +319,7 @@ fn test_min_confirmations_multiple_transactions() {
     // tx0: 11 confirmations -> confirmed
     // tx1: 6 confirmations -> trusted pending
     // tx2: 3 confirmations -> trusted pending
-    let balance_high = canonical_view.balance(outpoints, |_, _| true, 10);
+    let balance_high = canonical_view.balance(outpoints, |_tx| false, settled(tip_height, 10));
 
     assert_eq!(
         balance_high.confirmed,

--- a/crates/chain/tests/test_canonical_view.rs
+++ b/crates/chain/tests/test_canonical_view.rs
@@ -2,7 +2,10 @@
 
 use std::collections::BTreeMap;
 
-use bdk_chain::{local_chain::LocalChain, BlockId, ChainPosition, ConfirmationBlockTime, TxGraph};
+use bdk_chain::{
+    local_chain::LocalChain, BlockId, ChainPosition, ConfirmationBlockTime, Eligibility, Trust,
+    TxGraph,
+};
 use bdk_testenv::{hash, utils::new_tx};
 use bitcoin::{Amount, BlockHash, OutPoint, ScriptBuf, Transaction, TxIn, TxOut};
 
@@ -40,10 +43,31 @@ fn test_is_settled_boundary() {
 
     let mut tx_graph = TxGraph::default();
 
-    // Create a non-coinbase transaction
+    let parent = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(hash!("root"), 0),
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(50_000),
+            script_pubkey: ScriptBuf::new(),
+        }],
+        ..new_tx(0)
+    };
+    let parent_txid = parent.compute_txid();
+    let _ = tx_graph.insert_tx(parent.clone());
+    let _ = tx_graph.insert_anchor(
+        parent_txid,
+        ConfirmationBlockTime {
+            block_id: chain.get(1).unwrap().block_id(),
+            confirmation_time: 100,
+        },
+    );
+
+    // Create a non-coinbase transaction spending our confirmed parent.
     let tx = Transaction {
         input: vec![TxIn {
-            previous_output: OutPoint::new(hash!("parent"), 0),
+            previous_output: OutPoint::new(parent_txid, 0),
             ..Default::default()
         }],
         output: vec![TxOut {
@@ -223,10 +247,43 @@ fn test_min_confirmations_multiple_transactions() {
     // Create multiple transactions at different heights
     let mut outpoints = vec![];
 
+    // A deeply-confirmed parent (settled for every threshold tested) so each tx has a known,
+    // trusted ancestry, keeping the test focused on the confirmation threshold.
+    let parent = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(hash!("root"), 0),
+            ..Default::default()
+        }],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(10_000),
+                script_pubkey: ScriptBuf::new(),
+            },
+            TxOut {
+                value: Amount::from_sat(20_000),
+                script_pubkey: ScriptBuf::new(),
+            },
+            TxOut {
+                value: Amount::from_sat(30_000),
+                script_pubkey: ScriptBuf::new(),
+            },
+        ],
+        ..new_tx(0)
+    };
+    let parent_txid = parent.compute_txid();
+    let _ = tx_graph.insert_tx(parent.clone());
+    let _ = tx_graph.insert_anchor(
+        parent_txid,
+        ConfirmationBlockTime {
+            block_id: chain.get(1).unwrap().block_id(),
+            confirmation_time: 100,
+        },
+    );
+
     // Transaction 0: anchored at height 5, has 11 confirmations (tip-5+1 = 15-5+1 = 11)
     let tx0 = Transaction {
         input: vec![TxIn {
-            previous_output: OutPoint::new(hash!("parent0"), 0),
+            previous_output: OutPoint::new(parent_txid, 0),
             ..Default::default()
         }],
         output: vec![TxOut {
@@ -250,7 +307,7 @@ fn test_min_confirmations_multiple_transactions() {
     // Transaction 1: anchored at height 10, has 6 confirmations (15-10+1 = 6)
     let tx1 = Transaction {
         input: vec![TxIn {
-            previous_output: OutPoint::new(hash!("parent1"), 0),
+            previous_output: OutPoint::new(parent_txid, 1),
             ..Default::default()
         }],
         output: vec![TxOut {
@@ -274,7 +331,7 @@ fn test_min_confirmations_multiple_transactions() {
     // Transaction 2: anchored at height 13, has 3 confirmations (15-13+1 = 3)
     let tx2 = Transaction {
         input: vec![TxIn {
-            previous_output: OutPoint::new(hash!("parent2"), 0),
+            previous_output: OutPoint::new(parent_txid, 2),
             ..Default::default()
         }],
         output: vec![TxOut {
@@ -330,6 +387,606 @@ fn test_min_confirmations_multiple_transactions() {
         Amount::from_sat(20_000 + 30_000) // tx1 + tx2
     );
     assert_eq!(balance_high.untrusted_pending, Amount::ZERO);
+}
+
+#[test]
+fn test_balance_taint_propagates_through_unconfirmed_ancestry() {
+    use std::collections::HashSet;
+
+    let blocks: BTreeMap<u32, BlockHash> = [(0, hash!("g")), (1, hash!("b1")), (2, hash!("tip"))]
+        .into_iter()
+        .collect();
+    let chain = LocalChain::from_blocks(blocks).unwrap();
+    let mut tx_graph = TxGraph::<ConfirmationBlockTime>::default();
+
+    let owned_spk = ScriptBuf::new();
+
+    // A confirmed coin we own.
+    let coin = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(hash!("coinbase"), 0),
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(100_000),
+            script_pubkey: owned_spk.clone(),
+        }],
+        ..new_tx(0)
+    };
+    let coin_txid = coin.compute_txid();
+
+    // Unconfirmed, spends our own confirmed coin -> not tainted -> trusted_pending.
+    let trusted = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(coin_txid, 0),
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(40_000),
+            script_pubkey: owned_spk.clone(),
+        }],
+        ..new_tx(1)
+    };
+    let trusted_txid = trusted.compute_txid();
+
+    // Unconfirmed, funded by a third party (spends a foreign outpoint) -> taints itself.
+    let foreign = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(hash!("third_party"), 0),
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(30_000),
+            script_pubkey: owned_spk.clone(),
+        }],
+        ..new_tx(2)
+    };
+    let foreign_txid = foreign.compute_txid();
+
+    // Unconfirmed, spends our own `foreign` output -> tainted via its ancestor `foreign`.
+    let chained = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(foreign_txid, 0),
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(25_000),
+            script_pubkey: owned_spk.clone(),
+        }],
+        ..new_tx(3)
+    };
+    let chained_txid = chained.compute_txid();
+
+    let _ = tx_graph.insert_tx(coin.clone());
+    let _ = tx_graph.insert_anchor(
+        coin_txid,
+        ConfirmationBlockTime {
+            block_id: chain.get(1).unwrap().block_id(),
+            confirmation_time: 100,
+        },
+    );
+    for tx in [&trusted, &foreign, &chained] {
+        let _ = tx_graph.insert_tx(tx.clone());
+        let _ = tx_graph.insert_seen_at(tx.compute_txid(), 1000);
+    }
+
+    // The set of outpoints we own.
+    let owned = [
+        OutPoint::new(coin_txid, 0),
+        OutPoint::new(trusted_txid, 0),
+        OutPoint::new(foreign_txid, 0),
+        OutPoint::new(chained_txid, 0),
+    ]
+    .into_iter()
+    .collect::<HashSet<_>>();
+
+    let view = chain.canonical_view(&tx_graph, chain.tip().block_id(), Default::default());
+
+    // Our unspent owned outputs: `trusted` and `chained` (the others are spent).
+    let utxos = [
+        OutPoint::new(trusted_txid, 0),
+        OutPoint::new(chained_txid, 0),
+    ];
+
+    let balance = view.balance(
+        utxos,
+        // Taint any transaction that spends an outpoint we do not own.
+        |c_tx| {
+            c_tx.tx
+                .input
+                .iter()
+                .any(|txin| !owned.contains(&txin.previous_output))
+        },
+        |pos| pos.is_confirmed(),
+    );
+
+    assert_eq!(balance.confirmed, Amount::ZERO);
+    assert_eq!(balance.immature, Amount::ZERO);
+    // `trusted` spends only our own (confirmed) coin -> trusted.
+    assert_eq!(balance.trusted_pending, Amount::from_sat(40_000));
+    // `chained` inherits taint from its foreign-funded ancestor `foreign`.
+    assert_eq!(balance.untrusted_pending, Amount::from_sat(25_000));
+}
+
+/// `is_settled` is the sole authority on the settled boundary: a caller may treat an unconfirmed
+/// output as settled, and its value must be counted (as settled), never silently dropped.
+#[test]
+fn test_balance_is_settled_is_authoritative_for_unconfirmed() {
+    let blocks: BTreeMap<u32, BlockHash> =
+        [(0, hash!("g")), (1, hash!("tip"))].into_iter().collect();
+    let chain = LocalChain::from_blocks(blocks).unwrap();
+    let mut tx_graph = TxGraph::<ConfirmationBlockTime>::default();
+
+    let tx = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(hash!("parent"), 0),
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(50_000),
+            script_pubkey: ScriptBuf::new(),
+        }],
+        ..new_tx(1)
+    };
+    let txid = tx.compute_txid();
+    let _ = tx_graph.insert_tx(tx);
+    let _ = tx_graph.insert_seen_at(txid, 1000);
+
+    let view = chain.canonical_view(&tx_graph, chain.tip().block_id(), Default::default());
+
+    // An `is_settled` that claims everything is settled counts the (mature, non-coinbase)
+    // unconfirmed output as settled rather than dropping it, even when it is tainted.
+    let balance = view.balance([OutPoint::new(txid, 0)], |_| true, |_| true);
+    assert_eq!(balance.confirmed, Amount::from_sat(50_000));
+    assert_eq!(balance.immature, Amount::ZERO);
+    assert_eq!(balance.trusted_pending, Amount::ZERO);
+    assert_eq!(balance.untrusted_pending, Amount::ZERO);
+}
+
+/// Taint must not cross the settled boundary: a settled (mined) ancestor that `does_taint` would
+/// flag does not taint its unsettled descendants, because the walk stops at settled transactions
+/// and never taints them.
+#[test]
+fn test_balance_taint_stops_at_settled_ancestor() {
+    use std::collections::HashSet;
+
+    let blocks: BTreeMap<u32, BlockHash> = [(0, hash!("g")), (1, hash!("b1")), (2, hash!("tip"))]
+        .into_iter()
+        .collect();
+    let chain = LocalChain::from_blocks(blocks).unwrap();
+    let mut tx_graph = TxGraph::<ConfirmationBlockTime>::default();
+    let owned_spk = ScriptBuf::new();
+
+    // A *settled* (confirmed) tx that itself spends a third-party coin — `does_taint` would flag
+    // it.
+    let settled_foreign = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(hash!("third_party"), 0),
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(50_000),
+            script_pubkey: owned_spk.clone(),
+        }],
+        ..new_tx(0)
+    };
+    let settled_foreign_txid = settled_foreign.compute_txid();
+
+    // Unconfirmed child spending our own (settled) output.
+    let child = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(settled_foreign_txid, 0),
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(45_000),
+            script_pubkey: owned_spk.clone(),
+        }],
+        ..new_tx(1)
+    };
+    let child_txid = child.compute_txid();
+
+    let _ = tx_graph.insert_tx(settled_foreign.clone());
+    let _ = tx_graph.insert_anchor(
+        settled_foreign_txid,
+        ConfirmationBlockTime {
+            block_id: chain.get(1).unwrap().block_id(),
+            confirmation_time: 100,
+        },
+    );
+    let _ = tx_graph.insert_tx(child.clone());
+    let _ = tx_graph.insert_seen_at(child_txid, 1000);
+
+    let owned = [
+        OutPoint::new(settled_foreign_txid, 0),
+        OutPoint::new(child_txid, 0),
+    ]
+    .into_iter()
+    .collect::<HashSet<_>>();
+
+    let view = chain.canonical_view(&tx_graph, chain.tip().block_id(), Default::default());
+
+    // `child` is the only UTXO (`settled_foreign:0` is spent by it).
+    let by_op = view
+        .classify_outpoints(
+            [OutPoint::new(child_txid, 0)],
+            |c_tx| {
+                c_tx.tx
+                    .input
+                    .iter()
+                    .any(|txin| !owned.contains(&txin.previous_output))
+            },
+            |pos| pos.is_confirmed(),
+        )
+        .map(|(txout, eligibility)| (txout.outpoint, eligibility))
+        .collect::<std::collections::HashMap<_, _>>();
+
+    // The foreign-spending ancestor is settled, so the walk stops there and never taints `child`.
+    assert_eq!(
+        by_op[&OutPoint::new(child_txid, 0)],
+        Eligibility::Unsettled(Trust::Trusted)
+    );
+}
+
+/// `classify_outpoints` distinguishes an immature coinbase from a settled output.
+#[test]
+fn test_classify_immature_and_settled() {
+    let blocks: BTreeMap<u32, BlockHash> = [(0, hash!("g")), (1, hash!("b1")), (2, hash!("tip"))]
+        .into_iter()
+        .collect();
+    let chain = LocalChain::from_blocks(blocks).unwrap();
+    let mut tx_graph = TxGraph::<ConfirmationBlockTime>::default();
+    let spk = ScriptBuf::new();
+
+    // Coinbase confirmed at height 1; far below `COINBASE_MATURITY` -> immature.
+    let coinbase = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::null(),
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(50_000),
+            script_pubkey: spk.clone(),
+        }],
+        ..new_tx(0)
+    };
+    let coinbase_txid = coinbase.compute_txid();
+    assert!(coinbase.is_coinbase());
+
+    // A normal (non-coinbase) confirmed output.
+    let normal = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(hash!("ext"), 0),
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(30_000),
+            script_pubkey: spk.clone(),
+        }],
+        ..new_tx(1)
+    };
+    let normal_txid = normal.compute_txid();
+
+    for (txid, tx) in [(coinbase_txid, &coinbase), (normal_txid, &normal)] {
+        let _ = tx_graph.insert_tx(tx.clone());
+        let _ = tx_graph.insert_anchor(
+            txid,
+            ConfirmationBlockTime {
+                block_id: chain.get(1).unwrap().block_id(),
+                confirmation_time: 100,
+            },
+        );
+    }
+
+    let view = chain.canonical_view(&tx_graph, chain.tip().block_id(), Default::default());
+    let ops = [
+        OutPoint::new(coinbase_txid, 0),
+        OutPoint::new(normal_txid, 0),
+    ];
+
+    let by_op = view
+        .classify_outpoints(ops, |_| false, |pos| pos.is_confirmed())
+        .map(|(txout, eligibility)| (txout.outpoint, eligibility))
+        .collect::<std::collections::HashMap<_, _>>();
+    assert_eq!(
+        by_op[&OutPoint::new(coinbase_txid, 0)],
+        Eligibility::Immature
+    );
+    assert_eq!(by_op[&OutPoint::new(normal_txid, 0)], Eligibility::Settled);
+
+    // The balance buckets reflect the same classification.
+    let balance = view.balance(ops, |_| false, |pos| pos.is_confirmed());
+    assert_eq!(balance.immature, Amount::from_sat(50_000));
+    assert_eq!(balance.confirmed, Amount::from_sat(30_000));
+}
+
+/// Two UTXOs that share one tainting ancestor are both untrusted. Because the taint cache is shared
+/// across outpoints, that common ancestor is only walked once.
+#[test]
+fn test_balance_taint_shared_ancestor() {
+    use std::collections::HashSet;
+
+    let blocks: BTreeMap<u32, BlockHash> =
+        [(0, hash!("g")), (1, hash!("tip"))].into_iter().collect();
+    let chain = LocalChain::from_blocks(blocks).unwrap();
+    let mut tx_graph = TxGraph::<ConfirmationBlockTime>::default();
+    let owned_spk = ScriptBuf::new();
+
+    // Unconfirmed, funded by a third party -> taints itself. Two outputs.
+    let foreign = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(hash!("third_party"), 0),
+            ..Default::default()
+        }],
+        output: vec![
+            TxOut {
+                value: Amount::from_sat(30_000),
+                script_pubkey: owned_spk.clone(),
+            },
+            TxOut {
+                value: Amount::from_sat(20_000),
+                script_pubkey: owned_spk.clone(),
+            },
+        ],
+        ..new_tx(0)
+    };
+    let foreign_txid = foreign.compute_txid();
+
+    // Two children, each spending one of `foreign`'s outputs, so both share the tainting ancestor.
+    let child_a = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(foreign_txid, 0),
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(29_000),
+            script_pubkey: owned_spk.clone(),
+        }],
+        ..new_tx(1)
+    };
+    let child_a_txid = child_a.compute_txid();
+    let child_b = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(foreign_txid, 1),
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(19_000),
+            script_pubkey: owned_spk.clone(),
+        }],
+        ..new_tx(2)
+    };
+    let child_b_txid = child_b.compute_txid();
+
+    for tx in [&foreign, &child_a, &child_b] {
+        let _ = tx_graph.insert_tx(tx.clone());
+        let _ = tx_graph.insert_seen_at(tx.compute_txid(), 1000);
+    }
+
+    let owned = [
+        OutPoint::new(foreign_txid, 0),
+        OutPoint::new(foreign_txid, 1),
+        OutPoint::new(child_a_txid, 0),
+        OutPoint::new(child_b_txid, 0),
+    ]
+    .into_iter()
+    .collect::<HashSet<_>>();
+
+    let view = chain.canonical_view(&tx_graph, chain.tip().block_id(), Default::default());
+
+    // Both children descend from the same tainting `foreign`, so both are untrusted.
+    let balance = view.balance(
+        [
+            OutPoint::new(child_a_txid, 0),
+            OutPoint::new(child_b_txid, 0),
+        ],
+        |c_tx| {
+            c_tx.tx
+                .input
+                .iter()
+                .any(|txin| !owned.contains(&txin.previous_output))
+        },
+        |pos| pos.is_confirmed(),
+    );
+    assert_eq!(balance.trusted_pending, Amount::ZERO);
+    assert_eq!(balance.untrusted_pending, Amount::from_sat(29_000 + 19_000));
+}
+
+/// `classify_outpoints` skips outpoints that are already spent or absent from the view.
+#[test]
+fn test_classify_skips_spent_and_unknown() {
+    let blocks: BTreeMap<u32, BlockHash> =
+        [(0, hash!("g")), (1, hash!("tip"))].into_iter().collect();
+    let chain = LocalChain::from_blocks(blocks).unwrap();
+    let mut tx_graph = TxGraph::<ConfirmationBlockTime>::default();
+    let spk = ScriptBuf::new();
+
+    // `parent`'s output is spent by `child`.
+    let parent = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(hash!("ext"), 0),
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(50_000),
+            script_pubkey: spk.clone(),
+        }],
+        ..new_tx(0)
+    };
+    let parent_txid = parent.compute_txid();
+    let child = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(parent_txid, 0),
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(40_000),
+            script_pubkey: spk.clone(),
+        }],
+        ..new_tx(1)
+    };
+    let child_txid = child.compute_txid();
+    for tx in [&parent, &child] {
+        let _ = tx_graph.insert_tx(tx.clone());
+        let _ = tx_graph.insert_seen_at(tx.compute_txid(), 1000);
+    }
+
+    let view = chain.canonical_view(&tx_graph, chain.tip().block_id(), Default::default());
+
+    let classified = view
+        .classify_outpoints(
+            [
+                OutPoint::new(parent_txid, 0),      // spent by `child` -> skipped
+                OutPoint::new(hash!("unknown"), 0), // not in the view -> skipped
+                OutPoint::new(child_txid, 0),       // the only real UTXO
+            ],
+            |_| false,
+            |pos| pos.is_confirmed(),
+        )
+        .collect::<Vec<_>>();
+
+    assert_eq!(classified.len(), 1);
+    assert_eq!(classified[0].0.outpoint, OutPoint::new(child_txid, 0));
+}
+
+/// An immature coinbase stays `Immature` even when `is_settled` treats it as unsettled.
+#[test]
+fn test_immature_coinbase_stays_immature_when_unsettled() {
+    let blocks: BTreeMap<u32, BlockHash> =
+        [(0, hash!("g")), (1, hash!("tip"))].into_iter().collect();
+    let chain = LocalChain::from_blocks(blocks).unwrap();
+    let mut tx_graph = TxGraph::<ConfirmationBlockTime>::default();
+
+    let coinbase = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::null(),
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(50_000),
+            script_pubkey: ScriptBuf::new(),
+        }],
+        ..new_tx(0)
+    };
+    let txid = coinbase.compute_txid();
+    let _ = tx_graph.insert_tx(coinbase);
+    let _ = tx_graph.insert_anchor(
+        txid,
+        ConfirmationBlockTime {
+            block_id: chain.get(1).unwrap().block_id(),
+            confirmation_time: 100,
+        },
+    );
+
+    let view = chain.canonical_view(&tx_graph, chain.tip().block_id(), Default::default());
+    let tip_height = view.tip().height;
+
+    // Require 3 confirmations to be settled.
+    let by_op = view
+        .classify_outpoints([OutPoint::new(txid, 0)], |_| false, settled(tip_height, 3))
+        .map(|(txout, e)| (txout.outpoint, e))
+        .collect::<std::collections::HashMap<_, _>>();
+
+    assert_eq!(by_op[&OutPoint::new(txid, 0)], Eligibility::Immature);
+}
+
+/// Check maturity and settledness are independent axes.
+#[test]
+fn test_mature_coinbase_is_settled_not_immature() {
+    let blocks: BTreeMap<u32, BlockHash> = [(0, hash!("g")), (1, hash!("b1")), (100, hash!("tip"))]
+        .into_iter()
+        .collect();
+    let chain = LocalChain::from_blocks(blocks).unwrap();
+    let mut tx_graph = TxGraph::<ConfirmationBlockTime>::default();
+
+    let coinbase = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::null(),
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(50_000),
+            script_pubkey: ScriptBuf::new(),
+        }],
+        ..new_tx(0)
+    };
+    let txid = coinbase.compute_txid();
+    let _ = tx_graph.insert_tx(coinbase);
+    let _ = tx_graph.insert_anchor(
+        txid,
+        ConfirmationBlockTime {
+            block_id: chain.get(1).unwrap().block_id(),
+            confirmation_time: 100,
+        },
+    );
+
+    let view = chain.canonical_view(&tx_graph, chain.tip().block_id(), Default::default());
+    let tip_height = view.tip().height;
+
+    let by_op = view
+        .classify_outpoints([OutPoint::new(txid, 0)], |_| false, settled(tip_height, 3))
+        .map(|(txout, e)| (txout.outpoint, e))
+        .collect::<std::collections::HashMap<_, _>>();
+
+    assert_eq!(by_op[&OutPoint::new(txid, 0)], Eligibility::Settled);
+}
+
+/// An unconfirmed chain whose root parent tx is missing from the Canonical set is
+/// `Unsettled(Unknown)`.
+#[test]
+fn test_unsettled_unknown_when_parent_root_missing() {
+    let blocks: BTreeMap<u32, BlockHash> =
+        [(0, hash!("g")), (1, hash!("tip"))].into_iter().collect();
+    let chain = LocalChain::from_blocks(blocks).unwrap();
+    let mut tx_graph = TxGraph::<ConfirmationBlockTime>::default();
+
+    let child1 = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(hash!("missing_root"), 0),
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(50_000),
+            script_pubkey: ScriptBuf::new(),
+        }],
+        ..new_tx(1)
+    };
+    let child1_txid = child1.compute_txid();
+
+    let child2 = Transaction {
+        input: vec![TxIn {
+            previous_output: OutPoint::new(child1_txid, 0),
+            ..Default::default()
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(50_000),
+            script_pubkey: ScriptBuf::new(),
+        }],
+        ..new_tx(2)
+    };
+    let child2_txid = child2.compute_txid();
+
+    for tx in [&child1, &child2] {
+        let _ = tx_graph.insert_tx(tx.clone());
+        let _ = tx_graph.insert_seen_at(tx.compute_txid(), 1000);
+    }
+    // `missing_root` is not inserted.
+
+    let view = chain.canonical_view(&tx_graph, chain.tip().block_id(), Default::default());
+
+    let by_op = view
+        .classify_outpoints(
+            [OutPoint::new(child2_txid, 0)],
+            |_| false,
+            |pos| pos.is_confirmed(),
+        )
+        .map(|(txout, e)| (txout.outpoint, e))
+        .collect::<std::collections::HashMap<_, _>>();
+
+    assert_eq!(
+        by_op[&OutPoint::new(child2_txid, 0)],
+        Eligibility::Unsettled(Trust::Unknown)
+    );
 }
 
 /// Txs with stale anchor and that have `last_evicted >= last_seen` should be excluded from

--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -374,16 +374,15 @@ fn reindex_reaches_fixed_point() {
 ///
 /// Keychains:
 ///
-/// keychain_1: Trusted
-/// keychain_2: Untrusted
+/// keychain_1 and keychain_2 are owned.
 ///
 /// Transactions:
 ///
-/// tx1: A Coinbase, sending 70000 sats to "trusted" address. [Block 0]
-/// tx2: A external Receive, sending 30000 sats to "untrusted" address. [Block 1]
-/// tx3: Internal Spend. Spends tx2 and returns change of 10000 to "trusted" address. [Block 2]
-/// tx4: Mempool tx, sending 20000 sats to "untrusted" address.
-/// tx5: Mempool tx, sending 15000 sats to "trusted" address.
+/// tx1: A Coinbase, sending 70000 sats to a keychain_1 address. [Block 0]
+/// tx2: A external Receive, sending 30000 sats to a keychain_2 address. [Block 1]
+/// tx3: Internal Spend. Spends tx2 and returns change of 10000 to a keychain_1 address. [Block 2]
+/// tx4: Mempool tx, sending 20000 sats to a keychain_2 address.
+/// tx5: Mempool tx, sending 15000 sats to a keychain_1 address.
 /// tx6: Complete unrelated tx. [Block 3]
 ///
 /// Different transactions are added via `insert_relevant_txs`.
@@ -418,10 +417,10 @@ fn test_list_owned_txouts() {
         indexer
     });
 
-    // Get trusted and untrusted addresses
+    // Get addresses for both keychains
 
-    let mut trusted_spks: Vec<ScriptBuf> = Vec::new();
-    let mut untrusted_spks: Vec<ScriptBuf> = Vec::new();
+    let mut keychain_1_spks: Vec<ScriptBuf> = Vec::new();
+    let mut keychain_2_spks: Vec<ScriptBuf> = Vec::new();
 
     {
         // we need to scope here to take immutable reference of the graph
@@ -431,7 +430,7 @@ fn test_list_owned_txouts() {
                 .reveal_next_spk("keychain_1".to_string())
                 .unwrap();
             // TODO Assert indexes
-            trusted_spks.push(script.to_owned());
+            keychain_1_spks.push(script.to_owned());
         }
     }
     {
@@ -440,7 +439,7 @@ fn test_list_owned_txouts() {
                 .index
                 .reveal_next_spk("keychain_2".to_string())
                 .unwrap();
-            untrusted_spks.push(script.to_owned());
+            keychain_2_spks.push(script.to_owned());
         }
     }
 
@@ -454,21 +453,21 @@ fn test_list_owned_txouts() {
         }],
         output: vec![TxOut {
             value: Amount::from_sat(70000),
-            script_pubkey: trusted_spks[0].to_owned(),
+            script_pubkey: keychain_1_spks[0].to_owned(),
         }],
         ..new_tx(1)
     };
 
-    // tx2 is an incoming transaction received at untrusted keychain at block 1.
+    // tx2 is an incoming transaction received at keychain_2 at block 1.
     let tx2 = Transaction {
         output: vec![TxOut {
             value: Amount::from_sat(30000),
-            script_pubkey: untrusted_spks[0].to_owned(),
+            script_pubkey: keychain_2_spks[0].to_owned(),
         }],
         ..new_tx(2)
     };
 
-    // tx3 spends tx2 and gives a change back in trusted keychain. Confirmed at Block 2.
+    // tx3 spends tx2 and gives a change back in keychain_1. Confirmed at Block 2.
     let tx3 = Transaction {
         input: vec![TxIn {
             previous_output: OutPoint::new(tx2.compute_txid(), 0),
@@ -476,25 +475,31 @@ fn test_list_owned_txouts() {
         }],
         output: vec![TxOut {
             value: Amount::from_sat(10000),
-            script_pubkey: trusted_spks[1].to_owned(),
+            script_pubkey: keychain_1_spks[1].to_owned(),
         }],
         ..new_tx(3)
     };
 
-    // tx4 is an external transaction receiving at untrusted keychain, unconfirmed.
+    // tx4 is unconfirmed and pays one of our addresses, but it spends a third-party
+    // coin we don't own. That foreign input is what makes its ancestry untrusted.
     let tx4 = Transaction {
+        input: vec![TxIn {
+            // A coin outside our wallet, never inserted into the graph.
+            previous_output: OutPoint::new(new_tx(40).compute_txid(), 0),
+            ..Default::default()
+        }],
         output: vec![TxOut {
             value: Amount::from_sat(20000),
-            script_pubkey: untrusted_spks[1].to_owned(),
+            script_pubkey: keychain_2_spks[1].to_owned(),
         }],
         ..new_tx(4)
     };
 
-    // tx5 is an external transaction receiving at trusted keychain, unconfirmed.
+    // tx5 is an external transaction receiving at keychain_1, unconfirmed.
     let tx5 = Transaction {
         output: vec![TxOut {
             value: Amount::from_sat(15000),
-            script_pubkey: trusted_spks[2].to_owned(),
+            script_pubkey: keychain_1_spks[2].to_owned(),
         }],
         ..new_tx(5)
     };
@@ -544,9 +549,9 @@ fn test_list_owned_txouts() {
                 .collect::<Vec<_>>();
 
             let balance = canonical_view.balance(
-                graph.index.outpoints().iter().cloned(),
-                |_, txout| trusted_spks.contains(&txout.txout.script_pubkey),
-                0,
+                graph.index.outpoints().iter().map(|(_, op)| *op),
+                bdk_chain::taints_unowned(&graph.index),
+                |pos| pos.is_confirmed(),
             );
 
             let confirmed_txouts_txid = txouts
@@ -640,7 +645,7 @@ fn test_list_owned_txouts() {
                 immature: Amount::from_sat(70000),          // immature coinbase
                 trusted_pending: Amount::from_sat(25000),   // tx3, tx5
                 untrusted_pending: Amount::from_sat(20000), // tx4
-                confirmed: Amount::ZERO                     // Nothing is confirmed yet
+                ..Default::default()
             }
         );
     }
@@ -678,7 +683,7 @@ fn test_list_owned_txouts() {
                 immature: Amount::from_sat(70000),          // immature coinbase
                 trusted_pending: Amount::from_sat(25000),   // tx3, tx5
                 untrusted_pending: Amount::from_sat(20000), // tx4
-                confirmed: Amount::from_sat(0)              // tx2 got confirmed (but spent by 3)
+                confirmed: Amount::from_sat(0),             // tx2 got confirmed (but spent by 3)
             }
         );
     }
@@ -719,7 +724,7 @@ fn test_list_owned_txouts() {
                 immature: Amount::from_sat(70000),          // immature coinbase
                 trusted_pending: Amount::from_sat(15000),   // tx5
                 untrusted_pending: Amount::from_sat(20000), // tx4
-                confirmed: Amount::from_sat(10000)          // tx3 got confirmed
+                confirmed: Amount::from_sat(10000),         // tx3 got confirmed
             }
         );
     }
@@ -760,7 +765,7 @@ fn test_list_owned_txouts() {
                 immature: Amount::from_sat(70000),          // immature coinbase
                 trusted_pending: Amount::from_sat(15000),   // tx5
                 untrusted_pending: Amount::from_sat(20000), // tx4
-                confirmed: Amount::from_sat(10000)          // tx3 is confirmed
+                confirmed: Amount::from_sat(10000),         // tx3 is confirmed
             }
         );
     }
@@ -773,10 +778,10 @@ fn test_list_owned_txouts() {
         assert_eq!(
             balance,
             Balance {
-                immature: Amount::ZERO,                     // coinbase matured
                 trusted_pending: Amount::from_sat(15000),   // tx5
                 untrusted_pending: Amount::from_sat(20000), // tx4
-                confirmed: Amount::from_sat(80000)          // tx1 + tx3
+                confirmed: Amount::from_sat(80000),         // tx1 + tx3
+                ..Default::default()
             }
         );
     }

--- a/crates/chain/tests/test_tx_graph_conflicts.rs
+++ b/crates/chain/tests/test_tx_graph_conflicts.rs
@@ -116,10 +116,8 @@ fn test_tx_conflict_handling() {
             exp_chain_txouts: HashSet::from([("tx1", 0), ("tx_conflict_2", 0)]),
             exp_unspents: HashSet::from([("tx_conflict_2", 0)]),
             exp_balance: Balance {
-                immature: Amount::ZERO,
                 trusted_pending: Amount::from_sat(30000),
-                untrusted_pending: Amount::ZERO,
-                confirmed: Amount::ZERO,
+                ..Default::default()
             },
         },
         Scenario {
@@ -152,10 +150,8 @@ fn test_tx_conflict_handling() {
             exp_chain_txouts: HashSet::from([("tx1", 0), ("tx1", 1), ("tx_conflict_2", 0)]),
             exp_unspents: HashSet::from([("tx_conflict_2", 0)]),
             exp_balance: Balance {
-                immature: Amount::ZERO,
                 trusted_pending: Amount::from_sat(30000),
-                untrusted_pending: Amount::ZERO,
-                confirmed: Amount::ZERO,
+                ..Default::default()
             },
         },
         Scenario {
@@ -195,10 +191,8 @@ fn test_tx_conflict_handling() {
             exp_chain_txouts: HashSet::from([("tx1", 0), ("tx_conflict_3", 0)]),
             exp_unspents: HashSet::from([("tx_conflict_3", 0)]),
             exp_balance: Balance {
-                immature: Amount::ZERO,
                 trusted_pending: Amount::from_sat(40000),
-                untrusted_pending: Amount::ZERO,
-                confirmed: Amount::ZERO,
+                ..Default::default()
             },
         },
         Scenario {
@@ -232,10 +226,8 @@ fn test_tx_conflict_handling() {
             exp_chain_txouts: HashSet::from([("tx1", 0), ("tx_orphaned_conflict", 0)]),
             exp_unspents: HashSet::from([("tx_orphaned_conflict", 0)]),
             exp_balance: Balance {
-                immature: Amount::ZERO,
                 trusted_pending: Amount::from_sat(30000),
-                untrusted_pending: Amount::ZERO,
-                confirmed: Amount::ZERO,
+                ..Default::default()
             },
         },
         Scenario {
@@ -269,10 +261,8 @@ fn test_tx_conflict_handling() {
             exp_chain_txouts: HashSet::from([("tx1", 0), ("tx_conflict_1", 0)]),
             exp_unspents: HashSet::from([("tx_conflict_1", 0)]),
             exp_balance: Balance {
-                immature: Amount::ZERO,
-                trusted_pending: Amount::from_sat(20000),
-                untrusted_pending: Amount::ZERO,
-                confirmed: Amount::ZERO,
+                untrusted_pending: Amount::from_sat(20000),
+                ..Default::default()
             },
         },
         Scenario {
@@ -319,10 +309,8 @@ fn test_tx_conflict_handling() {
             exp_chain_txouts: HashSet::from([("tx1", 0), ("tx_confirmed_conflict", 0)]),
             exp_unspents: HashSet::from([("tx_confirmed_conflict", 0)]),
             exp_balance: Balance {
-                immature: Amount::ZERO,
-                trusted_pending: Amount::ZERO,
-                untrusted_pending: Amount::ZERO,
                 confirmed: Amount::from_sat(50000),
+                ..Default::default()
             },
         },
         Scenario {
@@ -364,10 +352,8 @@ fn test_tx_conflict_handling() {
             exp_chain_txouts: HashSet::from([("A", 0), ("B", 0), ("C", 0)]),
             exp_unspents: HashSet::from([("C", 0)]),
             exp_balance: Balance {
-                immature: Amount::ZERO,
-                trusted_pending: Amount::from_sat(30000),
-                untrusted_pending: Amount::ZERO,
-                confirmed: Amount::ZERO,
+                untrusted_pending: Amount::from_sat(30000),
+                ..Default::default()
             },
         },
         Scenario {
@@ -406,10 +392,8 @@ fn test_tx_conflict_handling() {
             exp_chain_txouts: HashSet::from([("A", 0), ("B'", 0)]),
             exp_unspents: HashSet::from([("B'", 0)]),
             exp_balance: Balance {
-                immature: Amount::ZERO,
-                trusted_pending: Amount::ZERO,
-                untrusted_pending: Amount::ZERO,
                 confirmed: Amount::from_sat(20000),
+                ..Default::default()
             },
         },
         Scenario {
@@ -453,10 +437,8 @@ fn test_tx_conflict_handling() {
             ]),
             exp_unspents: HashSet::from([("C", 0)]),
             exp_balance: Balance {
-                immature: Amount::ZERO,
                 trusted_pending: Amount::from_sat(30000),
-                untrusted_pending: Amount::ZERO,
-                confirmed: Amount::ZERO,
+                ..Default::default()
             },
         },
         Scenario {
@@ -499,10 +481,8 @@ fn test_tx_conflict_handling() {
             exp_chain_txouts: HashSet::from([("A", 0), ("B'", 0)]),
             exp_unspents: HashSet::from([("B'", 0)]),
             exp_balance: Balance {
-                immature: Amount::ZERO,
                 trusted_pending: Amount::from_sat(30000),
-                untrusted_pending: Amount::ZERO,
-                confirmed: Amount::ZERO,
+                ..Default::default()
             },
         },
         Scenario {
@@ -545,10 +525,8 @@ fn test_tx_conflict_handling() {
             exp_chain_txouts: HashSet::from([("A", 0), ("B'", 0)]),
             exp_unspents: HashSet::from([("B'", 0)]),
             exp_balance: Balance {
-                immature: Amount::ZERO,
-                trusted_pending: Amount::ZERO,
-                untrusted_pending: Amount::ZERO,
                 confirmed: Amount::from_sat(50000),
+                ..Default::default()
             },
         },
         Scenario {
@@ -597,10 +575,8 @@ fn test_tx_conflict_handling() {
             exp_chain_txouts: HashSet::from([("A", 0), ("B'", 0)]),
             exp_unspents: HashSet::from([("B'", 0)]),
             exp_balance: Balance {
-                immature: Amount::ZERO,
-                trusted_pending: Amount::ZERO,
-                untrusted_pending: Amount::ZERO,
                 confirmed: Amount::from_sat(50000),
+                ..Default::default()
             },
         },
         Scenario {
@@ -630,10 +606,8 @@ fn test_tx_conflict_handling() {
             exp_chain_txouts: HashSet::from([("first", 0), ("second", 0), ("anchored", 0)]),
             exp_unspents: HashSet::from([("anchored", 0)]),
             exp_balance: Balance {
-                immature: Amount::ZERO,
-                trusted_pending: Amount::ZERO,
-                untrusted_pending: Amount::ZERO,
                 confirmed: Amount::from_sat(800),
+                ..Default::default()
             }
         },
         Scenario {
@@ -697,7 +671,7 @@ fn test_tx_conflict_handling() {
             exp_chain_txs: HashSet::from(["root", "tx"]),
             exp_chain_txouts: HashSet::from([("tx", 0)]),
             exp_unspents: HashSet::from([("tx", 0)]),
-            exp_balance: Balance { trusted_pending: Amount::from_sat(9000), ..Default::default() }
+            exp_balance: Balance { untrusted_pending: Amount::from_sat(9000), ..Default::default() }
         },
         Scenario {
             name: "tx spends from 2 conflicting transactions where a conflict spends another",
@@ -764,7 +738,7 @@ fn test_tx_conflict_handling() {
             exp_chain_txs: HashSet::from(["A", "S1", "B"]),
             exp_chain_txouts: HashSet::from([("A", 0), ("B", 0), ("S1", 0)]),
             exp_unspents: HashSet::from([("B", 0)]),
-            exp_balance: Balance { trusted_pending: Amount::from_sat(8_000), ..Default::default() },
+            exp_balance: Balance { untrusted_pending: Amount::from_sat(8_000), ..Default::default() },
         },
         Scenario {
             name: "tx spends from 2 conflicting transactions where the conflict is nested (different last_seens)",
@@ -801,7 +775,7 @@ fn test_tx_conflict_handling() {
             exp_chain_txs: HashSet::from(["A", "S1", "B"]),
             exp_chain_txouts: HashSet::from([("A", 0), ("B", 0), ("S1", 0)]),
             exp_unspents: HashSet::from([("B", 0)]),
-            exp_balance: Balance { trusted_pending: Amount::from_sat(8_000), ..Default::default() },
+            exp_balance: Balance { untrusted_pending: Amount::from_sat(8_000), ..Default::default() },
         },
         Scenario {
             name: "assume-canonical-tx displaces unconfirmed chain",
@@ -845,10 +819,9 @@ fn test_tx_conflict_handling() {
             exp_chain_txouts: HashSet::from([("root", 0), ("root", 1), ("assume_canonical", 0)]),
             exp_unspents: HashSet::from([("root", 1), ("assume_canonical", 0)]),
             exp_balance: Balance {
-                immature: Amount::ZERO,
                 trusted_pending: Amount::from_sat(19_000),
-                untrusted_pending: Amount::ZERO,
                 confirmed: Amount::from_sat(21_000),
+                ..Default::default()
             },
         },
         Scenario {
@@ -893,10 +866,9 @@ fn test_tx_conflict_handling() {
             exp_chain_txouts: HashSet::from([("root", 0), ("root", 1), ("assume_canonical", 0)]),
             exp_unspents: HashSet::from([("root", 1), ("assume_canonical", 0)]),
             exp_balance: Balance {
-                immature: Amount::ZERO,
                 trusted_pending: Amount::from_sat(19_000),
-                untrusted_pending: Amount::ZERO,
                 confirmed: Amount::from_sat(21_000),
+                ..Default::default()
             },
         },
         Scenario {
@@ -937,10 +909,8 @@ fn test_tx_conflict_handling() {
             exp_chain_txouts: HashSet::from([("root", 0), ("assume_c", 0)]),
             exp_unspents: HashSet::from([("assume_c", 0)]),
             exp_balance: Balance {
-                immature: Amount::ZERO,
                 trusted_pending: Amount::from_sat(18_000),
-                untrusted_pending: Amount::ZERO,
-                confirmed: Amount::ZERO,
+                ..Default::default()
             },
         },
         Scenario {
@@ -959,10 +929,7 @@ fn test_tx_conflict_handling() {
             exp_chain_txouts: HashSet::from([]),
             exp_unspents: HashSet::from([]),
             exp_balance: Balance {
-                immature: Amount::ZERO,
-                trusted_pending: Amount::ZERO,
-                untrusted_pending: Amount::ZERO,
-                confirmed: Amount::ZERO,
+                ..Default::default()
             }
         }
     ];
@@ -1028,13 +995,9 @@ fn test_tx_conflict_handling() {
         );
 
         let balance = canonical_view.balance(
-            env.indexer.outpoints().iter().cloned(),
-            |_, txout| {
-                env.indexer
-                    .index_of_spk(txout.txout.script_pubkey.as_script())
-                    .is_some()
-            },
-            0,
+            env.indexer.outpoints().iter().map(|(_, op)| *op),
+            bdk_chain::taints_unowned(&env.indexer),
+            |pos| pos.is_confirmed(),
         );
         assert_eq!(
             balance, scenario.exp_balance,

--- a/crates/electrum/tests/test_electrum.rs
+++ b/crates/electrum/tests/test_electrum.rs
@@ -62,7 +62,11 @@ fn get_balance(
             recv_chain.tip().block_id(),
             Default::default(),
         )
-        .balance(outpoints, |_, _| true, 0);
+        .balance(
+            outpoints.into_iter().map(|(_, op)| op),
+            bdk_chain::taints_unowned(&recv_graph.index),
+            |pos| pos.is_confirmed(),
+        );
     Ok(balance)
 }
 
@@ -592,7 +596,7 @@ fn test_sync() -> anyhow::Result<()> {
     assert_eq!(
         get_balance(&recv_chain, &recv_graph)?,
         Balance {
-            trusted_pending: SEND_AMOUNT,
+            untrusted_pending: SEND_AMOUNT,
             ..Balance::default()
         },
         "balance must be correct",
@@ -634,7 +638,7 @@ fn test_sync() -> anyhow::Result<()> {
     assert_eq!(
         get_balance(&recv_chain, &recv_graph)?,
         Balance {
-            trusted_pending: SEND_AMOUNT,
+            untrusted_pending: SEND_AMOUNT,
             ..Balance::default()
         },
     );
@@ -770,7 +774,7 @@ fn tx_can_become_unconfirmed_after_reorg() -> anyhow::Result<()> {
         assert_eq!(
             get_balance(&recv_chain, &recv_graph)?,
             Balance {
-                trusted_pending: SEND_AMOUNT * depth as u64,
+                untrusted_pending: SEND_AMOUNT * depth as u64,
                 confirmed: SEND_AMOUNT * (REORG_COUNT - depth) as u64,
                 ..Balance::default()
             },


### PR DESCRIPTION
Solves #2267

### Description

Takes over #2235 (thanks @evanlinjin for the go-ahead). It reworks `CanonicalView::balance` to derive trust from an output's unconfirmed ancestry, and adds `classify_outpoints`, a per-output spend-eligibility classifier that `balance` becomes a thin fold over.

The old `balance` decided trust using a per-output `trust_predicate`, which cannot express transitive trust. As a result, owned outputs whose unconfirmed ancestry included foreign coins were counted as trusted. That is the root cause of the wallet trust-classification bugs (bitcoindevkit/bdk_wallet#16, bitcoindevkit/bdk_wallet#273).

The API now takes two separate predicates, one per concern:

- `does_taint(&tx)` - should this transaction be considered tainted? (e.g., because it spends a foreign unconfirmed output)
- `is_settled(&pos)` - do we consider this chain position settled / final? (generalizes `min_confirmations`)

For each unspent output, `classify_outpoints` reports its chain-level spend eligibility:

- `Settled` if considered settled according to `is_settled`
- `Immature` for a coinbase output that has not yet matured
- `Unsettled(Trust)` otherwise, where `Trust` is:
  - `Trusted` if the whole unconfirmed ancestry only spends owned coins
  - `Untrusted` if the output itself, or any unconfirmed ancestor, is tainted
  - `Unknown` if part of the ancestry is missing from the view, so trust can't be determined

`balance` then sums each output's value into the bucket corresponding to its `Eligibility`.

### Notes to the reviewers

- Trust is resolved through a self-contained ancestry walk. The traversal is memoized: each visited transaction is cached so that already-classified transactions (and their ancestors) do not need to be walked again.
- Kept `Balance::confirmed` and did not rename it to `settled`. That rename is out of scope here. The folding logic is slated to move into `bdk_wallet`, and the current `balance` function in chain will eventually be deprecated.
- `balance` also drops the `O` generic and now takes plain `OutPoint`s, since the taint predicate operates on transactions rather than per-outpoint associated data.
- `does_taint` is evaluated at most once per transaction.
- More sophisticated classification rules (e.g., for coin control or locked funds) can be built on top of `classify_outpoints`. Left for a follow-up.

### Changelog notice

- **Breaking**: `CanonicalView::balance` now takes `does_taint: impl FnMut(&CanonicalTx) -> bool` and `is_settled: impl Fn(&ChainPosition) -> bool` instead of a per-output trust predicate and `min_confirmations`, and plain `OutPoint`s instead of `(identifier, outpoint)` pairs (this drops the `O` generic). Trust is now derived from an output's unconfirmed ancestry.
- **Breaking**: added `Balance::unknown_pending`, where outputs whose trust can't be determined are counted instead of being lumped into `untrusted_pending`.
- Added `CanonicalView::classify_outpoints` and the `Eligibility` enum.

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just p` before pushing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [x] This pull request breaks the existing API
