### PR TITLE
esplora: bump esplora-client to 0.13.0

### DIFF
--- a/crates/esplora/Cargo.toml
+++ b/crates/esplora/Cargo.toml
@@ -17,13 +17,13 @@ workspace = true
 
 [dependencies]
 bdk_core = { path = "../core", version = "0.6.1", default-features = false }
-esplora-client = { version = "0.12.3", default-features = false }
+esplora-client = { version = "0.13.0", default-features = false }
 async-trait = { version = "0.1.66", optional = true }
 futures = { version = "0.3.26", optional = true }
 serde_json = { version = "1.0", features = ["alloc"] }
 
 [dev-dependencies]
-esplora-client = { version = "0.12.0" }
+esplora-client = { version = "0.13.0" }
 bdk_chain = { path = "../chain" }
 bdk_testenv = { path = "../testenv" }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }

--- a/crates/esplora/src/async_ext.rs
+++ b/crates/esplora/src/async_ext.rs
@@ -314,7 +314,7 @@ where
     I: Iterator<Item = Indexed<SpkWithExpectedTxids>> + Send,
     S: Sleeper + Clone + Send + Sync,
 {
-    type TxsOfSpkIndex = (u32, Vec<esplora_client::Tx>, HashSet<Txid>);
+    type TxsOfSpkIndex = (u32, Vec<esplora_client::EsploraTx>, HashSet<Txid>);
 
     let mut update = TxUpdate::<ConfirmationBlockTime>::default();
     let mut last_active_index = Option::<u32>::None;
@@ -335,7 +335,7 @@ where
                     let mut last_seen = None;
                     let mut spk_txs = Vec::new();
                     loop {
-                        let txs = client.scripthash_txs(&spk, last_seen).await?;
+                        let txs = client.get_scripthash_txs(&spk, last_seen).await?;
                         let tx_count = txs.len();
                         last_seen = txs.last().map(|tx| tx.txid);
                         spk_txs.extend(txs);

--- a/crates/esplora/src/blocking_ext.rs
+++ b/crates/esplora/src/blocking_ext.rs
@@ -6,7 +6,7 @@ use bdk_core::{
     bitcoin::{BlockHash, OutPoint, Txid},
     BlockId, CheckPoint, ConfirmationBlockTime, Indexed, TxUpdate,
 };
-use esplora_client::{OutputStatus, Tx};
+use esplora_client::{EsploraTx, OutputStatus};
 use std::thread::JoinHandle;
 
 use crate::{insert_anchor_or_seen_at_from_status, insert_prevouts};
@@ -282,7 +282,7 @@ fn fetch_txs_with_keychain_spks<I: Iterator<Item = Indexed<SpkWithExpectedTxids>
     last_revealed: Option<u32>,
     parallel_requests: usize,
 ) -> Result<(TxUpdate<ConfirmationBlockTime>, Option<u32>), Error> {
-    type TxsOfSpkIndex = (u32, Vec<esplora_client::Tx>, HashSet<Txid>);
+    type TxsOfSpkIndex = (u32, Vec<esplora_client::EsploraTx>, HashSet<Txid>);
 
     let mut update = TxUpdate::<ConfirmationBlockTime>::default();
     let mut last_active_index = Option::<u32>::None;
@@ -303,7 +303,7 @@ fn fetch_txs_with_keychain_spks<I: Iterator<Item = Indexed<SpkWithExpectedTxids>
                     let mut last_txid = None;
                     let mut spk_txs = Vec::new();
                     loop {
-                        let txs = client.scripthash_txs(&spk, last_txid)?;
+                        let txs = client.get_scripthash_txs(&spk, last_txid)?;
                         let tx_count = txs.len();
                         last_txid = txs.last().map(|tx| tx.txid);
                         spk_txs.extend(txs);
@@ -414,7 +414,7 @@ fn fetch_txs_with_txids<I: IntoIterator<Item = Txid>>(
                         .map(|t| (txid, t))
                 })
             })
-            .collect::<Vec<JoinHandle<Result<(Txid, Option<Tx>), Error>>>>();
+            .collect::<Vec<JoinHandle<Result<(Txid, Option<EsploraTx>), Error>>>>();
 
         if handles.is_empty() {
             break;

--- a/crates/esplora/src/lib.rs
+++ b/crates/esplora/src/lib.rs
@@ -21,7 +21,7 @@
 //! [`esplora_client::AsyncClient`].
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
-use bdk_core::bitcoin::{Amount, OutPoint, TxOut, Txid};
+use bdk_core::bitcoin::{OutPoint, TxOut, Txid};
 use bdk_core::{BlockId, ConfirmationBlockTime, TxUpdate};
 use esplora_client::TxStatus;
 
@@ -76,7 +76,7 @@ fn insert_prevouts(
             OutPoint::new(prev_txid, prev_vout),
             TxOut {
                 script_pubkey: prev_txout.scriptpubkey,
-                value: Amount::from_sat(prev_txout.value),
+                value: prev_txout.value,
             },
         );
     }


### PR DESCRIPTION
### Description
Closes #2214

esplora-client 0.12.3 pulled in `minreq`, which depends on an unpatched
`rustls-webpki` (RUSTSEC-2026-0104: reachable panic in CRL parsing).
esplora-client 0.13.0 already migrated to `bitreq` upstream, which pins
a patched `rustls-webpki` (^0.103.13), so this is a version bump rather
than a from-scratch fix.

Bumping to 0.13.0 required adapting to its API changes:
- `Tx` renamed to `EsploraTx`
- `scripthash_txs` renamed to `get_scripthash_txs`

### Notes to the reviewers
While fixing the build against 0.13.0, I also hit an unrelated compile
error: `TxOut.value` is now typed as `Amount` rather than `u64` in the
`rust-bitcoin` version this pulls in, so the existing
`Amount::from_sat(prev_txout.value)` call was redundantly re-wrapping
an already-`Amount` value. I dropped the wrap and the now-unused
`Amount` import. Happy to split this into a separate commit/PR if
preferred, but it was a required fix to get this compiling.

### Changelog notice
Bump `esplora-client` dependency to 0.13.0, fixing RUSTSEC-2026-0104.

### Checklists
#### All Submissions:
- [x] I followed the contribution guidelines
#### Bugfixes:
- [ ] This pull request breaks the existing API
- [x] I've added tests to reproduce the issue which are now passing
- [x] I'm linking the issue being fixed by this PR