### PR TITLE
fix(chain): let the indexer decide how far to rescan

### DIFF
--- a/crates/chain/src/indexed_tx_graph.rs
+++ b/crates/chain/src/indexed_tx_graph.rs
@@ -145,18 +145,16 @@ where
 
     /// Synchronizes the indexer to reflect every entry in the transaction graph.
     ///
-    /// Iterates over **all** full transactions and floating outputs in `self.graph`, passing each
-    /// into `self.index`. Any indexer-side changes produced (via `index_tx` or `index_txout`) are
-    /// merged into a fresh `ChangeSet`, which is then returned.
+    /// Hands the whole graph to [`Indexer::rescan`] and returns the indexer-side changes it
+    /// produces. How thoroughly the graph is walked is the indexer's decision: one whose set of
+    /// recognized outputs grows as it matches — `KeychainTxOutIndex` extends its lookahead past
+    /// each newly revealed index — has to look more than once to reach everything it can, and it is
+    /// the only party that knows when it is done.
     pub fn reindex(&mut self) -> ChangeSet<A, I::ChangeSet> {
-        let mut changeset = ChangeSet::<A, I::ChangeSet>::default();
-        for tx in self.graph.full_txs() {
-            changeset.indexer.merge(self.index.index_tx(&tx));
+        ChangeSet {
+            tx_graph: Default::default(),
+            indexer: self.index.rescan(&self.graph),
         }
-        for (op, txout) in self.graph.floating_txouts() {
-            changeset.indexer.merge(self.index.index_txout(op, txout));
-        }
-        changeset
     }
 
     fn index_tx_graph_changeset(

--- a/crates/chain/src/indexer.rs
+++ b/crates/chain/src/indexer.rs
@@ -2,6 +2,8 @@
 
 use bitcoin::{OutPoint, Transaction, TxOut};
 
+use crate::{tx_graph::TxGraph, Merge};
+
 #[cfg(feature = "miniscript")]
 pub mod keychain_txout;
 pub mod spk_txout;
@@ -30,4 +32,27 @@ pub trait Indexer {
 
     /// Determines whether the transaction should be included in the index.
     fn is_tx_relevant(&self, tx: &Transaction) -> bool;
+
+    /// Index everything in `graph` that this indexer has not already accounted for.
+    ///
+    /// The default implementation offers every full transaction and floating output to
+    /// [`index_tx`](Self::index_tx) and [`index_txout`](Self::index_txout) exactly once, which is
+    /// all an indexer needs when what it recognizes is fixed up front.
+    ///
+    /// Override this when a match can *widen* what the indexer recognizes, so that an output
+    /// offered earlier in the walk could match on a later look. Only the indexer knows when its
+    /// recognition set has stopped growing, so only the indexer can decide when to stop looking.
+    fn rescan<A>(&mut self, graph: &TxGraph<A>) -> Self::ChangeSet
+    where
+        Self::ChangeSet: Merge,
+    {
+        let mut changeset = Self::ChangeSet::default();
+        for tx in graph.full_txs() {
+            changeset.merge(self.index_tx(&tx));
+        }
+        for (op, txout) in graph.floating_txouts() {
+            changeset.merge(self.index_txout(op, txout));
+        }
+        changeset
+    }
 }

--- a/crates/chain/src/indexer/keychain_txout.rs
+++ b/crates/chain/src/indexer/keychain_txout.rs
@@ -8,6 +8,7 @@ use crate::{
     spk_client::{FullScanRequestBuilder, SyncRequestBuilder},
     spk_iter::BIP32_MAX_INDEX,
     spk_txout::SpkTxOutIndex,
+    tx_graph::TxGraph,
     DescriptorExt, DescriptorId, Indexed, Indexer, KeychainIndexed, SpkIterator,
 };
 use alloc::{borrow::ToOwned, vec::Vec};
@@ -197,6 +198,28 @@ impl<K: Clone + Ord + Debug> Indexer for KeychainTxOutIndex<K> {
 
     fn is_tx_relevant(&self, tx: &bitcoin::Transaction) -> bool {
         self.inner.is_relevant(tx)
+    }
+
+    /// Looks repeatedly, because a match here widens what the next look can find: revealing an
+    /// index replenishes the lookahead past it, bringing spks into the derived set that outputs
+    /// already walked past may pay to. Looking once would make the outcome depend on the order the
+    /// graph happens to yield its transactions.
+    fn rescan<A>(&mut self, graph: &TxGraph<A>) -> Self::ChangeSet {
+        let mut changeset = ChangeSet::default();
+        loop {
+            // The frontier, not `changeset.is_empty()`: the changeset also carries staged spk cache
+            // entries, which move without the frontier moving and would buy a pointless extra look.
+            let frontier = self.last_revealed.clone();
+            for tx in graph.full_txs() {
+                changeset.merge(self.index_tx(&tx));
+            }
+            for (op, txout) in graph.floating_txouts() {
+                changeset.merge(self.index_txout(op, txout));
+            }
+            if self.last_revealed == frontier {
+                return changeset;
+            }
+        }
     }
 }
 

--- a/crates/chain/tests/test_indexed_tx_graph.rs
+++ b/crates/chain/tests/test_indexed_tx_graph.rs
@@ -10,7 +10,7 @@ use bdk_chain::{
     indexer::keychain_txout::KeychainTxOutIndex,
     local_chain::LocalChain,
     spk_txout::SpkTxOutIndex,
-    tx_graph, Balance, ChainPosition, ConfirmationBlockTime, DescriptorExt, SpkIterator,
+    tx_graph, Balance, ChainPosition, ConfirmationBlockTime, DescriptorExt, Merge, SpkIterator,
 };
 use bdk_testenv::{
     anyhow::{self},
@@ -300,6 +300,69 @@ fn insert_relevant_txs() {
     };
 
     assert_eq!(graph.initial_changeset(), initial_changeset);
+}
+
+/// `reindex` must climb to the highest index the lookahead can reach, not stop at whichever match
+/// it happened to see first.
+///
+/// A match widens the derived window the *remaining* outputs are judged against, so one pass can
+/// miss an output it already walked past. Two transactions would express that too, but the walk
+/// order over the graph is a `HashMap` order — the very thing that is unreliable — so such a test
+/// would pass a single-pass implementation about half the time. One transaction with both outputs
+/// pins it down: `index_tx` walks `tx.output`, a `Vec`, in vout order, so `far` at vout 0 is
+/// always judged against the initial window and always missed, and `near` at vout 1 only then
+/// lifts the frontier that brings `far` into range. Nothing here depends on a hash seed.
+#[test]
+fn reindex_reaches_fixed_point() {
+    let (descriptor, _) = Descriptor::parse_descriptor(&Secp256k1::signing_only(), DESCRIPTORS[0])
+        .expect("must be valid");
+    let did = descriptor.descriptor_id();
+
+    let lookahead = 10;
+    let near = lookahead - 1;
+    let far = lookahead + 5;
+    assert!(
+        far >= lookahead && far < 2 * lookahead,
+        "`far` must be out of the initial window but within the one `near` widens it to",
+    );
+
+    let tx = Transaction {
+        output: [far, near]
+            .iter()
+            .map(|&index| TxOut {
+                value: Amount::from_sat(10_000),
+                script_pubkey: descriptor
+                    .at_derivation_index(index)
+                    .unwrap()
+                    .script_pubkey(),
+            })
+            .collect(),
+        ..new_tx(0)
+    };
+
+    let (mut graph, changeset) =
+        IndexedTxGraph::<ConfirmationBlockTime, KeychainTxOutIndex<()>>::from_changeset(
+            indexed_tx_graph::ChangeSet {
+                tx_graph: tx_graph::ChangeSet {
+                    txs: [Arc::new(tx)].into(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            |_| -> anyhow::Result<_> {
+                let mut indexer = KeychainTxOutIndex::new(lookahead, true);
+                assert!(indexer.insert_descriptor((), descriptor.clone()).unwrap());
+                Ok(indexer)
+            },
+        )
+        .expect("must construct");
+
+    assert_eq!(graph.index.last_revealed_index(()), Some(far));
+    assert_eq!(changeset.indexer.last_revealed.get(&did), Some(&far));
+    assert!(
+        graph.reindex().is_empty(),
+        "reindexing an already-reindexed graph must find nothing new",
+    );
 }
 
 /// Ensure consistency IndexedTxGraph list_* and balance methods. These methods lists


### PR DESCRIPTION
### Description

`IndexedTxGraph::reindex` was a single pass over `TxGraph::full_txs`, which iterates a `HashMap`. That made it **nondeterministic**: the same graph reindexed twice could produce two different `last_revealed` results.

Each match inside `KeychainTxOutIndex::_index_txout` bumps `last_revealed` and then calls `replenish_inner_index`, whose stop index is `last_revealed + 1 + lookahead`. So a match *widens the derived window the remaining outputs are judged against*. An output far enough out to need that widening was skipped if it happened to be visited first, and no pass revisited it.

Concretely, with `lookahead` 1000 and an empty frontier the derived set is `0..1001`. Given one tx paying index 900 and another paying 1850: visited 900-first, the window grows to 1901 and both are found; visited 1850-first, 1850 is missed and stays missed. Same inputs, different index, decided by `HashMap` iteration order.

The usual objection — that callers should reveal before reindexing — does not hold. The lookahead exists precisely to catch indices the persisted frontier does not know about: a restored wallet, another signer on the same descriptor, an externally built PSBT paying one of our far indices. Whenever the lookahead does its job the frontier moves mid-walk, so the order dependence is present in the intended use, not just in misuse.

### The change

Add `Indexer::rescan`, handed the whole `TxGraph` and returning the indexing it produced:

```rust
fn rescan<A>(&mut self, graph: &TxGraph<A>) -> Self::ChangeSet
where
    Self::ChangeSet: Merge,
```

The default implementation offers every full transaction and floating output to `index_tx` / `index_txout` exactly once — all an indexer needs when what it recognizes is fixed up front — and `IndexedTxGraph::reindex` becomes a call to it. `KeychainTxOutIndex` overrides it and looks repeatedly, stopping when a pass leaves its revealed frontier unmoved.

Whether to look more than once belongs to the indexer, because the indexer is the only thing that knows whether its recognition set can still grow. Two things follow from putting it there rather than in `IndexedTxGraph`:

- **An indexer that does not widen what it matches is walked exactly once**, as today. `SpkTxOutIndex` is unaffected. There is no convergence requirement imposed on implementors, and no way for a third-party indexer to be spun forever by a loop it never asked for.
- **`KeychainTxOutIndex` can key the loop on its own frontier** rather than on whether a changeset came back empty. That matters: the changeset also carries staged spk cache entries, which move *without* the frontier moving. A `changeset.is_empty()` loop therefore spends an extra full walk on the ordinary restore path. I measured this — with `persist_spks = true`, restoring via `from_changeset` with a correct frontier takes **1 pass** keyed on the frontier versus **2** keyed on changeset emptiness.

### Notes to the reviewers

**On the test shape.** The regression test uses **one** transaction with two of our outputs rather than two transactions. A two-transaction test would depend on graph walk order — the very thing that is unreliable — and so would pass a single-pass implementation about half the time, which is a test that fails to fail. `index_tx` walks `tx.output`, a `Vec`, in vout order, so a single tx paying a far index at vout 0 and a near one at vout 1, against an empty frontier, misses the far output on every pass on every run. It is deterministic by construction; I verified it fails against the old implementation on five consecutive runs (`left: Some(9)`, `right: Some(15)`).

**On cost.** `KeychainTxOutIndex::rescan` re-walks the whole graph per look, so it is O(looks × txs), with looks bounded by the number of distinct frontier advances plus one. Measured: the settled/restore case is 1 look; the recovery case in the test (empty frontier, far output only reachable after the near one lands) is 3. Making a later look re-examine only the outputs that did not already match would need the indexer to say *what* to re-offer rather than just *whether*, which is a bigger change than this fix.

**Trait change.** `rescan` is a defaulted method, so existing `Indexer` implementations keep compiling unchanged. It is generic over the anchor `A`, which makes `Indexer` no longer object-safe — nothing in the workspace uses `dyn Indexer`.

**Known adjacent gap, not addressed here.** `index_tx_graph_changeset` — used by `insert_tx`, `insert_txout`, `apply_update` and `apply_block_relevant` — is still a single pass and has the same order dependence. Feeding the one-transaction case above through `insert_tx` yields `last_revealed = Some(9)` and only one of the two outpoints, so a live wallet can drop the far UTXO until the next restart re-runs `reindex`. It needs the incremental paths to go through the same mechanism rather than their own copy; I kept this PR to `reindex` to stay reviewable, and am happy to follow up.

### Changelog notice

- Added: `Indexer::rescan`, which indexes an entire `TxGraph` and lets an implementation decide how many looks that takes. Defaulted, so existing implementations are unaffected.
- Fixed: `IndexedTxGraph::reindex` no longer depends on `HashMap` iteration order. It previously made a single pass and could miss outputs at derivation indices that only came into range after another output in the same walk advanced the lookahead; `KeychainTxOutIndex` now looks until its revealed frontier stops moving.

### Checklists

#### All Submissions:

* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature

#### Bugfixes:

* [ ] This pull request breaks the existing API
* [x] I've added tests to reproduce the issue which are now passing
