### PR TITLE
feat(chain): add ChainPosition::confirmations_lower_bound

### DIFF
--- a/crates/chain/src/chain_data.rs
+++ b/crates/chain/src/chain_data.rs
@@ -83,6 +83,21 @@ impl<A: Anchor> ChainPosition<A> {
             ChainPosition::Unconfirmed { .. } => None,
         }
     }
+
+    /// Number of confirmations of this position, given `tip`.
+    ///
+    /// Returns `0` if unconfirmed, or if the confirmation height is above `tip`.
+    pub fn confirmations_lower_bound(&self, tip: u32) -> u32 {
+        let Some(height) = self.confirmation_height_upper_bound() else {
+            return 0;
+        };
+
+        if height > tip {
+            return 0;
+        }
+
+        tip - height + 1
+    }
 }
 
 /// Ordering for `ChainPosition`:
@@ -334,5 +349,30 @@ mod test {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn test_confirmations_lower_bound() {
+        let confirmed_at = |height: u32| ChainPosition::Confirmed {
+            anchor: ConfirmationBlockTime {
+                confirmation_time: 0,
+                block_id: BlockId {
+                    height,
+                    ..Default::default()
+                },
+            },
+            transitively: None,
+        };
+
+        assert_eq!(confirmed_at(100).confirmations_lower_bound(100), 1);
+        assert_eq!(confirmed_at(99).confirmations_lower_bound(100), 2);
+        assert_eq!(confirmed_at(90).confirmations_lower_bound(100), 11);
+        assert_eq!(confirmed_at(101).confirmations_lower_bound(100), 0);
+
+        let unconfirmed = ChainPosition::<ConfirmationBlockTime>::Unconfirmed {
+            first_seen: Some(1),
+            last_seen: Some(2),
+        };
+        assert_eq!(unconfirmed.confirmations_lower_bound(100), 0);
     }
 }


### PR DESCRIPTION
Suggested by @nymius in https://github.com/bitcoindevkit/bdk/pull/2246#discussion_r3796478212.

### Description

Adds `ChainPosition::confirmations_lower_bound(tip)`, which returns the number of blocks mined on top of a confirmed position's block, given the chain `tip`. Returns `None` if the position is unconfirmed, or if the confirmation height is above `tip`.

### Changelog notice

- Added `ChainPosition::confirmations_lower_bound`, returning the number of blocks mined on top of a confirmed position's block given the chain tip.

### Checklists

#### All Submissions:

* [x] I've signed all my commits
* [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
* [x] I ran `just p` before committing

#### New Features:

* [x] I've added tests for the new feature
* [x] I've added docs for the new feature
