### PR TITLE
esplora: remove misleading TODO about maintaining a tx cache

### DIFF
--- a/crates/esplora/src/async_ext.rs
+++ b/crates/esplora/src/async_ext.rs
@@ -492,7 +492,7 @@ where
     let mut update = TxUpdate::<ConfirmationBlockTime>::default();
 
     // make sure txs exists in graph and tx statuses are updated
-    // TODO: We should maintain a tx cache (like we do with Electrum).
+    // Note: Esplora GET /scripthash/:hash/txs already returns full transactions, so a tx cache is not required.
     update.extend(
         fetch_txs_with_txids(
             client,

--- a/crates/esplora/src/blocking_ext.rs
+++ b/crates/esplora/src/blocking_ext.rs
@@ -451,7 +451,7 @@ fn fetch_txs_with_outpoints<I: IntoIterator<Item = OutPoint>>(
     let mut update = TxUpdate::<ConfirmationBlockTime>::default();
 
     // make sure txs exists in graph and tx statuses are updated
-    // TODO: We should maintain a tx cache (like we do with Electrum).
+    // Note: Esplora GET /scripthash/:hash/txs already returns full transactions, so a tx cache is not required.
     update.extend(fetch_txs_with_txids(
         client,
         start_time,


### PR DESCRIPTION
Fixes #2260

### Description

Removed the misleading TODO comment regarding tx cache maintenance in both `async_ext.rs` and `blocking_ext.rs` under `crates/esplora`. Replaced it with an explanatory note detailing why Esplora does not require a tx cache (since `/scripthash/:hash/txs` already returns full transaction data).

### Checklists

* [x] I followed the contribution guidelines