### PR TITLE
fix(chain): sanitize and bound-check derivation indices near BIP32_MAX_INDEX

### DIFF
--- a/crates/chain/src/indexer/keychain_txout.rs
+++ b/crates/chain/src/indexer/keychain_txout.rs
@@ -992,6 +992,7 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
             }
         }
         for (did, index) in changeset.last_revealed {
+            let index = index.min(BIP32_MAX_INDEX);
             let v = self.last_revealed.entry(did).or_default();
             *v = index.max(*v);
             self.replenish_inner_index_did(did, self.lookahead);
@@ -1225,5 +1226,36 @@ mod test {
         // The cache is optional at load time
         let index = KeychainTxOutIndex::<i32>::from_changeset(lookahead, false, init_cs);
         assert!(index.spk_cache.is_empty());
+    }
+
+    #[test]
+    fn apply_changeset_clamps_out_of_range_index_and_derives_correct_spk() {
+        let s = DESCRIPTORS[0];
+        let desc = Descriptor::parse_descriptor(&Secp256k1::new(), s)
+            .unwrap()
+            .0;
+        let mut index = KeychainTxOutIndex::new(0, false);
+        let did = desc.descriptor_id();
+        let _ = index.insert_descriptor(0i32, desc.clone());
+        let seed_index = BIP32_MAX_INDEX - 1;
+        let spk = desc
+            .at_derivation_index(seed_index)
+            .unwrap()
+            .script_pubkey();
+        index.inner.insert_spk((0i32, seed_index), spk);
+        let changeset = ChangeSet {
+            last_revealed: [(did, BIP32_MAX_INDEX + 1)].into(),
+            ..Default::default()
+        };
+        index.apply_changeset(changeset);
+        assert_eq!(index.last_revealed_index(0i32), Some(BIP32_MAX_INDEX));
+        assert_eq!(
+            index.spk_at_index(0i32, BIP32_MAX_INDEX),
+            Some(
+                desc.at_derivation_index(BIP32_MAX_INDEX)
+                    .unwrap()
+                    .script_pubkey()
+            )
+        );
     }
 }

--- a/crates/chain/src/indexer/keychain_txout.rs
+++ b/crates/chain/src/indexer/keychain_txout.rs
@@ -601,7 +601,9 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
         // Exclusive: index to stop at.
         let stop_index = if descriptor.has_wildcard() {
             let next_reveal_index = self.last_revealed.get(&did).map_or(0, |v| *v + 1);
-            (next_reveal_index + lookahead).min(BIP32_MAX_INDEX)
+            next_reveal_index
+                .saturating_add(lookahead)
+                .min(BIP32_MAX_INDEX + 1)
         } else {
             1
         };
@@ -1257,5 +1259,52 @@ mod test {
                     .script_pubkey()
             )
         );
+    }
+
+    /// Build an index with `last_revealed` (and the matching spk) at `last_revealed_index`.
+    fn indexer_with_last_revealed_at(last_revealed_index: u32) -> KeychainTxOutIndex<i32> {
+        let s = DESCRIPTORS[0];
+        let desc = Descriptor::parse_descriptor(&Secp256k1::new(), s)
+            .unwrap()
+            .0;
+        let mut index = KeychainTxOutIndex::new(0, false);
+        let did = desc.descriptor_id();
+        let _ = index.insert_descriptor(0i32, desc.clone());
+
+        let spk = desc
+            .at_derivation_index(last_revealed_index)
+            .unwrap()
+            .script_pubkey();
+        index.inner.insert_spk((0i32, last_revealed_index), spk);
+        index.last_revealed.insert(did, last_revealed_index);
+        index
+    }
+
+    #[test]
+    fn reveal_next_spk_and_next_unused_spk_return_last_script_when_saturated() {
+        let mut index = indexer_with_last_revealed_at(BIP32_MAX_INDEX);
+        let (i, changeset) = index.reveal_next_spk(0i32).unwrap();
+        assert_eq!(i.0, BIP32_MAX_INDEX);
+        assert!(changeset.is_empty());
+        assert!(index.mark_used(0i32, BIP32_MAX_INDEX));
+        let (i, changeset) = index.next_unused_spk(0i32).unwrap();
+        assert_eq!(i.0, BIP32_MAX_INDEX);
+        assert!(changeset.is_empty());
+    }
+
+    #[test]
+    fn reveal_to_target_with_target_at_bip32_max_index() {
+        let mut index = indexer_with_last_revealed_at(BIP32_MAX_INDEX - 1);
+        let (spks, _changeset) = index.reveal_to_target(0i32, BIP32_MAX_INDEX).unwrap();
+        assert_eq!(spks.len(), 1);
+        assert_eq!(spks[0].0, BIP32_MAX_INDEX);
+    }
+
+    #[test]
+    fn reveal_to_target_with_target_above_bip32_max_index() {
+        let mut index = indexer_with_last_revealed_at(BIP32_MAX_INDEX - 1);
+        let (spks, _changeset) = index.reveal_to_target(0i32, BIP32_MAX_INDEX + 5).unwrap();
+        assert_eq!(spks.len(), 1);
+        assert_eq!(spks[0].0, BIP32_MAX_INDEX);
     }
 }

--- a/crates/chain/src/indexer/keychain_txout.rs
+++ b/crates/chain/src/indexer/keychain_txout.rs
@@ -563,11 +563,9 @@ impl<K: Clone + Ord + Debug> KeychainTxOutIndex<K> {
     pub fn lookahead_to_target(&mut self, keychain: K, target_index: u32) -> ChangeSet {
         let mut changeset = ChangeSet::default();
         if let Some((next_index, _)) = self.next_index(keychain.clone()) {
-            let temp_lookahead = (target_index + 1)
-                .checked_sub(next_index)
-                .filter(|&index| index > 0);
+            let temp_lookahead = target_index.saturating_add(1).saturating_sub(next_index);
 
-            if let Some(temp_lookahead) = temp_lookahead {
+            if temp_lookahead > 0 {
                 self.replenish_inner_index_keychain(keychain, temp_lookahead);
             }
         }
@@ -1306,5 +1304,29 @@ mod test {
         let (spks, _changeset) = index.reveal_to_target(0i32, BIP32_MAX_INDEX + 5).unwrap();
         assert_eq!(spks.len(), 1);
         assert_eq!(spks[0].0, BIP32_MAX_INDEX);
+    }
+
+    #[test]
+    fn lookahead_to_target_past_bip32_max_clamps() {
+        let mut index = indexer_with_last_revealed_at(BIP32_MAX_INDEX - 1);
+        // `u32::MAX` is past `BIP32_MAX_INDEX`, so it must clamp down to it and store the final
+        // spk.
+        let changeset = index.lookahead_to_target(0i32, u32::MAX);
+        assert!(
+            changeset.last_revealed.is_empty(),
+            "lookahead must not reveal"
+        );
+        // `spk_at_index` is aware of lookahead spks.
+        assert!(index.spk_at_index(0i32, BIP32_MAX_INDEX).is_some());
+    }
+
+    #[test]
+    fn lookahead_to_target_at_bip32_max_does_not_overflow() {
+        let mut index = indexer_with_last_revealed_at(BIP32_MAX_INDEX);
+        let changeset = index.lookahead_to_target(0i32, u32::MAX - 1);
+        assert!(
+            changeset.last_revealed.is_empty(),
+            "lookahead must not reveal"
+        );
     }
 }


### PR DESCRIPTION
Fixes [bdk_wallet/issues/60](https://github.com/bitcoindevkit/bdk_wallet/issues/60)

### Description

`KeychainTxOutIndex::apply_changeset` accepted `ChangeSet::last_revealed` values with no upper bound, allowing an index greater than `BIP32_MAX_INDEX` (2^31 - 1) to be stored, violating an invariant relied on by `next_index()`.

The changes in this PR address boundary issues around derivation indices:

1. **`apply_changeset`**: clamps `last_revealed` to `BIP32_MAX_INDEX` before storing it, instead of storing the raw value.
2. **`replenish_inner_index`**: fixes an off-by-one in the `stop_index` calculation that caused a panic (`"we just inserted it"`) when a keychain's derivation index was revealed exactly up to `BIP32_MAX_INDEX`. The exclusive upper bound was clamped to `BIP32_MAX_INDEX` instead of `BIP32_MAX_INDEX + 1`, silently excluding the boundary value itself.
3. **`lookahead_to_target`**: fixes an integer overflow panic when called with `target_index == u32::MAX`, and changes out of range targets to clamp and replenish up to `BIP32_MAX_INDEX` instead of silently doing nothing.

### Notes to the reviewers

This revisits the earlier implementation attempt (#1792) and implements the clamp-in-`apply_changeset` approach from that review discussion.

The second and third fixes were found while adding the boundary tests requested in review of an earlier version of this PR.

Also added a test documenting current saturation behavior: `reveal_next_spk`/`next_unused_spk` return the last revealed script with an empty `ChangeSet`, not `None`, once the index is saturated. This matches `reveal_next_spk`'s existing doc comment.

Went through the other index-taking methods (`spk_at_index`, `is_used`, `mark_used`, `unmark_used`) as well. These are plain lookups with no boundary-sensitive logic, so no dedicated tests were added there.

### Changelog notice

- Clamped `last_revealed` to `BIP32_MAX_INDEX` in `KeychainTxOutIndex::apply_changeset` to prevent it accepting an out-of-range derivation index.
- Fixed an off-by-one in `replenish_inner_index` that could panic when revealing up to `BIP32_MAX_INDEX`.
- Fixed an integer overflow in `lookahead_to_target` when called with `target_index == u32::MAX`, and changed out of range targets to clamp to `BIP32_MAX_INDEX` instead of silently doing nothing.

### Checklists

**All Submissions**

- [x] I've signed all my commits
- [x] I followed the [contribution guidelines](https://github.com/bitcoindevkit/bdk/blob/master/CONTRIBUTING.md)
- [x]  I ran `just p` before committing

**Bugfixes**

- [ ] This pull request breaks the existing API
- [x] I've added tests to cover the issue which are now passing
- [x] I'm linking the issue being fixed by this PR