### PR TITLE
fix(chain): persist corrected floating txouts

### DIFF
--- a/crates/chain/src/rusqlite_impl.rs
+++ b/crates/chain/src/rusqlite_impl.rs
@@ -665,7 +665,7 @@ mod test {
     use super::*;
 
     use bdk_testenv::{anyhow, hash};
-    use bitcoin::{absolute, transaction, TxIn, TxOut};
+    use bitcoin::{absolute, transaction, Amount, OutPoint, ScriptBuf, TxIn, TxOut};
 
     #[test]
     fn can_persist_anchors_and_txs_independently() -> anyhow::Result<()> {
@@ -725,6 +725,45 @@ mod test {
             assert!(changeset.txs.contains(&tx));
             assert!(changeset.anchors.contains(&(anchor, txid)));
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn can_persist_replaced_floating_txout() -> anyhow::Result<()> {
+        type ChangeSet = tx_graph::ChangeSet<ConfirmationBlockTime>;
+        let mut conn = rusqlite::Connection::open_in_memory()?;
+
+        {
+            let db_tx = conn.transaction()?;
+            ChangeSet::init_sqlite_tables(&db_tx)?;
+            db_tx.commit()?;
+        }
+
+        let outpoint = OutPoint::new(hash!("floating txout"), 0);
+        let original = TxOut {
+            value: Amount::from_sat(1_000),
+            script_pubkey: ScriptBuf::new(),
+        };
+        let replacement = TxOut {
+            value: Amount::from_sat(2_000),
+            script_pubkey: ScriptBuf::new(),
+        };
+
+        for txout in [original, replacement.clone()] {
+            let changeset = ChangeSet {
+                txouts: [(outpoint, txout)].into(),
+                ..Default::default()
+            };
+            let db_tx = conn.transaction()?;
+            changeset.persist_to_sqlite(&db_tx)?;
+            db_tx.commit()?;
+        }
+
+        let db_tx = conn.transaction()?;
+        let changeset = ChangeSet::from_sqlite(&db_tx)?;
+        db_tx.commit()?;
+        assert_eq!(changeset.txouts.get(&outpoint), Some(&replacement));
 
         Ok(())
     }

--- a/crates/chain/src/tx_graph.rs
+++ b/crates/chain/src/tx_graph.rs
@@ -616,7 +616,7 @@ impl<A: Anchor> TxGraph<A> {
     /// about.
     ///
     /// The [`ChangeSet`] result will be empty if the `outpoint` (or a full transaction containing
-    /// the `outpoint`) already existed in `self`.
+    /// the `outpoint`) already existed in `self` with the same output.
     ///
     /// [`apply_changeset`]: Self::apply_changeset
     pub fn insert_txout(&mut self, outpoint: OutPoint, txout: TxOut) -> ChangeSet<A> {
@@ -1127,10 +1127,12 @@ impl<A> ChangeSet<A> {
 
 impl<A: Ord> Merge for ChangeSet<A> {
     fn merge(&mut self, other: Self) {
-        // We use `extend` instead of `BTreeMap::append` due to performance issues with `append`.
-        // Refer to https://github.com/rust-lang/rust/issues/34666#issuecomment-675658420
         self.txs.extend(other.txs);
-        self.txouts.extend(other.txouts);
+        // Floating txouts may be corrected by a later chain source. Keep the newest value when
+        // aggregating changesets so persisted state follows the in-memory graph.
+        for (outpoint, txout) in other.txouts {
+            self.txouts.insert(outpoint, txout);
+        }
         self.anchors.extend(other.anchors);
 
         // first_seen timestamps should only decrease

--- a/crates/chain/tests/test_tx_graph.rs
+++ b/crates/chain/tests/test_tx_graph.rs
@@ -1180,6 +1180,31 @@ fn test_changeset_last_seen_merge() {
     }
 }
 
+/// Ensure that merging changesets keeps the latest floating txout value.
+#[test]
+fn test_changeset_txouts_merge_replaces_conflicts() {
+    let outpoint = OutPoint::new(hash!("floating txout"), 0);
+    let original = TxOut {
+        value: Amount::from_sat(1_000),
+        script_pubkey: ScriptBuf::new(),
+    };
+    let replacement = TxOut {
+        value: Amount::from_sat(2_000),
+        script_pubkey: ScriptBuf::new(),
+    };
+
+    let mut changeset = ChangeSet::<BlockId> {
+        txouts: [(outpoint, original)].into(),
+        ..Default::default()
+    };
+    changeset.merge(ChangeSet {
+        txouts: [(outpoint, replacement.clone())].into(),
+        ..Default::default()
+    });
+
+    assert_eq!(changeset.txouts.get(&outpoint), Some(&replacement));
+}
+
 #[test]
 fn transactions_inserted_into_tx_graph_are_not_canonical_until_they_have_an_anchor_in_best_chain() {
     let txs = vec![new_tx(0), new_tx(1)];


### PR DESCRIPTION
### Description

Fixes #2274. Floating `TxOut` corrections now remain consistent across the in-memory graph, aggregated `ChangeSet`s, and SQLite persistence:

- make `ChangeSet::merge` explicitly keep the newer floating `TxOut` for a conflicting outpoint;
- keep the existing replacement behavior in `TxGraph::insert_txout` and clarify its documentation;
- add regressions for changeset aggregation and SQLite round-tripping.

This is a new proposal after #2276 was closed. The earlier PR's maintainer feedback about `ChangeSet::merge` and persistence is addressed here.

### Verification

- `cargo fmt --all -- --check` (stable toolchain; emits only the repository's existing nightly-option warnings)
- `cargo test -p bdk_chain --features rusqlite` — 14 unit tests, all integration suites, and 16 doc tests passed (1 ignored by repository configuration)
- `git diff --check`
- commit `66346d8c` is GPG-signed; the public key is being registered on the GitHub account

### Checklist

- [x] Added regression tests for the bug
- [x] Linked the issue being fixed
- [x] Followed the repository contribution workflow
